### PR TITLE
feat(admin): make surcharge-grid blocks brand-aware via methodCode arg

### DIFF
--- a/Block/Adminhtml/System/Config/Field/SurchargeGrid.php
+++ b/Block/Adminhtml/System/Config/Field/SurchargeGrid.php
@@ -40,6 +40,16 @@ class SurchargeGrid extends Field
     /** @var BrandRegistryInterface */
     private $brandRegistry;
 
+    /**
+     * Payment method code whose config subtree this grid reads/writes
+     * (e.g. `two_payment`, `abn_payment`). Brand-overlay packages pass
+     * their own code via `<arguments>` in di.xml; the default keeps
+     * existing vanilla installs working unchanged.
+     *
+     * @var string
+     */
+    private $methodCode;
+
     /** @var string */
     private $scope = 'default';
 
@@ -52,13 +62,15 @@ class SurchargeGrid extends Field
         StoreManagerInterface $storeManager,
         CurrencyRatesProviderInterface $ratesProvider,
         BrandRegistryInterface $brandRegistry,
-        array $data = []
+        array $data = [],
+        string $methodCode = 'two_payment'
     ) {
         parent::__construct($context, $data);
         $this->scopeConfig = $scopeConfig;
         $this->storeManager = $storeManager;
         $this->ratesProvider = $ratesProvider;
         $this->brandRegistry = $brandRegistry;
+        $this->methodCode = $methodCode;
     }
 
     /**
@@ -84,10 +96,10 @@ class SurchargeGrid extends Field
      */
     public function getActiveTerms(): array
     {
-        $selected = $this->getConfigValue(ConfigRepository::XML_PATH_PAYMENT_TERMS);
+        $selected = $this->getConfigValue($this->path('payment_terms'));
         $terms = array_filter(array_map('intval', explode(',', (string)$selected)));
 
-        $custom = (int)$this->getConfigValue(ConfigRepository::XML_PATH_PAYMENT_TERMS_DURATION_DAYS);
+        $custom = (int)$this->getConfigValue($this->path('payment_terms_duration_days'));
         if ($custom > 0) {
             $terms[] = $custom;
         }
@@ -102,8 +114,7 @@ class SurchargeGrid extends Field
      */
     public function getSavedValue(int $days, string $field): string
     {
-        $path = sprintf('payment/two_payment/surcharge_%d_%s', $days, $field);
-        $value = $this->getConfigValue($path);
+        $value = $this->getConfigValue($this->path(sprintf('surcharge_%d_%s', $days, $field)));
         return $value !== null ? (string)$value : '';
     }
 
@@ -112,7 +123,7 @@ class SurchargeGrid extends Field
      */
     public function getDefaultTerm(): int
     {
-        return (int)$this->getConfigValue(ConfigRepository::XML_PATH_DEFAULT_PAYMENT_TERM);
+        return (int)$this->getConfigValue($this->path('default_payment_term'));
     }
 
     /**
@@ -120,7 +131,7 @@ class SurchargeGrid extends Field
      */
     public function getSurchargeType(): string
     {
-        return (string)$this->getConfigValue(ConfigRepository::XML_PATH_SURCHARGE_TYPE);
+        return (string)$this->getConfigValue($this->path('surcharge_type'));
     }
 
     /**
@@ -332,7 +343,7 @@ class SurchargeGrid extends Field
         if ($this->scope === 'default') {
             return false;
         }
-        $path = sprintf('payment/two_payment/surcharge_%d_%s', $days, $field);
+        $path = $this->path(sprintf('surcharge_%d_%s', $days, $field));
         $value = $this->scopeConfig->getValue($path, $this->scope, $this->scopeId);
         $defaultValue = $this->scopeConfig->getValue($path);
         return $value === $defaultValue;
@@ -392,5 +403,16 @@ class SurchargeGrid extends Field
             return $this->scopeConfig->getValue($path, $this->scope, $this->scopeId);
         }
         return $this->scopeConfig->getValue($path);
+    }
+
+    /**
+     * Build a fully-qualified config path under the configured payment
+     * method subtree. Brand-overlay packages set `methodCode` via di.xml
+     * so their merchant config (e.g. `payment/abn_payment/payment_terms`)
+     * is read instead of the vanilla `payment/two_payment/*` subtree.
+     */
+    private function path(string $suffix): string
+    {
+        return 'payment/' . $this->methodCode . '/' . $suffix;
     }
 }

