### PR TITLE
ABN-287/fix: surface API validation details in checkout error messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ TWO_API_BASE_URL     ?= https://api.staging.two.inc
 TWO_CHECKOUT_BASE_URL ?= https://checkout.staging.two.inc
 TWO_STORE_COUNTRY    ?= NO
 
-.PHONY: help install configure run stop clean logs archive patch minor major format
+.PHONY: help install configure compile run stop clean logs archive patch minor major format
 
 .DEFAULT_GOAL := help
 
@@ -28,7 +28,6 @@ install: clean
 		--name=$(CONTAINER) \
 		-p $(PORT):80 \
 		-e URL=$(URL) \
-		-e MAGE_MODE=developer \
 		-e TWO_API_BASE_URL=$(TWO_API_BASE_URL) \
 		-e TWO_CHECKOUT_BASE_URL=$(TWO_CHECKOUT_BASE_URL) \
 		-v $(CURDIR):/data/extensions/workdir \
@@ -56,6 +55,12 @@ configure:
 		-e TWO_STORE_COUNTRY=$(TWO_STORE_COUNTRY) \
 		$(CONTAINER) php /data/extensions/workdir/dev/configure
 	docker exec $(CONTAINER) php bin/magento cache:flush
+	docker restart $(CONTAINER)
+
+## Recompile DI and restart
+compile:
+	docker exec $(CONTAINER) php bin/magento setup:di:compile
+	docker restart $(CONTAINER)
 
 ## Start the Magento container
 run:

--- a/Model/Config/Repository.php
+++ b/Model/Config/Repository.php
@@ -9,6 +9,7 @@ namespace Two\Gateway\Model\Config;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\ProductMetadataInterface;
+use Magento\Framework\App\State;
 use Magento\Framework\Encryption\EncryptorInterface;
 use Magento\Framework\UrlInterface;
 use Magento\Store\Model\ScopeInterface;
