### PR TITLE
feat: ApiTranslator hook (plain value objects, zero new deps)

### DIFF
--- a/Api/ApiCall.php
+++ b/Api/ApiCall.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Api;
+
+/**
+ * Outbound HTTP call carrier. Mutable on purpose — the api-translator's job
+ * is to rewrite fields in place. Brand-proxy translators MAY rewrite any field.
+ */
+final class ApiCall
+{
+    /** @var string HTTP method: GET / POST / PUT */
+    public $method;
+
+    /** @var string fully-qualified dispatch URL */
+    public $url;
+
+    /** @var array<string, string> header name → value */
+    public $headers;
+
+    /** @var string request body (already JSON-encoded for body-carrying methods) */
+    public $body;
+
+    /**
+     * @param array<string, string> $headers
+     */
+    public function __construct(string $method, string $url, array $headers, string $body)
+    {
+        $this->method = $method;
+        $this->url = $url;
+        $this->headers = $headers;
+        $this->body = $body;
+    }
+}

--- a/Api/ApiResult.php
+++ b/Api/ApiResult.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Api;
+
+/**
+ * Inbound HTTP response carrier. Mutable; the api-translator may rewrite any field.
+ */
+final class ApiResult
+{
+    /** @var int HTTP status code */
+    public $status;
+
+    /** @var array<string, string|string[]> response header name → value(s) */
+    public $headers;
+
+    /** @var string response body */
+    public $body;
+
+    /**
+     * @param array<string, string|string[]> $headers
+     */
+    public function __construct(int $status, array $headers, string $body)
+    {
+        $this->status = $status;
+        $this->headers = $headers;
+        $this->body = $body;
+    }
+}

--- a/Api/ApiTranslatorInterface.php
+++ b/Api/ApiTranslatorInterface.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Api;
+
+/**
+ * Hook for translating outbound HTTP between Two's native protocol and a brand
+ * proxy's protocol. Default binding is
+ * {@see \Two\Gateway\Model\ApiTranslator\NullApiTranslator} (passthrough); a
+ * brand overlay rebinds via di.xml <preference>.
+ *
+ * Named ApiTranslator (not bare Translator) to avoid confusion with Magento's
+ * i18n translator.
+ *
+ * Contract:
+ *   - Implementations MUST return a non-null ApiCall / ApiResult.
+ *   - Throwables propagate; Adapter wraps them as a 502 envelope with
+ *     error_source='api_translator'.
+ *   - The merchant API key arrives on the ApiCall as the X-API-Key header.
+ *     Implementations MUST NOT log, persist, or otherwise exfiltrate it.
+ *
+ * The brand owns the rest of the contract: URL rewriting, body shape, header
+ * naming, idempotency-key forwarding, etc.
+ */
+interface ApiTranslatorInterface
+{
+    public function translateRequest(ApiCall $call): ApiCall;
+
+    public function translateResponse(ApiResult $result): ApiResult;
+}

--- a/Model/ApiTranslator/NullApiTranslator.php
+++ b/Model/ApiTranslator/NullApiTranslator.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Model\ApiTranslator;
+
+use Two\Gateway\Api\ApiTranslatorInterface;
+
+/**
+ * Default passthrough api-translator. Bound to {@see ApiTranslatorInterface}
+ * by etc/di.xml in vanilla installs. Brand overlays rebind via <preference>.
+ *
+ * Not `final`: integration-test spies may extend. Production should not.
+ */
+class NullApiTranslator implements ApiTranslatorInterface
+{
+    use PassthroughTrait;
+}

--- a/Model/ApiTranslator/PassthroughTrait.php
+++ b/Model/ApiTranslator/PassthroughTrait.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Model\ApiTranslator;
+
+use Two\Gateway\Api\ApiCall;
+use Two\Gateway\Api\ApiResult;
+
+/**
+ * Forward-compatible default implementations for
+ * {@see \Two\Gateway\Api\ApiTranslatorInterface}. Brand api-translators
+ * `use PassthroughTrait;` so minor-version additions to the interface
+ * ship with passthrough defaults.
+ */
+trait PassthroughTrait
+{
+    public function translateRequest(ApiCall $call): ApiCall
+    {
+        return $call;
+    }
+
+    public function translateResponse(ApiResult $result): ApiResult
+    {
+        return $result;
+    }
+}

