### PR TITLE
feat(admin): friendly row labels + dedicated Version section

### DIFF
--- a/Block/Adminhtml/System/Config/Field/Version.php
+++ b/Block/Adminhtml/System/Config/Field/Version.php
@@ -16,17 +16,19 @@ use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
 
 /**
- * Renders a deployment-status panel listing every gateway-stack module
- * installed alongside Two_Gateway (parent, Hyva extension, brand
- * overlays) plus a single assets-freshness row.
+ * Renders the admin "Version" panel: one row per gateway-stack module
+ * (parent payment method, Hyva extension, brand overlays) plus a
+ * single assets-freshness row.
  *
  * Per-module signals: composer.json version (authoritative for what's
  * deployed), gitSync worktree commit SHA, source mtime.
  * Panel-level: assets mtime + stale warning when assets are older than
  * the newest module's source.
  *
- * The module list comes from the `moduleNames` DI argument. Brand
- * overlays rebind the type and prepend their own module. Unregistered
+ * Rows come from the `moduleLabels` DI argument — a label-keyed map
+ * from human-readable row title to ComponentRegistrar module name.
+ * Brand overlays rebind the type with their own labels (e.g. ABN
+ * adds "Payment Method Theme" / "Hyva Theme" rows). Unregistered
  * entries (e.g. Hyva when not installed) are silently skipped.
  */
 class Version extends Field
@@ -48,23 +50,24 @@ class Version extends Field
     private string $moduleName;
 
     /**
-     * @var string[]
+     * @var array<string, string> Label => module-name map (ordered).
      */
-    private array $moduleNames;
+    private array $moduleLabels;
 
     /**
      * @param ConfigRepository $configRepository
      * @param Context $context
-     * @param ComponentRegistrar|null $componentRegistrar
-     * @param DirectoryList|null $directoryList
-     * @param TimezoneInterface|null $timezone
+     * @param ComponentRegistrar $componentRegistrar
+     * @param DirectoryList $directoryList
+     * @param TimezoneInterface $timezone
      * @param string $moduleName Primary module — used by getVersion() fallback
      *                           and for any caller still expecting a single
      *                           module identity.
-     * @param string[] $moduleNames Ordered list of modules to enumerate in
-     *                              the panel. Defaults to [moduleName,
-     *                              'Two_GatewayHyva']. Unregistered entries
-     *                              are skipped.
+     * @param array<string, string> $moduleLabels Ordered label=>module-name map.
+     *                              Defaults to [Payment Method => Two_Gateway,
+     *                              Hyva Extension => Two_GatewayHyva].
+     *                              Brand overlays rebind to append theme rows.
+     *                              Unregistered modules are skipped.
      * @param array $data
      */
     public function __construct(
@@ -74,7 +77,7 @@ class Version extends Field
         DirectoryList $directoryList,
         TimezoneInterface $timezone,
         string $moduleName = 'Two_Gateway',
-        array $moduleNames = [],
+        array $moduleLabels = [],
         array $data = []
     ) {
         $this->configRepository = $configRepository;
@@ -82,9 +85,12 @@ class Version extends Field
         $this->directoryList = $directoryList;
         $this->timezone = $timezone;
         $this->moduleName = $moduleName;
-        $this->moduleNames = !empty($moduleNames)
-            ? $moduleNames
-            : [$moduleName, 'Two_GatewayHyva'];
+        $this->moduleLabels = !empty($moduleLabels)
+            ? $moduleLabels
+            : [
+                'Payment Method' => 'Two_Gateway',
+                'Hyva Extension' => 'Two_GatewayHyva',
+            ];
         parent::__construct($context, $data);
     }
 
