### PR TITLE
ci: replace unreachable two-inc/merge-or-pr-action with inline gh logic

### DIFF
--- a/.github/workflows/merge-back.yml
+++ b/.github/workflows/merge-back.yml
@@ -8,17 +8,68 @@ concurrency:
   group: merge-main
   cancel-in-progress: true
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   main-to-develop:
     name: main → develop
     runs-on: ${{ vars.RUNNER_STANDARD }}
     if: github.ref_name == 'main'
     steps:
-      - name: Merge or create pull request
-        uses: two-inc/merge-or-pr-action@main
+      # Use the org GitHub App token — branch protection on `develop`
+      # blocks the default GITHUB_TOKEN from pushing, and a PR opened
+      # with GITHUB_TOKEN wouldn't trigger downstream CI on the new
+      # PR branch.
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
         with:
           client-id: ${{ vars.TWO_INC_APP_CLIENT_ID }}
-          app-private-key: ${{ secrets.TWO_INC_APP_PRIVATE_KEY }}
-          source-ref: main
-          target-ref: develop
-          reviewer: brtkwr
+          private-key: ${{ secrets.TWO_INC_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Fast-forward develop to main (or fall back to a sync PR)
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.noreply.github.com"
+          git fetch origin develop
+          # No-op when develop is already at or ahead of main.
+          behind=$(gh api "repos/${REPO}/compare/develop...main" --jq '.ahead_by')
+          if [ "$behind" = "0" ]; then
+            echo "develop already at or ahead of main — nothing to merge back."
+            exit 0
+          fi
+          git checkout develop
+          if git merge --ff-only origin/main; then
+            git push origin develop
+            echo "Fast-forwarded develop to main ($behind commit(s))."
+            exit 0
+          fi
+          # Diverged — open a sync PR instead. Use a deterministic
+          # branch name so repeated runs update the same PR rather
+          # than spawning new ones.
+          echo "develop diverged from main — opening a sync PR."
+          sync_branch="sync/main-to-develop"
+          git checkout -B "$sync_branch" origin/main
+          git push --force-with-lease origin "$sync_branch"
+          existing=$(gh pr list --base develop --head "$sync_branch" --state open --json number --jq '.[0].number // ""')
+          if [ -z "$existing" ]; then
+            gh pr create \
+              --base develop \
+              --head "$sync_branch" \
+              --reviewer brtkwr \
+              --title "chore: sync main → develop" \
+              --body "Auto-sync PR opened by .github/workflows/merge-back.yml after a push to main that couldn't fast-forward into develop. Resolve any conflicts and merge."
+          else
+            echo "Sync PR #$existing already open — updated branch."
+          fi


### PR DESCRIPTION
Merge-back workflow has been hard-failing on every push to main: `Unable to resolve action \`two-inc/merge-or-pr-action\`, not found`. Replace the broken action with inline gh+git logic that does the same FF-or-PR dance.