### PR TITLE
v6 brand overlay PR A: foundation (additive)

### DIFF
--- a/Brand/DescriptorBackedBrandRegistry.php
+++ b/Brand/DescriptorBackedBrandRegistry.php
@@ -11,13 +11,13 @@ use Two\Gateway\Api\BrandRegistryInterface;
 use Two\Gateway\Model\Brand\ActiveBrandResolver;
 
 /**
- * Bridge between v6's brand.xml-sourced Descriptor and the legacy
+ * Bridge between the brand.xml-sourced Descriptor and the legacy
  * BrandRegistryInterface still consumed by Two, Adapter, Repository,
  * controllers and several admin blocks.
  *
- * The legacy interface is scheduled for deletion (v6 §12.1); until
- * every consumer migrates to Descriptor-direct, this adapter lets
- * brand identity flow from brand.xml through the existing API.
+ * The legacy interface is scheduled for deletion; until every
+ * consumer migrates to Descriptor-direct, this adapter lets brand
+ * identity flow from brand.xml through the existing API.
  */
 class DescriptorBackedBrandRegistry implements BrandRegistryInterface
 {

--- a/Brand/DescriptorBackedBrandRegistry.php
+++ b/Brand/DescriptorBackedBrandRegistry.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Brand;
+
+use Two\Gateway\Api\BrandRegistryInterface;
+use Two\Gateway\Model\Brand\ActiveBrandResolver;
+
+/**
+ * Bridge between v6's brand.xml-sourced Descriptor and the legacy
+ * BrandRegistryInterface still consumed by Two, Adapter, Repository,
+ * controllers and several admin blocks.
+ *
+ * The legacy interface is scheduled for deletion (v6 §12.1); until
+ * every consumer migrates to Descriptor-direct, this adapter lets
+ * brand identity flow from brand.xml through the existing API.
+ */
+class DescriptorBackedBrandRegistry implements BrandRegistryInterface
+{
+    public function __construct(
+        private readonly ActiveBrandResolver $activeBrandResolver
+    ) {
+    }
+
+    public function getProvider(): string
+    {
+        return $this->activeBrandResolver->resolve()->getProvider();
+    }
+
+    public function getProviderFullName(): string
+    {
+        return $this->activeBrandResolver->resolve()->getProviderFullName();
+    }
+
+    public function getProductName(): string
+    {
+        return $this->activeBrandResolver->resolve()->getProductName();
+    }
+
+    public function getCheckoutUrlTemplate(): string
+    {
+        return $this->activeBrandResolver->resolve()->getCheckoutUrlTemplate();
+    }
+
+    public function getAvailablePaymentTerms(): array
+    {
+        return $this->activeBrandResolver->resolve()->getAvailablePaymentTerms();
+    }
+
+    public function getSurchargeFixedMax(): ?array
+    {
+        return $this->activeBrandResolver->resolve()->getSurchargeFixedMax();
+    }
+
+    public function getSignUpUrl(): string
+    {
+        return $this->activeBrandResolver->resolve()->getSignUpUrl();
+    }
+
+    public function getDocumentationUrl(): string
+    {
+        return $this->activeBrandResolver->resolve()->getDocumentationUrl();
+    }
+
+    public function getBrandTag(): string
+    {
+        return $this->activeBrandResolver->resolve()->getBrandTag();
+    }
+}

--- a/Model/Brand/ActiveBrandResolver.php
+++ b/Model/Brand/ActiveBrandResolver.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Model\Brand;
+
+/**
+ * Resolves the single active brand for this install.
+ *
+ * Invariant (v6 §6): max one overlay brand atop Two.
+ *   - Two only          → Two is active.
+ *   - Two + one overlay → overlay is active.
+ *   - Three+ brands     → throws DomainException at first resolve().
+ *
+ * If business ever pivots to multi-brand-same-install, this class
+ * is the only thing that needs rewriting — see §6 Reversibility.
+ */
+class ActiveBrandResolver
+{
+    public const TWO_CODE = 'two_payment';
+
+    private ?Descriptor $active = null;
+
+    public function __construct(
+        private readonly Loader $loader
+    ) {
+    }
+
+    public function resolve(): Descriptor
+    {
+        if ($this->active !== null) {
+            return $this->active;
+        }
+
+        $brands = $this->loader->load();
+
+        if ($brands === []) {
+            throw new \DomainException(
+                'No brands registered. magento-plugin must ship its own etc/brand.xml.'
+            );
+        }
+
+        $overlays = array_filter(
+            $brands,
+            static fn(Descriptor $b) => $b->getCode() !== self::TWO_CODE
+        );
+
+        if (count($overlays) > 1) {
+            throw new \DomainException(sprintf(
+                'Multiple overlay brands installed: %s. '
+                . 'Only one overlay is supported per install.',
+                implode(', ', array_map(static fn(Descriptor $b) => $b->getCode(), $overlays))
+            ));
+        }
+
+        if ($overlays === []) {
+            if (!isset($brands[self::TWO_CODE])) {
+                throw new \DomainException(sprintf(
+                    'Two brand ("%s") not declared in any brand.xml; '
+                    . 'magento-plugin/etc/brand.xml is missing.',
+                    self::TWO_CODE
+                ));
+            }
+            return $this->active = $brands[self::TWO_CODE];
+        }
+
+        return $this->active = reset($overlays);
+    }
+
+    /**
+     * @return array<string,Descriptor> All registered brands keyed by code.
+     */
+    public function all(): array
+    {
+        return $this->loader->load();
+    }
+}

--- a/Model/Brand/ActiveBrandResolver.php
+++ b/Model/Brand/ActiveBrandResolver.php
@@ -10,13 +10,13 @@ namespace Two\Gateway\Model\Brand;
 /**
  * Resolves the single active brand for this install.
  *
- * Invariant (v6 §6): max one overlay brand atop Two.
+ * Invariant: max one overlay brand atop Two.
  *   - Two only          → Two is active.
  *   - Two + one overlay → overlay is active.
  *   - Three+ brands     → throws DomainException at first resolve().
  *
- * If business ever pivots to multi-brand-same-install, this class
- * is the only thing that needs rewriting — see §6 Reversibility.
+ * Reversible to a multi-brand registry by rewriting this class
+ * alone if business ever needs multi-brand-same-install.
  */
 class ActiveBrandResolver
 {

--- a/Model/Brand/BrandPaymentMethodFactory.php
+++ b/Model/Brand/BrandPaymentMethodFactory.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Two\Gateway\Model\Brand;
 
 use Magento\Framework\ObjectManagerInterface;
+use Two\Gateway\Api\BrandRegistryInterface;
 use Two\Gateway\Model\GenericPaymentMethod;
 
 /**
@@ -21,6 +22,11 @@ use Two\Gateway\Model\GenericPaymentMethod;
  * Singleton-scoped via DI lifetime; for CLI/consumer processes
  * the cache persists for the process lifetime, which is fine
  * because Descriptors are immutable per process.
+ *
+ * v6 PR A: passes the Descriptor's code as the legacy `code`
+ * argument and the DI-resolved BrandRegistryInterface (currently
+ * DescriptorBackedBrandRegistry) as the `brand` argument. PR B
+ * replaces both with a single `descriptor` constructor arg.
  */
 class BrandPaymentMethodFactory
 {
@@ -28,7 +34,8 @@ class BrandPaymentMethodFactory
     private array $instances = [];
 
     public function __construct(
-        private readonly ObjectManagerInterface $objectManager
+        private readonly ObjectManagerInterface $objectManager,
+        private readonly BrandRegistryInterface $brandRegistry
     ) {
     }
 
@@ -42,7 +49,10 @@ class BrandPaymentMethodFactory
         /** @var GenericPaymentMethod $instance */
         $instance = $this->objectManager->create(
             GenericPaymentMethod::class,
-            ['descriptor' => $descriptor]
+            [
+                'code' => $code,
+                'brand' => $this->brandRegistry,
+            ]
         );
 
         return $this->instances[$code] = $instance;

--- a/Model/Brand/BrandPaymentMethodFactory.php
+++ b/Model/Brand/BrandPaymentMethodFactory.php
@@ -23,10 +23,11 @@ use Two\Gateway\Model\GenericPaymentMethod;
  * the cache persists for the process lifetime, which is fine
  * because Descriptors are immutable per process.
  *
- * v6 PR A: passes the Descriptor's code as the legacy `code`
- * argument and the DI-resolved BrandRegistryInterface (currently
- * DescriptorBackedBrandRegistry) as the `brand` argument. PR B
- * replaces both with a single `descriptor` constructor arg.
+ * Passes the Descriptor's code as the legacy `code` argument and
+ * the DI-resolved BrandRegistryInterface (currently
+ * DescriptorBackedBrandRegistry) as the `brand` argument, preserving
+ * the existing GenericPaymentMethod constructor signature so legacy
+ * overlay virtualTypes continue to compile.
  */
 class BrandPaymentMethodFactory
 {

--- a/Model/Brand/BrandPaymentMethodFactory.php
+++ b/Model/Brand/BrandPaymentMethodFactory.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Model\Brand;
+
+use Magento\Framework\ObjectManagerInterface;
+use Two\Gateway\Model\GenericPaymentMethod;
+
+/**
+ * Manufactures GenericPaymentMethod instances bound to a given
+ * Descriptor. Owns a per-request cache keyed by brand code —
+ * Magento's Helper\Data::$_methodInstances cache is NOT populated
+ * when our around-plugin short-circuits $proceed (the parent's
+ * cache-write line lives in the original method body), so we
+ * cache here instead.
+ *
+ * Singleton-scoped via DI lifetime; for CLI/consumer processes
+ * the cache persists for the process lifetime, which is fine
+ * because Descriptors are immutable per process.
+ */
+class BrandPaymentMethodFactory
+{
+    /** @var array<string,GenericPaymentMethod> */
+    private array $instances = [];
+
+    public function __construct(
+        private readonly ObjectManagerInterface $objectManager
+    ) {
+    }
+
+    public function build(Descriptor $descriptor): GenericPaymentMethod
+    {
+        $code = $descriptor->getCode();
+        if (isset($this->instances[$code])) {
+            return $this->instances[$code];
+        }
+
+        /** @var GenericPaymentMethod $instance */
+        $instance = $this->objectManager->create(
+            GenericPaymentMethod::class,
+            ['descriptor' => $descriptor]
+        );
+
+        return $this->instances[$code] = $instance;
+    }
+}

--- a/Model/Brand/Descriptor.php
+++ b/Model/Brand/Descriptor.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Model\Brand;
+
+/**
+ * Install-time-immutable brand identity. Materialised from
+ * one <brand> element in a module's etc/brand.xml by Loader.
+ *
+ * All mutable settings (api_key, mode, payment_terms selections,
+ * surcharge_grid …) are read live from CCD per request via
+ * ScopeConfigInterface keyed on payment/<code>/<setting>. The
+ * Descriptor never caches those.
+ */
+final class Descriptor
+{
+    /**
+     * @param string $code Magento payment-method code (e.g. "two_payment").
+     * @param int $tabSortOrder Admin Configuration tab sortOrder.
+     * @param string $provider Short brand name shown in admin headers.
+     * @param string $providerFullName Legal entity name.
+     * @param string $productName Customer-facing product label.
+     * @param string $tabLabel Admin Configuration tab label.
+     * @param string $tabCssClass CSS class on the admin tab `<li>`.
+     * @param string $checkoutUrlTemplate sprintf template, %s = env tag.
+     * @param string $brandTag Disambiguator for shared-host checkouts; '' = none.
+     * @param string $signUpUrl Merchant sign-up link shown in admin header.
+     * @param string $documentationUrl Plugin docs URL shown in admin header.
+     * @param string $apiBaseUrl Outbound API base URL.
+     * @param int[] $availablePaymentTerms Buyer-selectable terms in days.
+     * @param array{amount:float,currency:string}|null $surchargeFixedMax
+     * @param string[] $cspOrigins Additional CSP fetch-policy origins.
+     * @param string $adminResource ACL resource for the brand's admin form.
+     * @param array<array{label:string,module:string}> $moduleLabelChain Version-panel rows.
+     * @param string[] $allowedCurrencies ISO codes; empty = unrestricted.
+     * @param string[] $allowedCountries ISO codes; empty = unrestricted.
+     * @param array<string,string> $extraHttpHeaders name=>value, decoration on outbound requests.
+     */
+    public function __construct(
+        private readonly string $code,
+        private readonly int $tabSortOrder,
+        private readonly string $provider,
+        private readonly string $providerFullName,
+        private readonly string $productName,
+        private readonly string $tabLabel,
+        private readonly string $tabCssClass,
+        private readonly string $checkoutUrlTemplate,
+        private readonly string $brandTag,
+        private readonly string $signUpUrl,
+        private readonly string $documentationUrl,
+        private readonly string $apiBaseUrl,
+        private readonly array $availablePaymentTerms,
+        private readonly ?array $surchargeFixedMax,
+        private readonly array $cspOrigins,
+        private readonly string $adminResource,
+        private readonly array $moduleLabelChain,
+        private readonly array $allowedCurrencies,
+        private readonly array $allowedCountries,
+        private readonly array $extraHttpHeaders
+    ) {
+    }
+
+    public function getCode(): string
+    {
+        return $this->code;
+    }
+
+    public function getTabSortOrder(): int
+    {
+        return $this->tabSortOrder;
+    }
+
+    public function getProvider(): string
+    {
+        return $this->provider;
+    }
+
+    public function getProviderFullName(): string
+    {
+        return $this->providerFullName !== '' ? $this->providerFullName : $this->provider;
+    }
+
+    public function getProductName(): string
+    {
+        return $this->productName;
+    }
+
+    public function getTabLabel(): string
+    {
+        return $this->tabLabel;
+    }
+
+    public function getTabCssClass(): string
+    {
+        return $this->tabCssClass;
+    }
+
+    public function getCheckoutUrlTemplate(): string
+    {
+        return $this->checkoutUrlTemplate;
+    }
+
+    public function getBrandTag(): string
+    {
+        return $this->brandTag;
+    }
+
+    public function getSignUpUrl(): string
+    {
+        return $this->signUpUrl;
+    }
+
+    public function getDocumentationUrl(): string
+    {
+        return $this->documentationUrl;
+    }
+
+    public function getApiBaseUrl(): string
+    {
+        return $this->apiBaseUrl;
+    }
+
+    /** @return int[] */
+    public function getAvailablePaymentTerms(): array
+    {
+        return $this->availablePaymentTerms;
+    }
+
+    /** @return array{amount:float,currency:string}|null */
+    public function getSurchargeFixedMax(): ?array
+    {
+        return $this->surchargeFixedMax;
+    }
+
+    /** @return string[] */
+    public function getCspOrigins(): array
+    {
+        return $this->cspOrigins;
+    }
+
+    public function getAdminResource(): string
+    {
+        return $this->adminResource;
+    }
+
+    /** @return array<array{label:string,module:string}> */
+    public function getModuleLabelChain(): array
+    {
+        return $this->moduleLabelChain;
+    }
+
+    /** @return string[] */
+    public function getAllowedCurrencies(): array
+    {
+        return $this->allowedCurrencies;
+    }
+
+    /** @return string[] */
+    public function getAllowedCountries(): array
+    {
+        return $this->allowedCountries;
+    }
+
+    /** @return array<string,string> */
+    public function getExtraHttpHeaders(): array
+    {
+        return $this->extraHttpHeaders;
+    }
+}

--- a/Model/Brand/Loader.php
+++ b/Model/Brand/Loader.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Model\Brand;
+
+use Magento\Framework\Component\ComponentRegistrar;
+
+/**
+ * Enumerates installed modules via ComponentRegistrar and loads
+ * each module's etc/brand.xml into Descriptor objects.
+ *
+ * No OM dependency — ComponentRegistrar is populated by every
+ * module's registration.php and available at any post-autoload
+ * phase. Safe to call from boot-time code.
+ */
+class Loader
+{
+    /** @var array<string,Descriptor>|null */
+    private ?array $cache = null;
+
+    public function __construct(
+        private readonly ComponentRegistrar $componentRegistrar
+    ) {
+    }
+
+    /**
+     * @return array<string,Descriptor> Indexed by brand code.
+     */
+    public function load(): array
+    {
+        if ($this->cache !== null) {
+            return $this->cache;
+        }
+
+        $brands = [];
+        foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::MODULE) as $modulePath) {
+            $brandXmlPath = $modulePath . '/etc/brand.xml';
+            if (!is_file($brandXmlPath)) {
+                continue;
+            }
+
+            $xml = $this->loadXml($brandXmlPath);
+            foreach ($xml->brand as $brandElement) {
+                $descriptor = $this->buildDescriptor($brandElement, $brandXmlPath);
+                if (isset($brands[$descriptor->getCode()])) {
+                    throw new \DomainException(sprintf(
+                        'Brand code "%s" is declared in multiple modules; '
+                        . 'each brand code must be unique across the install.',
+                        $descriptor->getCode()
+                    ));
+                }
+                $brands[$descriptor->getCode()] = $descriptor;
+            }
+        }
+
+        return $this->cache = $brands;
+    }
+
+    private function loadXml(string $path): \SimpleXMLElement
+    {
+        $previous = libxml_use_internal_errors(true);
+        try {
+            $xml = simplexml_load_file($path);
+            if ($xml === false) {
+                $errors = array_map(
+                    static fn(\LibXMLError $e) => trim($e->message),
+                    libxml_get_errors()
+                );
+                libxml_clear_errors();
+                throw new \DomainException(sprintf(
+                    'Failed to parse brand.xml at %s: %s',
+                    $path,
+                    implode('; ', $errors)
+                ));
+            }
+            return $xml;
+        } finally {
+            libxml_use_internal_errors($previous);
+        }
+    }
+
+    private function buildDescriptor(\SimpleXMLElement $brand, string $sourcePath): Descriptor
+    {
+        $code = (string)$brand['code'];
+        $tabSortOrder = (int)$brand['tab_sort_order'];
+
+        if ($code === '') {
+            throw new \DomainException(sprintf(
+                'brand.xml at %s declares a <brand> element with empty code attribute',
+                $sourcePath
+            ));
+        }
+
+        $terms = [];
+        if (isset($brand->available_payment_terms->term)) {
+            foreach ($brand->available_payment_terms->term as $term) {
+                $terms[] = (int)$term;
+            }
+        }
+
+        $surchargeFixedMax = null;
+        if (isset($brand->surcharge_fixed_max)) {
+            $surchargeFixedMax = [
+                'amount' => (float)$brand->surcharge_fixed_max['amount'],
+                'currency' => (string)$brand->surcharge_fixed_max['currency'],
+            ];
+        }
+
+        $cspOrigins = [];
+        if (isset($brand->csp_origins->origin)) {
+            foreach ($brand->csp_origins->origin as $origin) {
+                $cspOrigins[] = (string)$origin;
+            }
+        }
+
+        $moduleLabelChain = [];
+        if (isset($brand->module_label_chain->module)) {
+            foreach ($brand->module_label_chain->module as $module) {
+                $moduleLabelChain[] = [
+                    'label' => (string)$module['label'],
+                    'module' => (string)$module,
+                ];
+            }
+        }
+
+        $allowedCurrencies = [];
+        if (isset($brand->allowed_currencies->currency)) {
+            foreach ($brand->allowed_currencies->currency as $currency) {
+                $allowedCurrencies[] = (string)$currency;
+            }
+        }
+
+        $allowedCountries = [];
+        if (isset($brand->allowed_countries->country)) {
+            foreach ($brand->allowed_countries->country as $country) {
+                $allowedCountries[] = (string)$country;
+            }
+        }
+
+        $extraHttpHeaders = [];
+        if (isset($brand->extra_http_headers->header)) {
+            foreach ($brand->extra_http_headers->header as $header) {
+                $extraHttpHeaders[(string)$header['name']] = (string)$header;
+            }
+        }
+
+        return new Descriptor(
+            $code,
+            $tabSortOrder,
+            (string)$brand->provider,
+            (string)($brand->provider_full_name ?? ''),
+            (string)$brand->product_name,
+            (string)$brand->tab_label,
+            (string)($brand->tab_css_class ?? ''),
+            (string)$brand->checkout_url_template,
+            (string)($brand->brand_tag ?? ''),
+            (string)($brand->sign_up_url ?? ''),
+            (string)($brand->documentation_url ?? ''),
+            (string)$brand->api_base_url,
+            $terms,
+            $surchargeFixedMax,
+            $cspOrigins,
+            (string)$brand->admin_resource,
+            $moduleLabelChain,
+            $allowedCurrencies,
+            $allowedCountries,
+            $extraHttpHeaders
+        );
+    }
+}

--- a/Model/GenericPaymentMethod.php
+++ b/Model/GenericPaymentMethod.php
@@ -39,7 +39,15 @@ use Two\Gateway\Service\UrlCookie;
  * is sufficient to expose a distinct payment method without copying
  * the 600-line Two class.
  *
- * Example brand-overlay binding (in the overlay package's etc/di.xml):
+ * Under v6 the v6 brand mechanism instantiates this class via
+ * Brand\BrandPaymentMethodFactory, which passes the resolved
+ * Descriptor's code as the `code` argument and the
+ * DescriptorBackedBrandRegistry as the `brand` argument. The
+ * constructor signature is preserved verbatim during v6 PR A so
+ * legacy overlay virtualTypes (e.g. ABN_Gateway's AbnPayment) keep
+ * compiling. PR B replaces the two args with a single Descriptor.
+ *
+ * Example brand-overlay binding (legacy, still supported under PR A):
  *
  *   <virtualType name="ABN\Gateway\Model\AbnPayment"
  *                type="Two\Gateway\Model\GenericPaymentMethod">
@@ -48,10 +56,6 @@ use Two\Gateway\Service\UrlCookie;
  *           <argument name="brand" xsi:type="object">ABN\Gateway\Model\AbnBrand</argument>
  *       </arguments>
  *   </virtualType>
- *
- * The default Two-branded binding continues to use the parent `Two`
- * class directly via `etc/config.xml` `<model>`. See magento-abn-plugin
- * docs/implementation-plan.md §3.1 + §6.1 for the design.
  */
 class GenericPaymentMethod extends Two
 {

--- a/Model/GenericPaymentMethod.php
+++ b/Model/GenericPaymentMethod.php
@@ -39,15 +39,12 @@ use Two\Gateway\Service\UrlCookie;
  * is sufficient to expose a distinct payment method without copying
  * the 600-line Two class.
  *
- * Under v6 the v6 brand mechanism instantiates this class via
- * Brand\BrandPaymentMethodFactory, which passes the resolved
- * Descriptor's code as the `code` argument and the
- * DescriptorBackedBrandRegistry as the `brand` argument. The
- * constructor signature is preserved verbatim during v6 PR A so
- * legacy overlay virtualTypes (e.g. ABN_Gateway's AbnPayment) keep
- * compiling. PR B replaces the two args with a single Descriptor.
+ * Brand\BrandPaymentMethodFactory instantiates this class with the
+ * active brand's code and the DI-resolved BrandRegistryInterface
+ * (DescriptorBackedBrandRegistry), so legacy overlay virtualTypes
+ * keep working alongside the brand.xml-sourced descriptor pipeline.
  *
- * Example brand-overlay binding (legacy, still supported under PR A):
+ * Example brand-overlay binding (legacy, still supported):
  *
  *   <virtualType name="ABN\Gateway\Model\AbnPayment"
  *                type="Two\Gateway\Model\GenericPaymentMethod">

--- a/Plugin/Magento/Payment/Helper/Data/InterceptGetMethodInstance.php
+++ b/Plugin/Magento/Payment/Helper/Data/InterceptGetMethodInstance.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Plugin\Magento\Payment\Helper\Data;
+
+use Magento\Payment\Helper\Data as PaymentHelper;
+use Magento\Payment\Model\MethodInterface;
+use Two\Gateway\Model\Brand\ActiveBrandResolver;
+use Two\Gateway\Model\Brand\BrandPaymentMethodFactory;
+
+/**
+ * Manufactures a GenericPaymentMethod for the active brand's code
+ * before Magento consults the CCD-stored model FQCN. The CCD
+ * payment/<code>/model row is read by Magento but never used by
+ * our path — we short-circuit $proceed.
+ *
+ * Belt: on non-active codes (or after uninstall of the brand
+ * module), $proceed runs Magento's normal path, which may
+ * autoload-fail on an orphan FQCN. Catching \Error returns null,
+ * matching Magento's documented "method not found" contract for
+ * downstream consumers (PaymentMethodList::getActiveList already
+ * filters null entries).
+ */
+class InterceptGetMethodInstance
+{
+    public function __construct(
+        private readonly ActiveBrandResolver $activeBrandResolver,
+        private readonly BrandPaymentMethodFactory $brandPaymentMethodFactory
+    ) {
+    }
+
+    /**
+     * @param PaymentHelper $subject
+     * @param callable $proceed
+     * @param string $code
+     * @return MethodInterface|null
+     */
+    public function aroundGetMethodInstance(
+        PaymentHelper $subject,
+        callable $proceed,
+        $code
+    ) {
+        $active = $this->activeBrandResolver->resolve();
+        if ($code === $active->getCode()) {
+            return $this->brandPaymentMethodFactory->build($active);
+        }
+
+        try {
+            return $proceed($code);
+        } catch (\Error $e) {
+            return null;
+        }
+    }
+}

--- a/Plugin/Magento/Payment/Model/PaymentMethodList/AppendBrands.php
+++ b/Plugin/Magento/Payment/Model/PaymentMethodList/AppendBrands.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Plugin\Magento\Payment\Model\PaymentMethodList;
+
+use Magento\Payment\Model\PaymentMethodList;
+use Two\Gateway\Model\Brand\ActiveBrandResolver;
+use Two\Gateway\Model\Brand\BrandPaymentMethodFactory;
+
+/**
+ * Appends the active brand's payment method to the lists Magento
+ * builds from compiled payment.xml metadata. afterGetList covers
+ * the generic-list path; afterGetActiveList covers the
+ * payment/<code>/active=1 gated path used by checkout. The brand
+ * instance produced here is the same one Helper\Data manufactures.
+ */
+class AppendBrands
+{
+    public function __construct(
+        private readonly ActiveBrandResolver $activeBrandResolver,
+        private readonly BrandPaymentMethodFactory $brandPaymentMethodFactory
+    ) {
+    }
+
+    public function afterGetList(PaymentMethodList $subject, array $result, $storeId): array
+    {
+        return $this->merge($result);
+    }
+
+    public function afterGetActiveList(PaymentMethodList $subject, array $result, $storeId): array
+    {
+        $active = $this->activeBrandResolver->resolve();
+        $instance = $this->brandPaymentMethodFactory->build($active);
+        if (!$instance->isActive((int)$storeId)) {
+            return $result;
+        }
+        return $this->merge($result);
+    }
+
+    private function merge(array $methods): array
+    {
+        $active = $this->activeBrandResolver->resolve();
+        $instance = $this->brandPaymentMethodFactory->build($active);
+
+        $byCode = [];
+        foreach ($methods as $method) {
+            $byCode[$method->getCode()] = $method;
+        }
+        $byCode[$active->getCode()] = $instance;
+
+        return array_values($byCode);
+    }
+}

--- a/etc/brand.xml
+++ b/etc/brand.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ *
+ * Default Two brand. Brand-overlay modules ship their own etc/brand.xml
+ * to register additional brands. ActiveBrandResolver enforces the
+ * single-overlay invariant; see Model/Brand/ActiveBrandResolver.php.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:two-inc:magento2:Brand/etc/brand.xsd">
+    <brand code="two_payment" tab_sort_order="500">
+        <provider>Two</provider>
+        <provider_full_name>Two</provider_full_name>
+        <product_name>Two</product_name>
+        <tab_label>Two</tab_label>
+        <tab_css_class>two-extension two-extension--no-caption</tab_css_class>
+        <checkout_url_template>https://%s.two.inc</checkout_url_template>
+        <brand_tag></brand_tag>
+        <sign_up_url>https://portal.two.inc/auth/merchant/signup</sign_up_url>
+        <documentation_url>https://docs.two.inc/developer-portal/plugins/magento</documentation_url>
+        <api_base_url>https://api.two.inc</api_base_url>
+        <available_payment_terms>
+            <term>14</term>
+            <term>30</term>
+            <term>60</term>
+            <term>90</term>
+        </available_payment_terms>
+        <admin_resource>Magento_Sales::config_sales</admin_resource>
+        <module_label_chain>
+            <module label="Payment Method">Two_Gateway</module>
+            <module label="Hyva Extension">Two_GatewayHyva</module>
+        </module_label_chain>
+    </brand>
+</config>

--- a/etc/brand.xsd
+++ b/etc/brand.xsd
@@ -1,0 +1,112 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ *
+ * Schema for etc/brand.xml. One <brand> element per brand module
+ * describes the brand-identity values (immutable at install time)
+ * consumed by Two\Gateway\Model\Brand\Loader.
+ */
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:element name="config">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="brand" type="brandType" minOccurs="1" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+        <xs:unique name="uniqueBrandCode">
+            <xs:selector xpath="brand"/>
+            <xs:field xpath="@code"/>
+        </xs:unique>
+    </xs:element>
+
+    <xs:complexType name="brandType">
+        <xs:all>
+            <xs:element name="provider" type="xs:string"/>
+            <xs:element name="provider_full_name" type="xs:string" minOccurs="0"/>
+            <xs:element name="product_name" type="xs:string"/>
+            <xs:element name="tab_label" type="xs:string"/>
+            <xs:element name="tab_css_class" type="xs:string" minOccurs="0"/>
+            <xs:element name="checkout_url_template" type="xs:string"/>
+            <xs:element name="brand_tag" type="xs:string" minOccurs="0"/>
+            <xs:element name="sign_up_url" type="xs:string" minOccurs="0"/>
+            <xs:element name="documentation_url" type="xs:string" minOccurs="0"/>
+            <xs:element name="api_base_url" type="xs:string"/>
+            <xs:element name="available_payment_terms" type="paymentTermsType"/>
+            <xs:element name="surcharge_fixed_max" type="surchargeFixedMaxType" minOccurs="0"/>
+            <xs:element name="csp_origins" type="cspOriginsType" minOccurs="0"/>
+            <xs:element name="admin_resource" type="xs:string"/>
+            <xs:element name="module_label_chain" type="moduleLabelChainType" minOccurs="0"/>
+            <xs:element name="allowed_currencies" type="allowedCurrenciesType" minOccurs="0"/>
+            <xs:element name="allowed_countries" type="allowedCountriesType" minOccurs="0"/>
+            <xs:element name="extra_http_headers" type="extraHttpHeadersType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="code" type="brandCodeType" use="required"/>
+        <xs:attribute name="tab_sort_order" type="xs:integer" use="required"/>
+    </xs:complexType>
+
+    <xs:simpleType name="brandCodeType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[a-z][a-z0-9_]*"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="paymentTermsType">
+        <xs:sequence>
+            <xs:element name="term" type="xs:positiveInteger" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="surchargeFixedMaxType">
+        <xs:attribute name="amount" type="xs:decimal" use="required"/>
+        <xs:attribute name="currency" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="cspOriginsType">
+        <xs:sequence>
+            <xs:element name="origin" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="moduleLabelChainType">
+        <xs:sequence>
+            <xs:element name="module" minOccurs="1" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:simpleContent>
+                        <xs:extension base="xs:string">
+                            <xs:attribute name="label" type="xs:string" use="required"/>
+                        </xs:extension>
+                    </xs:simpleContent>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="allowedCurrenciesType">
+        <xs:sequence>
+            <xs:element name="currency" type="xs:string" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="allowedCountriesType">
+        <xs:sequence>
+            <xs:element name="country" type="xs:string" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="extraHttpHeadersType">
+        <xs:sequence>
+            <xs:element name="header" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:simpleContent>
+                        <xs:extension base="xs:string">
+                            <xs:attribute name="name" type="xs:string" use="required"/>
+                        </xs:extension>
+                    </xs:simpleContent>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+</xs:schema>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -26,7 +26,7 @@
         no longer flows through a DI-rebound interface.
     -->
     <preference for="Two\Gateway\Api\BrandRegistryInterface"
-                type="Two\Gateway\Brand\TwoBrand"/>
+                type="Two\Gateway\Brand\DescriptorBackedBrandRegistry"/>
     <!--
         Brand overlay registry. The default implementation reads its
         `overlays` constructor argument; overlay packages append entries

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -19,7 +19,12 @@
                 type="Two\Gateway\Model\Webapi\Surcharges"/>
     <preference for="Two\Gateway\Api\CurrencyRatesProviderInterface"
                 type="Two\Gateway\Model\CurrencyRatesProvider"/>
-    <!-- Default brand binding. Overlay packages may rebind via their own DI preference. -->
+    <!--
+        v6 brand mechanism: ActiveBrandResolver loads brand.xml from every
+        installed module and returns the single active Descriptor. The legacy
+        <preference for="BrandRegistryInterface"> is dropped — brand identity
+        no longer flows through a DI-rebound interface.
+    -->
     <preference for="Two\Gateway\Api\BrandRegistryInterface"
                 type="Two\Gateway\Brand\TwoBrand"/>
     <!--
@@ -118,5 +123,22 @@
                 <item name="two_payment" xsi:type="string">two_payment</item>
             </argument>
         </arguments>
+    </type>
+
+    <!--
+        v6 brand-overlay plugins. Each intercepts a chokepoint where Magento
+        turns a payment-method code into an instance, allowing the active
+        brand (resolved via etc/brand.xml descriptors) to participate
+        without per-brand DI virtual-types.
+    -->
+    <type name="Magento\Payment\Helper\Data">
+        <plugin name="two_brand_intercept_get_method_instance"
+                type="Two\Gateway\Plugin\Magento\Payment\Helper\Data\InterceptGetMethodInstance"
+                sortOrder="10"/>
+    </type>
+    <type name="Magento\Payment\Model\PaymentMethodList">
+        <plugin name="two_brand_append_brands"
+                type="Two\Gateway\Plugin\Magento\Payment\Model\PaymentMethodList\AppendBrands"
+                sortOrder="10"/>
     </type>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -20,14 +20,14 @@
     <preference for="Two\Gateway\Api\CurrencyRatesProviderInterface"
                 type="Two\Gateway\Model\CurrencyRatesProvider"/>
     <!--
-        Brand-identity now flows from each module's etc/brand.xml via
-        ActiveBrandResolver. The DescriptorBackedBrandRegistry adapter
-        implements the legacy BrandRegistryInterface from the resolved
-        Descriptor so existing consumers (Two, Adapter, Repository,
-        controllers, admin blocks) keep working unchanged.
+        Default brand binding. The brand.xml-sourced descriptor pipeline
+        (Model/Brand/* + Brand/DescriptorBackedBrandRegistry) is shipped
+        alongside but not yet wired here — activation lives in the PR
+        that retires Brand/TwoBrand together with the ABN strip-down,
+        so brand identity transitions everywhere in one step.
     -->
     <preference for="Two\Gateway\Api\BrandRegistryInterface"
-                type="Two\Gateway\Brand\DescriptorBackedBrandRegistry"/>
+                type="Two\Gateway\Brand\TwoBrand"/>
     <!--
         Brand overlay registry. The default implementation reads its
         `overlays` constructor argument; overlay packages append entries
@@ -124,22 +124,5 @@
                 <item name="two_payment" xsi:type="string">two_payment</item>
             </argument>
         </arguments>
-    </type>
-
-    <!--
-        Brand-overlay chokepoint plugins. Each intercepts a point where
-        Magento turns a payment-method code into an instance, letting the
-        active brand (resolved via etc/brand.xml descriptors) participate
-        without per-brand DI virtual-types.
-    -->
-    <type name="Magento\Payment\Helper\Data">
-        <plugin name="two_brand_intercept_get_method_instance"
-                type="Two\Gateway\Plugin\Magento\Payment\Helper\Data\InterceptGetMethodInstance"
-                sortOrder="10"/>
-    </type>
-    <type name="Magento\Payment\Model\PaymentMethodList">
-        <plugin name="two_brand_append_brands"
-                type="Two\Gateway\Plugin\Magento\Payment\Model\PaymentMethodList\AppendBrands"
-                sortOrder="10"/>
     </type>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -20,10 +20,11 @@
     <preference for="Two\Gateway\Api\CurrencyRatesProviderInterface"
                 type="Two\Gateway\Model\CurrencyRatesProvider"/>
     <!--
-        v6 brand mechanism: ActiveBrandResolver loads brand.xml from every
-        installed module and returns the single active Descriptor. The legacy
-        <preference for="BrandRegistryInterface"> is dropped — brand identity
-        no longer flows through a DI-rebound interface.
+        Brand-identity now flows from each module's etc/brand.xml via
+        ActiveBrandResolver. The DescriptorBackedBrandRegistry adapter
+        implements the legacy BrandRegistryInterface from the resolved
+        Descriptor so existing consumers (Two, Adapter, Repository,
+        controllers, admin blocks) keep working unchanged.
     -->
     <preference for="Two\Gateway\Api\BrandRegistryInterface"
                 type="Two\Gateway\Brand\DescriptorBackedBrandRegistry"/>
@@ -126,9 +127,9 @@
     </type>
 
     <!--
-        v6 brand-overlay plugins. Each intercepts a chokepoint where Magento
-        turns a payment-method code into an instance, allowing the active
-        brand (resolved via etc/brand.xml descriptors) to participate
+        Brand-overlay chokepoint plugins. Each intercepts a point where
+        Magento turns a payment-method code into an instance, letting the
+        active brand (resolved via etc/brand.xml descriptors) participate
         without per-brand DI virtual-types.
     -->
     <type name="Magento\Payment\Helper\Data">


### PR DESCRIPTION
## Summary

Foundation classes for the brand-overlay refactor. **Dormant by design** — all new files are present but the activation wiring in `etc/di.xml` is intentionally absent. Net runtime behaviour on this branch is identical to `main`.

Design reference: `magento-abn-plugin/docs/brand-overlay-design-v6.md`.

## What's in this PR

**New files (dormant code):**
- `etc/brand.xsd` — schema for the per-module brand descriptor
- `etc/brand.xml` — magento-plugin's own Two-brand descriptor
- `Model/Brand/Descriptor.php` — immutable brand-identity value object
- `Model/Brand/Loader.php` — enumerates installed modules via `ComponentRegistrar` and parses each module's `etc/brand.xml`
- `Model/Brand/ActiveBrandResolver.php` — single-active-brand resolver
- `Model/Brand/BrandPaymentMethodFactory.php` — manufactures `GenericPaymentMethod` instances with a per-process cache
- `Brand/DescriptorBackedBrandRegistry.php` — adapter implementing the legacy `BrandRegistryInterface` from a Descriptor; replaces `Brand/TwoBrand.php` when activation lands
- `Plugin/Magento/Payment/Helper/Data/InterceptGetMethodInstance.php` — `aroundGetMethodInstance` chokepoint
- `Plugin/Magento/Payment/Model/PaymentMethodList/AppendBrands.php` — `afterGetList`/`afterGetActiveList` plugins

**Edited:**
- `etc/di.xml` — comment-only update on the existing `BrandRegistryInterface` preference (still points at `TwoBrand`). The two chokepoint plugin registrations are **deliberately omitted** until activation.
- `Model/GenericPaymentMethod.php` — doc-block update only; constructor signature preserved verbatim so ABN's existing virtualType keeps compiling.

## Why dormant

Adversarial review (architect + BC + impl reviewers, in parallel) surfaced three blockers that all stem from activating the new mechanism on a live ABN merchant **before** ABN ships its own `etc/brand.xml`:

1. **Factory bypasses overlay virtualType arguments.** `ObjectManager::create` on the concrete `GenericPaymentMethod` class skips the `AbnPayment` virtualType wiring in ABN's `plugin/etc/di.xml`. ABN's `configRepository → AbnConfigRepository` override is silently dropped; the manufactured instance reads `payment/two_payment/*` instead of `payment/abn_payment/*`.
2. **Silent brand identity swap.** Flipping the `BrandRegistryInterface` preference to `DescriptorBackedBrandRegistry` on an ABN merchant currently routes the resolver through `ActiveBrandResolver`. ABN ships no `etc/brand.xml` today, so the resolver returns Two as active; every "ABN AMRO" admin header / brand label / API brand-name silently switches to "Two".
3. **`catch (\Error)` too broad.** Swallows `TypeError`, `ArgumentCountError`, and PHP-8 fatal promotions in lower-sortOrder around-plugins on the same method.

All three dissolve when activation lands **together with** the ABN strip-down: ABN ships `etc/brand.xml`, ABN's `AbnPayment` virtualType disappears, the around-plugin catch tightens.

## Activation plan

Activation is deferred to the final PR-set in the sequence (the one that retires `BrandRegistryInterface` family + strips `magento-abn-plugin` to data + assets only). Intermediate PRs (Structure\Reader form synthesis, payment.xml synth, CSP collector, LayoutProcessor) will ship their plugins with a feature-flag gate (`system/two_brand_synthesis/<layer>/enabled`), default-off, so staging instances can flip individual flags to validate each layer in isolation before the final big-bang activation.

## What's *not* in this PR

- The `BrandRegistryInterface` preference flip
- Registration of the chokepoint plugins in `etc/di.xml`
- The Structure\Reader form-synthesis machinery (next PR)
- payment.xml synthesis, CSP collector, LayoutProcessor (next PR)
- `BrandRegistryInterface` family retirement (final PR)
- `magento-abn-plugin` strip-down (separate repo, final PR)

## Reviewer findings — deferred

The non-blocker findings worth flagging for follow-up PRs:

- **`Brand/TwoBrand.php`** becomes dead code at activation time; deletion lives in the BrandRegistryInterface-retirement PR
- **No XSD validation in `Loader`** — `etc/brand.xsd` is unused at runtime. Wire `Magento\Framework\Config\Dom` or drop the schema, decide at the PR that activates
- **`ActiveBrandResolver` should log and fall back** when no brands found, rather than throwing — decide at the PR that activates
- **Plugin `sortOrder=10` collisions** with Adyen/Stripe/Klarna unresearched; check before activation
- **Regression test** asserting the factory's instance cache returns the same object on repeat calls

## Test plan

- [ ] `bin/magento setup:di:compile` succeeds (vanilla Two install + ABN install)
- [ ] `bin/magento setup:upgrade` succeeds (vanilla Two install + ABN install)
- [ ] Existing Two checkout works unchanged (Luma + Hyva)
- [ ] Existing ABN checkout works unchanged (Luma + Hyva)
- [ ] Admin Configuration → Payment Methods renders unchanged on both
- [ ] PHPUnit `Test/Unit/` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)