--- a/Service/Api/Adapter.php
+++ b/Service/Api/Adapter.php
@@ -9,7 +9,11 @@ namespace Two\Gateway\Service\Api;
 
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\HTTP\Client\Curl;
+use Magento\Framework\HTTP\Client\CurlFactory;
 use Throwable;
+use Two\Gateway\Api\ApiCall;
+use Two\Gateway\Api\ApiResult;
+use Two\Gateway\Api\ApiTranslatorInterface;
 use Two\Gateway\Api\BrandRegistryInterface;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
 use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
@@ -29,32 +33,30 @@ class Adapter
     private $brandRegistry;
 
     /**
-     * @var Curl
+     * @var CurlFactory
      */
-    private $curlClient;
+    private $curlFactory;
 
     /**
      * @var LogRepository
      */
     private $logRepository;
 
-    /**
-     * Adapter constructor.
-     *
-     * @param ConfigRepository $configRepository
-     * @param Curl $curlClient
-     * @param LogRepository $logRepository
-     */
+    /** @var ApiTranslatorInterface */
+    private $apiTranslator;
+
     public function __construct(
         ConfigRepository $configRepository,
         BrandRegistryInterface $brandRegistry,
-        Curl $curlClient,
-        LogRepository $logRepository
+        CurlFactory $curlFactory,
+        LogRepository $logRepository,
+        ApiTranslatorInterface $apiTranslator
     ) {
         $this->configRepository = $configRepository;
         $this->brandRegistry = $brandRegistry;
-        $this->curlClient = $curlClient;
+        $this->curlFactory = $curlFactory;
         $this->logRepository = $logRepository;
+        $this->apiTranslator = $apiTranslator;
     }
 
     /**
@@ -78,54 +80,86 @@ class Adapter
             $url = $this->configRepository->addVersionDataInURL(
                 sprintf('%s%s', $this->configRepository->getCheckoutApiUrl($mode), $endpoint)
             );
-            $this->curlClient->addHeader("Content-Type", "application/json");
-            $this->curlClient->addHeader("X-API-Key", $this->configRepository->getApiKey($storeId));
-            $this->curlClient->setOption(CURLOPT_RETURNTRANSFER, true);
-            $this->curlClient->setOption(CURLOPT_SSL_VERIFYHOST, 0);
-            $this->curlClient->setOption(CURLOPT_SSL_VERIFYPEER, 0);
-            $this->curlClient->setOption(CURLOPT_TIMEOUT, 60);
+            $body = ($method == "POST" || $method == "PUT")
+                ? (empty($payload) ? '' : (string)json_encode($payload))
+                : '';
+            $call = new ApiCall(
+                $method,
+                $url,
+                [
+                    'Content-Type' => 'application/json',
+                    'X-API-Key' => $this->configRepository->getApiKey($storeId),
+                ],
+                $body
+            );
 
-            if ($method == "POST" || $method == "PUT") {
-                $params = empty($payload) ? '' : json_encode($payload);
-                $this->curlClient->addHeader("Content-Length", strlen($params));
-                $this->curlClient->post($url, $params);
-            } else {
-                $this->curlClient->setOption(CURLOPT_FOLLOWLOCATION, true);
-                $this->curlClient->get($url);
+            try {
+                $call = $this->apiTranslator->translateRequest($call);
+            } catch (Throwable $e) {
+                return $this->translatorFailure('request', $e, $endpoint, $method);
             }
 
-            $body = trim($this->curlClient->getBody());
-            if (in_array($this->curlClient->getStatus(), [200, 201, 202])) {
-                $result = [];
+            $curl = $this->curlFactory->create();
+            foreach ($call->headers as $name => $value) {
+                $curl->addHeader($name, $value);
+            }
+            $curl->setOption(CURLOPT_RETURNTRANSFER, true);
+            $curl->setOption(CURLOPT_SSL_VERIFYHOST, 0);
+            $curl->setOption(CURLOPT_SSL_VERIFYPEER, 0);
+            $curl->setOption(CURLOPT_TIMEOUT, 60);
+
+            if ($call->method == "POST" || $call->method == "PUT") {
+                $curl->addHeader("Content-Length", strlen($call->body));
+                $curl->post($call->url, $call->body);
+            } else {
+                $curl->setOption(CURLOPT_FOLLOWLOCATION, true);
+                $curl->get($call->url);
+            }
+
+            $result = new ApiResult(
+                (int)$curl->getStatus(),
+                $curl->getHeaders() ?: [],
+                (string)$curl->getBody()
+            );
+
+            try {
+                $result = $this->apiTranslator->translateResponse($result);
+            } catch (Throwable $e) {
+                return $this->translatorFailure('response', $e, $endpoint, $method);
+            }
+
+            $body = trim($result->body);
+            if (in_array($result->status, [200, 201, 202])) {
+                $decoded = [];
                 if ((!$body || $body === '""')) {
                     if (in_array($endpoint, [
                             SoleTraderInterface::DELEGATION_TOKEN_ENDPOINT,
                             SoleTraderInterface::AUTOFILL_TOKEN_ENDPOINT])) {
-                        $result = $this->curlClient->getHeaders();
-                        foreach ($result as $key => $value) {
-                            $result[strtolower($key)] = $value;
+                        $decoded = $result->headers;
+                        foreach ($decoded as $key => $value) {
+                            $decoded[strtolower($key)] = $value;
                         }
                     }
                 } else {
-                    $result = json_decode($body, true);
+                    $decoded = json_decode($body, true);
                 }
                 $this->logRepository->addDebugLog(
-                    sprintf('API response %s %s (status: %s)', $method, $endpoint, $this->curlClient->getStatus()),
-                    $result
+                    sprintf('API response %s %s (status: %s)', $method, $endpoint, $result->status),
+                    $decoded
                 );
-                return $result;
+                return $decoded;
             } else {
                 if ($body) {
-                    $result = json_decode($body, true) ?: [];
-                    $result['http_status'] = $this->curlClient->getStatus();
+                    $decoded = json_decode($body, true) ?: [];
+                    $decoded['http_status'] = $result->status;
                     $this->logRepository->addDebugLog(
-                        sprintf('API response %s %s (status: %s)', $method, $endpoint, $this->curlClient->getStatus()),
-                        $result
+                        sprintf('API response %s %s (status: %s)', $method, $endpoint, $result->status),
+                        $decoded
                     );
-                    return $result;
+                    return $decoded;
                 } else {
                     $this->logRepository->addDebugLog(
-                        sprintf('API response %s %s (status: %s)', $method, $endpoint, $this->curlClient->getStatus()),
+                        sprintf('API response %s %s (status: %s)', $method, $endpoint, $result->status),
                         'Invalid API response.'
                     );
                     throw new LocalizedException(
@@ -139,5 +173,26 @@ class Adapter
                 'error_message' => $exception->getMessage(),
             ];
         }
+    }
+
+    private function translatorFailure(string $phase, Throwable $e, string $endpoint, string $method): array
+    {
+        $this->logRepository->addErrorLog(
+            sprintf(
+                '[api-translator-failure] phase=%s class=%s endpoint=%s method=%s message=%s',
+                $phase,
+                get_class($this->apiTranslator),
+                $endpoint,
+                $method,
+                $e->getMessage()
+            ),
+            null
+        );
+        return [
+            'error_code' => 502,
+            'http_status' => 502,
+            'error_source' => 'api_translator',
+            'error_message' => 'Translator failure',
+        ];
     }
 }

--- a/Test/E2E/ApiAdapterTest.php
+++ b/Test/E2E/ApiAdapterTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
 use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
 use Two\Gateway\Service\Api\Adapter;
-use Two\Gateway\Test\E2E\Http\RealCurl;
+use Two\Gateway\Test\E2E\Http\RealAdapterFactoryTrait;
 
 /**
  * End-to-end tests for Service\Api\Adapter against the real Two API.
@@ -17,6 +17,8 @@ use Two\Gateway\Test\E2E\Http\RealCurl;
  */
 class ApiAdapterTest extends TestCase
 {
+    use RealAdapterFactoryTrait;
+
     private Adapter $adapter;
 
     protected function setUp(): void
@@ -29,9 +31,7 @@ class ApiAdapterTest extends TestCase
         $config->method('addVersionDataInURL')->willReturnArgument(0);
         $config->method('getApiKey')->willReturn($apiKey);
 
-        $log = $this->createMock(LogRepository::class);
-
-        $this->adapter = new Adapter($config, new RealCurl(), $log);
+        $this->adapter = $this->buildRealAdapter($config, $this->createMock(LogRepository::class));
     }
 
     public function testApiKeyIsValid(): void
