### PR TITLE
ABN-363/perf: O(1) isset() lookup for Surcharge allowed-methods

### DIFF
--- a/Model/Total/Surcharge.php
+++ b/Model/Total/Surcharge.php
@@ -50,8 +50,11 @@ class Surcharge extends AbstractTotal
     private $logRepository;
 
     /**
-     * @var string[] payment-method codes that engage the surcharge collector.
-     *               Populated via DI; brand overlays append their own code.
+     * @var array<string, true> set of payment-method codes (as keys) that
+     *                          engage the surcharge collector. Populated via
+     *                          DI; brand overlays append their own code.
+     *                          Keyed set so collect() uses O(1) isset() on
+     *                          the hot collectTotals path.
      */
     private $allowedMethods;
 
@@ -66,7 +69,7 @@ class Surcharge extends AbstractTotal
         $this->configRepository = $configRepository;
         $this->surchargeCalculator = $surchargeCalculator;
         $this->logRepository = $logRepository;
-        $this->allowedMethods = array_values($allowedMethods);
+        $this->allowedMethods = array_fill_keys(array_values($allowedMethods), true);
         $this->setCode('two_surcharge');
     }
 
@@ -97,7 +100,7 @@ class Surcharge extends AbstractTotal
         // entire checkout flow.
         $payment = $quote->getPayment();
         $paymentMethod = $payment ? $payment->getMethod() : null;
-        if (!$paymentMethod || !in_array($paymentMethod, $this->allowedMethods, true)) {
+        if (!isset($this->allowedMethods[$paymentMethod])) {
             $this->logRepository->addDebugLog(
                 'TotalCollector: skipped (payment method: ' . ($paymentMethod ?: 'none') . ')',
                 []

--- a/Model/Total/Surcharge.php
+++ b/Model/Total/Surcharge.php
@@ -69,7 +69,7 @@ class Surcharge extends AbstractTotal
         $this->configRepository = $configRepository;
         $this->surchargeCalculator = $surchargeCalculator;
         $this->logRepository = $logRepository;
-        $this->allowedMethods = array_fill_keys(array_values($allowedMethods), true);
+        $this->allowedMethods = array_fill_keys($allowedMethods, true);
         $this->setCode('two_surcharge');
     }
 

--- a/view/adminhtml/web/css/source/_module.less
+++ b/view/adminhtml/web/css/source/_module.less
@@ -80,6 +80,14 @@
     display: none;
 }
 
+// With the caption hidden and the :before icon floated, the title's
+// content area collapses to its padding (~38px) — visibly shorter
+// than peer section titles (~55px). Match the peer height so the row
+// reads as a normal nav entry rather than a squashed one.
+.two-extension--no-caption .admin__page-nav-title {
+    min-height: 55px;
+}
+
 
 .api-key-status-icon::before {
     display: inline-block;


### PR DESCRIPTION
## Summary

- Switches \`Two\\Gateway\\Model\\Total\\Surcharge::\$allowedMethods\` from a positional array to a keyed set (\`array_fill_keys\`) so \`collect()\` uses O(1) \`isset()\` on the \`collectTotals()\` hot path instead of O(n) \`in_array(..., true)\`.
- Drops the redundant \`!\$paymentMethod\` null guard — \`isset()\` on a null key already returns false.

## Why

Follow-up to PR #142 (now merged). gemini-code-assist surfaced both findings inline; the optimization was suggested before merge but the PR landed before the patch could be added.

\`collectTotals()\` is high-frequency — runs on every cart mutation in checkout. Even with a small allowed-methods list, the O(1) lookup is the idiomatic Magento pattern.

## Backwards compatibility

- DI ctor signature unchanged: still accepts \`array \$allowedMethods\`. The keying happens inside the ctor, transparent to callers.
- ABN overlay's \`plugin/etc/di.xml\` array-merge entry continues to work.

## Test plan

- [ ] \`bin/magento setup:di:compile\` succeeds.
- [ ] \`two_payment\` still triggers the surcharge collector.
- [ ] \`abn_payment\` still triggers (post-overlay).
- [ ] Non-listed method (e.g. \`checkmo\`) still clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)