--- a/Model/Config/Backend/SurchargeGrid.php
+++ b/Model/Config/Backend/SurchargeGrid.php
@@ -44,6 +44,15 @@ class SurchargeGrid extends Value
     /** @var BrandRegistryInterface */
     private $brandRegistry;
 
+    /**
+     * Payment method code whose config subtree this grid persists into
+     * (e.g. `two_payment`, `abn_payment`). Brand-overlay packages pass
+     * their own code via `<arguments>` in di.xml.
+     *
+     * @var string
+     */
+    private $methodCode;
+
     public function __construct(
         Context $context,
         Registry $registry,
@@ -55,13 +64,15 @@ class SurchargeGrid extends Value
         BrandRegistryInterface $brandRegistry,
         ?AbstractResource $resource = null,
         ?AbstractDb $resourceCollection = null,
-        array $data = []
+        array $data = [],
+        string $methodCode = 'two_payment'
     ) {
         parent::__construct($context, $registry, $config, $cacheTypeList, $resource, $resourceCollection, $data);
         $this->configWriter = $configWriter;
         $this->storeManager = $storeManager;
         $this->ratesProvider = $ratesProvider;
         $this->brandRegistry = $brandRegistry;
+        $this->methodCode = $methodCode;
     }
 
     /**
@@ -111,7 +122,7 @@ class SurchargeGrid extends Value
                     continue;
                 }
 
-                $path = sprintf('payment/two_payment/surcharge_%d_%s', $days, $type);
+                $path = sprintf('payment/%s/surcharge_%d_%s', $this->methodCode, $days, $type);
 
                 if (isset($inheritData[$days][$type]) && $inheritData[$days][$type]) {
                     $this->configWriter->delete($path, $scope, $scopeId);
@@ -134,7 +145,7 @@ class SurchargeGrid extends Value
         // Persist the base currency so fixed amounts remain meaningful
         $currencyCode = $this->resolveBaseCurrency($scope, $scopeId);
         $this->configWriter->save(
-            ConfigRepository::XML_PATH_SURCHARGE_FIXED_CURRENCY,
+            sprintf('payment/%s/surcharge_fixed_currency', $this->methodCode),
             $currencyCode,
             $scope,
             $scopeId


### PR DESCRIPTION
## Summary

- Add `methodCode` constructor arg (default `'two_payment'`) to `SurchargeGrid` admin block + backend model
- Replace hardcoded `payment/two_payment/...` literals and `ConfigRepository::XML_PATH_*` constants with dynamic `payment/{$methodCode}/...` paths via a `path()` helper
- Vanilla installs see zero behavioural change; brand-overlay packages can now wire `methodCode='abn_payment'` (etc.) in di.xml so the rendered grid reads from / writes into their own merchant subtree

## Why

The brand-overlay 2.0 architecture (`Two\Gateway\Api\BrandRegistryInterface`) intends for downstream packages like `ABN_Gateway` to compose a complete payment method by injecting their own `Brand` + `ConfigRepository`. The admin surcharge-grid widget was the last piece that hadn't been parameterised — both the block and the backend model still hardcoded `payment/two_payment/` everywhere.

This blocks restoring the abn-1.14.1 merchant config UX (per-term surcharge grid + payment-terms multi-select) without forking the parent block classes. With this PR, the ABN overlay only needs a thin subclass per block + a 1-line `methodCode` argument in `di.xml`.

## Test plan

- [ ] Vanilla install: `Stores → Config → Sales → Two — Zakelijk op Rekening → Payment Terms` grid renders and saves as before (no change to behaviour or stored paths)
- [ ] Brand-overlay install (ABN, with companion magento-abn-plugin PR landed): grid renders from `payment/abn_payment/payment_terms`, saves per-term values into `payment/abn_payment/surcharge_{days}_{type}`, persists currency at `payment/abn_payment/surcharge_fixed_currency`
- [ ] CI green
