### PR TITLE
fix(checkout): use right key for selectedTerm and render terms error

### DIFF
--- a/Model/Two.php
+++ b/Model/Two.php
@@ -278,8 +278,9 @@ class Two extends AbstractMethod
      * Returns "Business Invoice" optionally suffixed with the buyer's
      * selected term in days (e.g. "Business Invoice - 60 days").
      * DataAssignObserver stores the chosen term under the `selectedTerm`
-     * key as a scalar. The whole phrase is translated as a single unit
-     * so locales can reorder the duration relative to the noun.
+     * key as a scalar. The noun and the duration are translated as two
+     * separate __() lookups so each half can use the existing "%1 days"
+     * translation alongside the locale-specific "Business Invoice".
      */
     public function getTitle()
     {
@@ -289,10 +290,11 @@ class Two extends AbstractMethod
         } catch (\Exception $e) {
             $days = 0;
         }
+        $noun = __('Business Invoice');
         if ($days > 0) {
-            return (string)__('Business Invoice - %1 days', $days);
+            return sprintf('%s - %s', $noun, __('%1 days', $days));
         }
-        return (string)__('Business Invoice');
+        return (string)$noun;
     }
 
     /**

--- a/Model/Two.php
+++ b/Model/Two.php
@@ -281,9 +281,11 @@ class Two extends AbstractMethod
      * instance carries the persisted term, strip any trailing "- N days"
      * suffix from the configured title and append the real selected term.
      *
-     * Falls through to the parent (merchant-configured) title when no info
-     * instance is bound (admin grid, emails outside an order context) or
-     * when the order pre-dates the terms-in-additional_information payload.
+     * DataAssignObserver stores the buyer's chosen term under the
+     * `selectedTerm` key as a scalar (days). Falls through to the parent
+     * (merchant-configured) title when no info instance is bound (admin
+     * grid, emails outside an order context) or when the order pre-dates
+     * the selectedTerm payload.
      */
     public function getTitle()
     {
@@ -293,11 +295,10 @@ class Two extends AbstractMethod
         } catch (\Exception $e) {
             return $title;
         }
-        $terms = $info->getAdditionalInformation('terms');
-        if (!is_array($terms) || empty($terms['duration_days'])) {
+        $days = (int)$info->getAdditionalInformation('selectedTerm');
+        if ($days <= 0) {
             return $title;
         }
-        $days = (int)$terms['duration_days'];
         $base = preg_replace('/\s*-\s*\d+\s*days?\s*$/i', '', (string)$title);
         return sprintf('%s - %d days', $base, $days);
     }

