### PR TITLE
drop redundant Version field label

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -305,7 +305,7 @@
                 <label>Version</label>
                 <field id="version" translate="label" type="button" sortOrder="10" showInDefault="1"
                        showInWebsite="1" showInStore="1">
-                    <label>Version</label>
+                    <label/>
                     <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\Version</frontend_model>
                 </field>
             </group>


### PR DESCRIPTION
Field already sits inside section 'Version' / group 'Version' — the third label on the row is noise. Use `<label/>` so the row structure (empty left cell, panel in the right cell) survives.