### PR TITLE
INF-1159/ci: skip Auto-PR when develop has nothing ahead of main

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -29,11 +29,22 @@ jobs:
       - name: Ensure open PR develop → main
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           existing=$(gh pr list --base main --head develop --state open --json number --jq '.[0].number // ""')
           if [ -n "$existing" ]; then
             echo "PR #$existing already open — nothing to do."
+            exit 0
+          fi
+          # No-op when develop has nothing ahead of main. Happens
+          # right after a merge-back fast-forwards develop to match
+          # main — there's no diff for `gh pr create`, which would
+          # otherwise fail with "No commits between main and develop"
+          # and leave a red check on the auto-PR workflow.
+          ahead=$(gh api "repos/${REPO}/compare/main...develop" --jq '.ahead_by')
+          if [ "$ahead" = "0" ]; then
+            echo "develop has no commits ahead of main — nothing to sync."
             exit 0
           fi
           gh pr create \


### PR DESCRIPTION
[Linear: INF-1159](https://linear.app/tillit/issue/INF-1159/magento-abn-plugin-revamp-ci-workflows)

Right after merge-back fast-forwards develop to match main, the next push event on develop fires Auto-PR — but `gh pr create` fails with `No commits between main and develop` because there's no diff. The job then reports failed even though the system is in a perfectly fine state (we observed this on 25495685711 just now).

Adds a pre-flight check via the GitHub compare API:

```
ahead=$(gh api "repos/${REPO}/compare/main...develop" --jq '.ahead_by')
if [ "$ahead" = "0" ]; then exit 0; fi
```

The 'PR already open' guard is preserved as the first short-circuit.

Same fix being landed on magento-abn-plugin in #65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
