### PR TITLE
ci: trigger CI on PRs/pushes targeting staging instead of develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, staging]
   pull_request:
-    branches: [main, develop]
+    branches: [main, staging]
 
 # Cancel in-progress runs for the same ref when a new push lands.
 # Each PR / branch gets its own group so concurrent unrelated work is


### PR DESCRIPTION
PRs against `staging` silently skipped the whole CI workflow because `on.push.branches` and `on.pull_request.branches` listed only `main` and `develop`. `develop` was abandoned in favour of `staging` on this repo, so swap it out.

Without this, #121 and #122 either ran no checks at all or relied on stale runs from earlier pushes — neither merged through the real PHPUnit gate.