### PR TITLE
ABN-298 / ABN-356 / ABN-366: chip-summary sync, fee column polish, deferred invoice

### DIFF
--- a/Model/Ui/ConfigProvider.php
+++ b/Model/Ui/ConfigProvider.php
@@ -169,6 +169,7 @@ class ConfigProvider implements ConfigProviderInterface
 
         try {
             $quote = $this->checkoutSession->getQuote();
+            $storeId = (int)$quote->getStoreId();
             // Subtract any existing surcharge to avoid circular base
             $existingSurcharge = (float)$this->checkoutSession->getTwoSurchargeGross();
             $grandTotal = (float)$quote->getGrandTotal() - $existingSurcharge;
@@ -191,7 +192,8 @@ class ConfigProvider implements ConfigProviderInterface
                         $grandTotal,
                         $days,
                         $country,
-                        $currency
+                        $currency,
+                        $storeId
                     );
                     $net = $result['amount'];
                     $tax = round($net * ($result['tax_rate'] / 100), 2);

--- a/Observer/SalesOrderSaveAfter.php
+++ b/Observer/SalesOrderSaveAfter.php
@@ -115,7 +115,7 @@ class SalesOrderSaveAfter implements ObserverInterface
         if (!$this->isWholeOrderShipped($order)) {
             $error = __(
                 "%1 requires whole order to be shipped before it can be fulfilled.",
-                $this->configRepository::PRODUCT_NAME
+                $this->configRepository::PROVIDER
             );
             throw new LocalizedException($error);
         }

--- a/Observer/SalesOrderSaveAfter.php
+++ b/Observer/SalesOrderSaveAfter.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Two\Gateway\Observer;
 
 use Exception;
+use Magento\Framework\DB\Transaction;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Exception\LocalizedException;
@@ -15,7 +16,9 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\OrderStatusHistoryRepositoryInterface;
 use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Invoice;
 use Magento\Sales\Model\Order\Status\HistoryFactory;
+use Magento\Sales\Model\Service\InvoiceService;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
 use Two\Gateway\Model\Two;
 use Two\Gateway\Service\Api\Adapter;
