### PR TITLE
feat(brand-overlay): Layer C+D — payment.xml + CSP + KO renderer synthesis (all dormant)

### DIFF
--- a/Plugin/Magento/Checkout/Block/LayoutProcessor/SynthesiseBrandRenderers.php
+++ b/Plugin/Magento/Checkout/Block/LayoutProcessor/SynthesiseBrandRenderers.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Plugin\Magento\Checkout\Block\LayoutProcessor;
+
+use Magento\Checkout\Block\Checkout\LayoutProcessor;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Two\Gateway\Model\Brand\ActiveBrandResolver;
+use Two\Gateway\Model\Brand\Descriptor;
+
+/**
+ * Synthesises a KO renderer-bootstrap entry for the active overlay
+ * brand so its `payment/<code>/*` checkout surface is registered
+ * against the brand-agnostic gateway_method renderer.
+ *
+ * The default Two brand is already registered via the static
+ * view/frontend/web/js/view/payment/two_payment.js file shipped
+ * with magento-plugin. This plugin therefore only emits a synthesis
+ * entry when the resolved active brand is something other than the
+ * default Two brand (i.e. when an overlay package such as the
+ * future data-only magento-abn-plugin is installed and contributes
+ * its own etc/brand.xml).
+ *
+ * Gated by the system/two_brand_synthesis/checkout_renderers/enabled
+ * flag, default 0. While dormant, afterProcess is a pass-through.
+ */
+class SynthesiseBrandRenderers
+{
+    private const FLAG_PATH = 'two_brand_synthesis/checkout_renderers/enabled';
+
+    private readonly bool $enabled;
+
+    public function __construct(
+        ScopeConfigInterface $scopeConfig,
+        private readonly ActiveBrandResolver $activeBrandResolver
+    ) {
+        $this->enabled = $scopeConfig->isSetFlag(self::FLAG_PATH);
+    }
+
+    public function afterProcess(LayoutProcessor $subject, array $jsLayout): array
+    {
+        if (!$this->enabled) {
+            return $jsLayout;
+        }
+
+        $active = $this->activeBrandResolver->resolve();
+        if ($active->getCode() === ActiveBrandResolver::TWO_CODE) {
+            return $jsLayout;
+        }
+
+        return $this->injectRenderer($jsLayout, $active);
+    }
+
+    private function injectRenderer(array $jsLayout, Descriptor $brand): array
+    {
+        $code = $brand->getCode();
+
+        $jsLayout['components']['checkout']['children']['steps']['children']
+            ['billing-step']['children']['payment']['children']['renders']
+            ['children'][$code] = [
+                'component' => 'Two_Gateway/js/view/payment/brand-registrar',
+                'config' => [
+                    'brandCode' => $code,
+                ],
+                'methods' => [
+                    $code => [
+                        'isBillingAddressRequired' => true,
+                    ],
+                ],
+            ];
+
+        return $jsLayout;
+    }
+}

--- a/Plugin/Magento/Checkout/Block/LayoutProcessor/SynthesiseBrandRenderers.php
+++ b/Plugin/Magento/Checkout/Block/LayoutProcessor/SynthesiseBrandRenderers.php
@@ -38,6 +38,10 @@ class SynthesiseBrandRenderers
         ScopeConfigInterface $scopeConfig,
         private readonly ActiveBrandResolver $activeBrandResolver
     ) {
+        // Read once at construction. Per design v6 §16.3 the synthesis
+        // flags are cached for the request lifetime — a runtime flag
+        // flip via config:set requires a cache:flush + process restart
+        // to take effect, same as any other Magento config:default.
         $this->enabled = $scopeConfig->isSetFlag(self::FLAG_PATH);
     }
 

--- a/Plugin/Magento/Csp/Model/Collector/SynthesiseBrandOrigins.php
+++ b/Plugin/Magento/Csp/Model/Collector/SynthesiseBrandOrigins.php
@@ -11,7 +11,6 @@ use Magento\Csp\Api\Data\PolicyInterface;
 use Magento\Csp\Model\Collector\CspWhitelistXmlCollector;
 use Magento\Csp\Model\Policy\FetchPolicy;
 use Magento\Framework\App\Config\ScopeConfigInterface;
-use Two\Gateway\Model\Brand\ActiveBrandResolver;
 use Two\Gateway\Model\Brand\Descriptor;
 use Two\Gateway\Model\Brand\Loader;
 

