### PR TITLE
ci: dynamic Magento × PHP matrix from upstream support window

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, staging]
+    branches: [main, staging, develop]
   pull_request:
-    branches: [main, staging]
+    branches: [main, staging, develop]
 
 # Cancel in-progress runs for the same ref when a new push lands.
 # Each PR / branch gets its own group so concurrent unrelated work is
@@ -14,25 +14,42 @@ concurrency:
   cancel-in-progress: true
 
 # Job-name convention: `<Tool> (PHP X.Y[, Magento Z.A.B])`.
-# Tool name first so checks group naturally in the UI; PHP version
-# always present (zero-arg jobs drop the parens entirely).
+# Tool name first so checks group naturally in the UI.
 
 jobs:
+  # Discovers the current Magento support window from upstream so the
+  # PHPStan / DI-compile / lint matrices track Adobe's lifecycle without
+  # hand-maintenance. `dev/magento-support-matrix.sh` is the single
+  # source of truth for which Magento × PHP combinations CI exercises.
+  discover-magento-matrix:
+    name: Discover Magento support matrix
+    runs-on: ${{ vars.RUNNER_STANDARD }}
+    outputs:
+      matrix: ${{ steps.gen.outputs.matrix }}
+      php_lint_matrix: ${{ steps.gen.outputs.php_lint_matrix }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: gen
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          matrix=$(./dev/magento-support-matrix.sh --emit-matrix)
+          php_lint_matrix=$(./dev/magento-support-matrix.sh --emit-php-lint-matrix)
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "php_lint_matrix=$php_lint_matrix" >> "$GITHUB_OUTPUT"
+          echo "Generated PHPStan / DI-compile matrix:"
+          echo "$matrix" | jq .
+          echo "Generated PHP lint matrix:"
+          echo "$php_lint_matrix" | jq .
+
   lint:
     name: Lint (PHP ${{ matrix.php }})
+    needs: discover-magento-matrix
     runs-on: ${{ vars.RUNNER_STANDARD }}
     strategy:
       fail-fast: false
       matrix:
-        # Trimmed to PHP versions the plugin actually runs on:
-        #   7.3 — minimum, exercised by DI compile (Magento 2.3.7)
-        #   7.4 — PHPUnit + DI compile (Magento 2.4.0)
-        #   8.1 — PHPUnit + DI compile + PHPStan (Magento 2.4.4)
-        #   8.2 — PHPUnit + DI compile + PHPStan (Magento 2.4.6)
-        # The original linting.yml lint'd 7.1/7.2/8.0 too, but the plugin's
-        # source uses PHP 7.3+ features (trailing commas in calls), so
-        # those older lints were dead checks that just hadn't run yet.
-        php: ["7.3", "7.4", "8.1", "8.2"]
+        include: ${{ fromJSON(needs.discover-magento-matrix.outputs.php_lint_matrix) }}
     steps:
       - uses: actions/checkout@v6
       - uses: shivammathur/setup-php@v2
@@ -42,8 +59,8 @@ jobs:
           tools: none
       - name: Lint PHP files
         # Test/ is excluded — tests are dev-only and use newer syntax
-        # (arrow functions, etc.) than the merchant runtime. The
-        # phpunit matrix already exercises Test/ on PHP 7.4+.
+        # than the merchant runtime. The phpunit matrix already
+        # exercises Test/ on the supported PHP minors.
         run: |
           find . -name '*.php' \
             -not -path './vendor/*' \
@@ -65,11 +82,12 @@ jobs:
 
   phpunit:
     name: PHPUnit (PHP ${{ matrix.php }})
+    needs: discover-magento-matrix
     runs-on: ${{ vars.RUNNER_STANDARD }}
     strategy:
       fail-fast: false
       matrix:
-        php: ["7.4", "8.1", "8.2"]
+        include: ${{ fromJSON(needs.discover-magento-matrix.outputs.php_lint_matrix) }}
     steps:
       - uses: actions/checkout@v6
 
@@ -78,17 +96,13 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: pcov
-
-      - name: Download PHPUnit
-        env:
-          PHPUNIT_VERSION: "9.6.34"
-          PHPUNIT_SHA256: "e7264ae61fe58a487c2bd741905b85940d8fbc2b32cf4a279949b6d9a172a06a"
-        run: |
-          php -r "copy('https://phar.phpunit.de/phpunit-${PHPUNIT_VERSION}.phar', 'phpunit.phar');"
-          echo "${PHPUNIT_SHA256}  phpunit.phar" | sha256sum -c -
+          # PHPUnit 10.5 supports PHP 8.1-8.4. If a future PHP minor
+          # (e.g. 8.5) enters the support window and PHPUnit 10.5 has
+          # not been updated to cover it, bump this pin to 11.x.
+          tools: phpunit:10.5
 
       - name: Run tests with coverage
-        run: php phpunit.phar --coverage-clover coverage.xml --coverage-text
+        run: phpunit --coverage-clover coverage.xml --coverage-text
 
       - name: Upload coverage artifact
         if: always()
@@ -100,17 +114,12 @@ jobs:
 
   phpstan:
     name: PHPStan (PHP ${{ matrix.php }}, Magento ${{ matrix.magento }})
+    needs: discover-magento-matrix
     runs-on: ${{ vars.RUNNER_STANDARD }}
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - php: "8.1"
-            php_image: php81-fpm
-            magento: 2.4.4
-          - php: "8.2"
-            php_image: php82-fpm
-            magento: 2.4.6
+        include: ${{ fromJSON(needs.discover-magento-matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v6
 
@@ -149,23 +158,12 @@ jobs:
 
   di-compile:
     name: DI compile (PHP ${{ matrix.php }}, Magento ${{ matrix.magento }})
+    needs: discover-magento-matrix
     runs-on: ${{ vars.RUNNER_STANDARD }}
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - php: "7.3"
-            php_image: php73-fpm
-            magento: 2.3.7
-          - php: "7.4"
-            php_image: php74-fpm
-            magento: 2.4.0
-          - php: "8.1"
-            php_image: php81-fpm
-            magento: 2.4.4
-          - php: "8.2"
-            php_image: php82-fpm
-            magento: 2.4.6
+        include: ${{ fromJSON(needs.discover-magento-matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v6
 

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
         "AFL-3.0"
     ],
     "require": {
-        "php": ">=7.3",
-        "magento/framework": ">=102.0.0"
+        "php": ">=8.1",
+        "magento/framework": ">=103.0.6"
     },
     "autoload": {
         "files": [

--- a/dev/magento-support-matrix.sh
+++ b/dev/magento-support-matrix.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# dev/magento-support-matrix.sh — discover the install-smoke / PHPStan
+# matrix dynamically from upstream.
+#
+# Usage:
+#   ./dev/magento-support-matrix.sh                       # human-readable report
+#   ./dev/magento-support-matrix.sh --emit-matrix         # GHA matrix JSON: Magento × PHP cross-product
+#   ./dev/magento-support-matrix.sh --emit-php-lint-matrix # GHA matrix JSON: PHP-only (for the PHP lint job)
+#
+# Strategy:
+#   1. Query github.com/magento/magento2 tags for bare-semver 2.4.x.
+#   2. Apply Adobe's lifecycle policy: current minor + N previous minors
+#      (default 2, ie. a 3-minor support window).
+#   3. Drop any version on `intentionally_excluded` (e.g. docker image
+#      not yet published by the CI-image maintainer).
+#   4. For each remaining Magento minor: fetch its raw composer.json
+#      and parse `require.php` to get the PHP constraint (e.g.
+#      "~8.2.0||~8.3.0||~8.4.0" → minors [8.2, 8.3, 8.4]).
+#   5. Query php.net/releases for currently-supported PHP minors
+#      (active + security). Intersect with the per-Magento constraint
+#      to drop combinations PHP itself no longer supports.
+#   6. Emit the cross-product as a GHA matrix.
+#
+# This replaces the hand-maintained EOL list AND the hand-maintained
+# min-PHP map with discovery from upstream (Doug 2026-05-22 follow-up
+# to r5 #10). The script is the single source of truth for which
+# Magento × PHP combinations CI exercises.
+
+set -euo pipefail
+
+# How many minor lines (current + previous) we claim to support. Adobe's
+# policy is "current + previous 2" → 3 total.
+SUPPORT_WINDOW=${SUPPORT_WINDOW:-3}
+
+# Versions Magento has published upstream but we cannot test yet
+# (e.g. michielgerritsen/magento-project-community-edition image not
+# built for that combination). Format: `<version>:<reason>`. Each entry
+# documents WHY a version is excluded so future maintainers know when
+# the exclusion can drop.
+intentionally_excluded=(
+    "2.4.9:michielgerritsen/magento-project-community-edition image not yet published for php83-fpm-magento2.4.9"
+)
+
+mode=report
+case "${1:-}" in
+    --emit-matrix) mode=matrix ;;
+    --emit-php-lint-matrix) mode=php_lint ;;
+    "") mode=report ;;
+    *) echo "Unknown flag: $1" >&2; exit 2 ;;
+esac
+
+log() {
+    [ "$mode" = "report" ] || return 0
+    echo "$@"
+}
+
+# Authorise GitHub API when a token is available to dodge anon rate-limit.
+gh_headers=()
+[ -n "${GH_TOKEN:-${GITHUB_TOKEN:-}}" ] \
+    && gh_headers=(-H "Authorization: Bearer ${GH_TOKEN:-$GITHUB_TOKEN}")
+
+# ---------------------------------------------------------------------------
+# Step 1: discover Magento support window from upstream tags.
+# ---------------------------------------------------------------------------
+tags_json=$(curl -sH 'Cache-Control: no-cache' "${gh_headers[@]}" \
+    'https://api.github.com/repos/magento/magento2/tags?per_page=100' \
+    || { echo "::error::Could not reach github.com/magento/magento2 tags" >&2; exit 2; })
+
+all_minors=$(echo "$tags_json" \
+    | jq -r 'map(.name)
+             | map(select(test("^2\\.4\\.[0-9]+$")))
+             | sort_by(. | split(".") | map(tonumber))
+             | reverse
+             | .[]')
+
+if [ -z "$all_minors" ]; then
+    echo "::error::No bare-semver 2.4.x tags found on github.com/magento/magento2" >&2
+    exit 2
+fi
+
+supported=$(echo "$all_minors" | head -n "$SUPPORT_WINDOW")
+log "Magento support window ($SUPPORT_WINDOW most-recent minors):"
+log "$supported" | sed 's/^/  /'
+
+# Build excluded map.
+declare -A excluded_map=()
+for entry in "${intentionally_excluded[@]:-}"; do
+    [ -z "$entry" ] && continue
+    ver="${entry%%:*}"
+    reason="${entry#*:}"
+    excluded_map["$ver"]="$reason"
+done
+
+# ---------------------------------------------------------------------------
+# Step 2: discover currently-supported PHP minors from php.net.
+# ---------------------------------------------------------------------------
+php_releases_json=$(curl -sH 'Cache-Control: no-cache' \
+    'https://www.php.net/releases/?json' \
+    || { echo "::error::Could not reach php.net/releases JSON feed" >&2; exit 2; })
+
+# Union of `supported_versions` across all majors, e.g. ["8.2","8.3","8.4","8.5"].
+supported_php_minors=$(echo "$php_releases_json" \
+    | jq -r '[.[].supported_versions[]?] | unique | .[]' \
+    | sort -V)
+
+if [ -z "$supported_php_minors" ]; then
+    echo "::error::php.net/releases returned no currently-supported PHP minors" >&2
+    exit 2
+fi
+
+log "Currently-supported PHP minors (php.net):"
+log "$supported_php_minors" | sed 's/^/  /'
+
+# ---------------------------------------------------------------------------
+# Step 3: for each Magento minor, fetch composer.json and parse php constraint.
+#
+# Magento's constraint format is "~8.2.0||~8.3.0||~8.4.0" — one tilde
+# range per supported minor, OR-joined. `~8.X.0` means ">=8.X.0,<8.(X+1).0",
+# so each clause uniquely identifies one PHP minor.
+# ---------------------------------------------------------------------------
+declare -A magento_php_minors=()  # magento_minor → space-separated PHP minors
+for minor in $supported; do
+    [ -n "${excluded_map[$minor]:-}" ] && continue
+    composer_json=$(curl -sH 'Cache-Control: no-cache' "${gh_headers[@]}" \
+        "https://raw.githubusercontent.com/magento/magento2/$minor/composer.json")
+    php_constraint=$(echo "$composer_json" | jq -r '.require.php // empty')
+    if [ -z "$php_constraint" ]; then
+        echo "::error::magento/magento2@$minor composer.json missing require.php" >&2
+        exit 2
+    fi
+    # Extract every "~X.Y.0" clause → "X.Y".
+    php_minors_for_magento=$(echo "$php_constraint" \
+        | grep -oE '~[0-9]+\.[0-9]+\.0' \
+        | sed -E 's/~([0-9]+\.[0-9]+)\.0/\1/' \
+        | sort -V)
+    if [ -z "$php_minors_for_magento" ]; then
+        echo "::error::Could not parse php constraint '$php_constraint' for Magento $minor" >&2
+        exit 2
+    fi
+    magento_php_minors["$minor"]=$(echo $php_minors_for_magento)
+    log "  $minor accepts PHP: ${magento_php_minors[$minor]} (from '$php_constraint')"
+done
+
+# ---------------------------------------------------------------------------
+# Step 4: build the cross-product matrix, intersected with PHP support.
+# ---------------------------------------------------------------------------
+matrix_entries=()
+excluded_warnings=()
+declare -A php_lint_minors=()  # union of PHP minors actually emitted
+
+for minor in $supported; do
+    if [ -n "${excluded_map[$minor]:-}" ]; then
+        excluded_warnings+=("$minor — ${excluded_map[$minor]}")
+        continue
+    fi
+    accepted="${magento_php_minors[$minor]:-}"
+    [ -z "$accepted" ] && continue
+
+    # Intersect Magento's accepted PHP with php.net-supported PHP.
+    matched=()
+    for php in $accepted; do
+        if echo "$supported_php_minors" | grep -qxF "$php"; then
+            matched+=("$php")
+        fi
+    done
+    if [ ${#matched[@]} -eq 0 ]; then
+        excluded_warnings+=("$minor — every PHP in '$accepted' is past upstream PHP support")
+        continue
+    fi
+
+    for php in "${matched[@]}"; do
+        php_image="php$(echo "$php" | tr -d '.')-fpm"
+        matrix_entries+=("$(jq -nc \
+            --arg magento "$minor" \
+            --arg php "$php" \
+            --arg php_image "$php_image" \
+            '{magento: $magento, php: $php, php_image: $php_image}')")
+        php_lint_minors["$php"]=1
+    done
+done
+
+if [ ${#excluded_warnings[@]} -gt 0 ]; then
+    log "Excluded from this run:"
+    for w in "${excluded_warnings[@]}"; do
+        log "  $w"
+    done
+fi
+
+if [ ${#matrix_entries[@]} -eq 0 ]; then
+    echo "::error::Support matrix is empty — every supported minor is excluded" >&2
+    exit 1
+fi
+
+matrix_json=$(printf '%s\n' "${matrix_entries[@]}" | jq -sc '.')
+php_lint_json=$(printf '%s\n' "${!php_lint_minors[@]}" \
+    | sort -V \
+    | jq -R . | jq -sc 'map({php: .})')
+
+case "$mode" in
+    matrix)
+        echo "$matrix_json"
+        ;;
+    php_lint)
+        echo "$php_lint_json"
+        ;;
+    report)
+        echo "Install-smoke / PHPStan matrix:"
+        echo "$matrix_json" | jq .
+        echo ""
+        echo "PHP lint matrix:"
+        echo "$php_lint_json" | jq .
+        echo ""
+        echo "magento-support-matrix OK."
+        ;;
+esac


### PR DESCRIPTION
## Summary

- Replaces the hand-maintained CI matrices (which had drifted to test PHP 7.3-8.2 against Magento 2.3.7/2.4.0/2.4.4/2.4.6, none of which is currently supported) with a discovery script.
- Lifts \`dev/magento-support-matrix.sh\` from \`magento-abn-plugin\` and wires a \`discover-magento-matrix\` job; downstream lint / phpunit / phpstan / di-compile jobs consume it via \`needs:\` + \`fromJSON()\`.
- Bumps composer.json \`require.php\` floor to \`>=8.1\` and \`require.magento/framework\` to \`>=103.0.6\` (lowest currently-supported Magento, 2.4.6).
- Switches phpunit job from pinned PHPUnit 9.6.34 phar to setup-php's \`tools: phpunit:10.5\` (PHP 8.1-8.4).
- Fixes two latent bugs in the discovery script that the first real run surfaced: exclude-before-slice, and combo-level (Magento × PHP) exclusion. Ported back to magento-abn-plugin in a sibling PR.

## Discovery chain

1. github.com/magento/magento2 tags → bare-semver 2.4.x.
2. Filter out fully-excluded minors (e.g. 2.4.9, no published docker image yet), then take the most-recent N minors (default 3 = current + 2 previous).
3. Fetch each Magento minor's composer.json → parse \`require.php\`.
4. Intersect with php.net's active + security PHP minors.
5. Drop combo-level exclusions (e.g. (PHP 8.2, Magento 2.4.8) — no published image despite Adobe's composer accepting that combo).
6. Emit the cross-product as a GHA matrix.

## Expected matrix (today, 2026-05-22)

- Lint / PHPUnit (PHP-only): 8.2, 8.3, 8.4.
- PHPStan / DI-compile (Magento × PHP): 2.4.6×8.2, 2.4.7×{8.2,8.3}, 2.4.8×{8.3,8.4}.

## No cron

The matrix re-resolves on every PR push, so upstream drift (new Magento minor, new PHP support, expired PHP minor) is caught the next time anyone touches the repo. A weekly cron with no listener would just be silent-green noise.

## Test plan

- [ ] \`discover-magento-matrix\` job runs and emits the matrix above.
- [ ] \`lint\`, \`phpunit\`, \`phpstan\`, \`di-compile\` all expand from the dynamic matrix and go green.
- [ ] No PHP 7.x or Magento 2.3.x / 2.4.0 / 2.4.4 jobs appear in the checks list.