@@ -47,23 +50,39 @@ class SalesOrderSaveAfter implements ObserverInterface
     private $orderStatusHistoryRepository;
 
     /**
+     * @var InvoiceService
+     */
+    private $invoiceService;
+
+    /**
+     * @var Transaction
+     */
+    private $transaction;
+
+    /**
      * SalesOrderSaveAfter constructor.
      *
      * @param ConfigRepository $configRepository
      * @param Adapter $apiAdapter
      * @param HistoryFactory $historyFactory
      * @param OrderStatusHistoryRepositoryInterface $orderStatusHistoryRepository
+     * @param InvoiceService $invoiceService
+     * @param Transaction $transaction
      */
     public function __construct(
         ConfigRepository $configRepository,
         Adapter $apiAdapter,
         HistoryFactory $historyFactory,
-        OrderStatusHistoryRepositoryInterface $orderStatusHistoryRepository
+        OrderStatusHistoryRepositoryInterface $orderStatusHistoryRepository,
+        InvoiceService $invoiceService,
+        Transaction $transaction
     ) {
         $this->configRepository = $configRepository;
         $this->apiAdapter = $apiAdapter;
         $this->historyFactory = $historyFactory;
         $this->orderStatusHistoryRepository = $orderStatusHistoryRepository;
+        $this->invoiceService = $invoiceService;
+        $this->transaction = $transaction;
     }
 
     /**
@@ -73,29 +92,67 @@ class SalesOrderSaveAfter implements ObserverInterface
     public function execute(Observer $observer)
     {
         $order = $observer->getEvent()->getOrder();
-        if ($order
-            && $order->getPayment()->getMethod() === Two::CODE
-            && $order->getTwoOrderId()
+        if (!$order
+            || $order->getPayment()->getMethod() !== Two::CODE
+            || !$order->getTwoOrderId()
         ) {
-            if (($this->configRepository->getFulfillTrigger() == 'complete')
-                && in_array($order->getStatus(), $this->configRepository->getFulfillOrderStatusList())
-            ) {
-                if (!$this->isWholeOrderShipped($order)) {
-                    $error = __(
-                        "%1 requires whole order to be shipped before it can be fulfilled.",
-                        $this->configRepository::PROVIDER
-                    );
-                    throw new LocalizedException($error);
-                }
-
-                // full fulfilment
-                $response = $this->apiAdapter->execute(
-                    "/v1/order/" . $order->getTwoOrderId() . "/fulfillments",
-                );
-
-                $this->parseFulfillResponse($response, $order);
-            }
+            return;
         }
+
+        if ($this->configRepository->getFulfillTrigger() !== 'complete'
+            || !in_array($order->getStatus(), $this->configRepository->getFulfillOrderStatusList())
+        ) {
+            return;
+        }
+
+        // Idempotency gate: once we've created a Magento invoice, the order is
+        // already fulfilled on Two — do not re-post /fulfillments on subsequent
+        // saves of the same order.
+        if ($order->hasInvoices()) {
+            return;
+        }
+
+        if (!$this->isWholeOrderShipped($order)) {
+            $error = __(
+                "%1 requires whole order to be shipped before it can be fulfilled.",
+                $this->configRepository::PRODUCT_NAME
+            );
+            throw new LocalizedException($error);
+        }
+
+        $response = $this->apiAdapter->execute(
+            "/v1/order/" . $order->getTwoOrderId() . "/fulfillments"
+        );
+
+        $this->parseFulfillResponse($response, $order);
+
+        $this->createOfflinePaidInvoice($order);
+    }
+
+    /**
+     * Create a Magento invoice for the whole order and mark it paid.
+     *
+     * Two has already been told to fulfil the order via /fulfillments above,
+     * so this invoice records that fact in Magento — CAPTURE_OFFLINE prevents
+     * Two::capture() from re-posting /fulfillments.
+     *
+     * @param Order $order
+     * @throws \Exception
+     */
+    private function createOfflinePaidInvoice(Order $order): void
+    {
+        $invoice = $this->invoiceService->prepareInvoice($order);
+        if ($invoice->getGrandTotal() <= 0) {
+            return;
+        }
+        $invoice->setRequestedCaptureCase(Invoice::CAPTURE_OFFLINE);
+        $invoice->register();
+        $invoice->pay();
+        $invoice->setTransactionId($order->getPayment()->getLastTransId());
+        $this->transaction
+            ->addObject($invoice)
+            ->addObject($invoice->getOrder())
+            ->save();
     }
 
     /**

--- a/Observer/SalesOrderShipmentAfter.php
+++ b/Observer/SalesOrderShipmentAfter.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Two\Gateway\Observer;
 
 use Exception;
+use Magento\Framework\DB\Transaction;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Exception\LocalizedException;
@@ -16,7 +17,9 @@ use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\Data\ShipmentInterface;
 use Magento\Sales\Api\OrderStatusHistoryRepositoryInterface;
 use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Invoice;
 use Magento\Sales\Model\Order\Status\HistoryFactory;
+use Magento\Sales\Model\Service\InvoiceService;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
 use Two\Gateway\Model\Two;
 use Two\Gateway\Service\Api\Adapter;
@@ -54,6 +57,16 @@ class SalesOrderShipmentAfter implements ObserverInterface
     private $composeShipment;
 
     /**
+     * @var InvoiceService
+     */
+    private $invoiceService;
+
+    /**
+     * @var Transaction
+     */
+    private $transaction;
+
+    /**
      * SalesOrderShipmentAfter constructor.
      *
      * @param ConfigRepository $configRepository
@@ -61,19 +74,25 @@ class SalesOrderShipmentAfter implements ObserverInterface
      * @param HistoryFactory $historyFactory
      * @param OrderStatusHistoryRepositoryInterface $orderStatusHistoryRepository
      * @param ComposeShipment $composeShipment
+     * @param InvoiceService $invoiceService
+     * @param Transaction $transaction
      */
     public function __construct(
         ConfigRepository $configRepository,
         Adapter $apiAdapter,
         HistoryFactory $historyFactory,
         OrderStatusHistoryRepositoryInterface $orderStatusHistoryRepository,
-        ComposeShipment $composeShipment
+        ComposeShipment $composeShipment,
+        InvoiceService $invoiceService,
+        Transaction $transaction
     ) {
         $this->configRepository = $configRepository;
         $this->apiAdapter = $apiAdapter;
         $this->historyFactory = $historyFactory;
         $this->orderStatusHistoryRepository = $orderStatusHistoryRepository;
         $this->composeShipment = $composeShipment;
+        $this->invoiceService = $invoiceService;
+        $this->transaction = $transaction;
     }
 
     /**
@@ -119,28 +138,36 @@ class SalesOrderShipmentAfter implements ObserverInterface
 
                 $this->parseFulfillResponse($response, $order);
                 if ($isWholeOrderShipped) {
-                    foreach ($order->getInvoiceCollection() as $invoice) {
-                        $invoice->pay();
-                        $invoice->setTransactionId($order->getPayment()->getLastTransId());
-                        $invoice->save();
-                    }
+                    $this->createOfflinePaidInvoice($order);
                 }
-            } elseif ($this->configRepository->getFulfillTrigger() == 'complete') {
-                foreach ($order->getInvoiceCollection() as $invoice) {
-                    $invoice->pay();
-                    $invoice->setTransactionId($order->getPayment()->getLastTransId());
-                    $invoice->save();
-                }
-
-                $additionalInformation = $order->getPayment()->getAdditionalInformation();
-                $additionalInformation['marked_completed'] = true;
-
-                $order->getPayment()->setAdditionalInformation($additionalInformation);
-
-                $comment = __('%1 order invoice has not been issued yet.', $this->configRepository::PROVIDER);
-                $this->addStatusToOrderHistory($order, $comment->render());
             }
         }
+    }
+
+    /**
+     * Create a Magento invoice for the whole order and mark it paid.
+     *
+     * Two has already been told to fulfil the order via /fulfillments above,
+     * so this invoice records that fact in Magento — CAPTURE_OFFLINE prevents
+     * Two::capture() from re-posting /fulfillments.
+     *
+     * @param Order $order
+     * @throws \Exception
+     */
+    private function createOfflinePaidInvoice(Order $order): void
+    {
+        $invoice = $this->invoiceService->prepareInvoice($order);
+        if ($invoice->getGrandTotal() <= 0) {
+            return;
+        }
+        $invoice->setRequestedCaptureCase(Invoice::CAPTURE_OFFLINE);
+        $invoice->register();
+        $invoice->pay();
+        $invoice->setTransactionId($order->getPayment()->getLastTransId());
+        $this->transaction
+            ->addObject($invoice)
+            ->addObject($invoice->getOrder())
+            ->save();
     }
 
     /**

--- a/Observer/SalesOrderShipmentAfter.php
+++ b/Observer/SalesOrderShipmentAfter.php
@@ -137,7 +137,7 @@ class SalesOrderShipmentAfter implements ObserverInterface
                 }
 
                 $this->parseFulfillResponse($response, $order);
-                if ($isWholeOrderShipped) {
+                if ($isWholeOrderShipped && !$order->hasInvoices()) {
                     $this->createOfflinePaidInvoice($order);
                 }
             }

--- a/Service/Payment/OrderService.php
+++ b/Service/Payment/OrderService.php
@@ -9,18 +9,15 @@ namespace Two\Gateway\Service\Payment;
 
 use Exception;
 use Magento\Framework\App\RequestInterface;
-use Magento\Framework\DB\Transaction;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Url\DecoderInterface;
 use Magento\Sales\Api\OrderPaymentRepositoryInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Magento\Sales\Model\Order;
-use Magento\Sales\Model\Order\Invoice;
 use Magento\Sales\Model\Order\Payment\Transaction\BuilderInterface as TransactionBuilder;
 use Magento\Sales\Model\Order\Payment\Transaction\Repository as PaymentTransactionRepository;
 use Magento\Sales\Model\OrderFactory;
 use Magento\Sales\Model\ResourceModel\Order as OrderResource;
-use Magento\Sales\Model\Service\InvoiceService;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
 use Two\Gateway\Model\Two;
 use Two\Gateway\Service\Api\Adapter;
@@ -57,15 +54,6 @@ class OrderService
      */
     private $urlCookie;
 
