### PR TITLE
feat(brand-overlay): Layer C/3 §3.5 attribute-survival spike (dormant)

### DIFF
--- a/Plugin/Magento/Config/Model/Config/Structure/Converter/ProbeBrandCodeSurvival.php
+++ b/Plugin/Magento/Config/Model/Config/Structure/Converter/ProbeBrandCodeSurvival.php
@@ -1,0 +1,308 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Plugin\Magento\Config\Model\Config\Structure\Converter;
+
+use Magento\Config\Model\Config\Structure\Converter;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Diagnostic spike for design v6 §3.5.
+ *
+ * The admin_form synthesis layer (Layer C/3) hinges on whether
+ * Magento's `Config\Structure\Converter` preserves unknown XML
+ * attributes (specifically `brand_code`) on `<section>`, `<group>`
+ * and `<field>` nodes when it converts the merged adminhtml/system.xml
+ * DOM into the array form consumed by Structure\Data. Two possible
+ * worlds:
+ *
+ *   A. Attribute survives — the template emits `brand_code="{{code}}"`
+ *      on synthesised sections; the runtime resolves the active brand
+ *      by attribute lookup. Cleanest mechanism; design v6's preferred
+ *      path.
+ *
+ *   B. Attribute dropped — the template falls back to section-id
+ *      prefixing (e.g. id `brand_{{code}}_payment_terms`); the runtime
+ *      resolves by string-matching section ids. Slightly uglier but
+ *      well-understood. §3.5's documented fallback.
+ *
+ * This probe answers the question on a real instance without
+ * committing the template surface. When enabled, it clones the input
+ * DOM, injects one throwaway `<section>` carrying a `brand_code`
+ * attribute (with the same attribute set on a child `<group>` and
+ * `<field>`), passes the clone to the real converter, reads back the
+ * three corresponding result-array entries, and logs which attributes
+ * survived. The probe section is then stripped from the result so the
+ * Structure pipeline never sees it.
+ *
+ * Dormant by default. Flag-flip on staging once, tail the log, flip
+ * back off. Production never runs the probe.
+ *
+ * Gated by `system/two_brand_synthesis/admin_form_probe/enabled`.
+ */
+class ProbeBrandCodeSurvival
+{
+    private const FLAG_PATH = 'two_brand_synthesis/admin_form_probe/enabled';
+
+    /**
+     * Distinctive sentinel id and value so the log line and any leaked
+     * Structure trace are unambiguously this probe's output and never
+     * collide with a real section id.
+     */
+    private const PROBE_SECTION_ID = 'two_brand_synth_probe_xyzzy';
+    private const PROBE_GROUP_ID = 'probe_group';
+    private const PROBE_FIELD_ID = 'probe_field';
+    private const PROBE_BRAND_CODE_SECTION = 'PROBE_S_SENTINEL';
+    private const PROBE_BRAND_CODE_GROUP = 'PROBE_G_SENTINEL';
+    private const PROBE_BRAND_CODE_FIELD = 'PROBE_F_SENTINEL';
+
+    private readonly bool $enabled;
+
+    public function __construct(
+        ScopeConfigInterface $scopeConfig,
+        private readonly LoggerInterface $logger
+    ) {
+        $this->enabled = $scopeConfig->isSetFlag(self::FLAG_PATH);
+    }
+
+    /**
+     * @param Converter $subject
+     * @param callable $proceed
+     * @param \DOMNode $source
+     * @return array<string,mixed>
+     */
+    public function aroundConvert(Converter $subject, callable $proceed, \DOMNode $source): array
+    {
+        if (!$this->enabled) {
+            return $proceed($source);
+        }
+
+        // Failure of the probe must never break admin config rendering.
+        // On any error, fall through to the real converter on the
+        // original source and log the diagnostic regret.
+        try {
+            $clone = $this->cloneSource($source);
+            $injected = $this->injectProbe($clone);
+            if (!$injected) {
+                $this->logger->warning(
+                    '[two_brand_probe] could not locate <system><sections> insertion point; '
+                    . 'falling through to real converter without probe injection'
+                );
+                return $proceed($source);
+            }
+            $result = $proceed($clone);
+            $this->logFindings($result);
+            $this->stripProbe($result);
+            return $result;
+        } catch (\Throwable $e) {
+            $this->logger->error(sprintf(
+                '[two_brand_probe] probe raised %s: %s — falling through to unmodified convert',
+                $e::class,
+                $e->getMessage()
+            ));
+            return $proceed($source);
+        }
+    }
+
+    /**
+     * `$source` is the merged DOM passed from Reader. Cloning a
+     * detached DOMNode loses owner-document context, so we clone the
+     * owner document and re-root on its document element.
+     */
+    private function cloneSource(\DOMNode $source): \DOMNode
+    {
+        if ($source instanceof \DOMDocument) {
+            $clone = new \DOMDocument($source->xmlVersion ?: '1.0', $source->encoding ?: 'UTF-8');
+            $clone->appendChild($clone->importNode($source->documentElement, true));
+            return $clone;
+        }
+
+        $ownerDoc = $source->ownerDocument;
+        if ($ownerDoc === null) {
+            // Detached node — best-effort: deep-clone in place. The
+            // probe section will still be appended to the cloned node.
+            return $source->cloneNode(true);
+        }
+
+        $cloneDoc = new \DOMDocument($ownerDoc->xmlVersion ?: '1.0', $ownerDoc->encoding ?: 'UTF-8');
+        // Import the source node (not the document root) so the clone
+        // mirrors what the converter actually receives.
+        $cloneDoc->appendChild($cloneDoc->importNode($source, true));
+        return $cloneDoc;
+    }
+
+    /**
+     * Inject the probe under `<config><system><section id="...">`. The
+     * Magento adminhtml/system.xml schema nests section under system
+     * under config. We use XPath against the clone to find or create
+     * the insertion point.
+     *
+     * @return bool true if the probe was successfully appended, false
+     *              if the structure was unrecognised
+     */
+    private function injectProbe(\DOMNode $clone): bool
+    {
+        $doc = $clone instanceof \DOMDocument ? $clone : $clone->ownerDocument;
+        if ($doc === null) {
+            return false;
+        }
+
+        $xpath = new \DOMXPath($doc);
+        $systemNodes = $xpath->query('//system');
+        if ($systemNodes === false || $systemNodes->length === 0) {
+            return false;
+        }
+        $system = $systemNodes->item(0);
+        if (!$system instanceof \DOMElement) {
+            return false;
+        }
+
+        $section = $doc->createElement('section');
+        $section->setAttribute('id', self::PROBE_SECTION_ID);
+        $section->setAttribute('translate', 'label');
+        $section->setAttribute('sortOrder', '999999');
+        $section->setAttribute('showInDefault', '0');
+        $section->setAttribute('showInWebsite', '0');
+        $section->setAttribute('showInStore', '0');
+        $section->setAttribute('brand_code', self::PROBE_BRAND_CODE_SECTION);
+
+        $group = $doc->createElement('group');
+        $group->setAttribute('id', self::PROBE_GROUP_ID);
+        $group->setAttribute('translate', 'label');
+        $group->setAttribute('sortOrder', '10');
+        $group->setAttribute('showInDefault', '0');
+        $group->setAttribute('showInWebsite', '0');
+        $group->setAttribute('showInStore', '0');
+        $group->setAttribute('brand_code', self::PROBE_BRAND_CODE_GROUP);
+
+        $field = $doc->createElement('field');
+        $field->setAttribute('id', self::PROBE_FIELD_ID);
+        $field->setAttribute('translate', 'label');
+        $field->setAttribute('type', 'text');
+        $field->setAttribute('sortOrder', '10');
+        $field->setAttribute('showInDefault', '0');
+        $field->setAttribute('showInWebsite', '0');
+        $field->setAttribute('showInStore', '0');
+        $field->setAttribute('brand_code', self::PROBE_BRAND_CODE_FIELD);
+
+        $group->appendChild($field);
+        $section->appendChild($group);
+        $system->appendChild($section);
+        return true;
+    }
+
+    /**
+     * Walk the converted array and report whether the probe's
+     * brand_code attributes are present at each of section / group /
+     * field, with the observed value (so spurious wrong-value
+     * preservation is also caught).
+     */
+    private function logFindings(array $result): void
+    {
+        $section = $this->locateProbeSection($result);
+        if ($section === null) {
+            $this->logger->warning(
+                '[two_brand_probe] result has no entry at expected probe path — converter '
+                . 'either dropped the entire section or uses a different shape than expected. '
+                . 'Sampling top-level result keys: '
+                . implode(',', array_keys($result))
+            );
+            return;
+        }
+
+        $group = $section['children'][self::PROBE_GROUP_ID]
+            ?? $section['groups'][self::PROBE_GROUP_ID]
+            ?? null;
+        $field = null;
+        if (is_array($group)) {
+            $field = $group['children'][self::PROBE_FIELD_ID]
+                ?? $group['fields'][self::PROBE_FIELD_ID]
+                ?? null;
+        }
+
+        $sectionAttr = $section['brand_code'] ?? null;
+        $groupAttr = is_array($group) ? ($group['brand_code'] ?? null) : null;
+        $fieldAttr = is_array($field) ? ($field['brand_code'] ?? null) : null;
+
+        $this->logger->info(sprintf(
+            '[two_brand_probe] §3.5 attribute-survival result: '
+            . 'section.brand_code=%s, group.brand_code=%s, field.brand_code=%s. '
+            . 'section keys=[%s]; group keys=[%s]; field keys=[%s]',
+            $this->renderObserved($sectionAttr, self::PROBE_BRAND_CODE_SECTION),
+            $this->renderObserved($groupAttr, self::PROBE_BRAND_CODE_GROUP),
+            $this->renderObserved($fieldAttr, self::PROBE_BRAND_CODE_FIELD),
+            implode(',', array_keys($section)),
+            is_array($group) ? implode(',', array_keys($group)) : '<absent>',
+            is_array($field) ? implode(',', array_keys($field)) : '<absent>'
+        ));
+    }
+
+    /**
+     * Strip every trace of the probe from the result. The probe must
+     * never leak into the Structure consumed by the admin UI: a stray
+     * section with showInDefault=0 wouldn't render, but leaving it in
+     * would still pollute getSections() / getTabs() iteration.
+     */
+    private function stripProbe(array &$result): void
+    {
+        $this->walkAndRemove($result, self::PROBE_SECTION_ID);
+    }
+
+    /**
+     * Recurse the converted structure looking for the probe section
+     * keyed by id at any depth. Magento's converter has varied the
+     * exact nesting key over versions ('sections' vs 'children'),
+     * so a depth-first walk is more robust than a hardcoded path.
+     */
+    private function locateProbeSection(array $result): ?array
+    {
+        $stack = [$result];
+        while ($stack !== []) {
+            $node = array_pop($stack);
+            if (!is_array($node)) {
+                continue;
+            }
+            if (isset($node[self::PROBE_SECTION_ID]) && is_array($node[self::PROBE_SECTION_ID])) {
+                $candidate = $node[self::PROBE_SECTION_ID];
+                if (($candidate['id'] ?? self::PROBE_SECTION_ID) === self::PROBE_SECTION_ID) {
+                    return $candidate;
+                }
+            }
+            foreach ($node as $child) {
+                if (is_array($child)) {
+                    $stack[] = $child;
+                }
+            }
+        }
+        return null;
+    }
+
+    private function walkAndRemove(array &$node, string $needle): void
+    {
+        foreach ($node as $key => &$value) {
+            if ($key === $needle) {
+                unset($node[$key]);
+                continue;
+            }
+            if (is_array($value)) {
+                $this->walkAndRemove($value, $needle);
+            }
+        }
+    }
+
+    private function renderObserved(mixed $observed, string $expected): string
+    {
+        if ($observed === null) {
+            return 'DROPPED';
+        }
+        if ($observed === $expected) {
+            return 'SURVIVED';
+        }
+        return sprintf('MUTATED(%s)', is_scalar($observed) ? (string)$observed : gettype($observed));
+    }
+}

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -28,4 +28,16 @@
                 type="Two\Gateway\Plugin\Config\Structure\HidePaymentSection"
                 sortOrder="10"/>
     </type>
