### PR TITLE
ABN-363/fix: drop hardcoded 'NO' fallback in resolveBuyerCountry

### DIFF
--- a/Model/Total/Surcharge.php
+++ b/Model/Total/Surcharge.php
@@ -283,6 +283,14 @@ class Surcharge extends AbstractTotal
         return $this->configRepository->getDefaultPaymentTerm($storeId);
     }
 
+    /**
+     * Resolve buyer country in precedence order: billing, shipping, store
+     * default (`general/country/default`). Returns empty string if none
+     * are set — collect() runs after method selection, by which point
+     * the buyer has provided an address, so the empty branch is
+     * effectively dead in normal checkout. Better to surface "no
+     * country" than to invent a region-specific guess.
+     */
     private function resolveBuyerCountry(Quote $quote): string
     {
         $billing = $quote->getBillingAddress();
@@ -293,7 +301,7 @@ class Surcharge extends AbstractTotal
         if ($shipping && $shipping->getCountryId()) {
             return $shipping->getCountryId();
         }
-        return $quote->getStore()->getConfig('general/country/default') ?: 'NO';
+        return (string) $quote->getStore()->getConfig('general/country/default');
     }
 
     private function clearSessionSurcharge(): void


### PR DESCRIPTION
## Summary

- Drops the \`?: 'NO'\` last-ditch fallback in \`Two\\Gateway\\Model\\Total\\Surcharge::resolveBuyerCountry\`. Returns empty string instead.
- Vanilla mirror of the equivalent fix on \`magento-hyva-extension\` PR #20 (\`10b03cc\`), surfaced by gemini-code-assist there.

## Why

The Norway literal hid the "no country resolvable" state under a region-specific guess. Fine for Two's primary Nordic market; wrong the moment a brand overlay ships against a non-Nordic region (e.g. ABN_Gateway, NL).

\`collect()\` runs after the buyer picks a payment method, by which point Magento checkout has guaranteed a billing address with country — the empty branch is effectively dead in normal flows. If state ever does land empty, surface "no country" through the calculator rather than a confident wrong number.

## Test plan

- [ ] \`bin/magento setup:di:compile\` succeeds.
- [ ] Surcharge collector still runs correctly when billing country is set (normal checkout path).
- [ ] No regression in PHPStan / PHPUnit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)