@@ -51,9 +51,7 @@ class ApiAdapterTest extends TestCase
         $config->method('addVersionDataInURL')->willReturnArgument(0);
         $config->method('getApiKey')->willReturn('invalid-key');
 
-        $log = $this->createMock(LogRepository::class);
-
-        $adapter = new Adapter($config, new RealCurl(), $log);
+        $adapter = $this->buildRealAdapter($config, $this->createMock(LogRepository::class));
         $result = $adapter->execute('/v1/merchant/verify_api_key', [], 'GET');
 
         $this->assertEquals(401, $result['http_status']);

--- a/Test/E2E/Http/RealAdapterFactoryTrait.php
+++ b/Test/E2E/Http/RealAdapterFactoryTrait.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\E2E\Http;
+
+use Magento\Framework\HTTP\Client\CurlFactory;
+use Two\Gateway\Api\BrandRegistryInterface;
+use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
+use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
+use Two\Gateway\Model\ApiTranslator\NullApiTranslator;
+use Two\Gateway\Service\Api\Adapter;
+
+trait RealAdapterFactoryTrait
+{
+    private function buildRealAdapter(ConfigRepository $config, LogRepository $log): Adapter
+    {
+        $brand = $this->createMock(BrandRegistryInterface::class);
+        $brand->method('getProductName')->willReturn('Two');
+        $factory = $this->createMock(CurlFactory::class);
+        $factory->method('create')->willReturnCallback(fn() => new RealCurl());
+        return new Adapter($config, $brand, $factory, $log, new NullApiTranslator());
+    }
+}

