### PR TITLE
feat: Brand value-object and GenericPaymentMethod for brand-overlay packages

### DIFF
--- a/Model/Brand.php
+++ b/Model/Brand.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Model;
+
+use Two\Gateway\Api\BrandRegistryInterface;
+
+/**
+ * Value-object implementation of BrandRegistryInterface, intended to
+ * be configured via DI virtualType in brand-overlay packages.
+ *
+ * Brand overlays declare a virtualType of `Two\Gateway\Model\Brand`
+ * with their own provider / productName / checkoutUrlTemplate / etc
+ * constructor arguments, then bind the BrandRegistryInterface
+ * preference to that virtualType to inject brand-specific values
+ * throughout the gateway.
+ *
+ * The default Two binding lives at Two\Gateway\Brand\TwoBrand and
+ * does not use this class — it returns its values directly from
+ * hardcoded methods. This class exists to let downstream brand
+ * overlays declare a brand without writing a new PHP class for it.
+ */
+class Brand implements BrandRegistryInterface
+{
+    /** @var string */
+    private $provider;
+    /** @var string */
+    private $providerFullName;
+    /** @var string */
+    private $productName;
+    /** @var string */
+    private $checkoutUrlTemplate;
+    /** @var int[] */
+    private $availablePaymentTerms;
+    /** @var array{amount: float, currency: string}|null */
+    private $surchargeFixedMax;
+    /** @var string */
+    private $signUpUrl;
+    /** @var string */
+    private $documentationUrl;
+    /** @var string */
+    private $brandTag;
+
+    /**
+     * @param int[] $availablePaymentTerms
+     * @param array{amount: float, currency: string}|null $surchargeFixedMax
+     */
+    public function __construct(
+        string $provider,
+        string $providerFullName,
+        string $productName,
+        string $checkoutUrlTemplate,
+        array $availablePaymentTerms,
+        ?array $surchargeFixedMax = null,
+        string $signUpUrl = '',
+        string $documentationUrl = '',
+        string $brandTag = ''
+    ) {
+        $this->provider = $provider;
+        $this->providerFullName = $providerFullName;
+        $this->productName = $productName;
+        $this->checkoutUrlTemplate = $checkoutUrlTemplate;
+        $this->availablePaymentTerms = $availablePaymentTerms;
+        $this->surchargeFixedMax = $surchargeFixedMax;
+        $this->signUpUrl = $signUpUrl;
+        $this->documentationUrl = $documentationUrl;
+        $this->brandTag = $brandTag;
+    }
+
+    public function getProvider(): string
+    {
+        return $this->provider;
+    }
+
+    public function getProviderFullName(): string
+    {
+        return $this->providerFullName;
+    }
+
+    public function getProductName(): string
+    {
+        return $this->productName;
+    }
+
+    public function getCheckoutUrlTemplate(): string
+    {
+        return $this->checkoutUrlTemplate;
+    }
+
+    public function getAvailablePaymentTerms(): array
+    {
+        return $this->availablePaymentTerms;
+    }
+
+    public function getSurchargeFixedMax(): ?array
+    {
+        return $this->surchargeFixedMax;
+    }
+
+    public function getSignUpUrl(): string
+    {
+        return $this->signUpUrl;
+    }
+
+    public function getDocumentationUrl(): string
+    {
+        return $this->documentationUrl;
+    }
+
+    public function getBrandTag(): string
+    {
+        return $this->brandTag;
+    }
+}

