### PR TITLE
fix: switch overlay-hide plugin to Section::isVisible() (closes admin crash)

### DIFF
--- a/Plugin/Config/Structure/HidePaymentSection.php
+++ b/Plugin/Config/Structure/HidePaymentSection.php
@@ -8,13 +8,13 @@ declare(strict_types=1);
 
 namespace Two\Gateway\Plugin\Config\Structure;
 
-use Magento\Config\Model\Config\Structure;
+use Magento\Config\Model\Config\Structure\Element\Section;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Two\Gateway\Api\BrandOverlayRegistryInterface;
 
 /**
- * Hide every Two_Gateway admin config section (`two_general` and
- * `two_payment`) when:
+ * Hide every Two_Gateway admin config section (`two_general`,
+ * `two_payment`, `two_search`) when:
  *   - At least one brand overlay (e.g. ABN_Gateway) is registered, AND
  *   - `payment/two_payment/hide_when_overlay_installed` resolves to truthy.
  *
@@ -25,23 +25,27 @@ use Two\Gateway\Api\BrandOverlayRegistryInterface;
  *     bin/magento config:set payment/two_payment/hide_when_overlay_installed 0
  *     bin/magento cache:flush
  *
- * Returning null from afterGetElement makes the section invisible to
- * the admin config UI: the left-nav stops listing it, and direct
- * URL access (?section=two_payment) renders empty since `Structure`
- * is the authoritative element source. Returning null does not
- * delete any persisted CCD value; the overlay's `etc/config.xml`
- * still defaults `payment/two_payment/active = 0` as belt-and-braces.
+ * Plugs into `Section::isVisible()` rather than `Structure::getElement()`.
+ * The sidebar render path iterates `Structure::getTabs()` and per-tab
+ * children, then calls `isVisible()` on each section to decide whether
+ * to render it. The Edit controller (`Magento\Config\Controller\Adminhtml\System\Config\Edit`)
+ * also calls `isVisible()` after `getElement()` for direct URL access,
+ * and the previous `afterGetElement` hook returning null broke that
+ * code path with `Call to a member function isVisible() on null`.
  *
- * `two_general` is hidden because it carries Two-only fields
- * (API key, environment, debug toggle) that point at
- * `payment/two_payment/*` config paths — irrelevant to an overlay
- * merchant who configures their own brand under a separate admin
- * section.
+ * Returning false from `isVisible()` is the canonical "hide me" signal:
+ * the sidebar skips the section and the Edit controller treats it as
+ * unauthorised, redirecting away cleanly.
+ *
+ * `two_general` carries Two-only fields (API key, environment, debug
+ * toggle). `two_search` is the Two-side company-search admin. Both
+ * are irrelevant to an overlay merchant who configures their own
+ * brand under a separate admin section.
  */
 class HidePaymentSection
 {
     private const HIDE_FLAG_PATH = 'payment/two_payment/hide_when_overlay_installed';
-    private const TARGET_SECTIONS = ['two_general', 'two_payment'];
+    private const TARGET_SECTIONS = ['two_general', 'two_payment', 'two_search'];
 
     public function __construct(
         private readonly BrandOverlayRegistryInterface $overlayRegistry,
@@ -50,28 +54,20 @@ class HidePaymentSection
     }
 
     /**
-     * @param Structure $subject
-     * @param mixed     $result Whatever Structure::getElement returned.
-     * @param string    $path   Section/group path being resolved.
-     * @return mixed Null if the section should be hidden, original $result otherwise.
+     * @param Section $subject
+     * @param bool    $result Whatever Section::isVisible computed natively.
+     * @return bool false if the section should be hidden by overlay, $result otherwise.
      */
-    public function afterGetElement(Structure $subject, $result, $path)
+    public function afterIsVisible(Section $subject, $result)
     {
-        if (!$this->matchesTarget($path)) {
+        if (!$result) {
+            return $result;
+        }
+        if (!in_array($subject->getId(), self::TARGET_SECTIONS, true)) {
             return $result;
         }
         if (!$this->shouldHide()) {
             return $result;
-        }
-        return null;
-    }
-
-    private function matchesTarget(string $path): bool
-    {
-        foreach (self::TARGET_SECTIONS as $section) {
-            if ($path === $section || str_starts_with($path, $section . '/')) {
-                return true;
-            }
         }
         return false;
     }

--- a/Test/Unit/Plugin/Config/Structure/HidePaymentSectionTest.php
+++ b/Test/Unit/Plugin/Config/Structure/HidePaymentSectionTest.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Two\Gateway\Test\Unit\Plugin\Config\Structure;
 
-use Magento\Config\Model\Config\Structure;
+use Magento\Config\Model\Config\Structure\Element\Section;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use PHPUnit\Framework\TestCase;
 use Two\Gateway\Api\BrandOverlayRegistryInterface;
@@ -24,73 +24,71 @@ class HidePaymentSectionTest extends TestCase
         return new HidePaymentSection($registry, $scope);
     }
 
+    /**
+     * Build an anonymous subclass of Section that overrides getId(). We can't
+     * use createMock(Section::class) because getId comes from
+     * Magento\Framework\Data\Structure\Element's __call magic in the CI test
+     * stub (no declared method, PHPUnit throws MethodCannotBeConfiguredException),
+     * and we can't use ReflectionClass::newInstanceWithoutConstructor + setData
+     * because the test-bundled Section stub doesn't extend DataObject and so
+     * has no setData. Skipping the parent constructor keeps us independent of
+     * its required arguments.
+     */
+    private function section(string $id): Section
+    {
+        return new class($id) extends Section {
+            // phpcs:disable
+            public function __construct(private string $sectionId)
+            {
+                // skip parent constructor — only getId() is exercised by the plugin
+            }
+            public function getId()
+            {
+                return $this->sectionId;
+            }
+            // phpcs:enable
+        };
+    }
+
+    public function testPassThroughWhenSectionAlreadyHidden(): void
+    {
+        $plugin = $this->plugin(true, true);
+        $this->assertFalse($plugin->afterIsVisible($this->section('two_payment'), false));
+    }
+
     public function testPassThroughForUnrelatedSection(): void
     {
         $plugin = $this->plugin(true, true);
-        $sentinel = new \stdClass();
-        $this->assertSame(
-            $sentinel,
-            $plugin->afterGetElement($this->createMock(Structure::class), $sentinel, 'payment')
-        );
+        $this->assertTrue($plugin->afterIsVisible($this->section('catalog'), true));
     }
 
     public function testPassThroughWhenNoOverlayInstalled(): void
     {
         $plugin = $this->plugin(false, true);
-        $sentinel = new \stdClass();
-        $this->assertSame(
-            $sentinel,
-            $plugin->afterGetElement($this->createMock(Structure::class), $sentinel, 'two_payment')
-        );
+        $this->assertTrue($plugin->afterIsVisible($this->section('two_payment'), true));
     }
 
     public function testPassThroughWhenHideFlagDisabled(): void
     {
         $plugin = $this->plugin(true, false);
-        $sentinel = new \stdClass();
-        $this->assertSame(
-            $sentinel,
-            $plugin->afterGetElement($this->createMock(Structure::class), $sentinel, 'two_payment')
-        );
+        $this->assertTrue($plugin->afterIsVisible($this->section('two_payment'), true));
     }
 
-    public function testHidesTwoPaymentSectionWhenOverlayAndFlagBothSet(): void
+    public function testHidesTwoPaymentSection(): void
     {
         $plugin = $this->plugin(true, true);
-        $this->assertNull(
-            $plugin->afterGetElement($this->createMock(Structure::class), new \stdClass(), 'two_payment')
-        );
+        $this->assertFalse($plugin->afterIsVisible($this->section('two_payment'), true));
     }
 
-    public function testHidesTwoGeneralSectionWhenOverlayAndFlagBothSet(): void
+    public function testHidesTwoGeneralSection(): void
     {
         $plugin = $this->plugin(true, true);
-        $this->assertNull(
-            $plugin->afterGetElement($this->createMock(Structure::class), new \stdClass(), 'two_general')
-        );
+        $this->assertFalse($plugin->afterIsVisible($this->section('two_general'), true));
     }
 
-    public function testHidesNestedGroupUnderTwoPayment(): void
+    public function testHidesTwoSearchSection(): void
     {
         $plugin = $this->plugin(true, true);
-        $this->assertNull(
-            $plugin->afterGetElement(
-                $this->createMock(Structure::class),
-                new \stdClass(),
-                'two_payment/payment_method'
-            )
-        );
-    }
-
-    public function testHidesNestedGroupUnderTwoGeneral(): void
-    {
-        $plugin = $this->plugin(true, true);
-        $this->assertNull(
-            $plugin->afterGetElement(
-                $this->createMock(Structure::class),
-                new \stdClass(),
-                'two_general/general'
-            )
-        );
+        $this->assertFalse($plugin->afterIsVisible($this->section('two_search'), true));
     }
 }

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -14,11 +14,16 @@
                 type="Two\Gateway\Plugin\Model\Sales\CreditmemoSurchargeOverride" sortOrder="10"/>
     </type>
     <!--
