### PR TITLE
test: realign SurchargeCalculatorTest with Adapter constructor

### DIFF
--- a/Test/Unit/Service/Order/SurchargeCalculatorTest.php
+++ b/Test/Unit/Service/Order/SurchargeCalculatorTest.php
@@ -3,12 +3,13 @@ declare(strict_types=1);
 
 namespace Two\Gateway\Test\Unit\Service\Order;
 
-use Magento\Framework\HTTP\Client\Curl;
+use Magento\Framework\HTTP\Client\CurlFactory;
 use PHPUnit\Framework\TestCase;
 use Two\Gateway\Api\BrandRegistryInterface;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
 use Two\Gateway\Api\CurrencyRatesProviderInterface;
 use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
+use Two\Gateway\Model\ApiTranslator\NullApiTranslator;
 use Two\Gateway\Model\Config\Source\SurchargeType;
 use Two\Gateway\Service\Api\Adapter;
 use Two\Gateway\Service\Order\SurchargeCalculator;
@@ -34,8 +35,9 @@ class SurchargeCalculatorTest extends TestCase
             ->setConstructorArgs([
                 $this->config,
                 $this->createMock(BrandRegistryInterface::class),
-                $this->createMock(Curl::class),
+                $this->createMock(CurlFactory::class),
                 $this->createMock(LogRepository::class),
+                new NullApiTranslator(),
             ])
             ->onlyMethods(['execute'])
             ->getMock();


### PR DESCRIPTION
## Summary
`Adapter::__construct` accepts `CurlFactory` (not `Curl`) for arg #3 and requires `ApiTranslatorInterface` as arg #5. `SurchargeCalculatorTest`'s `setUp` still passed a `Curl` mock and omitted the translator, so all 24 test methods threw:

```
TypeError: Two\Gateway\Service\Api\Adapter::__construct(): Argument #3 ($curlFactory) must be of type Magento\Framework\HTTP\Client\CurlFactory, Mock_Curl_25f3f561 given
  at Test/Unit/Service/Order/SurchargeCalculatorTest.php:41
```

Mirror the shape used in `Test/Unit/Service/Api/AdapterTest.php`: `CurlFactory` mock + `NullApiTranslator`. The surcharge tests stub `Adapter::execute` directly, so the inner Curl wiring is unused — only the constructor types matter.

Picked up while triaging #121's PHPUnit failures.