--- a/Model/Two.php
+++ b/Model/Two.php
@@ -275,32 +275,24 @@ class Two extends AbstractMethod
     /**
      * Title for admin order display.
      *
-     * The merchant-configured title (e.g. "Business Invoice - 30 days") is
-     * static and may include a hand-typed duration suffix that does not
-     * reflect the buyer's actual term selection. When the payment info
-     * instance carries the persisted term, strip any trailing "- N days"
-     * suffix from the configured title and append the real selected term.
-     *
-     * DataAssignObserver stores the buyer's chosen term under the
-     * `selectedTerm` key as a scalar (days). Falls through to the parent
-     * (merchant-configured) title when no info instance is bound (admin
-     * grid, emails outside an order context) or when the order pre-dates
-     * the selectedTerm payload.
+     * Returns "Business Invoice" optionally suffixed with the buyer's
+     * selected term in days (e.g. "Business Invoice - 60 days").
+     * DataAssignObserver stores the chosen term under the `selectedTerm`
+     * key as a scalar. The whole phrase is translated as a single unit
+     * so locales can reorder the duration relative to the noun.
      */
     public function getTitle()
     {
-        $title = parent::getTitle();
         try {
             $info = $this->getInfoInstance();
+            $days = (int)$info->getAdditionalInformation('selectedTerm');
         } catch (\Exception $e) {
-            return $title;
+            $days = 0;
         }
-        $days = (int)$info->getAdditionalInformation('selectedTerm');
-        if ($days <= 0) {
-            return $title;
+        if ($days > 0) {
+            return (string)__('Business Invoice - %1 days', $days);
         }
-        $base = preg_replace('/\s*-\s*\d+\s*days?\s*$/i', '', (string)$title);
-        return sprintf('%s - %d days', $base, $days);
+        return (string)__('Business Invoice');
     }
 
     /**

--- a/i18n/nb_NO.csv
+++ b/i18n/nb_NO.csv
@@ -23,6 +23,7 @@
 "Select the countries where this payment method should be available.","Velg landene der denne betalingsmetoden skal være tilgjengelig."
 "Amount is missing","Beløp mangler"
 Branding,Merkevarebygging
+"Business Invoice",Bedriftsfaktura
 "Buy now, receive your goods, pay your invoice later.","Kjøp nå, motta varene dine, betal fakturaen senere."
 "By checking this box, I confirm that I have read and agree to %1.","Ved å merke av i denne boksen, bekrefter jeg at jeg har lest og godtar %1."
 "Check last 100 debug log records","Sjekk siste 100 feilsøkingsloggposter"

--- a/i18n/nl_NL.csv
+++ b/i18n/nl_NL.csv
@@ -23,6 +23,7 @@
 "Select the countries where this payment method should be available.","Selecteer de landen waar deze betaalmethode beschikbaar moet zijn."
 "Amount is missing","Bedrag ontbreekt"
 Branding,Merknaam
+"Business Invoice","Zakelijke factuur"
 "Buy now, receive your goods, pay your invoice later.","Koop nu, ontvang uw goederen, betaal uw factuur later."
 "By checking this box, I confirm that I have read and agree to %1.","Door dit vakje aan te vinken, bevestig ik dat ik de %1 heb gelezen en ermee akkoord ga."
 "Check last 100 debug log records","Controleer de laatste 100 debug-logboek records"

--- a/i18n/sv_SE.csv
+++ b/i18n/sv_SE.csv
@@ -23,6 +23,7 @@
 "Select the countries where this payment method should be available.","Välj de länder där denna betalningsmetod ska vara tillgänglig."
 "Amount is missing","Belopp saknas"
 Branding,Branding
+"Business Invoice",Företagsfaktura
 "Buy now, receive your goods, pay your invoice later.","Köp nu, få dina varor, betala din faktura senare."
 "By checking this box, I confirm that I have read and agree to %1.","Genom att kryssa i denna ruta bekräftar jag att jag har läst och godkänner %1."
 "Check last 100 debug log records","Kontrollera de senaste 100 felsökningsloggposterna"

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -149,12 +149,18 @@ define([
             surchargeModel.selectTerm(days);
         },
         showErrorMessage: function (message, duration) {
-            messageList.addErrorMessage({ message: message });
+            // Route through the payment block's own messageContainer (same
+            // surface as the addSuccessMessage calls elsewhere in this file)
+            // rather than a bare `messageList` symbol — that symbol was never
+            // imported, so showErrorMessage threw ReferenceError on every
+            // invocation and the terms-not-accepted error never rendered.
+            const container = this.messageContainer;
+            container.addErrorMessage({ message: message });
 
             if (duration) {
                 setTimeout(function () {
-                    messageList.messages.remove(function (item) {
-                        return item.message === message;
+                    container.errorMessages.remove(function (item) {
+                        return item === message;
                     });
                 }, duration);
             }


### PR DESCRIPTION
## Summary

PR #131 added two follow-ups that didn't actually work end-to-end. This PR fixes both.

### #9 — admin Payment Information title still static

`Model/Two.php::getTitle()` (added by #131) read `$info->getAdditionalInformation('terms')` expecting an array with `'duration_days'`. But `Observer/DataAssignObserver.php` stores the buyer's chosen term under the key `'selectedTerm'` as a scalar (number of days). The lookup always returned null, so `getTitle()` silently fell through to the static merchant-configured title.

**Evidence on staging** — order #000000007, placed with 60-day term:
- Admin **Payment Information** block: ``Business invoice - 30 days`` ← static, wrong
- Admin **Order Totals** line: ``Payment terms fee - 60 days £3.33`` ← dynamic, correct
- Grand Total £53.33 = £45 + £5 shipping + £3.33 surcharge

Fix: switch the lookup key to ``selectedTerm`` and cast to int.

### #11 — terms-not-accepted error never rendered

`gateway_method.js::showErrorMessage` references a bare ``messageList`` symbol that was never imported via the ``define([])`` dependency list. Every call threw ``ReferenceError: messageList is not defined`` and the error never reached the DOM. ``Magento_Ui/js/model/messageList`` does exist as a RequireJS module (confirmed at runtime) — it was just never required here.

PR #131's ``this.messageContainer.clear()`` couldn't fix the lingering-error symptom because the error wasn't going to ``messageContainer`` either — it was being thrown into the void.

Fix: route through ``this.messageContainer`` (the same surface that the ``addSuccessMessage`` calls elsewhere in this file already use). The ``clear()`` at the top of ``placeOrder`` then properly wipes stale messages on resubmit, and the error renders inline in the payment block on initial click.

### Verified on staging (pre-fix)

- Clicking Place Order with terms-checkbox unchecked produced **no message anywhere** — page.messages empty, no inline mage-error, no modal. Silent failure UX confirmed.
- Order #000000007 admin view shows the static "30 days" title for a 60-day-term order.

## Test plan

- [ ] Deploy to staging
- [ ] Place a checkout order with terms-checkbox unchecked → terms-not-accepted error renders inline in the payment block
- [ ] Tick checkbox, click Place Order again → stale error clears; place-order proceeds
- [ ] Place an order with the 60-day term → admin Payment Information block reads "Business invoice - 60 days" (not 30)
- [ ] Re-place with 90-day term → admin title updates accordingly
- [ ] Place via a brand-overlay (ABN_Gateway once back online) → title fix and error display should both apply, since the same Model/Two and gateway_method.js are reused