### PR TITLE
INF-1159/ci: shared release-notes script + auto-PR preview body

### DIFF
--- a/.github/scripts/release-notes.py
+++ b/.github/scripts/release-notes.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Build bucketed release notes from a git commit range.
+
+Usage:   scripts/release-notes.py <range> <output-file>
+Example: scripts/release-notes.py "abn-main..abn-develop" body.md
+
+Writes the bucketed markdown to <output-file>; prints the semver
+bump level (major | minor | patch) to stdout.
+
+Used by:
+
+- auto-pr.yml — populates the rolling sync PR's body with a
+  preview of the next release.
+- release.yml — renders the GitHub Release page's notes after
+  the bump.
+
+Bucketing rules — match the conventional-commit type, with an
+optional Linear ticket prefix (e.g. ABN-123/feat:):
+
+    Breaking  — <type>!: anywhere on subject, or 'BREAKING CHANGE:' trailer
+    Features  — feat[(scope)]:
+    Fixes     — fix[(scope)]:
+    Internals — chore | refactor | ci | docs | test | build | perf | style
+    Other     — anything that doesn't match
+
+Bump level = highest-severity bucket that has at least one entry:
+
+    any Breaking → major
+    any Features → minor
+    else         → patch
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Optional `<TICKET>/` prefix where TICKET is uppercase letters + digits
+# (ABN-123, INF-1159, etc.). Optional `(scope)`. Required type, then `:`.
+TICKET = r"(?:[A-Z]+-[0-9]+/)?"
+SCOPE = r"(?:\([^)]+\))?"
+
+BREAKING = re.compile(rf"^{TICKET}[a-z]+{SCOPE}!:|^BREAKING CHANGE:")
+FEATURE = re.compile(rf"^{TICKET}feat{SCOPE}:")
+FIX = re.compile(rf"^{TICKET}fix{SCOPE}:")
+INTERNAL = re.compile(
+    rf"^{TICKET}(?:chore|refactor|ci|docs|test|build|perf|style){SCOPE}:"
+)
+
+# Order matters: Breaking is checked before Feature/Fix because
+# `feat!:` should land in Breaking, not Features.
+BUCKETS: list[tuple[str, str, re.Pattern[str]]] = [
+    ("breaking", "## ⚠️ Breaking changes", BREAKING),
+    ("features", "## 🚀 Features", FEATURE),
+    ("fixes", "## 🐛 Fixes", FIX),
+    ("internals", "## 🧰 Internals", INTERNAL),
+    # The "other" bucket is the catch-all and has no regex.
+]
+
+
+def git_log(commit_range: str) -> list[tuple[str, str]]:
+    """Return list of (short_sha, subject) for non-merge commits in the range."""
+    out = subprocess.check_output(
+        ["git", "log", commit_range, "--no-merges", "--format=%h%x09%s"],
+        text=True,
+    )
+    rows: list[tuple[str, str]] = []
+    for line in out.splitlines():
+        if "\t" in line:
+            sha, subject = line.split("\t", 1)
+            rows.append((sha, subject))
+    return rows
+
+
+def bucket_commits(
+    commits: list[tuple[str, str]],
+) -> dict[str, list[str]]:
+    """Group commits into the named buckets defined by BUCKETS + 'other'."""
+    grouped: dict[str, list[str]] = {key: [] for key, _, _ in BUCKETS}
+    grouped["other"] = []
+    for sha, subject in commits:
+        line = f"- {subject} ({sha})"
+        for key, _, pattern in BUCKETS:
+            if pattern.search(subject):
+                grouped[key].append(line)
+                break
+        else:
+            grouped["other"].append(line)
+    return grouped
+
+
+def pick_level(grouped: dict[str, list[str]]) -> str:
+    if grouped["breaking"]:
+        return "major"
+    if grouped["features"]:
+        return "minor"
+    return "patch"
+
+
+def render(grouped: dict[str, list[str]]) -> str:
+    sections: list[str] = []
+    for key, heading, _ in BUCKETS:
+        if grouped[key]:
+            sections.append(heading)
+            sections.extend(grouped[key])
+            sections.append("")
+    if grouped["other"]:
+        sections.append("## Other")
+        sections.extend(grouped["other"])
+        sections.append("")
+    return "\n".join(sections)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        print(f"usage: {argv[0]} <range> <output-file>", file=sys.stderr)
+        return 2
+    commit_range, out_path = argv[1], argv[2]
+
+    commits = git_log(commit_range)
+    grouped = bucket_commits(commits)
+    Path(out_path).write_text(render(grouped))
+    print(pick_level(grouped))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -15,6 +15,11 @@ jobs:
     runs-on: ${{ vars.RUNNER_STANDARD }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Need full history so `.github/scripts/release-notes.py` can walk
+          # every commit not yet on main when building the preview
+          # release notes.
+          fetch-depth: 0
 
       # Use the org GitHub App token — PRs opened with the default
       # GITHUB_TOKEN do not trigger downstream workflows, so the
@@ -26,34 +31,55 @@ jobs:
           client-id: ${{ vars.TWO_INC_APP_CLIENT_ID }}
           private-key: ${{ secrets.TWO_INC_APP_PRIVATE_KEY }}
 
-      - name: Ensure open PR develop → main
+      - name: Build preview of next release notes
+        id: preview
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          existing=$(gh pr list --base main --head develop --state open --json number --jq '.[0].number // ""')
-          if [ -n "$existing" ]; then
-            echo "PR #$existing already open — nothing to do."
-            exit 0
-          fi
-          # No-op when develop has nothing ahead of main. Happens
-          # right after a merge-back fast-forwards develop to match
-          # main — there's no diff for `gh pr create`, which would
-          # otherwise fail with "No commits between main and develop"
-          # and leave a red check on the auto-PR workflow.
           ahead=$(gh api "repos/${REPO}/compare/main...develop" --jq '.ahead_by')
+          echo "ahead=$ahead" >> "$GITHUB_OUTPUT"
           if [ "$ahead" = "0" ]; then
             echo "develop has no commits ahead of main — nothing to sync."
             exit 0
           fi
-          gh pr create \
-            --base main \
-            --head develop \
-            --title "chore: sync develop → main" \
-            --body "$(cat <<'EOF'
-          Automated rolling sync PR opened by `.github/workflows/auto-pr-develop-to-main.yml`.
 
-          Merges everything currently on `develop` into `main`. Auto-updates as new commits land on `develop`. Close manually if you need to skip a sync window.
-          EOF
-          )"
+          # release-notes.py is the same script release.yml uses to
+          # render the GitHub Release page, so this preview matches
+          # what will actually ship when the sync PR merges.
+          # Use origin/main since actions/checkout only creates the
+          # workflow's own ref as a local branch — `main` alone
+          # wouldn't resolve here.
+          level=$(.github/scripts/release-notes.py "origin/main..HEAD" notes.md)
+
+          {
+            echo "Rolling sync PR opened by \`.github/workflows/auto-pr.yml\`. Merging this PR fires \`release.yml\` on \`main\` (auto bump + tag + GitHub Release) and \`merge-back.yml\` (fast-forwards \`develop\` to match)."
+            echo
+            echo "Predicted bump: **${level}** — based on the commits below."
+            echo
+            cat notes.md
+            echo
+            echo "_Close this PR manually if you need to skip a sync window._"
+          } > body.md
+
+          echo "--- body.md preview ---"
+          cat body.md
+
+      - name: Ensure open PR with current preview body
+        if: steps.preview.outputs.ahead != '0'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          existing=$(gh pr list --base main --head develop --state open --json number --jq '.[0].number // ""')
+          if [ -n "$existing" ]; then
+            echo "Updating PR #$existing body with refreshed preview..."
+            gh pr edit "$existing" --body-file body.md
+          else
+            gh pr create \
+              --base main \
+              --head develop \
+              --title "chore: sync develop → main" \
+              --body-file body.md
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,15 +64,11 @@ jobs:
           git config user.email "${{ vars.TWO_INC_APP_ID }}+two-inc-app[bot]@users.noreply.github.com"
 
       - name: Decide bump level + build release notes
