### PR TITLE
ci: auto-merge main → develop on push

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -1,0 +1,23 @@
+name: Merge main → develop
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: merge-main
+  cancel-in-progress: true
+
+jobs:
+  merge-main:
+    runs-on: ${{ vars.RUNNER_STANDARD }}
+    if: github.ref_name == 'main'
+    steps:
+      - name: Merge or create pull request
+        uses: two-inc/merge-or-pr-action@main
+        with:
+          client-id: ${{ vars.TWO_INC_APP_CLIENT_ID }}
+          app-private-key: ${{ secrets.TWO_INC_APP_PRIVATE_KEY }}
+          source-ref: main
+          target-ref: develop
+          reviewer: brtkwr


### PR DESCRIPTION
Standard two-inc merge-main workflow. On every push to `main`, runs `two-inc/merge-or-pr-action` to fast-forward `develop` to `main` (or open a back-merge PR if conflicts). Pairs with the existing auto-PR develop → main workflow (#90, in flight) — together they keep main and develop in sync without manual back-merges.

Mirrors the equivalent change just landed on the abn fork (`magento-abn-plugin#54`).