@@ -36,21 +37,29 @@ class Repository implements RepositoryInterface
      */
     private $productMetadata;
     /**
+     * @var State
+     */
+    private $appState;
+
+    /**
      * @param ScopeConfigInterface $scopeConfig
      * @param EncryptorInterface $encryptor
      * @param UrlInterface $urlBuilder
      * @param ProductMetadataInterface $productMetadata
+     * @param State $appState
      */
     public function __construct(
         ScopeConfigInterface $scopeConfig,
         EncryptorInterface $encryptor,
         UrlInterface $urlBuilder,
-        ProductMetadataInterface $productMetadata
+        ProductMetadataInterface $productMetadata,
+        State $appState
     ) {
         $this->scopeConfig = $scopeConfig;
         $this->encryptor = $encryptor;
         $this->urlBuilder = $urlBuilder;
         $this->productMetadata = $productMetadata;
+        $this->appState = $appState;
     }
 
     /**
@@ -232,7 +241,7 @@ class Repository implements RepositoryInterface
      */
     public function getCheckoutApiUrl(?string $mode = null): string
     {
-        if (getenv('MAGE_MODE') === 'developer') {
+        if ($this->appState->getMode() === State::MODE_DEVELOPER) {
             $envUrl = getenv('TWO_API_BASE_URL');
             if ($envUrl !== false && $envUrl !== '') {
                 return $envUrl;
@@ -248,7 +257,7 @@ class Repository implements RepositoryInterface
      */
     public function getCheckoutPageUrl(?string $mode = null): string
     {
-        if (getenv('MAGE_MODE') === 'developer') {
+        if ($this->appState->getMode() === State::MODE_DEVELOPER) {
             $envUrl = getenv('TWO_CHECKOUT_BASE_URL');
             if ($envUrl !== false && $envUrl !== '') {
                 return $envUrl;

--- a/Model/Two.php
+++ b/Model/Two.php
@@ -292,7 +292,7 @@ class Two extends AbstractMethod
             $traceID = $response['error_trace_id'];
         }
 
-        // Validation errors
+        // Validation errors — user-facing, no trace ID
         if (isset($response['error_json']) && is_array($response['error_json'])) {
             $errs = [];
             foreach ($response['error_json'] as $err) {
@@ -310,21 +310,23 @@ class Two extends AbstractMethod
                 }
             }
             if (count($errs) > 0) {
-                $message = __(
-                    'Your request to %1 failed. Reason: %2',
-                    $this->configRepository::PROVIDER,
-                    join(' ', $errs)
-                );
-                return $this->_getMessageWithTrace($message, $traceID);
+                return __(join(' ', $errs));
             }
         }
 
         if (isset($response['error_code'])) {
-            // Custom errors
+            $errorCode = $response['error_code'];
             $reason = $response['error_message'];
-            if ($response['error_code'] == 'SAME_BUYER_SELLER_ERROR') {
+
+            // User errors — no trace ID
+            if ($errorCode == 'SAME_BUYER_SELLER_ERROR') {
                 $reason = __('The buyer and the seller are the same company.');
             }
+            if (in_array($errorCode, ['SCHEMA_ERROR', 'SAME_BUYER_SELLER_ERROR', 'ORDER_INVALID'])) {
+                return $reason;
+            }
+
+            // System errors — include trace ID
             $message = __(
                 'Your request to %1 failed. Reason: %2',
                 $this->configRepository::PROVIDER,

--- a/Model/Two.php
+++ b/Model/Two.php
@@ -296,14 +296,17 @@ class Two extends AbstractMethod
         if (isset($response['error_json']) && is_array($response['error_json'])) {
             $errs = [];
             foreach ($response['error_json'] as $err) {
-                if ($err && $err['loc']) {
-                    $err_field = $this->getFieldFromLocStr(json_encode($err['loc']));
-                    if ($err_field) {
-                        array_push($errs, $err_field);
-                    } else {
-                        // Since err_field is empty, return general error message
-                        return $this->_getMessageWithTrace($generalError, $traceID);
-                    }
+                $fieldName = isset($err['loc'])
+                    ? $this->getFieldNameFromLoc(json_encode($err['loc']))
+                    : null;
+                $msg = isset($err['msg']) ? $this->cleanValidationMessage($err['msg']) : null;
+
+                if ($fieldName && $msg) {
+                    $errs[] = __('%1: %2.', $fieldName, $msg);
+                } elseif ($fieldName) {
+                    $errs[] = __('%1 is not valid.', $fieldName);
+                } elseif ($msg) {
+                    $errs[] = $msg;
                 }
             }
             if (count($errs) > 0) {
@@ -334,29 +337,39 @@ class Two extends AbstractMethod
     }
 
     /**
-     * Get validation message
+     * Get human-readable field name from a pydantic error loc array.
      *
-     * @param $loc_str
-     * @return string|null
+     * @param string $locStr JSON-encoded loc array, e.g. '["buyer","representative","phone_number"]'
+     * @return Phrase|null
      */
-    public function getFieldFromLocStr($loc_str): ?Phrase
+    public function getFieldNameFromLoc(string $locStr): ?Phrase
     {
-        $loc_str = preg_replace('/\s+/', '', $loc_str);
-        $fieldLocStrMapping = [
-            '["buyer","representative","phone_number"]' => __('Phone Number is not valid.'),
-            '["buyer","company","organization_number"]' => __('Company ID is not valid.'),
-            '["buyer","representative","first_name"]' => __('First Name is not valid.'),
-            '["buyer","representative","last_name"]' => __('Last Name is not valid.'),
-            '["buyer","representative","email"]' => __('Email Address is not valid.'),
-            '["billing_address","street_address"]' => __('Street Address is not valid.'),
-            '["billing_address","city"]' => __('City is not valid.'),
-            '["billing_address","country"]' => __('Country is not valid.'),
-            '["billing_address","postal_code"]' => __('Zip/Postal Code is not valid.'),
+        $locStr = preg_replace('/\s+/', '', $locStr);
+        $fieldNames = [
+            '["buyer","representative","phone_number"]' => __('Phone Number'),
+            '["buyer","company","organization_number"]' => __('Company ID'),
+            '["buyer","representative","first_name"]' => __('First Name'),
+            '["buyer","representative","last_name"]' => __('Last Name'),
+            '["buyer","representative","email"]' => __('Email Address'),
+            '["billing_address","street_address"]' => __('Street Address'),
+            '["billing_address","city"]' => __('City'),
+            '["billing_address","country"]' => __('Country'),
+            '["billing_address","postal_code"]' => __('Zip/Postal Code'),
         ];
-        if (array_key_exists($loc_str, $fieldLocStrMapping)) {
-            return $fieldLocStrMapping[$loc_str];
-        }
-        return null;
+        return $fieldNames[$locStr] ?? null;
+    }
+
+    /**
+     * Clean up a pydantic validation message for user display.
+     *
+     * @param string $msg Raw message, e.g. "Value error, Invalid phone number for GB: 00123456789"
+     * @return string Cleaned message, e.g. "Invalid phone number for GB: 00123456789"
+     */
+    private function cleanValidationMessage(string $msg): string
+    {
+        $msg = preg_replace('/^Value error,\s*/i', '', $msg);
+        $msg = preg_replace('/\s*\[type=.*$/', '', $msg);
+        return trim($msg);
     }
 
     /**

--- a/Model/Two.php
+++ b/Model/Two.php
@@ -292,8 +292,10 @@ class Two extends AbstractMethod
             $traceID = $response['error_trace_id'];
         }
 
+        $isClientError = isset($response['http_status']) && $response['http_status'] == 400;
+
         // Validation errors — user-facing, no trace ID
-        if (isset($response['error_json']) && is_array($response['error_json'])) {
+        if ($isClientError && isset($response['error_json']) && is_array($response['error_json'])) {
             $errs = [];
             foreach ($response['error_json'] as $err) {
                 $fieldName = isset($err['loc'])
@@ -322,7 +324,7 @@ class Two extends AbstractMethod
             if ($errorCode == 'SAME_BUYER_SELLER_ERROR') {
                 $reason = __('The buyer and the seller are the same company.');
             }
-            if (in_array($errorCode, ['SCHEMA_ERROR', 'SAME_BUYER_SELLER_ERROR', 'ORDER_INVALID'])) {
+            if ($isClientError && in_array($errorCode, ['SCHEMA_ERROR', 'SAME_BUYER_SELLER_ERROR', 'ORDER_INVALID'])) {
                 return $reason;
             }
 

--- a/Model/Two.php
+++ b/Model/Two.php
@@ -302,7 +302,7 @@ class Two extends AbstractMethod
                 $msg = isset($err['msg']) ? $this->cleanValidationMessage($err['msg']) : null;
 
                 if ($fieldName && $msg) {
-                    $errs[] = __('%1: %2.', $fieldName, $msg);
+                    $errs[] = __('%1: %2.', $fieldName, rtrim($msg, '.'));
                 } elseif ($fieldName) {
                     $errs[] = __('%1 is not valid.', $fieldName);
                 } elseif ($msg) {
@@ -344,18 +344,21 @@ class Two extends AbstractMethod
      */
     public function getFieldNameFromLoc(string $locStr): ?Phrase
     {
+        static $fieldNames = null;
+        if ($fieldNames === null) {
+            $fieldNames = [
+                '["buyer","representative","phone_number"]' => __('Phone Number'),
+                '["buyer","company","organization_number"]' => __('Company ID'),
+                '["buyer","representative","first_name"]' => __('First Name'),
+                '["buyer","representative","last_name"]' => __('Last Name'),
+                '["buyer","representative","email"]' => __('Email Address'),
+                '["billing_address","street_address"]' => __('Street Address'),
+                '["billing_address","city"]' => __('City'),
+                '["billing_address","country"]' => __('Country'),
+                '["billing_address","postal_code"]' => __('Zip/Postal Code'),
+            ];
+        }
         $locStr = preg_replace('/\s+/', '', $locStr);
-        $fieldNames = [
-            '["buyer","representative","phone_number"]' => __('Phone Number'),
-            '["buyer","company","organization_number"]' => __('Company ID'),
-            '["buyer","representative","first_name"]' => __('First Name'),
-            '["buyer","representative","last_name"]' => __('Last Name'),
-            '["buyer","representative","email"]' => __('Email Address'),
-            '["billing_address","street_address"]' => __('Street Address'),
-            '["billing_address","city"]' => __('City'),
-            '["billing_address","country"]' => __('Country'),
-            '["billing_address","postal_code"]' => __('Zip/Postal Code'),
-        ];
         return $fieldNames[$locStr] ?? null;
     }
 

--- a/Service/Api/Adapter.php
+++ b/Service/Api/Adapter.php
@@ -105,6 +105,7 @@ class Adapter
             } else {
                 if ($body) {
                     $result = json_decode($body, true) ?: [];
+                    $result['http_status'] = $this->curlClient->getStatus();
                     $this->logRepository->addDebugLog(
                         sprintf('API response %s %s (status: %s)', $method, $endpoint, $this->curlClient->getStatus()),
                         $result

--- a/i18n/nb_NO.csv
+++ b/i18n/nb_NO.csv
@@ -27,22 +27,23 @@ Branding,Merkevarebygging
 "By checking this box, I confirm that I have read and agree to %1.","Ved å merke av i denne boksen, bekrefter jeg at jeg har lest og godtar %1."
 "Check last 100 debug log records","Sjekk siste 100 feilsøkingsloggposter"
 "Check last 100 error log records","Sjekk siste 100 feilloggposter"
-"City is not valid.","By er ikke gyldig."
+"City",By
+"%1 is not valid.","%1 er ikke gyldig."
+"%1: %2.","%1: %2."
 "Click here to log in or sign up as a Sole Trader.","Klikk her for å logge inn eller registrere deg som eneforhandler."
 "Company ID",Organisasjonsnummer
-"Company ID is not valid.","Firma-ID er ikke gyldig."
 "Company Name",Selskapsnavn
 "Could not initiate capture with %1","Kunne ikke starte fangst med %1"
 "Could not initiate refund with %1","Kunne ikke starte refusjon med %1"
 "Could not update %1 order status to cancelled. Please contact support with order ID %2. Error: %3","Kunne ikke oppdatere %1 ordrestatus til kansellert. Ta kontakt med brukerstøtten med ordre-ID %2. Feil: %3"
-"Country is not valid.","Land er ikke gyldig."
+"Country",Land
 "Credit Note",Kreditnota
 "Debug Mode",Feilsøkingsmodus
 Department,Avdeling
 "Developed by Magmodules.","Utviklet av Magmodules."
 Download,"Last ned"
 "Download as .txt file","Last ned som .txt-fil"
-"Email Address is not valid.","E-postadresse er ikke gyldig."
+"Email Address",E-postadresse
 "Enable Address Search","Aktiver adressesøk"
 "Enable Company Search","Aktiver firmasøk"
 "Enable Order Intent","Aktiver ordrehensikt"
@@ -54,7 +55,7 @@ Environment,Miljø
 "Failed to refund order with %1. Reason: %2","Kunne ikke refundere bestillingen med %1. Årsak: %2"
 "Failed to update %1 customer address: %2","Kunne ikke oppdatere %1 kundeadresse: %2"
 "Find out more","Finn ut mer"
-"First Name is not valid.","Fornavn er ikke gyldig."
+"First Name",Fornavn
 "Fulfilment Order Status","Oppfyllelse av ordrestatus"
 "Fulfilment Trigger","Oppfyllelse utløser"
 General,Generelt
@@ -63,7 +64,7 @@ Invoice,Faktura
 "Invoice purchase with %1 is not available for this order.","Fakturakjøp med %1 er ikke tilgjengelig for denne bestillingen."
 "Last 100 debug log lines","Siste 100 feilsøkingslogglinjer"
 "Last 100 error log records","Siste 100 feilloggposter"
-"Last Name is not valid.","Etternavn er ikke gyldig."
+"Last Name",Etternavn
 "Log is empty","Loggen er tom"
 OK,OK
 "On Completion","Ved ferdigstillelse"
@@ -75,7 +76,7 @@ OK,OK
 "PO Number",PO-nummer
 Payment,Betaling
 "Payment Method",Betalingsmetode
-"Phone Number is not valid.","Telefonnummer er ikke gyldig."
+"Phone Number",Telefonnummer
 "Place Order","Plasser ordre"
 "Please try again later.","Vennligst prøv igjen senere."
 Production,Produksjon
@@ -88,7 +89,7 @@ Search,Søk
 "Sole Trader",Eneforhandler
 "Something went wrong with your request to %1. %2","Noe gikk galt med forespørselen din til %1. %2"
 "Sort Order",Sorteringsrekkefølge
-"Street Address is not valid.","Gateadresse er ikke gyldig."
+"Street Address",Gateadresse
 "Successfully refunded order with %1 for order ID: %2. Refund reference: %3","Vellykket refundert bestilling med %1 for bestillings-ID: %2. Refusjonsreferanse: %3"
 TWO,TWO
 "The %1 payment plugin for Magento simplifies B2B shopping, making it easy and safe for merchants to offer invoices as a payment method.<br>The payment method lives next to other payment methods in your existing checkout, and offers a variety of configuration options to suit your businesses needs.<br>If you would like to know more about how to configure the plugin, check out our <a href=""%2"" target=""_blank"">step by step guide</a>.","%1 betalingsplugin for Magento forenkler B2B shopping, og gjør det enkelt og trygt for selgere å tilby fakturaer som betalingsmåte. <br> Betalingsmetoden lever ved siden av andre betalingsmetoder i din eksisterende kassen, og tilbyr en rekke konfigurasjonsalternativer for å passe bedriftens behov. <br> Hvis du vil vite mer om hvordan du konfigurerer programtillegget, sjekk ut vår <a href=""%2"" target=""_blank""> trinnvise veiledning </a> ."
@@ -108,7 +109,7 @@ Version,Versjon
 "Your invoice purchase with %1 is likely to be accepted subject to additional checks.","Fakturakjøpet ditt med %1 vil sannsynligvis bli akseptert med forbehold om ytterligere kontroller."
 "Your request to %1 failed. Reason: %2","Din forespørsel til %1 mislyktes. Årsak: %2"
 "Your sole trader account could not be verified.","Din eneforhandlerkonto kunne ikke bekreftes."
-"Zip/Postal Code is not valid.","Postnummer er ikke gyldig."
+"Zip/Postal Code",Postnummer
 "Invoice email address","E-postadresse for faktura"
 "Please ensure that your invoice email address list only contains valid email addresses separated by commas.","Sørg for at listen over e-postadresser for faktura bare inneholder gyldige e-postadresser atskilt med komma."
 "Please enter 3 or more characters","Vennligst skriv inn 3 eller flere tegn"

--- a/i18n/nl_NL.csv
+++ b/i18n/nl_NL.csv
@@ -27,22 +27,23 @@ Branding,Merknaam
 "By checking this box, I confirm that I have read and agree to %1.","Door dit vakje aan te vinken, bevestig ik dat ik de %1 heb gelezen en ermee akkoord ga."
 "Check last 100 debug log records","Controleer de laatste 100 debug-logboek records"
 "Check last 100 error log records","Controleer de laatste 100 foutenlogboek records"
-"City is not valid.","Stad is niet geldig."
+"City",Stad
+"%1 is not valid.","%1 is niet geldig."
+"%1: %2.","%1: %2."
 "Click here to log in or sign up as a Sole Trader.","Klik hier om in te loggen of u aan te melden als zelfstandig ondernemer."
 "Company ID",Bedrijfs-ID
-"Company ID is not valid.","Bedrijfs-ID is niet geldig."
 "Company Name",Bedrijfsnaam
 "Could not initiate capture with %1","Kon geen vastlegging starten met %1"
 "Could not initiate refund with %1","Kon geen terugbetaling starten met %1"
 "Could not update %1 order status to cancelled. Please contact support with order ID %2. Error: %3","Kon %1 orderstatus niet updaten naar geannuleerd. Neem contact op met support met bestelnummer %2. Fout: %3"
-"Country is not valid.","Land is niet geldig."
+"Country",Land
 "Credit Note",Creditnota
 "Debug Mode",Debug-modus
 Department,Afdeling
 "Developed by Magmodules.","Ontwikkeld door Magmodules."
 Download,Download
 "Download as .txt file","Downloaden als .txt-bestand"
-"Email Address is not valid.","E-mailadres is niet geldig."
+"Email Address",E-mailadres
 "Enable Address Search","Adres zoeken inschakelen"
 "Enable Company Search","Bedrijf zoeken inschakelen"
 "Enable Order Intent","Bestelintentie inschakelen"
@@ -54,7 +55,7 @@ Environment,Omgeving
 "Failed to refund order with %1. Reason: %2","Het is niet gelukt om de bestelling met %1 terug te betalen. Reden: %2"
 "Failed to update %1 customer address: %2","Kon het adres van klant %1 niet bijwerken: %2"
 "Find out more","Meer informatie"
-"First Name is not valid.","Voornaam is niet geldig."
+"First Name",Voornaam
 "Fulfilment Order Status","Status van vervulling bestelling"
 "Fulfilment Trigger","Trigger voor vervulling"
 General,Algemeen
@@ -63,7 +64,7 @@ Invoice,Factuur
 "Invoice purchase with %1 is not available for this order.","Aankoop op factuur met %1 is niet beschikbaar voor deze bestelling."
 "Last 100 debug log lines","Laatste 100 debug-logregels"
 "Last 100 error log records","Laatste 100 foutenlogboek records"
-"Last Name is not valid.","Achternaam is niet geldig."
+"Last Name",Achternaam
 "Log is empty","Logboek is leeg"
 OK,OK
 "On Completion","Bij voltooiing"
@@ -75,7 +76,7 @@ OK,OK
 "PO Number",PO-nummer
 Payment,Betaling
 "Payment Method",Betaalmethode
-"Phone Number is not valid.","Telefoonnummer is niet geldig."
+"Phone Number",Telefoonnummer
 "Place Order","Bestelling plaatsen"
 "Please try again later.","Probeer het later opnieuw."
 Production,Productie
@@ -88,7 +89,7 @@ Search,Zoekopdracht
 "Sole Trader",Eenmanszaak
 "Something went wrong with your request to %1. %2","Er is iets misgegaan met uw verzoek aan %1. %2"
 "Sort Order",Sorteervolgorde
-"Street Address is not valid.","Straatadres is niet geldig."
+"Street Address",Straatadres
 "Successfully refunded order with %1 for order ID: %2. Refund reference: %3","Bestelling succesvol terugbetaald met %1 voor bestelnummer: %2. Terugbetalingsreferentie: %3"
 TWO,TWO
 "The %1 payment plugin for Magento simplifies B2B shopping, making it easy and safe for merchants to offer invoices as a payment method.<br>The payment method lives next to other payment methods in your existing checkout, and offers a variety of configuration options to suit your businesses needs.<br>If you would like to know more about how to configure the plugin, check out our <a href=""%2"" target=""_blank"">step by step guide</a>.","De %1-betaalplug-in voor Magento vereenvoudigt B2B-shoppen en maakt het voor verkopers eenvoudig en veilig om facturen als betaalmethode aan te bieden. <br> De betaalmethode staat naast andere betaalmethoden in je bestaande kassa en biedt een verscheidenheid aan configuratieopties die aansluiten op de behoeften van je bedrijf. <br> Als je meer wilt weten over het configureren van de plug-in, bekijk dan onze <a href=""%2"" target=""_blank""> stapsgewijze handleiding </a> ."
@@ -108,7 +109,7 @@ Version,Versie
 "Your invoice purchase with %1 is likely to be accepted subject to additional checks.","Uw aankoop op factuur met %1 wordt waarschijnlijk geaccepteerd, mits er aanvullende controles worden uitgevoerd."
 "Your request to %1 failed. Reason: %2","Uw verzoek aan %1 is mislukt. Reden: %2"
 "Your sole trader account could not be verified.","Uw eenmanszaakaccount kon niet worden geverifieerd."
-"Zip/Postal Code is not valid.","Postcode is niet geldig."
+"Zip/Postal Code",Postcode
 "Invoice email address","E-mailadres factuur"
 "Please ensure that your invoice email address list only contains valid email addresses separated by commas.","Zorg ervoor dat uw factuur-e-mailadreslijst alleen geldige e-mailadressen bevat, gescheiden door komma's."
 "Please enter 3 or more characters","Voer 3 of meer tekens in"

--- a/i18n/sv_SE.csv
+++ b/i18n/sv_SE.csv
@@ -27,22 +27,23 @@ Branding,Branding
 "By checking this box, I confirm that I have read and agree to %1.","Genom att kryssa i denna ruta bekräftar jag att jag har läst och godkänner %1."
 "Check last 100 debug log records","Kontrollera de senaste 100 felsökningsloggposterna"
 "Check last 100 error log records","Kontrollera de senaste 100 felloggposterna"
-"City is not valid.","Stad är inte giltig."
+"City",Stad
+"%1 is not valid.","%1 är inte giltigt."
+"%1: %2.","%1: %2."
 "Click here to log in or sign up as a Sole Trader.","Klicka här för att logga in eller registrera dig som enskild näringsidkare."
 "Company ID",Organisationsnummer
-"Company ID is not valid.","Företags-ID är inte giltigt."
 "Company Name",Företagsnamn
 "Could not initiate capture with %1","Kunde inte initiera infångning med %1"
 "Could not initiate refund with %1","Kunde inte initiera återbetalning med %1"
 "Could not update %1 order status to cancelled. Please contact support with order ID %2. Error: %3","Kunde inte uppdatera %1 orderstatus till annullerad. Kontakta supporten med beställnings-ID %2. Fel: %3"
-"Country is not valid.","Land är inte giltigt."
+"Country",Land
 "Credit Note",Kreditnota
 "Debug Mode",Felsökningsläge
 Department,Avdelning
 "Developed by Magmodules.","Utvecklad av Magmodules."
 Download,"Ladda ner"
 "Download as .txt file","Ladda ner som .txt-fil"
-"Email Address is not valid.","E-postadress är inte giltig."
+"Email Address",E-postadress
 "Enable Address Search","Aktivera adresssökning"
 "Enable Company Search","Aktivera företagssökning"
 "Enable Order Intent","Aktivera orderavsikt"
@@ -54,7 +55,7 @@ Environment,Miljö
 "Failed to refund order with %1. Reason: %2","Det gick inte att återbetala beställningen med %1. Orsak: %2"
 "Failed to update %1 customer address: %2","Misslyckades med att uppdatera %1 kundadress: %2"
 "Find out more","Ta reda på mer"
-"First Name is not valid.","Förnamn är inte giltigt."
+"First Name",Förnamn
 "Fulfilment Order Status","Uppfyllande orderstatus"
 "Fulfilment Trigger","Uppfyllelse trigger"
 General,Generellt
@@ -63,7 +64,7 @@ Invoice,Faktura
 "Invoice purchase with %1 is not available for this order.","Fakturaköp med %1 är inte tillgängligt för den här beställningen."
 "Last 100 debug log lines","Senaste 100 felsökningsloggraderna"
 "Last 100 error log records","Senaste 100 felloggposter"
-"Last Name is not valid.","Efternamn är inte giltigt."
+"Last Name",Efternamn
 "Log is empty","Loggen är tom"
 OK,OK
 "On Completion","Vid färdigställande"
@@ -75,7 +76,7 @@ OK,OK
 "PO Number",PO-nummer
 Payment,Betalning
 "Payment Method",Betalningsmetod
-"Phone Number is not valid.","Telefonnummer är inte giltigt."
+"Phone Number",Telefonnummer
 "Place Order",Beställa
 "Please try again later.","Försök igen senare."
 Production,Produktion
@@ -88,7 +89,7 @@ Search,Sök
 "Sole Trader","Enskild näringsidkare"
 "Something went wrong with your request to %1. %2","Något gick fel med din begäran till %1. %2"
 "Sort Order",Sorteringsordning
-"Street Address is not valid.","Gatuadress är inte giltig."
+"Street Address",Gatuadress
 "Successfully refunded order with %1 for order ID: %2. Refund reference: %3","Återbetalad beställning med %1 för beställnings-ID: %2. Återbetalningsreferens: %3"
 TWO,TWO
 "The %1 payment plugin for Magento simplifies B2B shopping, making it easy and safe for merchants to offer invoices as a payment method.<br>The payment method lives next to other payment methods in your existing checkout, and offers a variety of configuration options to suit your businesses needs.<br>If you would like to know more about how to configure the plugin, check out our <a href=""%2"" target=""_blank"">step by step guide</a>.","Betalningspluginet %1 för Magento förenklar B2B-shopping, vilket gör det enkelt och säkert för handlare att erbjuda fakturor som betalningsmetod. <br> Betalningsmetoden finns bredvid andra betalningsmetoder i din befintliga kassa, och erbjuder en mängd olika konfigurationsalternativ för att passa ditt företags behov. <br> Om du vill veta mer om hur du konfigurerar plugin-programmet, kolla in vår <a href=""%2"" target=""_blank""> steg-för-steg-guide </a> ."
@@ -108,7 +109,7 @@ Version,Version
 "Your invoice purchase with %1 is likely to be accepted subject to additional checks.","Ditt fakturaköp med %1 kommer sannolikt att accepteras under förutsättning av ytterligare kontroller."
 "Your request to %1 failed. Reason: %2","Din begäran till %1 misslyckades. Orsak: %2"
 "Your sole trader account could not be verified.","Ditt enskild näringsidkarekonto kunde inte verifieras."
-"Zip/Postal Code is not valid.","Postnummer är inte giltigt."
+"Zip/Postal Code",Postnummer
 "Invoice email address","E-postadress för faktura"
 "Please ensure that your invoice email address list only contains valid email addresses separated by commas.","Se till att din e-postadresslista för faktura endast innehåller giltiga e-postadresser separerade med kommatecken."
 "Please enter 3 or more characters","Ange 3 eller fler tecken"


### PR DESCRIPTION
Instead of showing generic "Phone Number is not valid." or falling back to "Something went wrong", now extracts the msg field from pydantic validation errors and displays it alongside the field name, e.g. "Phone Number: Invalid phone number for GB: 00123456789."

Refactored getFieldFromLocStr into getFieldNameFromLoc (returns field name only) and added cleanValidationMessage to strip pydantic prefixes. Updated nb_NO, sv_SE, and nl_NL translations accordingly.