### PR TITLE
feat: hide two_payment admin section when a brand overlay is installed

### DIFF
--- a/Api/BrandOverlayRegistryInterface.php
+++ b/Api/BrandOverlayRegistryInterface.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Two\Gateway\Api;
+
+/**
+ * Registry of brand-overlay packages that have declared themselves
+ * present in this Magento install.
+ *
+ * Overlay packages (e.g. ABN_Gateway) register their payment method
+ * code with the registry via DI, telling Two_Gateway "an alternative
+ * brand-bound payment method is installed alongside me". Two_Gateway
+ * uses this to drive UX decisions like hiding the parent-brand
+ * `two_payment` admin config section so merchants don't see two
+ * configurable payment groups by default.
+ *
+ * Behaviour:
+ *   - Empty registry (no overlays declared) = standalone Two_Gateway
+ *     install. Admin shows `two_payment` as normal.
+ *   - Non-empty registry = at least one overlay installed. Admin
+ *     hides `two_payment` by default; merchant opts in to re-show
+ *     via `payment/two_payment/hide_when_overlay_installed = 0`.
+ */
+interface BrandOverlayRegistryInterface
+{
+    /**
+     * @return bool True iff at least one overlay package is registered.
+     */
+    public function isOverlayInstalled(): bool;
+
+    /**
+     * @return array<string, string> Map of overlay key => method code.
+     */
+    public function getOverlays(): array;
+}

--- a/Model/BrandOverlayRegistry.php
+++ b/Model/BrandOverlayRegistry.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Two\Gateway\Model;
+
+use Two\Gateway\Api\BrandOverlayRegistryInterface;
+
+class BrandOverlayRegistry implements BrandOverlayRegistryInterface
+{
+    /** @var array<string, string> */
+    private array $overlays;
+
+    /**
+     * @param array<string, string> $overlays Map of overlay key => method
+     *        code. Overlay packages add entries via DI argument injection.
+     */
+    public function __construct(array $overlays = [])
+    {
+        $this->overlays = $overlays;
+    }
+
+    public function isOverlayInstalled(): bool
+    {
+        return $this->overlays !== [];
+    }
+
+    public function getOverlays(): array
+    {
+        return $this->overlays;
+    }
+}

--- a/Plugin/Config/Structure/HidePaymentSection.php
+++ b/Plugin/Config/Structure/HidePaymentSection.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Two\Gateway\Plugin\Config\Structure;
+
+use Magento\Config\Model\Config\Structure;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Two\Gateway\Api\BrandOverlayRegistryInterface;
+
+/**
+ * Hide the `two_payment` admin config section when:
+ *   - At least one brand overlay (e.g. ABN_Gateway) is registered, AND
+ *   - `payment/two_payment/hide_when_overlay_installed` resolves to truthy.
+ *
+ * Both conditions default to true on overlay-installed merchants
+ * (registry populated by overlay DI, config default = 1). Merchants
+ * who want both parent-brand and overlay-brand payment methods
+ * configurable in admin can opt out with:
+ *
+ *     bin/magento config:set payment/two_payment/hide_when_overlay_installed 0
+ *     bin/magento cache:flush
+ *
+ * Returning null from afterGetElement makes the section invisible to
+ * the admin config UI: the left-nav stops listing it, and direct
+ * URL access (?section=two_payment) renders empty since `Structure`
+ * is the authoritative element source. Returning null does not
+ * delete any persisted CCD value; the overlay's `etc/config.xml`
+ * still defaults `payment/two_payment/active = 0` as belt-and-braces.
+ */
+class HidePaymentSection
+{
+    private const HIDE_FLAG_PATH = 'payment/two_payment/hide_when_overlay_installed';
+    private const TARGET_SECTION = 'two_payment';
+
+    public function __construct(
+        private readonly BrandOverlayRegistryInterface $overlayRegistry,
+        private readonly ScopeConfigInterface $scopeConfig
+    ) {
+    }
+
+    /**
+     * @param Structure $subject
+     * @param mixed     $result Whatever Structure::getElement returned.
+     * @param string    $path   Section/group path being resolved.
+     * @return mixed Null if the section should be hidden, original $result otherwise.
+     */
+    public function afterGetElement(Structure $subject, $result, $path)
+    {
+        if (!$this->matchesTarget($path)) {
+            return $result;
+        }
+        if (!$this->shouldHide()) {
+            return $result;
+        }
+        return null;
+    }
+
+    private function matchesTarget(string $path): bool
+    {
+        return $path === self::TARGET_SECTION
+            || str_starts_with($path, self::TARGET_SECTION . '/');
+    }
+
+    private function shouldHide(): bool
+    {
+        if (!$this->overlayRegistry->isOverlayInstalled()) {
+            return false;
+        }
+        return (bool)$this->scopeConfig->getValue(self::HIDE_FLAG_PATH);
+    }
+}

