### PR TITLE
chore: rip out defunct magento-plugin-branding pull from Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ composer.lock
 # Local dev config
 .env.local
 .frpc.pid
-/.brand-repo/
 
 # Python
 *.venv

--- a/Makefile
+++ b/Makefile
@@ -10,27 +10,13 @@ TAG        := php82-fpm-magento2.4.6-sample-data
 PORT       := 1234
 URL        := http://localhost:$(PORT)/
 
-TWO_ACCOUNT_DOMAIN   := $(shell gcloud config get-value account 2>/dev/null | sed -n 's/.*@//p')
-TWO_ENV              := $(if $(filter two.inc,$(TWO_ACCOUNT_DOMAIN)),staging,sandbox)
+TWO_ENV              := $(shell gcloud config get-value account 2>/dev/null | grep -q '@two\.inc$$' && echo staging || echo sandbox)
 TWO_API_BASE_URL     ?= https://api.$(TWO_ENV).two.inc
 TWO_CHECKOUT_BASE_URL ?= https://checkout.$(TWO_ENV).two.inc
 TWO_STORE_COUNTRY    ?= NO
-TWO_BRAND            ?=
-TWO_BRAND_VERSION    ?=
-
-# Brand overlay (opt-in). magento-plugin is public, so the canonical
-# branding monorepo is only defaulted when the user's gcloud context
-# proves they're a Two employee. External users get vanilla-only and
-# must explicitly set BRAND_REPO if they have their own overlay.
-BRAND_NAME    ?=
-BRAND_REPO    ?= $(if $(filter two.inc,$(TWO_ACCOUNT_DOMAIN)),two-inc/magento-plugin-branding,)
-BRAND_BRANCH  ?= main
-BRAND_DIR     := $(CURDIR)/.brand-repo
-BRAND_REGEX   := ^[a-z][a-z0-9-]*$$
-
 export PORT
 
-.PHONY: help install configure compile run debug stop clean flush logs proxy archive patch minor major format test test-e2e brand _install-brand
+.PHONY: help install configure compile run debug stop clean flush logs proxy archive patch minor major format test test-e2e
 
 .DEFAULT_GOAL := help
 
@@ -40,12 +26,6 @@ help:
 
 ## Create Magento container, install plugin and Xdebug
 install: clean
-	@if [ -n "$(BRAND_NAME)" ]; then \
-		[ -n "$(BRAND_REPO)" ] || { echo "ERROR: BRAND_NAME=$(BRAND_NAME) but BRAND_REPO unset (set explicitly or use a gcloud context that defaults it)."; exit 1; }; \
-		echo "$(BRAND_NAME)" | grep -qE '$(BRAND_REGEX)' || { echo "ERROR: BRAND_NAME='$(BRAND_NAME)' must match regex $(BRAND_REGEX)"; exit 1; }; \
-		$(MAKE) brand; \
-		[ -f "$(BRAND_DIR)/brands/$(BRAND_NAME)/brand.json" ] || { echo "ERROR: brand '$(BRAND_NAME)' not in $(BRAND_REPO)@$(BRAND_BRANCH) (no brands/$(BRAND_NAME)/brand.json)"; exit 1; }; \
-	fi
 	docker run -d \
 		--name=$(CONTAINER) \
 		-p $(PORT):80 \
@@ -53,10 +33,7 @@ install: clean
 		-e URL=$(URL) \
 		-e TWO_API_BASE_URL=$(TWO_API_BASE_URL) \
 		-e TWO_CHECKOUT_BASE_URL=$(TWO_CHECKOUT_BASE_URL) \
-		$(if $(TWO_BRAND),-e TWO_BRAND=$(TWO_BRAND)) \
-		$(if $(TWO_BRAND_VERSION),-e TWO_BRAND_VERSION=$(TWO_BRAND_VERSION)) \
 		-v $(CURDIR):/data/extensions/workdir \
-		$(if $(BRAND_NAME),-v $(BRAND_DIR):/data/extensions/branding) \
 		$(IMAGE):$(TAG)
 	@echo "Waiting for Magento to start..."
 	@until docker exec $(CONTAINER) php bin/magento --version 2>/dev/null; do sleep 3; done
@@ -82,14 +59,6 @@ install: clean
 	# a hard dependency on it (every *GraphQl module transitively requires
 	# it). Even un-licensed it should be quiet at runtime in dev.
 	docker exec $(CONTAINER) php bin/magento module:enable Two_Gateway
-	@if [ -n "$(BRAND_NAME)" ]; then \
-		BRAND_PKG=$$(docker exec $(CONTAINER) php -r 'echo json_decode(file_get_contents($$argv[1]),true)["composer_package"];' /data/extensions/branding/brands/$(BRAND_NAME)/brand.json); \
-		BRAND_MOD=$$(docker exec $(CONTAINER) php -r 'echo json_decode(file_get_contents($$argv[1]),true)["module_name"];' /data/extensions/branding/brands/$(BRAND_NAME)/brand.json); \
-		echo "Installing brand overlay: $$BRAND_PKG ($$BRAND_MOD)"; \
-		docker exec $(CONTAINER) composer config repositories.branding-overlay path /data/extensions/branding/brands/$(BRAND_NAME); \
-		docker exec $(CONTAINER) composer require "$$BRAND_PKG:@dev" --no-plugins; \
-		docker exec $(CONTAINER) php bin/magento module:enable $$BRAND_MOD; \
-	fi
 	docker exec $(CONTAINER) php bin/magento setup:upgrade
 	docker exec $(CONTAINER) php bin/magento deploy:mode:set developer
 	docker exec $(CONTAINER) php bin/magento setup:di:compile
@@ -127,21 +96,6 @@ install: clean
 	echo " Credentials:   exampleuser / examplepassword123"; \
 	echo " Xdebug:        installed (activate with 'make debug')"; \
 	echo "========================================="