+    <!--
+        Layer C/3 spike: probe whether unknown XML attributes on
+        <section>/<group>/<field> survive Config\Structure\Converter.
+        Gated by system/two_brand_synthesis/admin_form_probe/enabled
+        (default 0). Dormant until explicitly flipped; result is
+        logged to var/log and consumed by the admin_form PR design.
+    -->
+    <type name="Magento\Config\Model\Config\Structure\Converter">
+        <plugin name="two-probe-brand-code-attribute-survival"
+                type="Two\Gateway\Plugin\Magento\Config\Model\Config\Structure\Converter\ProbeBrandCodeSurvival"
+                sortOrder="10"/>
+    </type>
 </config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -79,6 +79,21 @@
             <csp>
                 <enabled>0</enabled>
             </csp>
+            <!--
+                One-shot diagnostic probe for design v6 §3.5: does an
+                unknown `brand_code` attribute on `<section>`/`<group>`/
+                `<field>` survive Magento's Config\Structure\Converter?
+                Answer dictates the admin_form PR's template shape
+                (attribute-driven vs section-id-prefix fallback). Probe
+                injects a throwaway section into a CLONE of the DOM,
+                inspects the converted result, logs to
+                var/log/two_brand_probe.log, then strips the probe from
+                the returned array so no real config surface is altered.
+                Flag-flip on staging once, read the log, flip back off.
+            -->
+            <admin_form_probe>
+                <enabled>0</enabled>
+            </admin_form_probe>
         </two_brand_synthesis>
     </default>
 </config>