-        # Single pass over `<previous-numeric-tag>..HEAD`:
-        # - Buckets each non-merge commit into Breaking / Features /
-        #   Fixes / Internals / Other based on its conventional-commit
-        #   type, with optional Linear ticket prefix (e.g. CET-123/feat:).
-        # - Writes the bucketed list to release-notes.md so the GitHub
-        #   Release page reflects exactly what triggered the bump level
-        #   (any Breaking entries → major; any Features → minor; else
-        #   patch). Reading the notes makes the bump-level decision
-        #   visible without having to look at the workflow log.
+        # Both the bump level and the markdown notes come out of
+        # .github/scripts/release-notes.py — the same script auto-pr.yml
+        # uses to render the rolling sync PR's preview, so the
+        # GitHub Release page exactly matches what was previewed
+        # before merge.
         if: steps.gate.outputs.skip == '0'
         id: bump
         run: |
@@ -84,52 +80,10 @@ jobs:
             range="HEAD"
           fi
 
-          : > release-notes.md
-          : > /tmp/breaking
-          : > /tmp/features
-          : > /tmp/fixes
-          : > /tmp/internals
-          : > /tmp/other
-
-          while IFS=$'\t' read -r sha subject; do
-            line="- ${subject} (${sha})"
-            if echo "$subject" | grep -qE '^([A-Z]+-[0-9]+/)?[a-z]+(\([^)]+\))?!:|^BREAKING CHANGE:'; then
-              echo "$line" >> /tmp/breaking
-            elif echo "$subject" | grep -qE '^([A-Z]+-[0-9]+/)?feat(\([^)]+\))?:'; then
-              echo "$line" >> /tmp/features
-            elif echo "$subject" | grep -qE '^([A-Z]+-[0-9]+/)?fix(\([^)]+\))?:'; then
-              echo "$line" >> /tmp/fixes
-            elif echo "$subject" | grep -qE '^([A-Z]+-[0-9]+/)?(chore|refactor|ci|docs|test|build|perf|style)(\([^)]+\))?:'; then
-              echo "$line" >> /tmp/internals
-            else
-              echo "$line" >> /tmp/other
-            fi
-          done < <(git log "$range" --no-merges --format='%h%x09%s')
-
-          # Bump level is the highest-severity bucket that's non-empty.
-          if [ -s /tmp/breaking ]; then
-            level=major
-          elif [ -s /tmp/features ]; then
-            level=minor
-          else
-            level=patch
-          fi
+          level=$(.github/scripts/release-notes.py "$range" release-notes.md)
           echo "level=$level" >> "$GITHUB_OUTPUT"
