### PR TITLE
fix(checkout): drop "- N days" suffix from admin payment title

### DIFF
--- a/Model/Two.php
+++ b/Model/Two.php
@@ -284,17 +284,7 @@ class Two extends AbstractMethod
      */
     public function getTitle()
     {
-        try {
-            $info = $this->getInfoInstance();
-            $days = (int)$info->getAdditionalInformation('selectedTerm');
-        } catch (\Exception $e) {
-            $days = 0;
-        }
-        $noun = __('Business Invoice');
-        if ($days > 0) {
-            return sprintf('%s - %s', $noun, __('%1 days', $days));
-        }
-        return (string)$noun;
+        return (string)__('Business Invoice');
     }
 
     /**


### PR DESCRIPTION
## Summary
- The dynamic `- N days` suffix on the admin Payment Information title is unreliable: `selectedTerm` on the stored payment does not always match the term the order was actually placed on (observed live: a 60-day order rendered "Business Invoice - 30 days").
- Drop the suffix entirely; render just the translatable noun `Business Invoice`.
- The `"%1 days"` translations and the `Business Invoice` translations added in #138 remain in place — `Business Invoice` is still translatable, `%1 days` continues to be used elsewhere in the plugin.

## Test plan
- [ ] Place a fresh order on staging at a non-default term (e.g. 60 days)
- [ ] Confirm admin Payment Information block reads "Business Invoice" (no suffix)
- [ ] Confirm storefront / order email / invoice still render as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)