### PR DESCRIPTION
﻿## Summary

One-shot diagnostic spike for design v6 §3.5: does an unknown `brand_code` attribute on `<section>`/`<group>`/`<field>` survive Magento's `Config\Structure\Converter::convert` round-trip?

Ships **dormant** behind `system/two_brand_synthesis/admin_form_probe/enabled` (default 0). Production never runs it. The probe runs once, logs its finding, and dictates the next PR's shape.

## Why a spike before the real Layer C/3 PR

The full `admin_form` synthesis PR will need `etc/adminhtml/brand_form_template.xml` (~400-line clone of `system.xml` with `{{code}}` tokens), a new XSD, `TemplateReader`, the real `Structure\Reader` afterRead plugin, and a 5th flag. Whether `brand_code` survives the converter dictates the template's fundamental shape:

| Outcome | Mechanism | Template shape |
|---|---|---|
| Attribute survives | Resolve active brand by `brand_code` attribute on element | `<section id="brand_payment_terms" brand_code="{{code}}">…` |
| Attribute dropped | Resolve by section-id-prefix match (§3.5 fallback) | `<section id="brand_{{code}}_payment_terms">…` |

Committing the template to one shape blind risks rewriting ~400 lines twice. The probe is ~250 lines including comments and answers the question on the next staging deploy.