-        Hide the parent-brand `two_payment` config section in admin when a
-        brand overlay is installed and the merchant hasn't opted in to
-        seeing both. See Two\Gateway\Plugin\Config\Structure\HidePaymentSection.
+        Hide Two_Gateway admin config sections when a brand overlay is
+        installed and the merchant hasn't opted in to seeing both. See
+        Two\Gateway\Plugin\Config\Structure\HidePaymentSection.
+
+        Targets `Section::isVisible()` (not `Structure::getElement()`) so
+        that both the sidebar render path (iterates `Structure::getTabs()`
+        -> tab children -> isVisible) and the Edit controller's direct
+        URL handler (`getElement()->isVisible()`) see "hidden" consistently.
     -->
-    <type name="Magento\Config\Model\Config\Structure">
+    <type name="Magento\Config\Model\Config\Structure\Element\Section">
         <plugin name="two-hide-payment-section-when-overlay-installed"
                 type="Two\Gateway\Plugin\Config\Structure\HidePaymentSection"
                 sortOrder="10"/>


### PR DESCRIPTION
Followup to #133/#136.

## Bug

The \`afterGetElement\` plugin returned null on hidden sections. That:

- **Did NOT actually hide them from the sidebar.** Magento renders the left nav by iterating \`Structure::getTabs()\` -> tab children -> \`Section::isVisible()\`, never calling \`getElement(path)\` per section. So hidden sections still showed in the sidebar.
- **Crashed the Edit controller** on direct URL access: \`Magento\Config\Controller\Adminhtml\System\Config\Edit::49\` does \`$structure->getElement($current)->isVisible(...)\` -> nullptr deref. User saw "An error has happened during application run" when clicking the still-visible "General" link in the abn-side admin.

## Fix

Switch the hook to \`Section::isVisible()\`. Returning false is the canonical Magento "hide me" signal:

- Sidebar skips the section.
- Edit controller treats direct URL access as unauthorised, redirects away.

Also add \`two_search\` to the target list - the third section under the \`two_gateway\` tab (visible-but-irrelevant on overlay installs that have their own brand search UI).

## Tests

7 cases: pass-through for already-hidden section, unrelated section, no overlay, flag disabled; hide for each of the three target sections.

## Verification post-merge

1. Wait for gitsync rotation on magento-abn / magento-abn-dev.
2. Two_Gateway sections should disappear from the admin sidebar.
3. Direct URL access (e.g. \`/admin/admin/system_config/edit/section/two_general\`) should redirect cleanly, not crash.