--- a/Test/E2E/PricingFeeTest.php
+++ b/Test/E2E/PricingFeeTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
 use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
 use Two\Gateway\Service\Api\Adapter;
-use Two\Gateway\Test\E2E\Http\RealCurl;
+use Two\Gateway\Test\E2E\Http\RealAdapterFactoryTrait;
 
 /**
  * End-to-end tests for the pricing fee endpoint used by SurchargeCalculator.
@@ -18,6 +18,8 @@ use Two\Gateway\Test\E2E\Http\RealCurl;
  */
 class PricingFeeTest extends TestCase
 {
+    use RealAdapterFactoryTrait;
+
     private Adapter $adapter;
 
     protected function setUp(): void
@@ -30,9 +32,7 @@ class PricingFeeTest extends TestCase
         $config->method('addVersionDataInURL')->willReturnArgument(0);
         $config->method('getApiKey')->willReturn($apiKey);
 
-        $log = $this->createMock(LogRepository::class);
-
-        $this->adapter = new Adapter($config, new RealCurl(), $log);
+        $this->adapter = $this->buildRealAdapter($config, $this->createMock(LogRepository::class));
     }
 
     private function fetchFee(int $durationDays, float $grossAmount = 1000.0, string $country = 'NO'): array

--- a/Test/Stubs/CurlFactory.php
+++ b/Test/Stubs/CurlFactory.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Magento\Framework\HTTP\Client;
+
+/**
+ * Minimal CurlFactory stub for unit tests. Magento auto-generates the real
+ * factory at setup:di:compile; PHPUnit needs the create() method declared
+ * so it can be mocked.
+ */
+class CurlFactory
+{
+    public function create(): Curl
+    {
+        return new Curl();
+    }
+}

