### PR TITLE
fix(admin): read commit SHA from .git file, not realpath

### DIFF
--- a/Block/Adminhtml/System/Config/Field/Version.php
+++ b/Block/Adminhtml/System/Config/Field/Version.php
@@ -216,8 +216,14 @@ class Version extends Field
     {
         $gitFile = $modulePath . '/.git';
         if (is_file($gitFile)) {
-            $content = @file_get_contents($gitFile);
-            if ($content !== false && preg_match('#worktrees/([a-f0-9]{7,40})#', $content, $m)) {
+            // .git is always `gitdir: <relpath>\n`; cap the read defensively
+            // and trim before anchoring the regex to end-of-string so a
+            // worktrees/<sha> segment elsewhere in the path can't shadow
+            // the real SHA at the tail.
+            $content = @file_get_contents($gitFile, false, null, 0, 1024);
+            if ($content !== false
+                && preg_match('#worktrees/([a-f0-9]{7,40})/?$#', trim($content), $m)
+            ) {
                 return substr($m[1], 0, 7);
             }
         }

--- a/Block/Adminhtml/System/Config/Field/Version.php
+++ b/Block/Adminhtml/System/Config/Field/Version.php
@@ -201,17 +201,29 @@ class Version extends Field
     }
 
     /**
-     * 7-char SHA from the gitSync worktree symlink target. gitSync writes
-     * worktrees at `.worktrees/<sha>/` and points the module path symlink
-     * (or its parent) at the active worktree.
+     * 7-char SHA of the gitSync-pulled commit.
+     *
+     * gitSync v4 writes worktrees at `<root>/.git/worktrees/<sha>/` and
+     * names each worktree directory after the SHA it points at. The
+     * module's `.git` file (a single line `gitdir: <relpath>`) references
+     * that directory. Read it directly — robust whether the module path
+     * is a symlink straight to the worktree (older layout) or a real
+     * directory whose contents were copied/hardlinked at init (current
+     * Magento init job behaviour, which makes the realpath of
+     * registration.php contain no worktree segment).
      */
     private function extractCommit(string $modulePath): string
     {
-        $real = @realpath($modulePath . '/registration.php');
-        if (!$real) {
-            return '';
+        $gitFile = $modulePath . '/.git';
+        if (is_file($gitFile)) {
+            $content = @file_get_contents($gitFile);
+            if ($content !== false && preg_match('#worktrees/([a-f0-9]{7,40})#', $content, $m)) {
+                return substr($m[1], 0, 7);
+            }
         }
-        if (preg_match('#\.worktrees/([a-f0-9]{7,40})/#', $real, $m)) {
+        // Legacy fallback: module path is a symlink through the worktree.
+        $real = @realpath($modulePath . '/registration.php');
+        if ($real && preg_match('#\.worktrees/([a-f0-9]{7,40})/#', $real, $m)) {
             return substr($m[1], 0, 7);
         }
         return '';


### PR DESCRIPTION
## Summary

Deployment-status panel was rendering an empty Commit column on both brands. Root cause:

- Magento init copies (or hardlinks) gitSync-pulled module contents into `/var/www/html/plugins/<name>/` rather than symlinking through to the worktree.
- `realpath(registration.php)` on the deployed pod resolves to `/var/www/html/plugins/<name>/registration.php` — no `.worktrees/<sha>/` segment.
- Existing regex `\.worktrees/([a-f0-9]{7,40})/` never matched → empty string returned → blank Commit cell.

Fix: parse the SHA from the module's `.git` file (`gitdir: ../../.git/worktrees/<sha>` — gitSync names each worktree directory after the SHA it points at). Keep the realpath approach as fallback.

## Verified

On `magento-abn-9c869f78d-gp8lk:/var/www/html/plugins/upstream-gateway/.git`:
```
gitdir: ../../.git/worktrees/69794911a1ca701e3825642cc8c980803363d980
```

## Test plan

- [ ] Merge + redeploy. Confirm Commit column populated on vanilla (single row) and ABN (three rows).