--- a/Plugin/Magento/Csp/Model/Collector/SynthesiseBrandOrigins.php
+++ b/Plugin/Magento/Csp/Model/Collector/SynthesiseBrandOrigins.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Plugin\Magento\Csp\Model\Collector;
+
+use Magento\Csp\Api\Data\PolicyInterface;
+use Magento\Csp\Model\Collector\CspWhitelistXmlCollector;
+use Magento\Csp\Model\Policy\FetchPolicy;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Two\Gateway\Model\Brand\ActiveBrandResolver;
+use Two\Gateway\Model\Brand\Descriptor;
+use Two\Gateway\Model\Brand\Loader;
+
+/**
+ * Appends each registered brand's cspOrigins (declared in its
+ * etc/brand.xml) to the merged whitelist. Magento merges policies
+ * by id across modules: contributions sharing an id with an
+ * existing entry override; new ids are additive. The synthesis
+ * emits one FetchPolicy per `(brandCode, policyId)` pair so a
+ * brand's origins land under all the policies its checkout needs
+ * (form-action, base-uri, connect-src by default; configurable
+ * via the brand's csp_origins/policy nodes once the schema gains
+ * that field).
+ *
+ * Behaviour today: the default Two brand declares no cspOrigins
+ * (its CSP comes from the static etc/csp_whitelist.xml shipped
+ * alongside this module), so when no overlay is installed this
+ * plugin emits zero entries. Overlay brand modules whose own
+ * csp_whitelist.xml is dropped in the data-only release will
+ * declare cspOrigins in their etc/brand.xml and the synthesis
+ * picks them up here.
+ *
+ * Gated by system/two_brand_synthesis/csp/enabled, default 0.
+ * While dormant, afterCollect is a pass-through.
+ */
+class SynthesiseBrandOrigins
+{
+    private const FLAG_PATH = 'two_brand_synthesis/csp/enabled';
+
+    /**
+     * Policies a brand's cspOrigins are seeded under unless the
+     * brand declares a more specific list. Mirrors the set
+     * Two_Gateway's static etc/csp_whitelist.xml ships under for
+     * `*.two.inc`.
+     */
+    private const DEFAULT_POLICIES = ['form-action', 'base-uri', 'connect-src'];
+
+    private readonly bool $enabled;
+
+    public function __construct(
+        ScopeConfigInterface $scopeConfig,
+        private readonly Loader $loader
+    ) {
+        // Read once at construction; per design v6 §16.3 the synthesis
+        // flags are cached for the request lifetime.
+        $this->enabled = $scopeConfig->isSetFlag(self::FLAG_PATH);
+    }
+
+    /**
+     * @param CspWhitelistXmlCollector $subject
+     * @param PolicyInterface[] $result
+     * @return PolicyInterface[]
+     */
+    public function afterCollect(CspWhitelistXmlCollector $subject, array $result): array
+    {
+        if (!$this->enabled) {
+            return $result;
+        }
+
+        foreach ($this->loader->load() as $brand) {
+            foreach ($this->buildPoliciesForBrand($brand) as $policy) {
+                $result[] = $policy;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return PolicyInterface[]
+     */
+    private function buildPoliciesForBrand(Descriptor $brand): array
+    {
+        $origins = $brand->getCspOrigins();
+        if ($origins === []) {
+            return [];
+        }
+
+        $policies = [];
+        foreach (self::DEFAULT_POLICIES as $policyId) {
+            // FetchPolicy(id, isNoneAllowed, hostSources, schemeSources,
+            //   isSelfAllowed, isInlineAllowed, isEvalAllowed, ...) —
+            //   constructor shape is documented in module-csp/Model/Policy/FetchPolicy.php.
+            //   The minimal `host-sources` form is all we need.
+            $policies[] = new FetchPolicy(
+                $policyId,
+                false,
+                $origins
+            );
+        }
+        return $policies;
+    }
+}

--- a/Plugin/Magento/Payment/Model/Config/Reader/SynthesiseBrandMethods.php
+++ b/Plugin/Magento/Payment/Model/Config/Reader/SynthesiseBrandMethods.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Plugin\Magento\Payment\Model\Config\Reader;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Payment\Model\Config\Reader;
+use Two\Gateway\Model\Brand\ActiveBrandResolver;
+use Two\Gateway\Model\Brand\Loader;
+
+/**
+ * Appends a `methods` entry for each registered brand to the
+ * merged payment.xml config. The shipped Two_Gateway/etc/payment.xml
+ * historically declared the `two_payment` method's capability flags;
+ * the v6 mechanism replaces per-module payment.xml shipping with
+ * runtime synthesis driven by each module's etc/brand.xml.
+ *
+ * Mechanism: `Magento\Payment\Model\Config\Reader::read` (inherited
+ * from `Magento\Framework\Config\Reader\Filesystem`) returns the
+ * merged module config keyed by `methods` and `groups`. We append
+ * to `methods` rather than mutating existing entries, so a brand
+ * code that's also declared in a static payment.xml (e.g. during
+ * the transition window before overlay strip-down) is left intact
+ * — last-writer-wins on the merged array.
+ *
+ * Capability shape: keeps the synthesised entry minimal. Magento's
+ * default capability surface (`MethodInterface::canRefund`, etc.)
+ * lives on the method instance not in payment.xml; what payment.xml
+ * uniquely contributes is the method registration that makes
+ * `\Magento\Payment\Model\Config::getMethods()` enumerate the code.
+ *
+ * Gated by system/two_brand_synthesis/payment_xml/enabled, default 0.
+ * While dormant, afterRead is a pass-through.
+ */
+class SynthesiseBrandMethods
+{
+    private const FLAG_PATH = 'two_brand_synthesis/payment_xml/enabled';
+
+    private readonly bool $enabled;
+
+    public function __construct(
+        ScopeConfigInterface $scopeConfig,
+        private readonly Loader $loader
+    ) {
+        // Read once at construction; per design v6 §16.3 the synthesis
+        // flags are cached for the request lifetime.
+        $this->enabled = $scopeConfig->isSetFlag(self::FLAG_PATH);
+    }
+
+    /**
+     * @param Reader $subject
+     * @param array<string,mixed> $result
+     * @return array<string,mixed>
+     */
+    public function afterRead(Reader $subject, array $result): array
+    {
+        if (!$this->enabled) {
+            return $result;
+        }
+
+        if (!isset($result['methods']) || !is_array($result['methods'])) {
+            $result['methods'] = [];
+        }
+
+        foreach ($this->loader->load() as $brand) {
+            $code = $brand->getCode();
+            if (isset($result['methods'][$code])) {
+                // A static payment.xml in some module already declared
+                // this code (e.g. legacy overlay during the transition
+                // window). Don't clobber it — the merged config already
+                // has whatever capability flags they shipped, and the
+                // method-resolution chokepoint (Helper\Data plugin)
+                // handles instance construction independently.
+                continue;
+            }
+            $result['methods'][$code] = $this->defaultCapabilities();
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function defaultCapabilities(): array
+    {
+        return [
+            'allow_multiple_address' => 1,
+        ];
+    }
+}

--- a/Plugin/Magento/Payment/Model/Config/Reader/SynthesiseBrandMethods.php
+++ b/Plugin/Magento/Payment/Model/Config/Reader/SynthesiseBrandMethods.php
@@ -9,7 +9,6 @@ namespace Two\Gateway\Plugin\Magento\Payment\Model\Config\Reader;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Payment\Model\Config\Reader;
-use Two\Gateway\Model\Brand\ActiveBrandResolver;
 use Two\Gateway\Model\Brand\Loader;
 
 /**

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -58,5 +58,21 @@
                 <model>Two\Gateway\Model\Two</model>
             </two_payment>
         </payment>
+        <!--
+            Per-layer synthesis flags for the brand-overlay v6 mechanism.
+            Default 0 (OFF): the synthesis plugin ships dormant so this
+            change is purely additive on production. A follow-up PR
+            flips the default to 1 in lockstep with magento-abn-plugin's
+            data-only release (which deletes ABN's renderer-bootstrap
+            JS). Design v6 §16.3 specifies these as per-layer debugging
+            knobs, not a rollback mechanism. Layers shipped in
+            subsequent PRs (payment_xml, csp, admin_form) will add
+            their own siblings here.
+        -->
+        <two_brand_synthesis>
+            <checkout_renderers>
+                <enabled>0</enabled>
+            </checkout_renderers>
+        </two_brand_synthesis>
     </default>
 </config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -73,6 +73,12 @@
             <checkout_renderers>
                 <enabled>0</enabled>
             </checkout_renderers>
+            <payment_xml>
+                <enabled>0</enabled>
+            </payment_xml>
+            <csp>
+                <enabled>0</enabled>
+            </csp>
         </two_brand_synthesis>
     </default>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -125,4 +125,23 @@
             </argument>
         </arguments>
     </type>
+
+    <!--
+        Brand-overlay v6 synthesis plugins. Each is gated by its own
+        flag under system/two_brand_synthesis/<layer>/enabled in
+        etc/config.xml (default 0 in this PR — see header there).
+        Wiring is unconditional so a runtime flag flip via
+        `bin/magento config:set` + `cache:flush` activates the
+        synthesis without redeploying.
+    -->
+    <type name="Magento\Payment\Model\Config\Reader">
+        <plugin name="two-synthesise-brand-methods"
+                type="Two\Gateway\Plugin\Magento\Payment\Model\Config\Reader\SynthesiseBrandMethods"
+                sortOrder="10"/>
+    </type>
+    <type name="Magento\Csp\Model\Collector\CspWhitelistXmlCollector">
+        <plugin name="two-synthesise-brand-csp-origins"
+                type="Two\Gateway\Plugin\Magento\Csp\Model\Collector\SynthesiseBrandOrigins"
+                sortOrder="10"/>
+    </type>
 </config>

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -16,5 +16,8 @@
     <type name="Magento\Checkout\Block\Checkout\LayoutProcessor">
         <plugin name="add-delivery-date-field"
                 type="Two\Gateway\Plugin\Model\Checkout\LayoutProcessorPlugin" sortOrder="10"/>
+        <plugin name="two-synthesise-brand-renderers"
+                type="Two\Gateway\Plugin\Magento\Checkout\Block\LayoutProcessor\SynthesiseBrandRenderers"
+                sortOrder="20"/>
     </type>
 </config>

--- a/view/frontend/web/js/view/payment/brand-registrar.js
+++ b/view/frontend/web/js/view/payment/brand-registrar.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ *
+ * Generic brand-renderer registrar.
+ *
+ * The static two_payment.js registers the default Two brand at
+ * module-load time. Brand-overlay packages used to ship their own
+ * sibling file doing the same — that fanout is replaced by this
+ * component, instantiated once per overlay brand via the synthesis
+ * LayoutProcessor plugin which injects an entry under
+ * checkout.steps.billing-step.payment.renders.children.<brandCode>
+ * with `config.brandCode = <code>`.
+ *
+ * Push is deferred to `initialize` so each component instance gets
+ * its own push (one entry per brand) rather than the file-level
+ * single-push that two_payment.js does.
+ */
+define([
+    'uiComponent',
+    'Magento_Checkout/js/model/payment/renderer-list'
+], function (Component, rendererList) {
+    'use strict';
+
+    return Component.extend({
+        defaults: {
+            brandCode: ''
+        },
+
+        initialize: function () {
+            this._super();
+            if (this.brandCode) {
+                rendererList.push({
+                    type: this.brandCode,
+                    component: 'Two_Gateway/js/view/payment/method-renderer/gateway_method'
+                });
+            }
+            return this;
+        }
+    });
+});


### PR DESCRIPTION
## Summary

Three synthesis layers of the brand-overlay v6 staged rollout (design doc: `magento-abn-plugin/docs/brand-overlay-design-v6.md` §15, §16.3). All ship default-off — three flags under `system/two_brand_synthesis/<layer>/enabled` in `etc/config.xml`. Production impact: nil. A follow-up PR flips the defaults to 1 alongside magento-abn-plugin's data-only release.

### Commit 1 — Layer D (`checkout_renderers`)

- `Plugin/Magento/Checkout/Block/LayoutProcessor/SynthesiseBrandRenderers.php`: afterProcess plugin injecting `checkout.steps.billing-step.payment.renders.children.<brand_code>` for the active overlay brand.
- `view/frontend/web/js/view/payment/brand-registrar.js`: generic uiComponent reading `config.brandCode` and pushing onto Magento_Checkout's renderer-list at component init.
- Skips the default Two brand (still registered via static `view/frontend/web/js/view/payment/two_payment.js`; that file retires in the strip-down PR).

### Commit 2 — Layer C/1 (`payment_xml`) + Layer C/2 (`csp`)

- `Plugin/Magento/Payment/Model/Config/Reader/SynthesiseBrandMethods.php`: afterRead on the Payment Config Reader. Appends a methods entry per registered brand (skipping codes already declared in a static payment.xml). Capability surface is minimal (`allow_multiple_address`); real flags live on the method instance.
- `Plugin/Magento/Csp/Model/Collector/SynthesiseBrandOrigins.php`: afterCollect on `Magento\Csp\Model\Collector\CspWhitelistXmlCollector`. One FetchPolicy per `(brand, policy-id)` under form-action / base-uri / connect-src — mirrors the canonical etc/csp_whitelist.xml policy set. Default Two brand has no `csp_origins` so this is a no-op until an overlay brand ships its own.

Both Layer C plugins enumerate brands via `Brand\Loader::load()` (all registered) rather than `ActiveBrandResolver::resolve()` (only the active one) — payment-method enumeration and CSP policy declaration need to cover *every* declared brand so admin order-view of a historical order under a since-removed brand still finds its method entry.

## What's not in this PR

**Layer C/3 — `admin_form` (Structure\Reader synthesis)** is deferred to a separate PR. It requires:
- `etc/adminhtml/brand_form_template.xml` (~400-line clone of `etc/adminhtml/system.xml` with `{{code}}` tokens)
- A new `brand_form_template.xsd`
- `Model/Config/Brand/TemplateReader.php`
- A Structure\Reader afterRead plugin
- A runtime assertion validating design v6 §3.5's open question: does `brand_code` survive Magento's `Structure\Converter` round-trip? Per design that decision lands as a spike result, with a section-id-prefix fallback ready.

This is meaningfully more surface area than the three layers shipped here combined, and the brand_code-survival concern is the riskiest unresolved spike in Phase 0. Worth its own focused review pass.

## Design deviation flagged for the follow-up admin_form PR

That PR will need a fifth flag (`admin_form/enabled`) that design v6 §16.3 explicitly excluded. The §16.3 reasoning — "flag-flip would hide ALL admin Configuration sections" — only applies post-PR3 when `etc/adminhtml/system.xml` has been emptied. Pre-PR3, Structure\Reader synthesis would render the `two_payment` section twice (static + synthesised), so a flag is the only safe shipping mode.

## Caveats worth knowing

- The synthesis plugins for payment_xml and CSP are written against documented Magento public APIs (`Reader::read`, `CspWhitelistXmlCollector::collect`, `FetchPolicy::__construct`). I do not have a `vendor/` directory in this clone to verify the exact return shapes — the plugins assume the canonical Magento 2.4.x shapes from public documentation and module-csp / module-payment source. End-to-end activation has therefore **not been verified**; this is the deferred Phase 0 S2 / S3 spike landing as dormant code, with validation moving to the flag-flip PR once magento-abn-plugin ships its own `etc/brand.xml`.
- The CSP synthesis emits policies under a hardcoded set `{form-action, base-uri, connect-src}`. If a future overlay brand's static csp_whitelist.xml shipped policies beyond those three, deleting it without extending this synthesis would silently drop those origins. The brand contract is implicitly "only contribute to these three policies". Worth tightening in the admin_form / strip-down PR if the ABN csp_whitelist.xml audit (Phase 0 S6) finds otherwise.
- Per-layer flags are read at object construction and cached for the request lifetime (design v6 §16.3). A runtime `bin/magento config:set ... enabled 1` needs a `cache:flush` + pod rotation to take effect — same pattern as any other Magento config:default flag.

## Test plan

- [ ] Bharat / reviewer: inspect each plugin's flag-off branch — three pass-throughs verified by reading.
- [ ] (Post-merge, optional) Flip `checkout_renderers/enabled = 1` on staging with no overlay brand installed; verify no checkout regression (active brand is Two, plugin skips, layout unchanged).
- [ ] (Post-merge, optional) Flip `payment_xml/enabled = 1` on staging with no overlay; verify no admin order-view regression (Brand\Loader returns only Two, which is the existing two_payment code — synthesis no-ops because the merged config already enumerates it via `MethodList::getList`).
- [ ] (Post-merge, optional) Flip `csp/enabled = 1` on staging; verify no CSP-violation reports in browser DevTools on `/checkout/`.
- [ ] End-to-end overlay activation is exercised in the strip-down PR once magento-abn-plugin ships `etc/brand.xml` and the flags flip together.

## Files

```
new   Plugin/Magento/Checkout/Block/LayoutProcessor/SynthesiseBrandRenderers.php
new   Plugin/Magento/Csp/Model/Collector/SynthesiseBrandOrigins.php
new   Plugin/Magento/Payment/Model/Config/Reader/SynthesiseBrandMethods.php
new   view/frontend/web/js/view/payment/brand-registrar.js
edit  etc/config.xml      (+21 lines — three new flags)
edit  etc/di.xml          (+19 lines — two plugin wirings)
edit  etc/frontend/di.xml (+3 lines  — LayoutProcessor plugin wiring)
```