## How the probe works

`aroundConvert` plugin on `Magento\Config\Model\Config\Structure\Converter`:

1. **Short-circuits** to `$proceed($source)` when the flag is 0. Cost when dormant: one plugin dispatch per admin Structure load.
2. **Clones** the input DOM (`DOMNode` → fresh `DOMDocument`). The original `$source` is never mutated.
3. **Injects** a throwaway section under `<system>` carrying distinctive sentinel ids (`two_brand_synth_probe_xyzzy`) and `brand_code` attributes at all three levels (section/group/field), each with a distinct sentinel value so spurious wrong-value preservation is also caught.
4. **Calls `$proceed`** on the clone — the real converter runs against modified DOM.
5. **Walks** the result depth-first looking for the probe section (robust to nesting-key variations across Magento versions), then logs whether the `brand_code` attribute was `SURVIVED` / `DROPPED` / `MUTATED(actual)` at each level, plus the observed key set on each node for forensic context.
6. **Strips** every trace of the probe section from the result before returning. Structure consumers never see the probe.
7. **Wrapped in try/catch** — on any throw, falls through to `$proceed($source)` on the unmodified original and logs the regret. Probe cannot break admin config rendering even when explicitly enabled.

## Operator workflow

```bash
# Once-only on staging:
bin/magento config:set system/two_brand_synthesis/admin_form_probe/enabled 1
bin/magento cache:flush
# Touch /admin/system/config in browser to force a Structure read.
kubectl -n staging exec <pod> -c magento -- grep two_brand_probe /var/www/html/var/log/system.log
# Flip back:
bin/magento config:set system/two_brand_synthesis/admin_form_probe/enabled 0
bin/magento cache:flush
```