@@ -111,23 +117,18 @@ class Version extends Field
     /**
      * Rows for the multi-module panel.
      *
-     * @return array<int, array{name: string, version: ?string, commit: string, codeAt: string}>
+     * @return array<int, array{label: string, version: ?string, commit: string, codeAt: string}>
      */
     public function getModules(): array
     {
         $rows = [];
-        $seen = [];
-        foreach ($this->moduleNames as $name) {
-            if (isset($seen[$name])) {
-                continue;
-            }
-            $seen[$name] = true;
-            $path = $this->getModulePathFor($name);
+        foreach ($this->moduleLabels as $label => $moduleName) {
+            $path = $this->getModulePathFor($moduleName);
             if (!$path) {
                 continue;
             }
             $rows[] = [
-                'name' => $name,
+                'label' => $label,
                 'version' => $this->readComposerVersion($path),
                 'commit' => $this->extractCommit($path),
                 'codeAt' => $this->formatTs($this->getCodeTs($path)),
@@ -157,8 +158,8 @@ class Version extends Field
             return false;
         }
         $newestCode = 0;
-        foreach ($this->moduleNames as $name) {
-            $path = $this->getModulePathFor($name);
+        foreach ($this->moduleLabels as $moduleName) {
+            $path = $this->getModulePathFor($moduleName);
             if (!$path) {
                 continue;
             }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -20,11 +20,6 @@
             <group id="general" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1"
                    showInStore="1">
                 <label>General</label>
-                <field id="version" translate="label" type="button" sortOrder="10" showInDefault="1"
-                       showInWebsite="1" showInStore="1">
-                    <label>Deployment status</label>
-                    <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\Version</frontend_model>
-                </field>
                 <field id="mode" translate="label" type="select" sortOrder="35" showInDefault="1" showInWebsite="1"
                        showInStore="1">
                     <label>Environment</label>
@@ -290,6 +285,28 @@
                         <field id="enable_company_search">1</field>
                     </depends>
                     <config_path>payment/two_payment/enable_address_search</config_path>
+                </field>
+            </group>
+        </section>
+        <!--
+            Deployment version panel. Standalone section so the operator
+            can land directly on it from the left nav rather than scrolling
+            past General config. sortOrder=100 keeps it at the bottom of
+            the "Two" tab regardless of how many config sections grow above.
+        -->
+        <section id="two_version" translate="label" type="text" sortOrder="100" showInDefault="1" showInWebsite="1"
+                 showInStore="1">
+            <class>separator-top</class>
+            <label>Version</label>
+            <tab>two_gateway</tab>
+            <resource>Magento_Sales::config_sales</resource>
+            <group id="general" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1"
+                   showInStore="1">
+                <label>Version</label>
+                <field id="version" translate="label" type="button" sortOrder="10" showInDefault="1"
+                       showInWebsite="1" showInStore="1">
+                    <label>Version</label>
+                    <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\Version</frontend_model>
                 </field>
             </group>
         </section>

--- a/view/adminhtml/templates/system/config/field/version.phtml
+++ b/view/adminhtml/templates/system/config/field/version.phtml
@@ -29,7 +29,7 @@ $stale    = $block->isAssetsStale();
                 <?php foreach ($modules as $row): ?>
                     <tr>
                         <td style="padding:0.25em 1em 0.25em 0;">
-                            <strong><?= $block->escapeHtml($row['name']); ?></strong>
+                            <strong><?= $block->escapeHtml($row['label']); ?></strong>
                         </td>
                         <td style="padding:0.25em 1em 0.25em 0;">
                             <?php if (!empty($row['version'])): ?>


### PR DESCRIPTION
## Summary

- Row labels are now human-readable. `moduleNames` (`string[]`) → `moduleLabels` (`array<string,string>` label→module-name map). Defaults: `Payment Method => Two_Gateway`, `Hyva Extension => Two_GatewayHyva`. Brand overlays rebind to append theme rows.
- Field moves out of `two_general` to a new section `two_version` (sortOrder=100), giving the panel its own left-nav entry "Version" at the bottom of the Two tab. Field label is "Version" (was "Deployment status").

## ABN companion

magento-abn-plugin will land alongside with:
- `moduleLabels` binding that adds `Payment Method Theme => ABN_Gateway` and `Hyva Theme => ABN_GatewayHyva` (and reorders to put parent rows first per Doug's spec).
- ABN's own `abn_version` section move.

## BC note

`moduleNames` → `moduleLabels` is a rename. Magento DI silently ignores unknown argument names, so an out-of-step overlay (binding stale `moduleNames`) falls back to the vanilla default — two rows showing the parent runtime. Not actively wrong, but missing the brand theme rows until the overlay PR ships.

## Test plan

- [ ] Merge + redeploy. Confirm "Version" appears as the last left-nav entry under the Two tab.
- [ ] Confirm the panel shows "Payment Method" + "Hyva Extension" rows with version, commit, code-deployed-at, plus the assets line.
- [ ] Confirm `two_general` no longer has the Version field at the top.