--- a/Model/GenericPaymentMethod.php
+++ b/Model/GenericPaymentMethod.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Model;
+
+use Magento\Framework\Api\AttributeValueFactory;
+use Magento\Framework\Api\ExtensionAttributesFactory;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Data\Collection\AbstractDb;
+use Magento\Framework\Model\Context;
+use Magento\Framework\Model\ResourceModel\AbstractResource;
+use Magento\Framework\Registry;
+use Magento\Payment\Helper\Data;
+use Magento\Payment\Model\Method\Logger;
+use Magento\Sales\Api\OrderStatusHistoryRepositoryInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\Order\Status\HistoryFactory;
+use Two\Gateway\Api\BrandRegistryInterface;
+use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
+use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
+use Two\Gateway\Service\Api\Adapter;
+use Two\Gateway\Service\Order\ComposeCapture;
+use Two\Gateway\Service\Order\ComposeOrder;
+use Two\Gateway\Service\Order\ComposeRefund;
+use Two\Gateway\Service\UrlCookie;
+
+/**
+ * Brand-parameterised variant of the Two payment method.
+ *
+ * Brand-overlay packages declare a virtualType of this class with
+ * `code` (Magento payment method code) and `brand` (BrandRegistryInterface)
+ * constructor arguments. Magento's ObjectManager resolves the named
+ * arguments at instantiation time, so a single virtualType per brand
+ * is sufficient to expose a distinct payment method without copying
+ * the 600-line Two class.
+ *
+ * Example brand-overlay binding (in the overlay package's etc/di.xml):
+ *
+ *   <virtualType name="ABN\Gateway\Model\AbnPayment"
+ *                type="Two\Gateway\Model\GenericPaymentMethod">
+ *       <arguments>
+ *           <argument name="code" xsi:type="string">abn_payment</argument>
+ *           <argument name="brand" xsi:type="object">ABN\Gateway\Model\AbnBrand</argument>
+ *       </arguments>
+ *   </virtualType>
+ *
+ * The default Two-branded binding continues to use the parent `Two`
+ * class directly via `etc/config.xml` `<model>`. See magento-abn-plugin
+ * docs/implementation-plan.md §3.1 + §6.1 for the design.
+ */
+class GenericPaymentMethod extends Two
+{
+    /**
+     * @param string $code Magento payment-method code (overlay-specific).
+     * @param BrandRegistryInterface $brand Overlay brand binding.
+     */
+    public function __construct(
+        string $code,
+        BrandRegistryInterface $brand,
+        RequestInterface $request,
+        Context $context,
+        Registry $registry,
+        ExtensionAttributesFactory $extensionFactory,
+        AttributeValueFactory $customAttributeFactory,
+        ConfigRepository $configRepository,
+        Data $paymentData,
+        ScopeConfigInterface $scopeConfig,
+        Logger $logger,
+        UrlCookie $urlCookie,
+        ComposeOrder $composeOrder,
+        ComposeRefund $composeRefund,
+        ComposeCapture $composeCapture,
+        HistoryFactory $historyFactory,
+        OrderStatusHistoryRepositoryInterface $orderStatusHistoryRepository,
+        OrderRepositoryInterface $orderRepository,
+        Adapter $apiAdapter,
+        LogRepository $logRepository,
+        AbstractResource $resource = null,
+        AbstractDb $resourceCollection = null,
+        array $data = []
+    ) {
+        parent::__construct(
+            $request,
+            $context,
+            $registry,
+            $extensionFactory,
+            $customAttributeFactory,
+            $configRepository,
+            $brand,
+            $paymentData,
+            $scopeConfig,
+            $logger,
+            $urlCookie,
+            $composeOrder,
+            $composeRefund,
+            $composeCapture,
+            $historyFactory,
+            $orderStatusHistoryRepository,
+            $orderRepository,
+            $apiAdapter,
+            $logRepository,
+            $resource,
+            $resourceCollection,
+            $data
+        );
+        // Brand-overlay payment-method code, e.g. 'abn_payment'. Replaces
+        // the hardcoded `self::CODE` baked into the parent Two class so a
+        // single class can back multiple brand-overlay virtualTypes.
+        $this->_code = $code;
+    }
+}


### PR DESCRIPTION
Adds Two\Gateway\Model\Brand value-object and Two\Gateway\Model\GenericPaymentMethod (Two subclass with `code` + `brand` constructor args) so brand-overlay packages (magento-abn-plugin) can declare a payment method via DI virtualType without copying the 654-line Two class.

Default Two-branded etc/config.xml model is unchanged so existing merchants continue to instantiate Two directly. Both new classes are reachable only via virtualType - additive change.

magento-abn-plugin@staging/plugin/etc/di.xml references both types (`Model\Brand` for AbnBrand, `Model\GenericPaymentMethod` for AbnPayment). Without them, abn checkout 500s on beta staging with ReflectionException.

Phase 1 §3.1 + §3.1.3 of magento-abn-plugin docs/implementation-plan.md.