Log line example (anticipated, attribute-survival case):
```
INFO: [two_brand_probe] §3.5 attribute-survival result:
  section.brand_code=SURVIVED, group.brand_code=SURVIVED, field.brand_code=SURVIVED.
  section keys=[id,label,type,...,brand_code]; group keys=[...]; field keys=[...]
```

## What's not in this PR

- The real `Structure\Reader` afterRead synthesis plugin. Shape depends on the probe result.
- The `brand_form_template.xml` and its XSD. Depends on the probe result.
- The `admin_form/enabled` flag. Will be added by the real PR (and design v6 §16.3's "no flag" position will be deviated from there too, with rationale).

## Caveats

1. **Converter class finality not locally verifiable.** No `vendor/` in this clone. If `Magento\Config\Model\Config\Structure\Converter` is declared `final`, the DI plugin fails at compile-time with a clear "cannot decorate final class" error and the next-step fix is a `virtualType` decorator on `Magento\Framework\Config\ConverterInterface`. The class implements a framework converter interface, which is the same pluginable surface as the readers we already plugin elsewhere — pluginable in principle, but a known unknown until staging compiles.
2. **Logger goes to `system.log`, not a dedicated file.** Earlier prose mentioned `var/log/two_brand_probe.log`; the implementation uses the standard `LoggerInterface` (which writes to `system.log`) with a `[two_brand_probe]` grep prefix. A dedicated file would add a virtualType monolog handler — surface not worth it for a one-shot diagnostic.
3. **Probe section has `showInDefault/Website/Store="0"`** so even on the failure path where the strip step doesn't run, the section is invisible to the admin UI; it would only show in iteration outputs like `Structure::getSections()`. The strip step removes it entirely as belt-and-braces.

## Test plan

- [ ] Reviewer: read `ProbeBrandCodeSurvival.php` end-to-end — five-step linear flow.
- [ ] Reviewer: confirm `Magento\Config\Model\Config\Structure\Converter::convert` is non-final + non-static + public (the DI plugin requirements).
- [ ] (Post-merge, on staging) Flag-flip + cache:flush + admin page load + grep + flag-flip back. Single log line answers the question.
- [ ] (Post-merge, dormant verification) Storefront and admin remain unchanged with the flag at default 0 — three pass-throughs by reading.

## Files

```
new   Plugin/Magento/Config/Model/Config/Structure/Converter/ProbeBrandCodeSurvival.php
edit  etc/adminhtml/di.xml  (+12 lines — plugin wiring)
edit  etc/config.xml        (+15 lines — admin_form_probe/enabled flag, default 0)
```
