### PR TITLE
fix: accept brand-overlay payment method codes in Two-stack gates

### DIFF
--- a/Api/BrandOverlayRegistryInterface.php
+++ b/Api/BrandOverlayRegistryInterface.php
@@ -37,4 +37,18 @@ interface BrandOverlayRegistryInterface
      * @return array<string, string> Map of overlay key => method code.
      */
     public function getOverlays(): array;
+
+    /**
+     * True iff `$method` is a Two-stack payment method code: either the
+     * parent-brand canonical code (`Two::CODE` = 'two_payment') or one
+     * of the registered overlay codes.
+     *
+     * Callers that need to gate behaviour to "any Two-stack payment
+     * method" (observers, controllers, the order-reference lookup in
+     * Service\Payment\OrderService) use this instead of the previous
+     * pattern of `=== Two::CODE` which excluded overlay methods like
+     * `abn_payment` and produced "Unable to find the requested order"
+     * errors on overlay checkouts.
+     */
+    public function isTwoStackMethod(string $method): bool;
 }

--- a/Model/BrandOverlayRegistry.php
+++ b/Model/BrandOverlayRegistry.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Two\Gateway\Model;
 
 use Two\Gateway\Api\BrandOverlayRegistryInterface;
+use Two\Gateway\Model\Two;
 
 class BrandOverlayRegistry implements BrandOverlayRegistryInterface
 {
@@ -32,5 +33,13 @@ class BrandOverlayRegistry implements BrandOverlayRegistryInterface
     public function getOverlays(): array
     {
         return $this->overlays;
+    }
+
+    public function isTwoStackMethod(string $method): bool
+    {
+        if ($method === Two::CODE) {
+            return true;
+        }
+        return in_array($method, array_values($this->overlays), true);
     }
 }

--- a/Observer/SalesOrderAddressUpdate.php
+++ b/Observer/SalesOrderAddressUpdate.php
@@ -53,18 +53,23 @@ class SalesOrderAddressUpdate implements ObserverInterface
      * @param ComposeOrder $compositeOrder
      * @param Adapter $apiAdapter
      */
+    /** @var \Two\Gateway\Api\BrandOverlayRegistryInterface */
+    private $overlayRegistry;
+
     public function __construct(
         ConfigRepository $configRepository,
         BrandRegistryInterface $brandRegistry,
         OrderRepositoryInterface $orderRepository,
         ComposeOrder $compositeOrder,
-        Adapter $apiAdapter
+        Adapter $apiAdapter,
+        \Two\Gateway\Api\BrandOverlayRegistryInterface $overlayRegistry
     ) {
         $this->configRepository = $configRepository;
         $this->brandRegistry = $brandRegistry;
         $this->orderRepository = $orderRepository;
         $this->compositeOrder = $compositeOrder;
         $this->apiAdapter = $apiAdapter;
+        $this->overlayRegistry = $overlayRegistry;
     }
 
     /**
@@ -76,7 +81,10 @@ class SalesOrderAddressUpdate implements ObserverInterface
     {
         $orderId = $observer->getEvent()->getOrderId();
         $order = $this->orderRepository->get($orderId);
-        if ($order && $order->getPayment()->getMethod() === Two::CODE && $order->getTwoOrderId()) {
+        if ($order
+            && $this->overlayRegistry->isTwoStackMethod((string)$order->getPayment()->getMethod())
+            && $order->getTwoOrderId()
+        ) {
             try {
                 $additionalInformation = $order->getPayment()->getAdditionalInformation();
                 $payload = $this->compositeOrder->execute(

--- a/Observer/SalesOrderCancelAfter.php
+++ b/Observer/SalesOrderCancelAfter.php
@@ -11,9 +11,9 @@ use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Psr\Log\LoggerInterface;
+use Two\Gateway\Api\BrandOverlayRegistryInterface;
 use Two\Gateway\Api\BrandRegistryInterface;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
-use Two\Gateway\Model\Two;
 use Two\Gateway\Service\Payment\OrderService;
 
 /**
@@ -43,6 +43,9 @@ class SalesOrderCancelAfter implements ObserverInterface
     /** @var BrandRegistryInterface */
     private $brandRegistry;
 
