### PR TITLE
Revert #139: restore dynamic term suffix on getTitle

### DIFF
--- a/Model/Two.php
+++ b/Model/Two.php
@@ -284,7 +284,17 @@ class Two extends AbstractMethod
      */
     public function getTitle()
     {
-        return (string)__('Business Invoice');
+        try {
+            $info = $this->getInfoInstance();
+            $days = (int)$info->getAdditionalInformation('selectedTerm');
+        } catch (\Exception $e) {
+            $days = 0;
+        }
+        $noun = __('Business Invoice');
+        if ($days > 0) {
+            return sprintf('%s - %s', $noun, __('%1 days', $days));
+        }
+        return (string)$noun;
     }
 
     /**


### PR DESCRIPTION
## Summary
- Reverts #139. The "Business invoice - 30 days" we saw in the admin Order View was coming from the merchant-configured `payment/two_payment/title` config field, **not** from `Model\Two::getTitle()` — so dropping the suffix was patching the wrong surface.
- Restores PR #138's behaviour: `getTitle()` returns `"Business Invoice"` and appends `" - %1 days"` when `selectedTerm` is present on the payment. That suffix is still useful for the surfaces that *do* call live `getTitle()` (storefront checkout payment radio, order email, invoice).
- The hand-typed staging config value will be cleared in admin separately; the default in `etc/config.xml` is `<title>Two</title>` and does not bake in any suffix.

## Test plan
- [ ] Storefront checkout: payment method radio shows `Business Invoice - <selected> days`
- [ ] Order email / invoice: title renders with current selected term
- [ ] Admin Order View Payment Information block: rendered value matches whatever is configured under Stores → Configuration → Sales → Payment Methods → Two BNPL → Title

🤖 Generated with [Claude Code](https://claude.com/claude-code)