### PR TITLE
fix(checkout): dynamic admin title, Company number label, clear stale terms error

### DIFF
--- a/Model/Two.php
+++ b/Model/Two.php
@@ -273,6 +273,36 @@ class Two extends AbstractMethod
     }
 
     /**
+     * Title for admin order display.
+     *
+     * The merchant-configured title (e.g. "Business Invoice - 30 days") is
+     * static and may include a hand-typed duration suffix that does not
+     * reflect the buyer's actual term selection. When the payment info
+     * instance carries the persisted term, strip any trailing "- N days"
+     * suffix from the configured title and append the real selected term.
+     *
+     * Falls through to the parent (merchant-configured) title when no info
+     * instance is bound (admin grid, emails outside an order context) or
+     * when the order pre-dates the terms-in-additional_information payload.
+     */
+    public function getTitle()
+    {
+        $title = parent::getTitle();
+        try {
+            $info = $this->getInfoInstance();
+        } catch (\Exception $e) {
+            return $title;
+        }
+        $terms = $info->getAdditionalInformation('terms');
+        if (!is_array($terms) || empty($terms['duration_days'])) {
+            return $title;
+        }
+        $days = (int)$terms['duration_days'];
+        $base = preg_replace('/\s*-\s*\d+\s*days?\s*$/i', '', (string)$title);
+        return sprintf('%s - %d days', $base, $days);
+    }
+
+    /**
      *
      *
      * @param Phrase $message

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -299,6 +299,10 @@ define([
                 isPaymentTermsAccepted: this.isPaymentTermsAccepted()
             });
             if (event) event.preventDefault();
+            // Clear stale validation errors from a prior placeOrder attempt so
+            // resubmits don't render outdated messages (e.g. terms-not-accepted
+            // lingering after the box has been ticked).
+            this.messageContainer.clear();
             if (this.isPaymentTermsEnabled && !this.isPaymentTermsAccepted()) {
                 this.processTermsNotAcceptedErrorResponse();
                 return;

--- a/view/frontend/web/template/payment/gateway_method.html
+++ b/view/frontend/web/template/payment/gateway_method.html
@@ -158,7 +158,7 @@
                 </div>
                 <div class="field field-text required">
                     <label for="company_id" class="label">
-                        <span><!-- ko i18n: 'KVK number'--><!-- /ko --></span>
+                        <span><!-- ko i18n: 'Company number'--><!-- /ko --></span>
                     </label>
                     <div class="control">
                         <input
@@ -168,7 +168,7 @@
                             required="true"
                             data-bind='
                             attr: {
-                                title: $t("KVK number")
+                                title: $t("Company number")
                             },
                             value: companyId'
                             class="input-text"


### PR DESCRIPTION
## Summary

Three checkout/admin fixes surfaced during browser testing:

1. **Admin Payment Information caption is now dynamic.** Previously the admin order detail rendered the merchant-configured title verbatim (e.g. "Business Invoice - 30 days") regardless of which net term the buyer actually selected. `Two::getTitle()` now reads the persisted term from `additional_information.terms.duration_days`, strips any trailing `- N days` suffix from the configured title, and appends the actual selected duration. Falls through cleanly to the configured title when no info instance is bound (grid views, legacy orders).

2. **"KVK number" → "Company number"** in the storefront checkout label (`gateway_method.html`). KVK is NL-only (Kamer van Koophandel); UK / SE / NO / DE shops on the vanilla brand were rendering the source string and showing a Dutch identifier verbatim. Brand overlays (e.g. ABN) translate the new "Company number" key per locale.

3. **Clear stale validation errors on resubmit.** A "You must accept payment terms" message lingered briefly when the buyer re-submitted with terms ticked, before the next API round-trip overwrote it. `placeOrder` now clears the payment-method `messageContainer` at entry.

## Test plan

- [ ] Place an order with each configured term and confirm admin order detail Payment Information shows the chosen term, not the merchant default
- [ ] Confirm storefront checkout label reads "Company number" on UK / NL / SE / NO stores on the vanilla brand
- [ ] Tick payment-terms checkbox after the warning has shown and confirm the message clears immediately on resubmit
- [ ] Legacy orders (pre-terms-in-additional-information): admin title falls back to configured value without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)