### PR TITLE
fix: capture brandConfig before iteration to preserve KO context

### DIFF
--- a/Test/Js/gateway-method-this-context.test.js
+++ b/Test/Js/gateway-method-this-context.test.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ *
+ * Guard against the regression where `this._brandConfig` is referenced
+ * inside an iteration callback that doesn't preserve renderer `this`.
+ *
+ * The brand-overlay refactor (#128) moved per-instance config reads
+ * onto `this._brandConfig`, but the renderer still uses `_.each(...,
+ * function () { ... })` and `.forEach(function () { ... })` callbacks
+ * in several methods. Inside those callbacks `this` is NOT the KO
+ * component — `this._brandConfig` would be `undefined` and any deref
+ * throws `TypeError: Cannot read properties of undefined`.
+ *
+ * The fix everywhere is to capture `var x = this._brandConfig` (or
+ * use an arrow function / `_.each(..., fn, this)`). This test reads
+ * the renderer source and asserts no `function (...) { ...
+ * this._brandConfig... }` shape exists inside a `_.each` or
+ * `.forEach` body.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const SRC = fs.readFileSync(
+    path.resolve(__dirname, '../../view/frontend/web/js/view/payment/method-renderer/gateway_method.js'),
+    'utf8'
+);
+
+describe('gateway_method.js `this._brandConfig` lexical-this safety', () => {
+    /**
+     * Walks the source looking for a `_.each(...)` or `.forEach(...)`
+     * call where the callback is a `function (...)` (NOT an arrow),
+     * and the body of that callback references `this._brandConfig`.
+     * Returns the offending substrings (line + matched body) so test
+     * failures point at exactly the regression site.
+     */
+    function findUnsafeBrandConfigDerefs(src) {
+        const offenders = [];
+        // Match _.each(<args>, function (<params>) { <body> })
+        // and obj.forEach(function (<params>) { <body> }).
+        // The body match stops at the first `})` that closes the IIFE
+        // — non-greedy ensures we don't span across calls.
+        const re = /(?:_\.each\s*\([^,]+,\s*|\.forEach\s*\(\s*)function\s*\([^)]*\)\s*\{([\s\S]*?)\}\)/g;
+        let m;
+        while ((m = re.exec(src)) !== null) {
+            const body = m[1];
+            if (/\bthis\._brandConfig\b/.test(body)) {
+                const before = src.slice(0, m.index).split('\n').length;
+                offenders.push({ line: before, body: body.trim().slice(0, 200) });
+            }
+        }
+        return offenders;
+    }
+
+    it('contains no `this._brandConfig` reference inside a non-arrow iteration callback', () => {
+        const offenders = findUnsafeBrandConfigDerefs(SRC);
+        expect(offenders).toEqual([]);
+    });
+});

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -407,6 +407,10 @@ define([
                 }
             }
 
+            // Capture brand config before the iteration so the callback
+            // closure has access to it — arrow-fn would also work but
+            // keeping the existing `function` shape minimises diff.
+            var brandConfig = this._brandConfig;
             _.each(quote.getItems(), function (item) {
                 lineItems.push({
                     name: item['name'],
@@ -419,7 +423,7 @@ define([
                     tax_amount: parseFloat(item['tax_amount']).toFixed(2),
                     tax_rate: (parseFloat(item['tax_percent']) / 100).toFixed(6),
                     tax_class_name: '',
-                    quantity_unit: this._brandConfig.orderIntentConfig.weightUnit,
+                    quantity_unit: brandConfig.orderIntentConfig.weightUnit,
                     image_url: item['thumbnail'],
                     type: item['is_virtual'] === '0' ? 'PHYSICAL' : 'DIGITAL'
                 });


### PR DESCRIPTION
Live regression from the #128 refactor. \`placeOrderIntent\` does:

```js
_.each(quote.getItems(), function (item) {
    lineItems.push({
        ...
        quantity_unit: this._brandConfig.orderIntentConfig.weightUnit,
        ...
    });
});
```

Inside the underscore callback `this` is not the KO component, so `this._brandConfig` is `undefined` and the property access throws:

```
TypeError: Cannot read properties of undefined (reading "_brandConfig")
  at gateway_method.js:422
```

Captured during manual abn checkout testing. Two-branded merchants happen not to trip it because the callsite is in `placeOrderIntent`, only called when `isOrderIntentEnabled` config flag is true; abn has it on.

## Fix
Capture `var brandConfig = this._brandConfig;` outside the iteration so the closure has the right value. Same shape as the existing `var self = this` pattern elsewhere in the file.

## Regression guard
New `Test/Js/gateway-method-this-context.test.js` scans the renderer source for any `_.each(..., function (...))` or `.forEach(function (...))` whose body references `this._brandConfig`. The test fails-fast if anyone reintroduces the pattern.

`npm test` → 21 passed (3 suites, was 20).