-    /**
-     * @var InvoiceService
-     */
-    private $invoiceService;
-
-    /**
-     * @var Transaction
-     */
-    private $transaction;
     /**
      * @var DecoderInterface
      */
@@ -106,8 +94,6 @@ class OrderService
      * @param OrderResource $orderResource
      * @param OrderFactory $orderFactory
      * @param UrlCookie $urlCookie
-     * @param InvoiceService $invoiceService
-     * @param Transaction $transaction
      * @param DecoderInterface $urlDecoder
      * @param ConfigRepository $configRepository
      * @param RequestInterface $request
@@ -123,8 +109,6 @@ class OrderService
         OrderResource $orderResource,
         OrderFactory $orderFactory,
         UrlCookie $urlCookie,
-        InvoiceService $invoiceService,
-        Transaction $transaction,
         DecoderInterface $urlDecoder,
         ConfigRepository $configRepository,
         RequestInterface $request,
@@ -139,8 +123,6 @@ class OrderService
         $this->orderResource = $orderResource;
         $this->orderFactory = $orderFactory;
         $this->urlCookie = $urlCookie;
-        $this->invoiceService = $invoiceService;
-        $this->transaction = $transaction;
         $this->urlDecoder = $urlDecoder;
         $this->configRepository = $configRepository;
         $this->request = $request;
