### PR TITLE
fix: bump etc/config.xml version 1.14.1 -> 2.0.0-dev

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -26,7 +26,7 @@
                     Has no effect when no overlay is registered.
                 -->
                 <hide_when_overlay_installed>1</hide_when_overlay_installed>
-                <version>1.14.1</version>
+                <version>2.0.0-dev</version>
                 <title>Two</title>
                 <sort_order>-10</sort_order>
                 <mode>sandbox</mode>


### PR DESCRIPTION
## Summary

- `etc/config.xml` `<version>` was stuck at `1.14.1` since before the brand-aware refactor (`abdca90`) bumped `composer.json` to `2.0.0-dev`. bumpver.toml's file_patterns target both files but only fires on its own `bumpver update` invocations.
- `Repository::getExtensionVersionData()` reads `payment/two_payment/version` (which falls back to config.xml when no CCD row exists) and ships it as `client_v` in every outbound Two API URL. So every deployed Two_Gateway has been reporting itself as `1.14.1` regardless of actual code.
- One-line fix: align config.xml with composer.json. bumpver.toml deliberately left at `1.16.2` — that's release-pipeline state, not staging concern; the eventual 2.0.0 release cut from main will resync it.

## Test plan

- [ ] Merge, wait for gitSync + deploy
- [ ] Inspect a Two API call from staging and confirm `client_v=2.0.0-dev` in the URL
- [ ] Admin General continues to render (no regression vs PR #149's deployment-status panel)
