### PR TITLE
chore(INF-1130): migrate create-github-app-token to client-id

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -34,7 +34,7 @@ jobs:
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_app_id: ${{ vars.TWO_INC_APP_ID }}
+          github_app_client_id: ${{ vars.TWO_INC_APP_CLIENT_ID }}
           github_app_private_key: ${{ secrets.TWO_INC_APP_PRIVATE_KEY }}
           extra_prompt: |
 


### PR DESCRIPTION
## Summary

- Replaces deprecated `app-id` input on `actions/create-github-app-token@v3` with the new `client-id` input
- Sources value from new org var `TWO_INC_APP_CLIENT_ID` (already set up at org level)
- For composite action repos: also renames the action's own `app-id` input to `client-id` (breaking change for callers — coordinated rollout)
- For `infra` repo: also renames `TWO_INFRA_*` vars/secret refs to `TWO_PLATFORM_*` (rename only; numeric semantics preserved)

Linear: https://linear.app/tillit/issue/INF-1130

## Test plan

- [ ] CI green
- [ ] Workflow run succeeds without `app-id` deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)
