### PR TITLE
ABN-287/fix: replace State DI injection with MAGE_MODE env var check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ configure:
 	docker exec \
 		-e TWO_API_KEY=$(TWO_API_KEY) \
 		-e TWO_STORE_COUNTRY=$(TWO_STORE_COUNTRY) \
-		$(CONTAINER) php /data/extensions/workdir/dev/configure.php
+		$(CONTAINER) php /data/extensions/workdir/dev/configure
 	docker exec $(CONTAINER) php bin/magento cache:flush
 
 ## Start the Magento container

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ install: clean
 		--name=$(CONTAINER) \
 		-p $(PORT):80 \
 		-e URL=$(URL) \
+		-e MAGE_MODE=developer \
 		-e TWO_API_BASE_URL=$(TWO_API_BASE_URL) \
 		-e TWO_CHECKOUT_BASE_URL=$(TWO_CHECKOUT_BASE_URL) \
 		-v $(CURDIR):/data/extensions/workdir \

--- a/Model/Config/Repository.php
+++ b/Model/Config/Repository.php
@@ -9,7 +9,6 @@ namespace Two\Gateway\Model\Config;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\ProductMetadataInterface;
-use Magento\Framework\App\State;
 use Magento\Framework\Encryption\EncryptorInterface;
 use Magento\Framework\UrlInterface;
 use Magento\Store\Model\ScopeInterface;
@@ -37,29 +36,21 @@ class Repository implements RepositoryInterface
      */
     private $productMetadata;
     /**
-     * @var State
-     */
-    private $appState;
-
-    /**
      * @param ScopeConfigInterface $scopeConfig
      * @param EncryptorInterface $encryptor
      * @param UrlInterface $urlBuilder
      * @param ProductMetadataInterface $productMetadata
-     * @param State $appState
      */
     public function __construct(
         ScopeConfigInterface $scopeConfig,
         EncryptorInterface $encryptor,
         UrlInterface $urlBuilder,
-        ProductMetadataInterface $productMetadata,
-        State $appState
+        ProductMetadataInterface $productMetadata
     ) {
         $this->scopeConfig = $scopeConfig;
         $this->encryptor = $encryptor;
         $this->urlBuilder = $urlBuilder;
         $this->productMetadata = $productMetadata;
-        $this->appState = $appState;
     }
 
     /**
@@ -241,7 +232,7 @@ class Repository implements RepositoryInterface
      */
     public function getCheckoutApiUrl(?string $mode = null): string
     {
-        if ($this->appState->getMode() === State::MODE_DEVELOPER) {
+        if (getenv('MAGE_MODE') === 'developer') {
             $envUrl = getenv('TWO_API_BASE_URL');
             if ($envUrl !== false && $envUrl !== '') {
                 return $envUrl;
@@ -257,7 +248,7 @@ class Repository implements RepositoryInterface
      */
     public function getCheckoutPageUrl(?string $mode = null): string
     {
-        if ($this->appState->getMode() === State::MODE_DEVELOPER) {
+        if (getenv('MAGE_MODE') === 'developer') {
             $envUrl = getenv('TWO_CHECKOUT_BASE_URL');
             if ($envUrl !== false && $envUrl !== '') {
                 return $envUrl;

--- a/dev/configure
+++ b/dev/configure
@@ -1,3 +1,4 @@
+#!/usr/bin/env php
 <?php
 /**
  * Configure the Two payment plugin for local development.


### PR DESCRIPTION
The injected Magento\Framework\App\State dependency caused "Class get does not exist" during setup:di:compile in CI. Use getenv('MAGE_MODE') instead, which avoids DI entirely and is set via the container's -e flag in the Makefile.