### PR TITLE
fix: company-search ajax.url callback this-context (follow-up to #132)

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -536,13 +536,13 @@ define([
                                 url: function (params) {
                                     const queryParams = new URLSearchParams({
                                         country: self.countryCode()?.toUpperCase(),
-                                        limit: this._brandConfig.companySearchLimit,
+                                        limit: self._brandConfig.companySearchLimit,
                                         offset:
-                                            ((params.page || 1) - 1) * this._brandConfig.companySearchLimit,
+                                            ((params.page || 1) - 1) * self._brandConfig.companySearchLimit,
                                         q: unescape(params.term)
                                     });
                                     return `${
-                                        this._brandConfig.checkoutApiUrl
+                                        self._brandConfig.checkoutApiUrl
                                     }/companies/v2/company?${queryParams.toString()}`;
                                 },
                                 processResults: function (response, params) {


### PR DESCRIPTION
## Summary

- PR #132 captured `brandConfig` at the top of `placeOrderIntent` to keep the viewmodel reference reachable inside the `_.each` line-items iteration. The select2 `ajax.url` callback at the company-search dropdown (a few hundred lines down) is the same kind of non-arrow callback and was missed.
- Inside `function (params) { ... }`, `this` rebinds to the AJAX request scope, so `this._brandConfig` is `undefined`. Three callsites throw `TypeError: Cannot read properties of undefined (reading 'companySearchLimit')` on every keystroke; the search XHR never fires.
- Fix: route the three `_brandConfig` references onto the already-captured `self`. The sibling line (`country: self.countryCode()?.toUpperCase()`) already uses it. No new locals.

## Sniff test

Grepped the rest of `gateway_method.js` for similar patterns: every other non-method callback in the file uses arrow functions (`.then((json) => ...)`, `addEventListener('message', (event) => ...)`, `.catch(() => ...)`), so lexical `this` is preserved everywhere else. The select2 block is the only `function (...) {}`-style callback that reaches into the viewmodel via `this`.

## Test plan

- [ ] Storefront → checkout → expand Two payment method → start typing in the Company Name search field
- [ ] Expect: dropdown shows real company matches (XHR fires to `/companies/v2/company?…`)
- [ ] No `TypeError` in the JS console
- [ ] "Enter details manually" still works as a fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)