### PR TITLE
feat: expose overlay-hide override in admin Two General section

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -67,6 +67,13 @@
                     <label/>
                     <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Button\ErrorCheck</frontend_model>
                 </field>
+                <field id="hide_when_overlay_installed" translate="label comment" type="select" sortOrder="90"
+                       showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Hide Payment section when a brand overlay is installed</label>
+                    <comment><![CDATA[Only relevant when a brand-overlay package such as ABN_Gateway is installed alongside Two_Gateway. When enabled (default), the parent-brand <strong>Payment</strong> admin config section is hidden so the overlay merchant manages their own brand only. Disable to surface both brands side-by-side and configure them independently. Has no effect on standalone Two_Gateway installs.]]></comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <config_path>payment/two_payment/hide_when_overlay_installed</config_path>
+                </field>
             </group>
         </section>
         <section id="two_payment" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1"


### PR DESCRIPTION
Followup to #133.

The `hide_when_overlay_installed` flag was only settable via CLI because the field lives at `payment/two_payment/*` — the same section the flag itself hides on overlay-installed merchants. Chicken-and-egg.

Surface the toggle as a field in the **Two General** section (the API-key + debug section, which is **not** hidden by the overlay plugin). Same `config_path` so the existing default and HidePaymentSection plugin logic remain untouched.

## UX

Overlay merchants who want both brands side-by-side: flip "Hide Payment section when a brand overlay is installed" to **No** in Two General, save config. The `two_payment` section reappears next page load.

## Effect

- **Standalone Two_Gateway**: field is visible but has no effect (plugin no-ops when overlay registry is empty). Comment text makes this explicit.
- **Overlay-installed**: field is the UI path back to the parent-brand admin section.
- **CLI path still works**: `bin/magento config:set payment/two_payment/hide_when_overlay_installed 0` unchanged.