### PR TITLE
CET-455/feat: Order intent tax subtotals logging and updated getTaxSb…

### DIFF
--- a/Service/Order.php
+++ b/Service/Order.php
@@ -469,25 +469,27 @@ abstract class Order
     }
 
     /**
-     * @param array $linesItems
+     * @param array $lineItems
      * @return array
      */
-    public function getTaxSubtotals(array $linesItems): ?array
+    public function getTaxSubtotals(array $lineItems): ?array
     {
         if (!$this->configRepository->isTaxSubtotalsEnabled()) {
             return null;
         }
         $taxSubtotals = [];
-        foreach ($linesItems as $linesItem) {
-            $taxSubtotals[$linesItem['tax_rate']][] = [
-                'taxable_amount' => $linesItem['net_amount'],
+        foreach ($lineItems as $lineItem) {
+            $taxSubtotals[$lineItem['tax_rate']][] = [
+                'taxable_amount' => $lineItem['net_amount'],
+                'tax_amount' => $lineItem['tax_amount'],
+
             ];
         }
 
         $summary = [];
         foreach ($taxSubtotals as $taxRate => $amounts) {
             $taxableAmount = $this->getSum($amounts, 'taxable_amount');
-            $taxAmount = $taxableAmount * $taxRate;
+            $taxAmount = $this->getSum($amounts, 'tax_amount');
             $summary[] = [
                 'taxable_amount' => $this->roundAmt($taxableAmount),
                 'tax_amount' => $this->roundAmt($taxAmount),

--- a/Service/Order/ComposeOrder.php
+++ b/Service/Order/ComposeOrder.php
@@ -28,7 +28,7 @@ class ComposeOrder extends OrderService
      */
     public function execute(Order $order, string $orderReference, array $additionalData): array
     {
-        $linesItems = $this->getLineItemsOrder($order);
+        $lineItems = $this->getLineItemsOrder($order);
 
         return [
             'billing_address' => $this->getAddress($order, $additionalData, 'billing'),
@@ -42,9 +42,9 @@ class ComposeOrder extends OrderService
             'gross_amount' => $this->roundAmt($order->getGrandTotal()),
             'net_amount' => $this->roundAmt($order->getGrandTotal() - $order->getTaxAmount()),
             'tax_amount' => $this->roundAmt($order->getTaxAmount()),
-            'tax_subtotals' => $this->getTaxSubtotals($linesItems),
+            'tax_subtotals' => $this->getTaxSubtotals($lineItems),
             'invoice_type' => 'FUNDED_INVOICE',
-            'line_items' => $linesItems,
+            'line_items' => $lineItems,
             'merchant_order_id' => (string)($order->getIncrementId()),
             'merchant_urls' => [
                 'merchant_confirmation_url' => $this->url->getUrl(

--- a/view/frontend/web/js/view/payment/method-renderer/two_payment.js
+++ b/view/frontend/web/js/view/payment/method-renderer/two_payment.js
@@ -2,6 +2,34 @@
  * Copyright © Two.inc All rights reserved.
  * See COPYING.txt for license details.
  */
+
+
+// create tax subtotals for order intent for additional logging
+const calculateTaxSubtotals = (lineItems) => {
+    const taxSubtotals = {};
+
+    lineItems.forEach((item) => {
+        const taxRate = parseFloat(item.tax_rate);
+        const taxAmount = parseFloat(item.tax_amount);
+        const taxableAmount = parseFloat(item.net_amount);
+    
+
+        if (!taxSubtotals[taxRate]){
+            taxSubtotals[taxRate] = {
+                tax_amount: 0,
+                taxable_amount: 0,
+                tax_rate: taxRate
+            }
+        }
+        taxSubtotals[taxRate].tax_amount += taxAmount;
+        taxSubtotals[taxRate].taxable_amount += taxableAmount;
+
+        })
+
+        return Object.values(taxSubtotals);
+}
+
+
 define([
     'ko',
     'jquery',
@@ -326,30 +354,6 @@ define([
                 });
             });
 
-            // create tax subtotals for order intent for additional logging
-            const calculateTaxSubtotals = (lineItems) => {
-                const taxSubtotals = {}
-
-                lineItems.forEach((item) => {
-                    const taxRate = parseFloat(item.tax_rate);
-                    const taxAmount = parseFloat(item.tax_amount);
-                    const taxableAmount = parseFloat(item.net_amount);
-                
-
-                if (!taxSubtotals[taxRate]){
-                    taxSubtotals[taxRate] = {
-                        tax_amount: 0,
-                        taxable_amount: 0,
-                        tax_rate: taxRate
-                    }
-                }
-                taxSubtotals[taxRate].tax_amount += taxAmount
-                taxSubtotals[taxRate].taxable_amount += taxableAmount
-            })
-
-                return Object.values(taxSubtotals)
-        
-            }
 
             const orderIntentRequestBody = {
                 gross_amount: parseFloat(totals['grand_total']).toFixed(2),


### PR DESCRIPTION
Propsoed change to unblock cut direct for placing orders with correct tax subtotals

Previous error case here :

Debug Log entry:

`API POST /v1/order (status: 400): {"error_code":"SCHEMA_ERROR","error_details":"1 validation error for ValidateOrderSchema: __root__: gross_amount (128.55) != sum tax_subtotals (128.54 (type=value_error)","error_json":[{"loc":["__root__"],"msg":"gross_amount (128.55) != sum tax_subtotals (128.54","type":"value_error"}],"error_message":"Error parsing schema","error_trace_id":"1b5a0ed4bc459db0a5fe39b97ab02461"} [] []`

 

So on test our site this was a 1000mm x 1000mm product which gave the error (£128.55 inc. Delivery), changing it to 1000mm x 800mm (£104.83 inc. Delivery) worked.

I was able to reproduce this error on our test store here with the logs :

```
2024-09-30T12:55:49.602419+00:00
API POST /v1/order (status: 400): {"error_code":"SCHEMA_ERROR","error_details":"1 validation error for ValidateOrderSchema: __root__: gross_amount (128.55) != sum tax_subtotals (128.54 (type=value_error)","error_json":[{"loc":["__root__"],"msg":"gross_amount (128.55) != sum tax_subtotals (128.54","type":"value_error"}],"error_message":"Error parsing schema","error_trace_id":"e50a2f216df9bb82f542a0fde22d8a42"} [] []
```

Proposed change updates the getTaxSubtotalsFunction 
and adds some additional logging at the order intent stage.

Against the new changes was able to create the same order and have it be succesfully created on sandbox.

Order ID here :  https://admin.sandbox.two.inc/orders/1e0f5457-47b0-405d-81d8-8408d77181bb