--- a/Test/Unit/Service/Api/AdapterTest.php
+++ b/Test/Unit/Service/Api/AdapterTest.php
@@ -4,10 +4,16 @@ declare(strict_types=1);
 namespace Two\Gateway\Test\Unit\Service\Api;
 
 use Magento\Framework\HTTP\Client\Curl;
+use Magento\Framework\HTTP\Client\CurlFactory;
 use PHPUnit\Framework\TestCase;
+use Two\Gateway\Api\ApiCall;
+use Two\Gateway\Api\ApiResult;
+use Two\Gateway\Api\ApiTranslatorInterface;
 use Two\Gateway\Api\BrandRegistryInterface;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
 use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
+use Two\Gateway\Model\ApiTranslator\NullApiTranslator;
+use Two\Gateway\Model\ApiTranslator\PassthroughTrait;
 use Two\Gateway\Service\Api\Adapter;
 
 class AdapterTest extends TestCase
@@ -39,11 +45,15 @@ class AdapterTest extends TestCase
         $this->configRepository->method('addVersionDataInURL')->willReturnArgument(0);
         $this->configRepository->method('getApiKey')->willReturn('test-key');
 
+        $curlFactory = $this->createMock(CurlFactory::class);
+        $curlFactory->method('create')->willReturn($this->curl);
+
         $this->adapter = new Adapter(
             $this->configRepository,
             $this->brandRegistry,
-            $this->curl,
-            $this->logRepository
+            $curlFactory,
+            $this->logRepository,
+            new NullApiTranslator()
         );
     }
 
@@ -165,16 +175,83 @@ class AdapterTest extends TestCase
         $this->configRepository->method('getCheckoutApiUrl')
             ->willThrowException(new \RuntimeException('Connection failed'));
 
+        $curlFactory = $this->createMock(CurlFactory::class);
+        $curlFactory->method('create')->willReturn($this->curl);
+
         $adapter = new Adapter(
             $this->configRepository,
             $this->brandRegistry,
-            $this->curl,
-            $this->logRepository
+            $curlFactory,
+            $this->logRepository,
+            new NullApiTranslator()
         );
 
         $result = $adapter->execute('/v1/order');
 
         $this->assertEquals(400, $result['error_code']);
         $this->assertEquals('Connection failed', $result['error_message']);
+    }
+
+    // ── ApiTranslator hook ──────────────────────────────────────────────
+
+    public function testTranslatorRewritesUrl(): void
+    {
+        $this->curl->method('getStatus')->willReturn(200);
+        $this->curl->method('getBody')->willReturn('{"ok":true}');
+
+        $capturedUrl = null;
+        $this->curl->method('post')->willReturnCallback(function ($u) use (&$capturedUrl) {
+            $capturedUrl = $u;
+        });
+
+        $translator = new class implements ApiTranslatorInterface {
+            use PassthroughTrait;
+            public function translateRequest(ApiCall $call): ApiCall
+            {
+                $call->url = str_replace('/v1/', '/brand-proxy/v1/', $call->url);
+                return $call;
+            }
+        };
+
+        $curlFactory = $this->createMock(CurlFactory::class);
+        $curlFactory->method('create')->willReturn($this->curl);
+
+        $adapter = new Adapter(
+            $this->configRepository,
+            $this->brandRegistry,
+            $curlFactory,
+            $this->logRepository,
+            $translator
+        );
+        $adapter->execute('/v1/order', ['x' => 1]);
+
+        $this->assertSame('https://api.two.inc/brand-proxy/v1/order', $capturedUrl);
+    }
+
+    public function testTranslatorThrowReturns502Envelope(): void
+    {
+        $translator = new class implements ApiTranslatorInterface {
+            use PassthroughTrait;
+            public function translateRequest(ApiCall $call): ApiCall
+            {
+                throw new \RuntimeException('boom');
+            }
+        };
+
+        $curlFactory = $this->createMock(CurlFactory::class);
+        $curlFactory->method('create')->willReturn($this->curl);
+
+        $adapter = new Adapter(
+            $this->configRepository,
+            $this->brandRegistry,
+            $curlFactory,
+            $this->logRepository,
+            $translator
+        );
+        $result = $adapter->execute('/v1/order');
+
+        $this->assertSame(502, $result['error_code']);
+        $this->assertSame('api_translator', $result['error_source']);
+        $this->assertSame('Translator failure', $result['error_message']);
     }
 }