+    /** @var BrandOverlayRegistryInterface */
+    private $overlayRegistry;
+
     /**
      * @param OrderService $orderService
      * @param LoggerInterface $logger
@@ -50,11 +53,13 @@ class SalesOrderCancelAfter implements ObserverInterface
     public function __construct(
         OrderService $orderService,
         LoggerInterface $logger,
-        BrandRegistryInterface $brandRegistry
+        BrandRegistryInterface $brandRegistry,
+        BrandOverlayRegistryInterface $overlayRegistry
     ) {
         $this->orderService = $orderService;
         $this->logger = $logger;
         $this->brandRegistry = $brandRegistry;
+        $this->overlayRegistry = $overlayRegistry;
     }
 
     /**
@@ -65,7 +70,7 @@ class SalesOrderCancelAfter implements ObserverInterface
     {
         $order = $observer->getEvent()->getOrder();
         if (!$order
-            || $order->getPayment()->getMethod() !== Two::CODE
+            || !$this->overlayRegistry->isTwoStackMethod((string)$order->getPayment()->getMethod())
             || !$order->getTwoOrderId()
         ) {
             return;

--- a/Observer/SalesOrderPlaceAfter.php
+++ b/Observer/SalesOrderPlaceAfter.php
@@ -10,13 +10,19 @@ namespace Two\Gateway\Observer;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Sales\Model\Order;
-use Two\Gateway\Model\Two;
+use Two\Gateway\Api\BrandOverlayRegistryInterface;
 
 /**
  * Observer to disable order confirmation email
  */
 class SalesOrderPlaceAfter implements ObserverInterface
 {
+    private $overlayRegistry;
+
+    public function __construct(BrandOverlayRegistryInterface $overlayRegistry)
+    {
+        $this->overlayRegistry = $overlayRegistry;
+    }
 
     /**
      * @param Observer $observer
@@ -27,7 +33,7 @@ class SalesOrderPlaceAfter implements ObserverInterface
     {
         /** @var Order $order */
         $order = $observer->getEvent()->getOrder();
-        if ($order->getPayment()->getMethod() == Two::CODE) {
+        if ($this->overlayRegistry->isTwoStackMethod((string)$order->getPayment()->getMethod())) {
             $order->setCanSendNewEmailFlag(false);
         }
 

--- a/Observer/SalesOrderSaveAfter.php
+++ b/Observer/SalesOrderSaveAfter.php
@@ -73,6 +73,9 @@ class SalesOrderSaveAfter implements ObserverInterface
      * @param InvoiceService $invoiceService
      * @param TransactionFactory $transactionFactory
      */
+    /** @var \Two\Gateway\Api\BrandOverlayRegistryInterface */
+    private $overlayRegistry;
+
     public function __construct(
         ConfigRepository $configRepository,
         BrandRegistryInterface $brandRegistry,
@@ -80,7 +83,8 @@ class SalesOrderSaveAfter implements ObserverInterface
         HistoryFactory $historyFactory,
         OrderStatusHistoryRepositoryInterface $orderStatusHistoryRepository,
         InvoiceService $invoiceService,
-        TransactionFactory $transactionFactory
+        TransactionFactory $transactionFactory,
+        \Two\Gateway\Api\BrandOverlayRegistryInterface $overlayRegistry
     ) {
         $this->configRepository = $configRepository;
         $this->brandRegistry = $brandRegistry;
@@ -89,6 +93,7 @@ class SalesOrderSaveAfter implements ObserverInterface
         $this->orderStatusHistoryRepository = $orderStatusHistoryRepository;
         $this->invoiceService = $invoiceService;
         $this->transactionFactory = $transactionFactory;
+        $this->overlayRegistry = $overlayRegistry;
     }
 
     /**
@@ -99,7 +104,7 @@ class SalesOrderSaveAfter implements ObserverInterface
     {
         $order = $observer->getEvent()->getOrder();
         if (!$order
-            || $order->getPayment()->getMethod() !== Two::CODE
+            || !$this->overlayRegistry->isTwoStackMethod((string)$order->getPayment()->getMethod())
             || !$order->getTwoOrderId()
         ) {
             return;

--- a/Observer/SalesOrderShipmentAfter.php
+++ b/Observer/SalesOrderShipmentAfter.php
@@ -81,6 +81,9 @@ class SalesOrderShipmentAfter implements ObserverInterface
      * @param InvoiceService $invoiceService
      * @param TransactionFactory $transactionFactory
      */
+    /** @var \Two\Gateway\Api\BrandOverlayRegistryInterface */
+    private $overlayRegistry;
+
     public function __construct(
         ConfigRepository $configRepository,
         BrandRegistryInterface $brandRegistry,
@@ -89,7 +92,8 @@ class SalesOrderShipmentAfter implements ObserverInterface
         OrderStatusHistoryRepositoryInterface $orderStatusHistoryRepository,
         ComposeShipment $composeShipment,
         InvoiceService $invoiceService,
-        TransactionFactory $transactionFactory
+        TransactionFactory $transactionFactory,
+        \Two\Gateway\Api\BrandOverlayRegistryInterface $overlayRegistry
     ) {
         $this->configRepository = $configRepository;
         $this->brandRegistry = $brandRegistry;
@@ -99,6 +103,7 @@ class SalesOrderShipmentAfter implements ObserverInterface
         $this->composeShipment = $composeShipment;
         $this->invoiceService = $invoiceService;
         $this->transactionFactory = $transactionFactory;
+        $this->overlayRegistry = $overlayRegistry;
     }
 
     /**
@@ -111,7 +116,7 @@ class SalesOrderShipmentAfter implements ObserverInterface
         $shipment = $observer->getEvent()->getShipment();
         $order = $shipment->getOrder();
         if (!$order
-            || $order->getPayment()->getMethod() !== Two::CODE
+            || !$this->overlayRegistry->isTwoStackMethod((string)$order->getPayment()->getMethod())
             || !$order->getTwoOrderId()
         ) {
             return;

--- a/Plugin/Block/Widget/Button/Toolbar.php
+++ b/Plugin/Block/Widget/Button/Toolbar.php
@@ -12,13 +12,20 @@ use Magento\Backend\Block\Widget\Button\Toolbar as ToolbarContext;
 use Magento\Framework\View\Element\AbstractBlock;
 use Magento\Sales\Block\Adminhtml\Order\View;
 use Magento\Sales\Model\Order;
-use Two\Gateway\Model\Two;
+use Two\Gateway\Api\BrandOverlayRegistryInterface;
 
 /**
  * Plugin for remove order buttons
  */
 class Toolbar
 {
+    private $overlayRegistry;
+
+    public function __construct(BrandOverlayRegistryInterface $overlayRegistry)
+    {
+        $this->overlayRegistry = $overlayRegistry;
+    }
+
     /**
      * @param ToolbarContext $toolbar
      * @param AbstractBlock $context
@@ -39,7 +46,8 @@ class Toolbar
             return null;
         }
 
-        if ($order->getPayment()->getMethod() === Two::CODE && $order->getState() === Order::STATE_PENDING_PAYMENT) {
+        $isTwoStack = $this->overlayRegistry->isTwoStackMethod((string)$order->getPayment()->getMethod());
+        if ($isTwoStack && $order->getState() === Order::STATE_PENDING_PAYMENT) {
             $buttonList->remove('order_hold');
             $buttonList->remove('void_payment');
             $buttonList->remove('accept_payment');

--- a/Plugin/Model/Sales/AfterPlaceOrder.php
+++ b/Plugin/Model/Sales/AfterPlaceOrder.php
@@ -6,22 +6,27 @@
 
 namespace Two\Gateway\Plugin\Model\Sales;
 
-use Magento\Sales\Model\Order;
-use Two\Gateway\Model\Two;
 use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\Order;
+use Two\Gateway\Api\BrandOverlayRegistryInterface;
+use Two\Gateway\Model\Two;
 
 /**
  * AfterPlaceOrder Plugin
- * Set Two orders to status pending after place
+ * Set Two-stack orders (parent-brand `two_payment` + any registered
+ * brand overlays such as `abn_payment`) to status pending after place.
  */
 class AfterPlaceOrder
 {
     private $orderRepository;
+    private $overlayRegistry;
 
     public function __construct(
-        OrderRepositoryInterface $orderRepository
+        OrderRepositoryInterface $orderRepository,
+        BrandOverlayRegistryInterface $overlayRegistry
     ) {
         $this->orderRepository = $orderRepository;
+        $this->overlayRegistry = $overlayRegistry;
     }
 
     /**
@@ -31,7 +36,7 @@ class AfterPlaceOrder
      */
     public function afterPlace(Order $subject, Order $order)
     {
-        if ($order->getPayment()->getMethod() == Two::CODE) {
+        if ($this->overlayRegistry->isTwoStackMethod((string)$order->getPayment()->getMethod())) {
             $order->setState(Order::STATE_PENDING_PAYMENT);
             $order->setStatus(Two::STATUS_PENDING);
             $this->orderRepository->save($order);

--- a/Service/Payment/OrderService.php
+++ b/Service/Payment/OrderService.php
@@ -21,6 +21,7 @@ use Magento\Sales\Model\Order\Payment\Transaction\Repository as PaymentTransacti
 use Magento\Sales\Model\OrderFactory;
 use Magento\Sales\Model\ResourceModel\Order as OrderResource;
 use Magento\Sales\Model\Service\InvoiceService;
+use Two\Gateway\Api\BrandOverlayRegistryInterface;
 use Two\Gateway\Api\BrandRegistryInterface;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
 use Two\Gateway\Model\Two;
@@ -103,6 +104,9 @@ class OrderService
      */
     private $logRepository;
 
+    /** @var BrandOverlayRegistryInterface */
+    private $overlayRegistry;
+
     /**
      * OrderService constructor.
      * @param Adapter $apiAdapter
@@ -137,7 +141,8 @@ class OrderService
         PaymentTransactionRepository $paymentTransactionRepository,
         OrderPaymentRepositoryInterface $orderPaymentRepository,
         OrderRepositoryInterface $orderRepository,
-        LogRepository $logRepository
+        LogRepository $logRepository,
+        BrandOverlayRegistryInterface $overlayRegistry
     ) {
         $this->apiAdapter = $apiAdapter;
         $this->restoreQuote = $restoreQuote;
@@ -155,6 +160,7 @@ class OrderService
         $this->orderRepository = $orderRepository;
         $this->orderPaymentRepository = $orderPaymentRepository;
         $this->logRepository = $logRepository;
+        $this->overlayRegistry = $overlayRegistry;
     }
 
     /**
@@ -177,7 +183,10 @@ class OrderService
             'two_order_reference'
         );
 
-        if (!$order->getId() || $order->getPayment()->getMethod() !== Two::CODE || !$order->getTwoOrderId()) {
+        if (!$order->getId()
+            || !$this->overlayRegistry->isTwoStackMethod((string)$order->getPayment()->getMethod())
+            || !$order->getTwoOrderId()
+        ) {
             throw new LocalizedException($generalErrorMessage);
         }
 


### PR DESCRIPTION
ABN checkout completing on the backend (order created at `api.staging.achterafbetalen.abnamro.nl`) but failing in magento with `"Unable to find the requested Two order"` on return.

## Root cause

8 call sites compare `$order->getPayment()->getMethod() === Two::CODE` to gate behaviour to Two-stack orders. The hardcoded `Two::CODE = "two_payment"` excludes overlay codes like `abn_payment`:

| File | Behaviour on ABN orders before this PR |
|---|---|
| `Service/Payment/OrderService::getOrderByReference()` | throws "Unable to find requested order" |
| `Observer/SalesOrderSaveAfter` | no-ops → fulfilment never mirrored to backend |
| `Observer/SalesOrderShipmentAfter` | no-ops → shipment never mirrored |
| `Observer/SalesOrderCancelAfter` | no-ops → cancel never mirrored |
| `Observer/SalesOrderAddressUpdate` | no-ops → address-update never mirrored |
| `Observer/SalesOrderPlaceAfter` | no-ops → confirmation email not suppressed |
| `Plugin/Block/Widget/Button/Toolbar` | shows order_hold/void_payment/etc that should be hidden |
| `Plugin/Model/Sales/AfterPlaceOrder` | does not set state=pending_payment |

## Fix

Add `BrandOverlayRegistryInterface::isTwoStackMethod(string $method): bool` — returns true if `$method` is `Two::CODE` or any registered overlay code. Replace all 8 hardcoded checks with this helper.

Magento-plugin stays brand-agnostic; overlay packages populate the registry via DI (abn-plugin already does this in its `etc/di.xml`, from #87).

## Verification post-merge

1. abn checkout completes without "Unable to find the requested order".
2. Fulfilment / cancel / shipment / address-update events mirror to backend for ABN orders.

## Out of scope

The error message text `"Unable to find the requested %1 order"` interpolates `brandRegistry->getProductName()` which still resolves to "Two" on ABN installs (default DI preference). Separate brand-leak follow-up.