--- a/Test/Unit/Model/BrandOverlayRegistryTest.php
+++ b/Test/Unit/Model/BrandOverlayRegistryTest.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Model;
+
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Model\BrandOverlayRegistry;
+
+class BrandOverlayRegistryTest extends TestCase
+{
+    public function testEmptyByDefault(): void
+    {
+        $registry = new BrandOverlayRegistry();
+        $this->assertFalse($registry->isOverlayInstalled());
+        $this->assertSame([], $registry->getOverlays());
+    }
+
+    public function testReportsInstalledWhenConstructorReceivesEntries(): void
+    {
+        $registry = new BrandOverlayRegistry(['abn' => 'abn_payment']);
+        $this->assertTrue($registry->isOverlayInstalled());
+        $this->assertSame(['abn' => 'abn_payment'], $registry->getOverlays());
+    }
+}

--- a/Test/Unit/Plugin/Config/Structure/HidePaymentSectionTest.php
+++ b/Test/Unit/Plugin/Config/Structure/HidePaymentSectionTest.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Plugin\Config\Structure;
+
+use Magento\Config\Model\Config\Structure;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Api\BrandOverlayRegistryInterface;
+use Two\Gateway\Plugin\Config\Structure\HidePaymentSection;
+
+class HidePaymentSectionTest extends TestCase
+{
+    private function plugin(bool $overlayInstalled, bool $hideFlag): HidePaymentSection
+    {
+        $registry = $this->createMock(BrandOverlayRegistryInterface::class);
+        $registry->method('isOverlayInstalled')->willReturn($overlayInstalled);
+
+        $scope = $this->createMock(ScopeConfigInterface::class);
+        $scope->method('getValue')
+            ->with('payment/two_payment/hide_when_overlay_installed')
+            ->willReturn($hideFlag ? '1' : '0');
+
+        return new HidePaymentSection($registry, $scope);
+    }
+
+    public function testPassThroughForUnrelatedSection(): void
+    {
+        $plugin = $this->plugin(true, true);
+        $sentinel = new \stdClass();
+        $this->assertSame(
+            $sentinel,
+            $plugin->afterGetElement($this->createMock(Structure::class), $sentinel, 'payment')
+        );
+    }
+
+    public function testPassThroughWhenNoOverlayInstalled(): void
+    {
+        $plugin = $this->plugin(false, true);
+        $sentinel = new \stdClass();
+        $this->assertSame(
+            $sentinel,
+            $plugin->afterGetElement($this->createMock(Structure::class), $sentinel, 'two_payment')
+        );
+    }
+
+    public function testPassThroughWhenHideFlagDisabled(): void
+    {
+        $plugin = $this->plugin(true, false);
+        $sentinel = new \stdClass();
+        $this->assertSame(
+            $sentinel,
+            $plugin->afterGetElement($this->createMock(Structure::class), $sentinel, 'two_payment')
+        );
+    }
+
+    public function testHidesSectionWhenOverlayAndFlagBothSet(): void
+    {
+        $plugin = $this->plugin(true, true);
+        $this->assertNull(
+            $plugin->afterGetElement($this->createMock(Structure::class), new \stdClass(), 'two_payment')
+        );
+    }
+
+    public function testHidesNestedGroupUnderTargetSection(): void
+    {
+        $plugin = $this->plugin(true, true);
+        $this->assertNull(
+            $plugin->afterGetElement(
+                $this->createMock(Structure::class),
+                new \stdClass(),
+                'two_payment/payment_method'
+            )
+        );
+    }
+}

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -13,4 +13,14 @@
         <plugin name="two-creditmemo-surcharge-override"
                 type="Two\Gateway\Plugin\Model\Sales\CreditmemoSurchargeOverride" sortOrder="10"/>
     </type>