--- a/Test/bootstrap.php
+++ b/Test/bootstrap.php
@@ -46,6 +46,9 @@ if (!interface_exists(\Magento\Framework\App\Config\Storage\WriterInterface::cla
 if (!class_exists(\Magento\Framework\HTTP\Client\Curl::class)) {
     require_once __DIR__ . '/Stubs/Curl.php';
 }
+if (!class_exists(\Magento\Framework\HTTP\Client\CurlFactory::class)) {
+    require_once __DIR__ . '/Stubs/CurlFactory.php';
+}
 if (!class_exists(\Magento\Framework\Exception\LocalizedException::class)) {
     require_once __DIR__ . '/Stubs/LocalizedException.php';
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -22,6 +22,9 @@
     <!-- Default brand binding. Overlay packages may rebind via their own DI preference. -->
     <preference for="Two\Gateway\Api\BrandRegistryInterface"
                 type="Two\Gateway\Brand\TwoBrand"/>
+    <!-- Default outbound-API translator: passthrough. Brand overlays rebind. -->
+    <preference for="Two\Gateway\Api\ApiTranslatorInterface"
+                type="Two\Gateway\Model\ApiTranslator\NullApiTranslator"/>
 
     <type name="Two\Gateway\Logger\Handler">
         <arguments>


### PR DESCRIPTION
Re-do of #118 (which was reverted) using plain Two-defined value objects instead of PSR-7. No new composer deps — git-sync deploy model honoured.

## Why

A brand overlay (initial worked example: ABN) wants to front the Two API with a proxy that renames endpoints and reshapes payloads. We need a hook in the outbound HTTP path so the brand can install a translator without forking the plugin.

#118 used PSR-7 as the contract — universal HTTP-middleware shape, but it forced a runtime \`nyholm/psr7\` dep. The plugin deploys via git-sync into \`app/code/\`, which does not run composer install on plugin's \`require\`. Production fataled. Reverted.

This PR sidesteps the problem: define two small value objects (\`ApiCall\`, \`ApiResult\`) in our own namespace; translator takes them and returns them. Zero third-party deps. Brand translator author writes plain PHP against plain mutable structs.

## Contract

\`\`\`php
interface ApiTranslatorInterface
{
    public function translateRequest(ApiCall \$call): ApiCall;
    public function translateResponse(ApiResult \$result): ApiResult;
}
\`\`\`

\`ApiCall\`: mutable (method, url, headers, body). \`ApiResult\`: mutable (status, headers, body). Brand translator mutates in place or returns a new instance.

Default binding (\`NullApiTranslator\`) is passthrough — vanilla installs behave identically to pre-translator.

## Failure handling

Translator Throwable → 502 envelope (\`error_code=502, error_source='api_translator'\`), logged at ERROR. Existing 2xx/error branches unchanged from origin/staging.

## Adapter shape

\`execute()\` reads close to its pre-translator form. Helpers do PSR-7-style pre/post wrapping but in our own types. \`Curl\` injection swapped for \`CurlFactory\` to give each call a fresh client (no state leakage between calls).

## Test plan

- [x] PHP lint clean
- [ ] CI \`make test\` (unit): passthrough behaves as pre-translator, translator can rewrite URL, translator throw → 502
- [ ] CI \`make test-e2e\` (with TWO_API_KEY): green against staging
- [ ] Post-merge: verify magento + magento-abn pods do not crash-loop after git-sync picks up

## Out of scope (deliberately)

- PSR-7 contract (zero-dep alternative used)
- header preserve/restore guards, token-header guards, empty-body guards, correlation logging, translator-CPU WARN threshold — brand owns its contract
- ConfigProvider failure-envelope strip — pre-existing scope
- SoleTrader token-extraction refactor — pure refactor with no behavioural delta

🤖 Generated with [Claude Code](https://claude.com/claude-code)