-          echo "Selected bump level: $level (range: $range)"
-
-          # Render notes — only print sections that have entries.
-          {
-            [ -s /tmp/breaking ]  && { echo "## ⚠️ Breaking changes";  cat /tmp/breaking;  echo; }
-            [ -s /tmp/features ]  && { echo "## 🚀 Features";          cat /tmp/features;  echo; }
-            [ -s /tmp/fixes ]     && { echo "## 🐛 Fixes";              cat /tmp/fixes;     echo; }
-            [ -s /tmp/internals ] && { echo "## 🧰 Internals";          cat /tmp/internals; echo; }
-            [ -s /tmp/other ]     && { echo "## Other";                 cat /tmp/other;     echo; }
-          } > release-notes.md
-          # Stash the previous tag so the post-bump step can append a
-          # "Full diff" link with the proper <prev>..<new> range —
-          # the new tag isn't known yet at this point.
           echo "prev=$prev" >> "$GITHUB_OUTPUT"
-
+          echo "Selected bump level: $level (range: $range)"
           echo "--- release-notes.md preview ---"
           cat release-notes.md
 


### PR DESCRIPTION
[Linear: INF-1159](https://linear.app/tillit/issue/INF-1159/magento-abn-plugin-revamp-ci-workflows)

Mirrors the abn fork's #69.

New `.github/scripts/release-notes.py` is the single source of truth for the bucketing + bump-level decision:

- **`release.yml`** — calls it for the actual GitHub Release notes (replaces the inline bash bucketing).
- **`auto-pr.yml`** — calls it with `origin/main..HEAD` and uses the output as the rolling sync PR's body. The PR description refreshes on every push to `develop` with the bucketed list AND the predicted bump level.

## Why Python

Regex grows readable (named groups, real `re.match` instead of `grep -qE`); the script is testable as it grows. `setup-python` is already installed so the cost is marginal.

## Test plan

- [x] Local smoke test: `python3 .github/scripts/release-notes.py 1.16.0..1.16.2 out.md` prints `patch` and writes a bucketed file.
- [ ] After merge, the next push to `develop` either creates the sync PR with the preview body, or updates an existing PR's body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
