### PR TITLE
ABN-398: declare branch-alias for dev branches

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,11 @@
         "allow-plugins": {
             "magento/composer-dependency-version-audit-plugin": true
         }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-develop": "2.0.x-dev",
+            "dev-main": "2.0.x-dev"
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Adds `extra.branch-alias` for `dev-develop` and `dev-main` → `2.0.x-dev`.

## Why
Required by [`magento-plugin-branding` monorepo conversion (ABN-398)](https://linear.app/tillit/issue/ABN-398). When the branding repo's `dev/install.sh` resolves `BASE=develop`, Composer needs to know that the vanilla `dev-develop` branch aliases to a `2.0.x-dev` constraint so the brand overlay's `^2.0` constraint can match.

`dev/install.sh` carries inline `as 2.0.0` aliases as belt-and-braces; DO NOT remove those even once this lands.

## Test plan
- [ ] CI green
- [ ] `composer show two-inc/magento2 dev-develop` resolves once this is on `develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)