+    <!--
+        Hide the parent-brand `two_payment` config section in admin when a
+        brand overlay is installed and the merchant hasn't opted in to
+        seeing both. See Two\Gateway\Plugin\Config\Structure\HidePaymentSection.
+    -->
+    <type name="Magento\Config\Model\Config\Structure">
+        <plugin name="two-hide-payment-section-when-overlay-installed"
+                type="Two\Gateway\Plugin\Config\Structure\HidePaymentSection"
+                sortOrder="10"/>
+    </type>
 </config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -15,6 +15,17 @@
         <payment>
             <two_payment>
                 <active>1</active>
+                <!--
+                    When a brand overlay (e.g. ABN_Gateway) is installed
+                    alongside Two_Gateway, hide the `two_payment` admin
+                    config section by default. Merchants who want both
+                    parent-brand and overlay-brand payment methods
+                    configurable in admin can disable the hide:
+                      bin/magento config:set payment/two_payment/hide_when_overlay_installed 0
+                      bin/magento cache:flush
+                    Has no effect when no overlay is registered.
+                -->
+                <hide_when_overlay_installed>1</hide_when_overlay_installed>
                 <version>1.14.1</version>
                 <title>Two</title>
                 <sort_order>-10</sort_order>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -22,6 +22,14 @@
     <!-- Default brand binding. Overlay packages may rebind via their own DI preference. -->
     <preference for="Two\Gateway\Api\BrandRegistryInterface"
                 type="Two\Gateway\Brand\TwoBrand"/>
+    <!--
+        Brand overlay registry. The default implementation reads its
+        `overlays` constructor argument; overlay packages append entries
+        via <type name="...BrandOverlayRegistry"> in their own etc/di.xml.
+        Empty by default = standalone Two_Gateway install.
+    -->
+    <preference for="Two\Gateway\Api\BrandOverlayRegistryInterface"
+                type="Two\Gateway\Model\BrandOverlayRegistry"/>
     <!-- Default outbound-API translator: passthrough. Brand overlays rebind. -->
     <preference for="Two\Gateway\Api\ApiTranslatorInterface"
                 type="Two\Gateway\Model\ApiTranslator\NullApiTranslator"/>


### PR DESCRIPTION
## Why

Two_Gateway and brand-overlay packages (ABN_Gateway, future siblings) can be installed side-by-side. By default an overlay merchant should not see the parent-brand `two_payment` section in admin config — they only configure their own brand. They should be able to opt back in if they want both methods active.

PR [magento-abn-plugin#86](https://github.com/two-inc/magento-abn-plugin/pull/86) (merged) sets `payment/two_payment/active = 0` so the buyer-facing checkout no longer surfaces `two_payment`. But the admin config section remains visible. This PR hides the section entirely.

## How

1. **`BrandOverlayRegistryInterface`** — overlay packages register their method code via DI argument injection on `Two\Gateway\Model\BrandOverlayRegistry`. Empty by default = standalone install.

2. **`HidePaymentSection` plugin** on `Magento\Config\Model\Config\Structure::getElement()`. Returns null for path `two_payment` (and any nested group) when:
   - Registry non-empty (overlay installed), AND
   - `payment/two_payment/hide_when_overlay_installed = 1` (default).

3. **New config field** `payment/two_payment/hide_when_overlay_installed` defaults to `1` in `etc/config.xml`. Standalone installs (no overlay registered) are not affected.

4. **Admin-area-only**: the plugin is registered in `etc/adminhtml/di.xml`. Structure is not consulted on frontend.

## Merchant opt-in to see two_payment again

```
bin/magento config:set payment/two_payment/hide_when_overlay_installed 0
bin/magento cache:flush
```

## Impact

- **Standalone Two_Gateway**: no change (registry empty).
- **Overlay-installed (ABN-Gateway)**: `two_payment` section disappears from admin nav and renders empty on direct URL.
- **Existing CCD values**: preserved. Active toggle still flippable via opt-in.
- **Buyer-facing checkout**: unchanged by this PR. Gated separately via `payment/two_payment/active` (handled by abn-plugin#86).

## Tests

- `BrandOverlayRegistryTest` — empty / populated behaviour.
- `HidePaymentSectionTest` — passes through unrelated paths, no-overlay installs, flag-disabled merchants; returns null only when both conditions hold; nested path matching.

## Followups (separate PRs)

- ABN-Gateway registers `abn_payment` as an overlay via `Two\Gateway\Model\BrandOverlayRegistry` DI arguments. Without this, the registry stays empty on ABN installs and the plugin no-ops.