-
-## Clone or refresh the brand-overlay repo at .brand-repo/ (no-op if BRAND_REPO unset)
-brand:
-	@if [ -z "$(BRAND_REPO)" ]; then \
-		echo "BRAND_REPO unset — nothing to fetch. Set BRAND_REPO=<org/repo> or use a two.inc gcloud context."; \
-		exit 0; \
-	fi
-	@if [ -d "$(BRAND_DIR)/.git" ]; then \
-		echo "Refreshing $(BRAND_REPO) @ $(BRAND_BRANCH) in $(BRAND_DIR)..."; \
-		git -C $(BRAND_DIR) fetch --depth=1 origin $(BRAND_BRANCH); \
-		git -C $(BRAND_DIR) checkout -B $(BRAND_BRANCH) FETCH_HEAD; \
-	else \
-		echo "Cloning git@github.com:$(BRAND_REPO).git @ $(BRAND_BRANCH) into $(BRAND_DIR)..."; \
-		git clone --depth=1 --branch $(BRAND_BRANCH) git@github.com:$(BRAND_REPO).git $(BRAND_DIR); \
-	fi
 
 ## Update payment config: make configure TWO_API_KEY=xxx
 configure:

--- a/README.md
+++ b/README.md
@@ -107,49 +107,9 @@ Install also runs:
 
 ### Brand overlays
 
-The plugin supports brand-specific overlay packages that customise checkout copy, SVG assets, and DI bindings while reusing the same `Two_Gateway` core. Overlays live in a separate Composer package (one per brand) and are opt-in.
-
-```bash
-# Install vanilla + a brand overlay
-make install BRAND_NAME=abn
-```
-
-When `BRAND_NAME` is set, `make install`:
-
-1. Clones (or refreshes) the brand-overlay repo into `.brand-repo/` at the repo root.
-2. Mounts `.brand-repo/` into the Magento container alongside the vanilla bind-mount.
-3. Wires the brand's Composer package as a path repository, requires it, and enables the brand module after `Two_Gateway`.
-
-#### Variables
-
-| Variable | Default | Description |
-|---|---|---|
-| `BRAND_NAME` | _(unset)_ | Brand identifier matching `^[a-z][a-z0-9-]*$`. Must correspond to a `brands/<BRAND_NAME>/` directory in the overlay repo. |
-| `BRAND_REPO` | `two-inc/magento-plugin-branding` for `@two.inc` gcloud contexts; otherwise unset | GitHub `org/repo` of the overlay monorepo. External users with their own overlay should set this explicitly. |
-| `BRAND_BRANCH` | `main` | Branch of the overlay repo to check out. Use `develop` for unreleased overlay changes, or a feature branch for local testing. |
-
-The default for `BRAND_REPO` is computed at runtime from your gcloud account — `magento-plugin` is public and must not bake brand-repo names into source.
-
-#### Examples
-
-```bash
-# Vanilla only (default — no brand variables set):
-make install
-
-# ABN overlay on the main branch (default for @two.inc users):
-make install BRAND_NAME=abn
-
-# ABN overlay on a feature branch:
-make install BRAND_NAME=abn BRAND_BRANCH=feature/new-checkout-copy
-
-# Custom overlay repo:
-make install BRAND_NAME=myco BRAND_REPO=myorg/magento-plugin-overlay-myco
-
-# Manually refresh the overlay checkout without reinstalling:
-make brand BRAND_BRANCH=develop
-```
-
-The clone uses SSH (`git@github.com:<BRAND_REPO>.git`), so you need an SSH key registered with your GitHub account that has read access to the overlay repo.
+Brand-specific overlay packages (e.g. ABN AMRO's Zakelijk op Rekening) live in
+their own Composer packages and are installed separately from this plugin, not
+through `make install`. See `two-inc/magento-abn-plugin` for the ABN overlay.
 
 ### Debugging
 


### PR DESCRIPTION
## Summary

Removes the build-time brand-overlay machinery from `make install`. Superseded by separate Composer-package brand overlays (e.g. `two-inc/magento-abn-plugin`) with their own Makefiles.

Specifically removes from PR #111 (merged 2026-05-20):
- `BRAND_NAME` / `BRAND_REPO` / `BRAND_BRANCH` / `BRAND_DIR` / `BRAND_REGEX` Makefile vars
- `brand` target (clones `two-inc/magento-plugin-branding` into `.brand-repo/`)
- `_install-brand` shell block inside `install`
- `BRAND_NAME` validation precheck + `-v $(BRAND_DIR):/data/extensions/branding` bind-mount
- `.gitignore /.brand-repo/`
- README "Brand overlays" section (now a one-paragraph pointer to the overlay packages)

Also drops the now-vestigial `TWO_BRAND` / `TWO_BRAND_VERSION` env vars (their `docker -e` flags fed a brand-asset injection pipeline that no longer exists). The runtime getters in `Model/Config/Repository.php` still call `getenv()` and fall back to empty string, so live merchants are unaffected.

The FRP-proxy machinery, perf-tuning module disables, and static-content pre-deploy added in PR #111's other commits are unrelated to the branding pull and are kept.

## Context

ABN-398's brand-overlay-2.0 architecture moved brand overlays to independent Composer packages with virtual-type DI (see `two-inc/magento-abn-plugin` + its Makefile on port 1235). The Makefile-time bind-mount mechanism PR #111 added is the now-defunct logic this PR removes.

## Test plan
- [ ] `make install` boots a clean Magento container without `BRAND_*` errors
- [ ] `make install` (no brand args) still produces a working vanilla store at http://localhost:1234/
- [ ] FRP proxy, perf-tuning, static-content deploy all still run as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)