@@ -296,33 +278,17 @@ class OrderService
      */
     public function processOrder(Order $order, string $transactionId)
     {
-        $payment = $order->getPayment();
-        $fulfillTrigger = $this->configRepository->getFulfillTrigger();
-        if ($fulfillTrigger == 'shipment' || $fulfillTrigger == 'complete') {
-            $order->setIsInProcess(true);
-            $order->setState(Order::STATE_PROCESSING);
-            $order->setStatus(Order::STATE_PROCESSING);
-            $invoice = $this->invoiceService->prepareInvoice($order);
-            if ($invoice->getGrandTotal() > 0) {
-                $invoice->setRequestedCaptureCase(Invoice::CAPTURE_ONLINE);
-                $invoice->register();
-                $message = __(
-                    '%1 payment has been verified by the customer.',
-                    $this->configRepository::PROVIDER
-                );
-                $this->addOrderComment($order, $message);
-                $transactionSave = $this->transaction
-                    ->addObject(
-                        $payment
-                    )->addObject(
-                        $invoice
-                    )->addObject(
-                        $invoice->getOrder()
-                    );
-                $transactionSave->save();
-                $this->addAuthorizationTransaction($order, $transactionId);
-            }
-        }
+        $order->setIsInProcess(true);
+        $order->setState(Order::STATE_PROCESSING);
+        $order->setStatus(Order::STATE_PROCESSING);
+        $this->orderRepository->save($order);
+
+        $message = __(
+            '%1 payment has been verified by the customer.',
+            $this->configRepository::PRODUCT_NAME
+        );
+        $this->addOrderComment($order, $message);
+        $this->addAuthorizationTransaction($order, $transactionId);
         return $this;
     }
 

--- a/Service/Payment/OrderService.php
+++ b/Service/Payment/OrderService.php
@@ -285,7 +285,7 @@ class OrderService
 
         $message = __(
             '%1 payment has been verified by the customer.',
-            $this->configRepository::PRODUCT_NAME
+            $this->configRepository::PROVIDER
         );
         $this->addOrderComment($order, $message);
         $this->addAuthorizationTransaction($order, $transactionId);

