### PR TITLE
INF-1159/ci: auto bump+tag release on push to main with bucketed notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,182 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-main
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ${{ vars.RUNNER_STANDARD }}
+    # Skip ourselves: bumpver's commit lands on main and re-fires
+    # this workflow. Without this guard we'd loop forever.
+    if: "!startsWith(github.event.head_commit.message, 'chore: Bump version')"
+    steps:
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.TWO_INC_APP_CLIENT_ID }}
+          private-key: ${{ secrets.TWO_INC_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Skip if HEAD already tagged
+        id: gate
+        run: |
+          set -euo pipefail
+          # Match bare numeric tags (1.14.1 etc.) — the repo's
+          # established convention. Reject the legacy `abn-*` prefix
+          # so a stale fork tag pointing at HEAD doesn't suppress a
+          # legitimate release.
+          existing=$(git tag --points-at HEAD | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
+          if [ -n "$existing" ]; then
+            echo "HEAD already tagged as $existing — nothing to release."
+            echo "skip=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=0" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Python
+        if: steps.gate.outputs.skip == '0'
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install bumpver
+        if: steps.gate.outputs.skip == '0'
+        run: pip install bumpver
+
+      - name: Configure git identity
+        if: steps.gate.outputs.skip == '0'
+        run: |
+          git config user.name "two-inc-app[bot]"
+          git config user.email "${{ vars.TWO_INC_APP_ID }}+two-inc-app[bot]@users.noreply.github.com"
+
+      - name: Decide bump level + build release notes
+        # Single pass over `<previous-numeric-tag>..HEAD`:
+        # - Buckets each non-merge commit into Breaking / Features /
+        #   Fixes / Internals / Other based on its conventional-commit
+        #   type, with optional Linear ticket prefix (e.g. CET-123/feat:).
+        # - Writes the bucketed list to release-notes.md so the GitHub
+        #   Release page reflects exactly what triggered the bump level
+        #   (any Breaking entries → major; any Features → minor; else
+        #   patch). Reading the notes makes the bump-level decision
+        #   visible without having to look at the workflow log.
+        if: steps.gate.outputs.skip == '0'
+        id: bump
+        run: |
+          set -euo pipefail
+          prev=$(git tag --list --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          if [ -n "$prev" ]; then
+            range="${prev}..HEAD"
+          else
+            range="HEAD"
+          fi
+
+          : > release-notes.md
+          : > /tmp/breaking
+          : > /tmp/features
+          : > /tmp/fixes
+          : > /tmp/internals
+          : > /tmp/other
+
+          while IFS=$'\t' read -r sha subject; do
+            line="- ${subject} (${sha})"
+            if echo "$subject" | grep -qE '^([A-Z]+-[0-9]+/)?[a-z]+(\([^)]+\))?!:|^BREAKING CHANGE:'; then
+              echo "$line" >> /tmp/breaking
+            elif echo "$subject" | grep -qE '^([A-Z]+-[0-9]+/)?feat(\([^)]+\))?:'; then
+              echo "$line" >> /tmp/features
+            elif echo "$subject" | grep -qE '^([A-Z]+-[0-9]+/)?fix(\([^)]+\))?:'; then
+              echo "$line" >> /tmp/fixes
+            elif echo "$subject" | grep -qE '^([A-Z]+-[0-9]+/)?(chore|refactor|ci|docs|test|build|perf|style)(\([^)]+\))?:'; then
+              echo "$line" >> /tmp/internals
+            else
+              echo "$line" >> /tmp/other
+            fi
+          done < <(git log "$range" --no-merges --format='%h%x09%s')
+
+          # Bump level is the highest-severity bucket that's non-empty.
+          if [ -s /tmp/breaking ]; then
+            level=major
+          elif [ -s /tmp/features ]; then
+            level=minor
+          else
+            level=patch
+          fi
+          echo "level=$level" >> "$GITHUB_OUTPUT"
+          echo "Selected bump level: $level (range: $range)"
+
+          # Render notes — only print sections that have entries.
+          {
+            [ -s /tmp/breaking ]  && { echo "## ⚠️ Breaking changes";  cat /tmp/breaking;  echo; }
+            [ -s /tmp/features ]  && { echo "## 🚀 Features";          cat /tmp/features;  echo; }
+            [ -s /tmp/fixes ]     && { echo "## 🐛 Fixes";              cat /tmp/fixes;     echo; }
+            [ -s /tmp/internals ] && { echo "## 🧰 Internals";          cat /tmp/internals; echo; }
+            [ -s /tmp/other ]     && { echo "## Other";                 cat /tmp/other;     echo; }
+            if [ -n "$prev" ]; then
+              echo "**Full diff:** [\`${prev}..\`]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/compare/${prev}...HEAD)"
+            fi
+          } > release-notes.md
+
+          echo "--- release-notes.md preview ---"
+          cat release-notes.md
+
+      - name: Bump version (bumpver — files + commit only)
+        # bumpver.toml is the single source of truth for which files
+        # carry the version (composer.json + etc/config.xml + bumpver.toml
+        # itself). --no-tag --no-push because we tag and push manually
+        # after — the manual step lets us send the push under the App
+        # token (so downstream workflows fire) and ensures the tag is
+        # written explicitly rather than depending on bumpver defaults.
+        if: steps.gate.outputs.skip == '0'
+        env:
+          LEVEL: ${{ steps.bump.outputs.level }}
+        run: bumpver update "--${LEVEL}" --no-tag --no-push
+
+      - name: Read new version
+        if: steps.gate.outputs.skip == '0'
+        id: ver
+        run: |
+          new=$(bumpver show --environ | grep '^CURRENT_VERSION=' | cut -d= -f2)
+          echo "new=$new" >> "$GITHUB_OUTPUT"
+          echo "Released $new"
+
+      - name: Tag + push
+        if: steps.gate.outputs.skip == '0'
+        env:
+          NEW: ${{ steps.ver.outputs.new }}
+        run: |
+          set -euo pipefail
+          git tag -a "${NEW}" -m "Release v${NEW}"
+          # checkout@v5 already wrote the App token into the remote
+          # URL, so this push fires downstream workflows as the App
+          # identity (not GITHUB_TOKEN).
+          git push origin main
+          git push origin "${NEW}"
+
+      - name: Create GitHub Release
+        if: steps.gate.outputs.skip == '0'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          NEW: ${{ steps.ver.outputs.new }}
+        run: |
+          # Publishing the artifact is out of scope here — this just
+          # cuts the tag and Release page. --notes-file points at the
+          # bucketed changelog rendered in the bump-level step, so the
+          # Release page mirrors exactly what triggered the bump
+          # (Breaking → major, Features → minor, else patch).
+          gh release create "${NEW}" \
+            --target main \
+            --title "${NEW}" \
+            --notes-file release-notes.md


### PR DESCRIPTION
[Linear: INF-1159](https://linear.app/tillit/issue/INF-1159/magento-abn-plugin-revamp-ci-workflows)

## Summary

On every push to `main`:

- Walks `<previous-numeric-tag>..HEAD` once and buckets each non-merge commit by conventional-commit type (with optional Linear ticket prefix, e.g. `CET-123/feat:`):
  - **Breaking** — `<type>!:` or `BREAKING CHANGE:` trailer
  - **Features** — `feat:`
  - **Fixes** — `fix:`
  - **Internals** — `chore/refactor/ci/docs/test/build/perf/style:`
  - **Other** — anything else
- Picks the bump level from the highest-severity non-empty bucket: Breaking → major, Features → minor, else patch.
- Renders `release-notes.md` from the same buckets, so the GitHub Release page reflects exactly what triggered the bump — a reader can see at a glance why a release was a major/minor/patch.
- Runs `bumpver update --<level> --no-tag --no-push` so file rewrites stay aligned with `bumpver.toml`'s file_patterns (composer.json, etc/config.xml, bumpver.toml).
- Tags `X.Y.Z` (bare numeric, matching the repo's established tag convention — `1.14.1`, `1.13.2`, etc.).
- Creates a GitHub Release with `--notes-file release-notes.md` (rather than `--generate-notes`, since GitHub's auto-categorisation filters by PR labels which Two doesn't enforce).
- Auths via the org GitHub App so the bump push triggers downstream workflows as a human-authored push would.

Publishing the artifact is out of scope here.

## Example notes shape

```markdown
## 🚀 Features
- INF-123/feat: new chip selector (a1b2c3d)

## 🐛 Fixes
- INF-124/fix: avoid divide-by-zero in surcharge calc (e4f5g6h)

## 🧰 Internals
- INF-1159/ci: collapse php-lint to a real matrix (i7j8k9l)
```

→ minor bump, because Features is non-empty and Breaking is empty.

## Test plan

- [ ] CI green
- [ ] After merge + push to `main`, workflow fires; bump level matches the highest non-empty bucket; the Release page shows the bucketed notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
