### PR TITLE
INF-1159/ci: use bumpver --no-tag-commit (the actual flag)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,14 +135,14 @@ jobs:
       - name: Bump version (bumpver — files + commit only)
         # bumpver.toml is the single source of truth for which files
         # carry the version (composer.json + etc/config.xml + bumpver.toml
-        # itself). --no-tag --no-push because we tag and push manually
+        # itself). --no-tag-commit --no-push because we tag and push manually
         # after — the manual step lets us send the push under the App
         # token (so downstream workflows fire) and ensures the tag is
         # written explicitly rather than depending on bumpver defaults.
         if: steps.gate.outputs.skip == '0'
         env:
           LEVEL: ${{ steps.bump.outputs.level }}
-        run: bumpver update "--${LEVEL}" --no-tag --no-push
+        run: bumpver update "--${LEVEL}" --no-tag-commit --no-push
 
       - name: Read new version
         if: steps.gate.outputs.skip == '0'


### PR DESCRIPTION
[Linear: INF-1159](https://linear.app/tillit/issue/INF-1159/magento-abn-plugin-revamp-ci-workflows)

Codex P1 on the just-merged #93. `release.yml` uses `bumpver update --no-tag`, which doesn't exist as a flag — bumpver's pair is `--tag-commit / --no-tag-commit`. Workflow would fail at runtime before producing any version commit.

```
--commit / --no-commit          Create a commit with all updated files.
--tag-commit / --no-tag-commit  Tag the newly created commit.
--push / --no-push              Push to the default remote.
```

Switched the bump step to `--no-tag-commit --no-push`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
