### PR TITLE
ABN-369/fix: defensive matrix-script fetch with diagnostic + retry

### DIFF
--- a/dev/magento-support-matrix.sh
+++ b/dev/magento-support-matrix.sh
@@ -71,12 +71,50 @@ gh_headers=()
 
 # ---------------------------------------------------------------------------
 # Step 1: discover Magento support window from upstream tags.
+#
+# Fetches with one retry on transient failure. Validates HTTP status and
+# JSON shape before piping to jq — previously a rate-limited / 502 / HTML
+# response would surface as a cryptic jq error like "Cannot index string
+# with string \"name\"" instead of the actual upstream problem.
 # ---------------------------------------------------------------------------
-tags_json=$(curl -sH 'Cache-Control: no-cache' "${gh_headers[@]}" \
-    'https://api.github.com/repos/magento/magento2/tags?per_page=100' \
-    || { echo "::error::Could not reach github.com/magento/magento2 tags" >&2; exit 2; })
+fetch_magento_tags() {
+    local url='https://api.github.com/repos/magento/magento2/tags?per_page=100'
+    local attempt response http_code body
+    for attempt in 1 2; do
+        if ! response=$(curl -sS --max-time 30 -w '\n%{http_code}' \
+                -H 'Cache-Control: no-cache' "${gh_headers[@]}" "$url" 2>&1); then
+            echo "::warning::GitHub tags API attempt ${attempt}: curl failed: ${response}" >&2
+            [ "$attempt" -lt 2 ] && { sleep 5; continue; }
+            echo "::error::GitHub tags API unreachable after retry" >&2
+            return 2
+        fi
+        http_code="${response##*$'\n'}"
+        body="${response%$'\n'*}"
+        if [ "$http_code" != "200" ]; then
+            echo "::warning::GitHub tags API attempt ${attempt}: HTTP ${http_code}" >&2
+            echo "Response body (first 500 chars):" >&2
+            printf '%s' "$body" | head -c 500 >&2; echo >&2
+            [ "$attempt" -lt 2 ] && { sleep 5; continue; }
+            echo "::error::GitHub tags API persistently returning HTTP ${http_code}" >&2
+            return 2
+        fi
+        if ! printf '%s' "$body" | jq -e 'type == "array"' >/dev/null 2>&1; then
+            echo "::warning::GitHub tags API attempt ${attempt}: response is not a JSON array" >&2
+            echo "Response body (first 500 chars):" >&2
+            printf '%s' "$body" | head -c 500 >&2; echo >&2
+            [ "$attempt" -lt 2 ] && { sleep 5; continue; }
+            echo "::error::GitHub tags API persistently returning non-array response" >&2
+            return 2
+        fi
+        printf '%s' "$body"
+        return 0
+    done
+    return 2
+}
 
-all_minors=$(echo "$tags_json" \
+tags_json=$(fetch_magento_tags) || exit 2
+
+all_minors=$(printf '%s' "$tags_json" \
     | jq -r 'map(.name)
              | map(select(test("^2\\.4\\.[0-9]+$")))
              | sort_by(. | split(".") | map(tonumber))


### PR DESCRIPTION
## Summary

- Replaces the bare \`curl | jq\` call to GitHub's tags API in \`dev/magento-support-matrix.sh\` with a guarded \`fetch_magento_tags()\` helper that validates HTTP status and JSON shape before piping to jq.
- Adds one retry with a 5s backoff so transient rate-limit / 502 blips don't break CI.
- On persistent failure, prints HTTP code + first 500 chars of the response body so the cause shows up in the workflow log instead of being hidden behind a generic jq error.

## Why

The matrix-discovery job intermittently fails with cryptic jq errors like:

\`\`\`
jq: error (at <stdin>:5): Cannot index string with string "name"
parse error: Expected string key before ':' at line 1, column 4
\`\`\`

…depending on whether GitHub returned an error object, partial response, or HTML page that turn. The same root cause (response was not the expected JSON array) surfaced as two different jq errors across the same PR's two CI runs. No way to tell from the log whether it was a rate limit, a 502, or something else.

Hit on PR #143 — the perf-only change passed all 21 substantive checks (lint, PHPStan, PHPUnit, DI-compile, etc.) but matrix discovery flaked twice in a row, blocking merge. This patch makes the failure mode self-diagnosing.

## Behaviour change

- Happy path: unchanged. \`--emit-matrix\` produces byte-identical output. Verified locally.
- Transient failure: one retry instead of immediate fail; log shows what came back.
- Persistent failure: error block now includes the actual HTTP code and response prefix, not a downstream jq stack trace.

## Test plan

- [x] Local: \`./dev/magento-support-matrix.sh --emit-matrix\` produces identical output.
- [x] Local: stubbed 404 URL — script retries once, prints HTTP 404 + body preview, exits 2.
- [ ] CI: matrix-discovery job runs green on this PR.
- [ ] CI: when (not if) GitHub flakes again, the log shows the actual cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)