### PR TITLE
ABN-363/feat: Surcharge collector accepts DI-configured allowed-methods

### DIFF
--- a/Model/Total/Surcharge.php
+++ b/Model/Total/Surcharge.php
@@ -49,16 +49,24 @@ class Surcharge extends AbstractTotal
      */
     private $logRepository;
 
+    /**
+     * @var string[] payment-method codes that engage the surcharge collector.
+     *               Populated via DI; brand overlays append their own code.
+     */
+    private $allowedMethods;
+
     public function __construct(
         CheckoutSession $checkoutSession,
         ConfigRepository $configRepository,
         SurchargeCalculator $surchargeCalculator,
-        LogRepository $logRepository
+        LogRepository $logRepository,
+        array $allowedMethods = ['two_payment']
     ) {
         $this->checkoutSession = $checkoutSession;
         $this->configRepository = $configRepository;
         $this->surchargeCalculator = $surchargeCalculator;
         $this->logRepository = $logRepository;
+        $this->allowedMethods = array_values($allowedMethods);
         $this->setCode('two_surcharge');
     }
 
@@ -89,7 +97,7 @@ class Surcharge extends AbstractTotal
         // entire checkout flow.
         $payment = $quote->getPayment();
         $paymentMethod = $payment ? $payment->getMethod() : null;
-        if ($paymentMethod !== 'two_payment') {
+        if (!$paymentMethod || !in_array($paymentMethod, $this->allowedMethods, true)) {
             $this->logRepository->addDebugLog(
                 'TotalCollector: skipped (payment method: ' . ($paymentMethod ?: 'none') . ')',
                 []

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -105,4 +105,18 @@
             </argument>
         </arguments>
     </type>
+
+    <!--
+        Payment-method codes that engage the surcharge quote-total collector.
+        Brand overlays (e.g. ABN_Gateway) append their own code via a
+        matching <type> entry in their own etc/di.xml — Magento merges
+        named-array DI items across modules so the list grows additively.
+    -->
+    <type name="Two\Gateway\Model\Total\Surcharge">
+        <arguments>
+            <argument name="allowedMethods" xsi:type="array">
+                <item name="two_payment" xsi:type="string">two_payment</item>
+            </argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `$paymentMethod !== 'two_payment'` guard in `Two\Gateway\Model\Total\Surcharge::collect()` with a list lookup against a DI-configured `$allowedMethods` array.
- Default list (`['two_payment']`) is declared in `etc/di.xml` so brand overlays can append their own method code via array-merge.
- Companion change for the Hyvä-side buyer-terms chip (`magento-hyva-extension` PR #20) and the ABN overlay (`magento-abn-plugin` PR — coming next).

## Why

The surcharge total collector short-circuited on any payment method code other than `two_payment` — including the brand-overlay code `abn_payment`. Without this change, the buyer-terms chip is non-functional on overlay installs because the surcharge segment never appears in the order summary.

The fix keeps all the brand-aware logic in vanilla `Two_Gateway` (the architectural principle for this overlay model: vanilla holds logic, overlays hold configuration). Overlay packages append their method code via a one-line DI entry — no PHP duplication.

## Backwards compatibility

- Ctor default of `['two_payment']` preserves existing single-brand behaviour.
- No consumer of `Surcharge` outside DI — `etc/sales.xml` registers it as a quote-total collector.
- No schema or session-key changes.

## Test plan

- [ ] `bin/magento setup:di:compile` succeeds.
- [ ] On a vanilla install (no overlay), `two_payment` still triggers the surcharge segment.
- [ ] On a brand-overlay install (ABN), `abn_payment` also triggers the surcharge segment.
- [ ] On both, a non-Two method (e.g. `checkmo`) still clears the surcharge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)