### PR TITLE
chip: swap selected-chip palette to Two-brand blue to match .mode_item

### DIFF
--- a/view/frontend/web/css/style.css
+++ b/view/frontend/web/css/style.css
@@ -258,6 +258,14 @@
     margin-top: 4px;
 }
 
+/*
+ * Chip colour palette matches the `.mode_item` toggle elsewhere on the
+ * checkout page (Registered Organisation / Sole Trader): solid Two-brand
+ * blue (`--color-blue2`) for the selected state, white fill with blue
+ * text for unselected. Brand overlays that ship a different palette
+ * (e.g. ABN's teal/white pairing) override these rules from their own
+ * style.css which loads after this one.
+ */
 .two-term-chip {
     display: flex;
     flex-direction: column;
@@ -266,15 +274,16 @@
     border: 2px solid var(--color-gray89);
     border-radius: 8px;
     background: var(--color-white);
+    color: var(--color-blue2);
     cursor: pointer;
-    transition: border-color 0.15s ease;
+    transition: border-color 0.15s ease, background-color 0.15s ease, color 0.15s ease;
     min-width: 80px;
     font-family: inherit;
     position: relative;
 }
 
 .two-term-chip:hover {
-    border-color: #699797;
+    border-color: var(--color-blue2);
 }
 
 .two-term-chip:focus {
@@ -285,9 +294,9 @@
 .two-term-chip--selected:hover,
 .two-term-chip--selected:focus,
 .two-term-chip--selected:active {
-    border-color: #699797;
-    background: var(--color-white);
-    color: inherit;
+    border-color: var(--color-blue2);
+    background: var(--color-blue2);
+    color: var(--color-white);
 }
 
 .two-term-chip__days {
@@ -301,7 +310,7 @@
 
 .two-term-chip--selected .two-term-chip__days::before {
     content: '\2713';
-    color: #699797;
+    color: var(--color-white);
     font-size: 14px;
     font-weight: 700;
 }
@@ -315,7 +324,7 @@
 .two-term-chip__loading {
     display: inline-block;
     letter-spacing: 2px;
-    color: #999;
+    color: currentColor;
     font-size: 12px;
     line-height: 1.3;
     font-weight: 700;
@@ -338,14 +347,16 @@
     flex-direction: row;
     align-items: center;
     gap: 8px;
-    border-color: #699797;
+    border-color: var(--color-blue2);
+    background: var(--color-blue2);
+    color: var(--color-white);
     cursor: default;
     font-size: 14px;
     font-weight: 500;
 }
 
 .two-term-chip--single:hover {
-    border-color: #699797;
+    border-color: var(--color-blue2);
 }
 
 .two-term-chip--single .two-term-chip__surcharge {


### PR DESCRIPTION
## Summary

The term-chip widget previously rendered the selected state with a desaturated teal (`#699797`) border + tick on a white background. Other primary interactive elements on the checkout page — the `.mode_selector` / `.mode_item` toggle (Registered Organisation / Sole Trader) — use the Two-brand blue (`#3043d1`, exposed as `--color-blue2`) with a **solid fill** for the selected state.

This PR brings the chips into that family:

- **unselected chip**: white fill, blue text, light-gray border (border unchanged; text colour changes from `inherit` to blue)
- **selected chip**: solid blue fill, white text, blue border
- **selected tick** (`::before`): white (was teal)
- **single-term variant**: solid blue fill, white text — mirrors selected because it represents the active term when only one is offered
- **loading dots**: `currentColor` — now legible on both states (was `#999`)

## Brand overlays

ABN_Gateway ships a brand-specific overlay that prefers the old white-fill / teal-border pairing. Pinned in [magento-abn-plugin#doug/chip-abn-overlay-teal](https://github.com/two-inc/magento-abn-plugin/pulls?q=is%3Apr+head%3Adoug%2Fchip-abn-overlay-teal). Land that PR before/alongside this one to avoid a brief window where ABN merchants see the new blue chips.

Companion: [magento-hyva-extension#doug/chip-vanilla-blue](https://github.com/two-inc/magento-hyva-extension/pulls?q=is%3Apr+head%3Adoug%2Fchip-vanilla-blue) mirrors the same changes for the Hyvä checkout chip.

## Test plan

- [ ] On `magento.staging.two.inc/checkout/`, select `two_payment` and confirm the selected chip is solid `#3043d1` blue with white text + white tick.
- [ ] Hover an unselected chip → border switches to blue.
- [ ] Click between 30/60/90 — chip selection visibly swaps; loading dots remain legible during the transition.
- [ ] No regression on `magento.staging.achterafbetalen.co/default/checkout/` once the ABN overlay PR lands (should keep teal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)