--- a/view/adminhtml/templates/system/config/field/surcharge-grid.phtml
+++ b/view/adminhtml/templates/system/config/field/surcharge-grid.phtml
@@ -96,7 +96,7 @@ $columnLabels = [
                             <?php endif; ?>
                         </td>
                     <?php endforeach; ?>
-                    <td class="surcharge-grid__fee" data-term="<?= (int)$days ?>">&mdash;</td>
+                    <td class="surcharge-grid__fee" data-term="<?= (int)$days ?>"><span class="surcharge-grid__fee-loading"><span></span><span></span><span></span></span></td>
                     <?php if ($isNonDefault): ?>
                         <td class="surcharge-grid__inherit">
                             <?php foreach ($columns as $col): ?>

--- a/view/adminhtml/web/css/source/_surcharge-grid.less
+++ b/view/adminhtml/web/css/source/_surcharge-grid.less
@@ -4,7 +4,7 @@
 
     thead th {
         text-align: left;
-        padding: 8px 10px;
+        padding: 8px 10px 8px 0;
         font-weight: 600;
         border-bottom: 1px solid #d6d6d6;
     }

--- a/view/adminhtml/web/css/source/_surcharge-grid.less
+++ b/view/adminhtml/web/css/source/_surcharge-grid.less
@@ -25,6 +25,27 @@ td.surcharge-grid__fee {
     color: #666;
 }
 
+.surcharge-grid__fee-loading {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+
+    span {
+        width: 4px;
+        height: 4px;
+        border-radius: 50%;
+        background: #888;
+        animation: surcharge-grid__fee-dot 1.4s infinite ease-in-out both;
+    }
+    span:nth-child(1) { animation-delay: -0.32s; }
+    span:nth-child(2) { animation-delay: -0.16s; }
+}
+
+@keyframes surcharge-grid__fee-dot {
+    0%, 80%, 100% { opacity: 0.2; transform: scale(0.8); }
+    40% { opacity: 1; transform: scale(1); }
+}
+
 .surcharge-grid__default-badge {
     color: #999;
     font-size: 0.85em;

--- a/view/adminhtml/web/js/surcharge-grid.js
+++ b/view/adminhtml/web/js/surcharge-grid.js
@@ -269,16 +269,12 @@ define(['jquery', 'domReady!'], function ($) {
                     if (!fee) {
                         return;
                     }
-                    var pct = (fee.percentage !== undefined && fee.percentage !== null)
-                        ? Number(fee.percentage).toFixed(2) + '%'
-                        : null;
-                    var fixed = (fee.fixed !== undefined && fee.fixed !== null)
-                        ? Number(fee.fixed).toFixed(2)
-                        : null;
+                    var pct = Number(fee.percentage) || 0;
+                    var fixed = Number(fee.fixed) || 0;
                     var parts = [];
-                    if (pct !== null) { parts.push(pct); }
-                    if (fixed !== null) { parts.push(fixed + currencySuffix); }
-                    $cell.text(parts.length ? parts.join(' + ') : '—');
+                    if (pct > 0) { parts.push(pct.toFixed(2) + '%'); }
+                    if (fixed > 0) { parts.push(fixed.toFixed(2) + currencySuffix); }
+                    $cell.text(parts.length ? parts.join(' + ') : '0.00');
                 });
             });
             // .fail intentionally omitted: on error, cells stay "—".

--- a/view/adminhtml/web/js/surcharge-grid.js
+++ b/view/adminhtml/web/js/surcharge-grid.js
@@ -17,6 +17,8 @@ define(['jquery', 'domReady!'], function ($) {
         // Declared here (before update() is invoked at init) so the source-order
         // assignment doesn't overwrite a value loadFees set during init.
         var lastFeesKey = null;
+        var LOADING_DOTS = '<span class="surcharge-grid__fee-loading">'
+            + '<span></span><span></span><span></span></span>';
 
         // ── Helpers ──────────────────────────────────────────────────────
 
@@ -76,7 +78,7 @@ define(['jquery', 'domReady!'], function ($) {
                 html += '/></td>';
             });
 
-            html += '<td class="surcharge-grid__fee" data-term="' + days + '">&mdash;</td>';
+            html += '<td class="surcharge-grid__fee" data-term="' + days + '">' + LOADING_DOTS + '</td>';
             html += '</tr>';
             return $(html);
         }
@@ -276,6 +278,9 @@ define(['jquery', 'domReady!'], function ($) {
                     var term = String($cell.data('term'));
                     var fee = response.fees[term];
                     if (!fee) {
+                        // Server returned no row for this term — stop the
+                        // loading indicator and show an em-dash.
+                        $cell.html('&mdash;');
                         return;
                     }
                     var pct = Number(fee.percentage) || 0;

--- a/view/adminhtml/web/js/surcharge-grid.js
+++ b/view/adminhtml/web/js/surcharge-grid.js
@@ -13,6 +13,10 @@ define(['jquery', 'domReady!'], function ($) {
         var $currencyNote = $container.find('.surcharge-grid__currency-note');
         var maxFixed = parseInt($container.data('max-fixed'), 10) || 100;
         var maxPercentage = parseInt($container.data('max-percentage'), 10) || 100;
+        // Memoise last terms key to collapse repeat fires from update().
+        // Declared here (before update() is invoked at init) so the source-order
+        // assignment doesn't overwrite a value loadFees set during init.
+        var lastFeesKey = null;
 
         // ── Helpers ──────────────────────────────────────────────────────
 
@@ -211,6 +215,7 @@ define(['jquery', 'domReady!'], function ($) {
             updateTermRows();
             updateColumnVisibility();
             updateDifferentialState();
+            loadFees();
         }
 
         // ── Event bindings ───────────────────────────────────────────────
@@ -224,7 +229,6 @@ define(['jquery', 'domReady!'], function ($) {
 
         initInheritCheckboxes();
         update();
-        loadFees();
 
         // ── Fee column (read-only, fetched from Two API via admin proxy) ─
 
@@ -237,6 +241,11 @@ define(['jquery', 'domReady!'], function ($) {
             if (!terms.length) {
                 return;
             }
+            var key = terms.join(',');
+            if (key === lastFeesKey) {
+                return;
+            }
+            lastFeesKey = key;
             var $formKey = $('input[name="form_key"]').first();
             $.ajax({
                 url: url,
@@ -276,8 +285,12 @@ define(['jquery', 'domReady!'], function ($) {
                     if (fixed > 0) { parts.push(fixed.toFixed(2) + currencySuffix); }
                     $cell.text(parts.length ? parts.join(' + ') : '0.00');
                 });
+            }).fail(function () {
+                // Clear memo so the next term-set change retries; cells keep
+                // whatever they showed before (— on first attempt, or prior
+                // fees on a refresh).
+                lastFeesKey = null;
             });
-            // .fail intentionally omitted: on error, cells stay "—".
         }
     };
 });


### PR DESCRIPTION
## Summary

Five commits, four tickets, one branch.

- **ABN-298** — pass `storeId` from `Model/Ui/ConfigProvider` into `SurchargeCalculator::calculate()` so chip values resolve at the same scope as the Total Collector segment. Without this, any merchant config set at website/store scope (typical) made the page-load chip labels diverge from the order-summary segment value. Matches the "sometimes, mysteriously, the chips would show a different fee to the order summary" symptom.
- **ABN-356** — three changes to the admin surcharge grid Fee column:
  1. Omit zero components: `"x%"` if fixed is 0, `"y"` if percentage is 0, `"0.00"` if both.
  2. Refetch fees on any term-set change (term checkbox / custom-days / inherit toggle). Memoised by joined-terms key inside `loadFees()` so non-term-set changes collapse to no-op; `.fail` clears the memo so transient errors are retryable.
  3. Animated three-dot loading placeholder (CSS keyframes) replacing the static em-dash while a fetch is in flight; em-dash returns when the server omits a row.
- **ABN-366** — drop the eager `CAPTURE_ONLINE` invoice creation from `OrderService::processOrder()`. Magento invoice now lives behind the actual fulfilment in both observers (`SalesOrderShipmentAfter` for trigger=shipment, `SalesOrderSaveAfter` for trigger=complete), created with `CAPTURE_OFFLINE` after the `/v1/order/{id}/fulfillments` POST succeeds — so `Two::capture()` doesn't double-post. Idempotency on the complete branch via `\$order->hasInvoices()`. Shipment observer's `elseif (trigger == 'complete')` removed; SaveAfter is the sole trigger=complete handler.

## Test plan

- [ ] Place an order with `fulfill_trigger=shipment`: confirm shows Processing, no invoice, cancel button visible. Ship → invoice created and paid, email sends.
- [ ] Place an order with `fulfill_trigger=complete`: confirm shows Processing, no invoice. Save with status in `fulfill_order_status` list → `/fulfillments` posts, invoice created and paid. Re-save: no second `/fulfillments` (gated by `hasInvoices()`).
- [ ] `fulfill_trigger=invoice` (admin clicks Invoice in UI): unchanged path.
- [ ] Configure surcharge at website scope, open checkout: chip label matches order-summary segment value.
- [ ] Surcharge config grid: tick a new term → loading dots animate → fee renders within one round-trip. Type a custom-days value → fee renders for the typed value.
- [ ] Force a 500 on the fees proxy: cells keep prior content, next term-change retries.
- [ ] Surcharge config with one component zero: cell shows only the non-zero side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)