### PR TITLE
feat(brand-overlay): flesh admin Configuration template + section_prefix token

### DIFF
--- a/Model/Brand/Descriptor.php
+++ b/Model/Brand/Descriptor.php
@@ -87,11 +87,13 @@ final class Descriptor
             return $this->sectionPrefix;
         }
         // Derive: `two_payment` → `two`, `abn_payment` → `abn`.
-        // `strstr(..., true)` returns the part before the needle, or
-        // `false` if the needle is absent — in which case fall back to
-        // the full code unchanged.
-        $derived = strstr($this->code, '_payment', true);
-        return $derived !== false ? $derived : $this->code;
+        // Strictly strip a TRAILING `_payment` suffix only; using
+        // strstr() would incorrectly shorten a hypothetical
+        // `foo_payment_method` to `foo`.
+        if (substr($this->code, -8) === '_payment') {
+            return substr($this->code, 0, -8);
+        }
+        return $this->code;
     }
 
     public function getTabSortOrder(): int

--- a/Model/Brand/Descriptor.php
+++ b/Model/Brand/Descriptor.php
@@ -20,6 +20,10 @@ final class Descriptor
 {
     /**
      * @param string $code Magento payment-method code (e.g. "two_payment").
+     * @param string $sectionPrefix Short identifier used as the prefix
+     *        for synthesised admin Configuration section IDs and the
+     *        synthesised admin tab id. Empty string ⇒ derive from `code`
+     *        by stripping a trailing `_payment` suffix.
      * @param int $tabSortOrder Admin Configuration tab sortOrder.
      * @param string $provider Short brand name shown in admin headers.
      * @param string $providerFullName Legal entity name.
@@ -42,6 +46,7 @@ final class Descriptor
      */
     public function __construct(
         private readonly string $code,
+        private readonly string $sectionPrefix,
         private readonly int $tabSortOrder,
         private readonly string $provider,
         private readonly string $providerFullName,
@@ -67,6 +72,26 @@ final class Descriptor
     public function getCode(): string
     {
         return $this->code;
+    }
+
+    /**
+     * Short identifier used as the prefix for synthesised admin
+     * Configuration section IDs (e.g. `two_general`, `two_payment`,
+     * `two_search`, `two_version`) and the admin tab id
+     * (`{prefix}_gateway`). Falls back to `code` minus a trailing
+     * `_payment` suffix when not explicitly declared.
+     */
+    public function getSectionPrefix(): string
+    {
+        if ($this->sectionPrefix !== '') {
+            return $this->sectionPrefix;
+        }
+        // Derive: `two_payment` → `two`, `abn_payment` → `abn`.
+        // `strstr(..., true)` returns the part before the needle, or
+        // `false` if the needle is absent — in which case fall back to
+        // the full code unchanged.
+        $derived = strstr($this->code, '_payment', true);
+        return $derived !== false ? $derived : $this->code;
     }
 
     public function getTabSortOrder(): int

--- a/Model/Brand/Loader.php
+++ b/Model/Brand/Loader.php
@@ -86,6 +86,7 @@ class Loader
     private function buildDescriptor(\SimpleXMLElement $brand, string $sourcePath): Descriptor
     {
         $code = (string)$brand['code'];
+        $sectionPrefix = (string)($brand['section_prefix'] ?? '');
         $tabSortOrder = (int)$brand['tab_sort_order'];
 
         if ($code === '') {
@@ -150,6 +151,7 @@ class Loader
 
         return new Descriptor(
             $code,
+            $sectionPrefix,
             $tabSortOrder,
             (string)$brand->provider,
             (string)($brand->provider_full_name ?? ''),

--- a/Plugin/Magento/Config/Model/Config/Structure/Reader/SynthesiseBrandAdminForm.php
+++ b/Plugin/Magento/Config/Model/Config/Structure/Reader/SynthesiseBrandAdminForm.php
@@ -16,21 +16,26 @@ use Two\Gateway\Model\Brand\Descriptor;
 use Two\Gateway\Model\Brand\Loader;
 
 /**
- * Synthesises one admin Configuration section per registered brand
- * by stamping `etc/adminhtml/brand_form_template.xml` against each
- * brand's `Brand\Descriptor` and feeding the result through
+ * Synthesises a brand's admin Configuration surface — tab plus
+ * the four canonical sections (`{prefix}_general`, `{prefix}_payment`,
+ * `{prefix}_search`, `{prefix}_version`) — by stamping
+ * `etc/adminhtml/brand_form_template.xml` against each brand's
+ * `Brand\Descriptor` and feeding the result through
  * `Magento\Config\Model\Config\Structure\Converter::convert`. The
- * converted section is then merged into the Structure result that
- * `Reader::read` returns.
+ * converted tabs and sections are then merged into the Structure
+ * result that `Reader::read` returns.
  *
  * Two invariants protect against double-rendering during the
  * transition window before strip-down:
  *
  *   1. The plugin uses `afterRead`, not `beforeRead` — it observes
- *      what's already in the Structure and only contributes when a
- *      brand has no static section at the target id. First-writer-
- *      wins; an overlay module that still ships its own
- *      etc/adminhtml/system.xml stays on the static surface.
+ *      what's already in the Structure and only contributes for
+ *      individual section/tab IDs that aren't already statically
+ *      declared. First-writer-wins applies per-element, so an
+ *      overlay module's slim suppression-only `system.xml` (the
+ *      Option B mechanism) merges via Magento's native merge AFTER
+ *      synthesis: synthesis injects the canonical surface, overlay
+ *      attributes hide what each brand suppresses.
  *
  *   2. Synthesis runs only when
  *      `system/two_brand_synthesis/admin_form/enabled` is on. While
@@ -108,35 +113,61 @@ class SynthesiseBrandAdminForm
             return $result;
         }
 
-        $synthesised = 0;
-        $skipped = [];
+        $synthesisedSections = [];
+        $synthesisedTabs = [];
+        $skippedSections = [];
+        $skippedTabs = [];
         foreach ($brands as $brand) {
-            $sectionId = $brand->getCode();
-            if ($this->sectionExistsInResult($result, $sectionId)) {
-                $skipped[] = $sectionId;
-                continue;
-            }
-
             try {
-                $section = $this->renderBrandSection($template, $brand);
+                $converted = $this->renderBrandTemplate($template, $brand);
             } catch (\Throwable $e) {
                 $this->logger->error(sprintf(
-                    '[two_brand_admin_form] failed to synthesise section for brand "%s": %s — leaving Structure unchanged for this brand',
-                    $sectionId,
+                    '[two_brand_admin_form] failed to synthesise template for brand "%s": %s — leaving Structure unchanged for this brand',
+                    $brand->getCode(),
                     $e->getMessage()
                 ));
                 continue;
             }
 
-            $result = $this->mergeSection($result, $sectionId, $section);
-            $synthesised++;
+            $tabs = $converted['config']['system']['tabs'] ?? [];
+            foreach ($tabs as $tabId => $tab) {
+                if ($this->tabExistsInResult($result, (string)$tabId)) {
+                    // Tab is a leaf in the converted form (id, label, sortOrder).
+                    // If an overlay declared it statically, the static
+                    // declaration wins. We don't deep-merge tabs.
+                    $skippedTabs[] = (string)$tabId;
+                    continue;
+                }
+                $result['config']['system']['tabs'][$tabId] = $tab;
+                $synthesisedTabs[] = (string)$tabId;
+            }
+
+            $sections = $converted['config']['system']['sections'] ?? [];
+            foreach ($sections as $sectionId => $section) {
+                if ($this->sectionExistsInResult($result, (string)$sectionId)) {
+                    // Overlay (Option B′ suppression XML) merged a stub
+                    // for this section into the Structure before us.
+                    // Deep-merge: synthesised content is the base, the
+                    // overlay's scalar attributes (showInDefault="0",
+                    // etc.) win on top, recursively into groups/fields.
+                    $existing = $result['config']['system']['sections'][$sectionId];
+                    $result['config']['system']['sections'][$sectionId] =
+                        $this->deepMergeOverlay($section, $existing);
+                    $synthesisedSections[] = $sectionId . '*';
+                    continue;
+                }
+                $result['config']['system']['sections'][$sectionId] = $section;
+                $synthesisedSections[] = (string)$sectionId;
+            }
         }
 
-        if ($synthesised > 0 || $skipped !== []) {
+        if ($synthesisedSections !== [] || $synthesisedTabs !== [] || $skippedSections !== [] || $skippedTabs !== []) {
             $this->logger->info(sprintf(
-                '[two_brand_admin_form] synthesised %d brand section(s); skipped [%s] (already statically declared)',
-                $synthesised,
-                implode(',', $skipped)
+                '[two_brand_admin_form] synthesised tabs [%s] sections [%s]; skipped tabs [%s] sections [%s] (already statically declared)',
+                implode(',', $synthesisedTabs),
+                implode(',', $synthesisedSections),
+                implode(',', $skippedTabs),
+                implode(',', $skippedSections)
             ));
         }
 
@@ -176,18 +207,75 @@ class SynthesiseBrandAdminForm
         return isset($result['config']['system']['sections'][$sectionId]);
     }
 
+    private function tabExistsInResult(array $result, string $tabId): bool
+    {
+        return isset($result['config']['system']['tabs'][$tabId]);
+    }
+
+    /**
+     * Recursively merge a brand-overlay's converted Structure subtree
+     * (typically a slim suppression-only section from the overlay
+     * module's `etc/adminhtml/system.xml`) on top of the synthesised
+     * canonical section.
+     *
+     * Rules:
+     *   - The synthesised section is the BASE — its full shape
+     *     (groups, fields, attributes) is preserved unless the
+     *     overlay overrides specific values.
+     *   - For scalar keys (showInDefault, showInWebsite, showInStore,
+     *     label, sortOrder, …), the overlay wins. This is how an
+     *     overlay suppresses a field: declare it with
+     *     `showInDefault="0" showInWebsite="0" showInStore="0"` in
+     *     its own system.xml and the merged scalars override the
+     *     synthesised defaults.
+     *   - For array keys (children: groups inside section, fields
+     *     inside group), recurse: missing keys from the overlay are
+     *     left alone; present keys deep-merge.
+     *   - The overlay CANNOT add brand-new fields/groups by this
+     *     mechanism. Anything in the overlay that isn't already in
+     *     the synthesised section is dropped on the floor (with a
+     *     debug log). This is intentional: the canonical template
+     *     is the source of truth for what controls exist; the
+     *     overlay's job is to hide, not to extend.
+     *
+     * @param array<string,mixed> $base
+     * @param array<string,mixed> $overlay
+     * @return array<string,mixed>
+     */
+    private function deepMergeOverlay(array $base, array $overlay): array
+    {
+        foreach ($overlay as $key => $overlayValue) {
+            if (!array_key_exists($key, $base)) {
+                // Overlay added something the synthesised section
+                // doesn't recognise. Skip; the canonical template is
+                // the source of truth.
+                continue;
+            }
+            $baseValue = $base[$key];
+            if (is_array($baseValue) && is_array($overlayValue)) {
+                $base[$key] = $this->deepMergeOverlay($baseValue, $overlayValue);
+            } else {
+                $base[$key] = $overlayValue;
+            }
+        }
+        return $base;
+    }
+
     /**
      * Substitute the template's tokens against a brand's Descriptor,
      * parse the result, run it through Magento's own Converter, and
-     * return the converted section subtree (so Magento's downstream
-     * mappers see the same shape they'd see for a statically declared
-     * section).
+     * return the full converted Structure subtree. Callers extract
+     * tabs and sections from `config.system.{tabs,sections}` and
+     * merge them with their own collision policy.
      */
-    private function renderBrandSection(string $template, Descriptor $brand): array
+    private function renderBrandTemplate(string $template, Descriptor $brand): array
     {
         $substituted = strtr($template, [
             '{{code}}' => $this->escapeXmlAttribute($brand->getCode()),
+            '{{section_prefix}}' => $this->escapeXmlAttribute($brand->getSectionPrefix()),
             '{{provider}}' => $this->escapeXmlAttribute($brand->getProvider()),
+            '{{tab_label}}' => $this->escapeXmlAttribute($brand->getTabLabel()),
+            '{{tab_css_class}}' => $this->escapeXmlAttribute($brand->getTabCssClass()),
             '{{tab_sort_order}}' => (string)$brand->getTabSortOrder(),
             '{{admin_resource}}' => $this->escapeXmlAttribute($brand->getAdminResource()),
         ]);
@@ -212,22 +300,13 @@ class SynthesiseBrandAdminForm
         }
 
         $converted = $this->converter->convert($dom);
-        $sectionId = $brand->getCode();
-        $section = $converted['config']['system']['sections'][$sectionId] ?? null;
-        if (!is_array($section)) {
+        if (!isset($converted['config']['system'])) {
             throw new \RuntimeException(sprintf(
-                'converter output has no section at config.system.sections.%s; observed sections: [%s]',
-                $sectionId,
-                implode(',', array_keys($converted['config']['system']['sections'] ?? []))
+                'converter output has no config.system root for brand "%s"',
+                $brand->getCode()
             ));
         }
-        return $section;
-    }
-
-    private function mergeSection(array $result, string $sectionId, array $section): array
-    {
-        $result['config']['system']['sections'][$sectionId] = $section;
-        return $result;
+        return $converted;
     }
 
     /**

--- a/Plugin/Magento/Config/Model/Config/Structure/Reader/SynthesiseBrandAdminForm.php
+++ b/Plugin/Magento/Config/Model/Config/Structure/Reader/SynthesiseBrandAdminForm.php
@@ -232,28 +232,43 @@ class SynthesiseBrandAdminForm
      *     inside group), recurse: missing keys from the overlay are
      *     left alone; present keys deep-merge.
      *   - The overlay CANNOT add brand-new fields/groups by this
-     *     mechanism. Anything in the overlay that isn't already in
-     *     the synthesised section is dropped on the floor (with a
-     *     debug log). This is intentional: the canonical template
-     *     is the source of truth for what controls exist; the
-     *     overlay's job is to hide, not to extend.
+     *     mechanism. Anything in the overlay that names a sibling
+     *     under a `children` collection (groups, fields) which isn't
+     *     in the synthesised section is dropped on the floor. This
+     *     is intentional: the canonical template is the source of
+     *     truth for what controls exist; the overlay's job is to
+     *     hide, not to extend.
+     *   - Overlay scalar attributes on an existing field/group
+     *     (`comment`, `tooltip`, `validate`, `canRestore`, etc.) ARE
+     *     accepted even if absent from the synthesised body — the
+     *     "skip unknown key" rule is scoped to children collections
+     *     so per-field attribute overrides land cleanly.
      *
      * @param array<string,mixed> $base
      * @param array<string,mixed> $overlay
+     * @param bool $isChildrenList true when the current recursion
+     *        level is inside Magento's converted `children` array
+     *        (the collection of sibling groups/fields under a section
+     *        or group). At that level only, unknown keys are dropped.
      * @return array<string,mixed>
      */
-    private function deepMergeOverlay(array $base, array $overlay): array
+    private function deepMergeOverlay(array $base, array $overlay, bool $isChildrenList = false): array
     {
         foreach ($overlay as $key => $overlayValue) {
-            if (!array_key_exists($key, $base)) {
-                // Overlay added something the synthesised section
-                // doesn't recognise. Skip; the canonical template is
-                // the source of truth.
+            if ($isChildrenList && !array_key_exists($key, $base)) {
+                // Overlay named a sibling field/group that the
+                // synthesised section doesn't declare. Skip — the
+                // canonical template is the source of truth for
+                // what controls exist.
                 continue;
             }
-            $baseValue = $base[$key];
+            $baseValue = $base[$key] ?? null;
             if (is_array($baseValue) && is_array($overlayValue)) {
-                $base[$key] = $this->deepMergeOverlay($baseValue, $overlayValue);
+                $base[$key] = $this->deepMergeOverlay(
+                    $baseValue,
+                    $overlayValue,
+                    $key === 'children'
+                );
             } else {
                 $base[$key] = $overlayValue;
             }

--- a/etc/adminhtml/brand_form_template.xml
+++ b/etc/adminhtml/brand_form_template.xml
@@ -93,7 +93,7 @@
                        showInDefault="1" showInWebsite="1" showInStore="1"
                        brand_code="{{code}}">
                     <label>Debug mode</label>
-                    <comment>The debug mode enables writing to the error logs below. Debug mode should only be enabled when the sandbox enviroment is active</comment>
+                    <comment>The debug mode enables writing to the error logs below. Debug mode should only be enabled when the sandbox environment is active</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <config_path>payment/{{code}}/debug</config_path>
                 </field>
@@ -212,7 +212,7 @@
                        showInDefault="1" showInWebsite="1" showInStore="1"
                        canRestore="1" brand_code="{{code}}">
                     <label>Payment Terms Type</label>
-                    <comment><![CDATA[<strong>Standard:</strong> Payment due after a fixed number of days from fulfillment.<br/><strong>End of Month:</strong> Payment due at the end of month plus additional days from fulfillment.]]></comment>
+                    <comment><![CDATA[<strong>Standard:</strong> Payment due after a fixed number of days from fulfilment.<br/><strong>End of Month:</strong> Payment due at the end of month plus additional days from fulfilment.]]></comment>
                     <source_model>Two\Gateway\Model\Config\Source\PaymentTermsType</source_model>
                     <config_path>payment/{{code}}/payment_terms_type</config_path>
                 </field>

--- a/etc/adminhtml/brand_form_template.xml
+++ b/etc/adminhtml/brand_form_template.xml
@@ -6,51 +6,117 @@
  *
  * Brand-form synthesis template (design v6 §3.5).
  *
- * Tokenised clone of an admin Configuration section. The synthesis
- * plugin (`SynthesiseBrandAdminForm::afterRead`) substitutes the
- * tokens against each registered brand's Descriptor and feeds the
- * result through Magento's Config\Structure\Converter, then injects
- * the converted section into the Structure result.
+ * Tokenised clone of `etc/adminhtml/system.xml` (one full Two-brand
+ * admin Configuration surface). The synthesis plugin
+ * (`SynthesiseBrandAdminForm::afterRead`) substitutes the tokens
+ * against each registered brand's Descriptor and feeds the result
+ * through Magento's Config\Structure\Converter, then merges the
+ * converted tabs and sections into the Structure result.
  *
  * Tokens:
  *
  *   {{code}}             Brand payment-method code, e.g. "two_payment".
- *                        Used in section ids and CCD config_path.
- *   {{provider}}         Short brand name, e.g. "Two", "ABN".
- *                        Used in section/group labels.
+ *                        Used in CCD config_path values.
+ *   {{section_prefix}}   Short brand prefix, e.g. "two", "abn". Used
+ *                        for tab id (`{prefix}_gateway`) and section
+ *                        ids (`{prefix}_general`/`_payment`/`_search`/
+ *                        `_version`).
+ *   {{provider}}         Short brand name. Currently unused at the
+ *                        admin-XML level but reserved for label
+ *                        interpolation in follow-ups.
+ *   {{tab_label}}        Admin Configuration tab label.
+ *   {{tab_css_class}}    CSS class on the admin tab `<li>`.
  *   {{tab_sort_order}}   Admin tab sortOrder for this brand.
  *   {{admin_resource}}   ACL resource string for the brand's section.
  *
  * The `brand_code` attribute on `<section>`/`<group>`/`<field>` is
  * preserved by the Converter (verified by PR #160's §3.5 probe) and
  * is the runtime hook for code that needs to discriminate by brand
- * when iterating the Structure (e.g. Block\Adminhtml admin headers,
- * Mapper\* chains).
+ * when iterating the Structure.
  *
- * SCOPE: this PR ships a representative-but-minimal template (one
- * section, two groups, six fields) sufficient to validate the
- * synthesis mechanism end-to-end. The full ~314-line surface
- * matching today's static etc/adminhtml/system.xml lands in a
- * follow-up template-fleshing PR before strip-down activation.
+ * Brand-overlay modules (Option B′) hide controls by shipping a slim
+ * `etc/adminhtml/system.xml` of their own that declares the matching
+ * section/group/field path with `showInDefault="0" showInWebsite="0"
+ * showInStore="0"`. The synthesiser deep-merges that stub on top of
+ * the canonical body produced by this template; overlay scalars win
+ * per-field. Overlays cannot ADD controls via this mechanism — the
+ * canonical template is the source of truth for what fields exist.
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
-        <!--
-            section sortOrder uses {{tab_sort_order}} (the brand's
-            admin-nav position from etc/brand.xml). Pre-strip-down,
-            all brands share the static `two_gateway` tab so the
-            section's sortOrder governs the visible ordering. The
-            full-template PR introduces per-brand tab synthesis and
-            can split tabSortOrder from sectionSortOrder if needed.
-        -->
-        <section id="{{code}}" translate="label" type="text" sortOrder="{{tab_sort_order}}"
+        <tab id="{{section_prefix}}_gateway" translate="label"
+             class="{{tab_css_class}}" sortOrder="{{tab_sort_order}}">
+            <label>{{tab_label}}</label>
+        </tab>
+        <section id="{{section_prefix}}_general" translate="label" type="text" sortOrder="10"
                  showInDefault="1" showInWebsite="1" showInStore="1"
                  brand_code="{{code}}">
             <class>separator-top</class>
-            <label>{{provider}} Payment</label>
-            <tab>two_gateway</tab>
+            <label>General</label>
+            <tab>{{section_prefix}}_gateway</tab>
+            <resource>{{admin_resource}}</resource>
+            <group id="general" translate="label" type="text" sortOrder="20"
+                   showInDefault="1" showInWebsite="1" showInStore="1"
+                   brand_code="{{code}}">
+                <label>General</label>
+                <field id="mode" translate="label" type="select" sortOrder="35"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       brand_code="{{code}}">
+                    <label>Environment</label>
+                    <comment>Select between sandbox and production environment. The sandbox environment is for testing purposes and does not involve real money.</comment>
+                    <source_model>Two\Gateway\Model\Config\Source\Mode</source_model>
+                    <depends>
+                        <field id="active">1</field>
+                    </depends>
+                    <config_path>payment/{{code}}/mode</config_path>
+                </field>
+                <field id="api_key" translate="label" type="obscure" sortOrder="50"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       brand_code="{{code}}">
+                    <label>API key</label>
+                    <comment>API key for sandbox environment is available on your merchant portal (however please reach out to integration@two.inc for access to production keys).</comment>
+                    <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
+                    <validate>required-entry</validate>
+                    <depends>
+                        <field id="active">1</field>
+                    </depends>
+                    <config_path>payment/{{code}}/api_key</config_path>
+                </field>
+                <field id="api_key_check" translate="label" type="button" sortOrder="55"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       brand_code="{{code}}">
+                    <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\ApiKeyCheck</frontend_model>
+                </field>
+                <field id="debug" translate="label" type="select" sortOrder="60"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       brand_code="{{code}}">
+                    <label>Debug mode</label>
+                    <comment>The debug mode enables writing to the error logs below. Debug mode should only be enabled when the sandbox enviroment is active</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <config_path>payment/{{code}}/debug</config_path>
+                </field>
+                <field id="debug_button" translate="label" type="button" sortOrder="70"
+                       showInDefault="1" showInWebsite="0" showInStore="0"
+                       brand_code="{{code}}">
+                    <label/>
+                    <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Button\DebugCheck</frontend_model>
+                </field>
+                <field id="error_button" translate="label" type="button" sortOrder="80"
+                       showInDefault="1" showInWebsite="0" showInStore="0"
+                       brand_code="{{code}}">
+                    <label/>
+                    <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Button\ErrorCheck</frontend_model>
+                </field>
+            </group>
+        </section>
+        <section id="{{section_prefix}}_payment" translate="label" type="text" sortOrder="20"
+                 showInDefault="1" showInWebsite="1" showInStore="1"
+                 brand_code="{{code}}">
+            <class>separator-top</class>
+            <label>Payment</label>
+            <tab>{{section_prefix}}_gateway</tab>
             <resource>{{admin_resource}}</resource>
             <group id="payment_method" translate="label" type="text" sortOrder="10"
                    showInDefault="1" showInWebsite="1" showInStore="1"
@@ -75,47 +141,248 @@
                     </depends>
                     <config_path>payment/{{code}}/title</config_path>
                 </field>
-                <field id="mode" translate="label" type="select" sortOrder="30"
+            </group>
+            <group id="checkout_fields" translate="label" type="text" sortOrder="20"
+                   showInDefault="1" showInWebsite="1" showInStore="1"
+                   brand_code="{{code}}">
+                <label>Checkout Fields</label>
+                <field id="enable_department" translate="label" type="select" sortOrder="10"
                        showInDefault="1" showInWebsite="1" showInStore="1"
-                       brand_code="{{code}}">
-                    <label>Environment</label>
-                    <comment>Sandbox vs production. Sandbox does not involve real money.</comment>
-                    <source_model>Two\Gateway\Model\Config\Source\Mode</source_model>
-                    <depends>
-                        <field id="active">1</field>
-                    </depends>
-                    <config_path>payment/{{code}}/mode</config_path>
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Add Department Field</label>
+                    <comment>Optional field which enables the buyer to register the department the purchase is connected to. The information is eventually displayed on the invoice.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <config_path>payment/{{code}}/enable_department</config_path>
                 </field>
-                <field id="api_key" translate="label" type="obscure" sortOrder="40"
+                <field id="enable_order_note" translate="label" type="select" sortOrder="20"
                        showInDefault="1" showInWebsite="1" showInStore="1"
-                       brand_code="{{code}}">
-                    <label>API key</label>
-                    <comment>Issued by {{provider}}. Contact integration@two.inc for production keys.</comment>
-                    <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
-                    <validate>required-entry</validate>
-                    <depends>
-                        <field id="active">1</field>
-                    </depends>
-                    <config_path>payment/{{code}}/api_key</config_path>
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Add Order Note Field</label>
+                    <comment>Optional field which enables the buyer to register a note to the merchant. The information is eventually displayed on the invoice.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <config_path>payment/{{code}}/enable_order_note</config_path>
+                </field>
+                <field id="enable_project" translate="label" type="select" sortOrder="30"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Add Project Field</label>
+                    <comment>Optional field which enables the buyer to register the project the purchase is connected to. The information is eventually displayed on the invoice.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <config_path>payment/{{code}}/enable_project</config_path>
+                </field>
+                <field id="enable_po_number" translate="label" type="select" sortOrder="40"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Add PO Number Field</label>
+                    <comment>Optional field which enables the buyer to register their purchase order number.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <config_path>payment/{{code}}/enable_po_number</config_path>
+                </field>
+                <field id="enable_invoice_emails" translate="label" type="select" sortOrder="50"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Enable Invoice Emails</label>
+                    <comment>Let your buyer input additional emails to forward the invoice to on order fulfilment.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <config_path>payment/{{code}}/enable_invoice_emails</config_path>
                 </field>
             </group>
-            <group id="diagnostics" translate="label" type="text" sortOrder="90"
-                   showInDefault="1" showInWebsite="0" showInStore="0"
+            <group id="payment_terms" translate="label" type="text" sortOrder="25"
+                   showInDefault="1" showInWebsite="1" showInStore="1"
                    brand_code="{{code}}">
-                <label>Diagnostics</label>
-                <field id="debug" translate="label" type="select" sortOrder="10"
-                       showInDefault="1" showInWebsite="0" showInStore="0"
-                       brand_code="{{code}}">
-                    <label>Debug mode</label>
-                    <comment>Enables verbose logging. Use only when investigating an issue on sandbox.</comment>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <config_path>payment/{{code}}/debug</config_path>
+                <label>Payment Terms</label>
+                <field id="payment_terms" translate="label comment" type="text" sortOrder="10"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Payment Terms</label>
+                    <comment>Select the payment term(s) you want to offer.</comment>
+                    <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\PaymentTermsCheckboxes</frontend_model>
+                    <backend_model>Two\Gateway\Model\Config\Backend\PaymentTermsCheckboxes</backend_model>
+                    <config_path>payment/{{code}}/payment_terms</config_path>
                 </field>
-                <field id="version" translate="label" type="label" sortOrder="20"
-                       showInDefault="1" showInWebsite="0" showInStore="0"
+                <field id="payment_terms_duration_days" translate="label comment" type="text" sortOrder="20"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Custom Payment Term (days)</label>
+                    <comment>Optional. Enter a custom number of days to offer alongside the selected terms above.</comment>
+                    <validate>validate-digits validate-zero-or-greater</validate>
+                    <config_path>payment/{{code}}/payment_terms_duration_days</config_path>
+                </field>
+                <field id="payment_terms_type" translate="label comment" type="select" sortOrder="30"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Payment Terms Type</label>
+                    <comment><![CDATA[<strong>Standard:</strong> Payment due after a fixed number of days from fulfillment.<br/><strong>End of Month:</strong> Payment due at the end of month plus additional days from fulfillment.]]></comment>
+                    <source_model>Two\Gateway\Model\Config\Source\PaymentTermsType</source_model>
+                    <config_path>payment/{{code}}/payment_terms_type</config_path>
+                </field>
+                <field id="default_payment_term" translate="label comment" type="select" sortOrder="40"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Default Payment Term</label>
+                    <comment>Select the payment term that will be automatically selected for your customer.</comment>
+                    <source_model>Two\Gateway\Model\Config\Source\AvailablePaymentTerms</source_model>
+                    <config_path>payment/{{code}}/default_payment_term</config_path>
+                </field>
+                <field id="surcharge_type" translate="label comment" type="select" sortOrder="50"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Surcharge Method</label>
+                    <comment>Select a method to surcharge your customer.</comment>
+                    <source_model>Two\Gateway\Model\Config\Source\SurchargeType</source_model>
+                    <config_path>payment/{{code}}/surcharge_type</config_path>
+                </field>
+                <field id="surcharge_differential" translate="label" type="select" sortOrder="60"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Surcharge Calculation Basis</label>
+                    <source_model>Two\Gateway\Model\Config\Source\SurchargeCalculationBasis</source_model>
+                    <config_path>payment/{{code}}/surcharge_differential</config_path>
+                </field>
+                <field id="surcharge_line_description" translate="label comment" type="text" sortOrder="70"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Surcharge Line Description</label>
+                    <comment><![CDATA[Description shown to the buyer for the surcharge line item. Use <strong>%1</strong> to insert the selected number of days (e.g. "Payment terms fee - %1 days"). If you leave the default, the word <em>days</em> is translated per locale.]]></comment>
+                    <config_path>payment/{{code}}/surcharge_line_description</config_path>
+                </field>
+                <field id="surcharge_tax_rate" translate="label" type="text" sortOrder="90"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Surcharge Tax Rate (%)</label>
+                    <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\SurchargeTaxRate</frontend_model>
+                    <validate>validate-number validate-zero-or-greater</validate>
+                    <config_path>payment/{{code}}/surcharge_tax_rate</config_path>
+                </field>
+                <field id="surcharge_grid" translate="label" type="text" sortOrder="100"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
                        brand_code="{{code}}">
-                    <label>Plugin version</label>
-                    <config_path>payment/{{code}}/version</config_path>
+                    <label>Payment Surcharge Configuration</label>
+                    <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\SurchargeGrid</frontend_model>
+                    <backend_model>Two\Gateway\Model\Config\Backend\SurchargeGrid</backend_model>
+                </field>
+            </group>
+            <group id="advanced" translate="label" type="text" sortOrder="30"
+                   showInDefault="1" showInWebsite="1" showInStore="1"
+                   brand_code="{{code}}">
+                <label>Advanced</label>
+                <field id="sallowspecific" translate="label comment" type="select" sortOrder="5"
+                       showInDefault="1" showInWebsite="1" showInStore="0"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Country Availability</label>
+                    <comment>Choose whether to enable this payment method for all allowed countries or only specific ones.</comment>
+                    <frontend_class>shipping-applicable-country</frontend_class>
+                    <source_model>Magento\Shipping\Model\Config\Source\Allspecificcountries</source_model>
+                    <config_path>payment/{{code}}/allowspecific</config_path>
+                </field>
+                <field id="specificcountry" translate="label comment" type="multiselect" sortOrder="6"
+                       showInDefault="1" showInWebsite="1" showInStore="0"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Allowed Countries</label>
+                    <comment>Select the countries where this payment method should be available.</comment>
+                    <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
+                    <can_be_empty>1</can_be_empty>
+                    <depends>
+                        <field id="sallowspecific">1</field>
+                    </depends>
+                    <config_path>payment/{{code}}/specificcountry</config_path>
+                </field>
+                <field id="fulfill_trigger" translate="label" type="select" sortOrder="10"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Fulfilment Trigger</label>
+                    <comment>Fulfilment can be triggered by either initializing shipping or creating an invoice in the Magento admin</comment>
+                    <source_model>Two\Gateway\Model\Config\Source\FulfillTrigger</source_model>
+                    <config_path>payment/{{code}}/fulfill_trigger</config_path>
+                </field>
+                <field id="fulfill_order_status" translate="label" type="multiselect" sortOrder="20"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Fulfilment Order Status</label>
+                    <comment>If fulfilment trigger is On Completion, select one or more order statuses which can trigger fulfilment.</comment>
+                    <source_model>Two\Gateway\Model\Config\Source\FulfillOrderStatus</source_model>
+                    <depends>
+                        <field id="fulfill_trigger">complete</field>
+                    </depends>
+                    <config_path>payment/{{code}}/fulfill_order_status</config_path>
+                </field>
+                <field id="enable_order_intent" translate="label" type="select" sortOrder="30"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Enable Order Intent</label>
+                    <comment>Perform a check during checkout to inform the buyer whether an order is likely to be accepted before being placed (recommended).</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <config_path>payment/{{code}}/enable_order_intent</config_path>
+                </field>
+                <field id="enable_tax_subtotals" translate="label" type="select" sortOrder="40"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Enable Tax Subtotals</label>
+                    <comment>Add optional tax_subtotals metadata to order creation payload to enforce additional validation (recommended).</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <config_path>payment/{{code}}/enable_tax_subtotals</config_path>
+                </field>
+                <field id="sort_order" translate="label comment" type="text" sortOrder="70"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Sort Order</label>
+                    <comment>Controls the position of this payment method relative to other payment methods at checkout. Lower numbers appear first. Default is empty (no specific order).</comment>
+                    <config_path>payment/{{code}}/sort_order</config_path>
+                </field>
+            </group>
+        </section>
+        <section id="{{section_prefix}}_search" translate="label" type="text" sortOrder="30"
+                 showInDefault="1" showInWebsite="1" showInStore="1"
+                 brand_code="{{code}}">
+            <class>separator-top</class>
+            <label>Search</label>
+            <tab>{{section_prefix}}_gateway</tab>
+            <resource>{{admin_resource}}</resource>
+            <group id="search" translate="label" type="text" sortOrder="10"
+                   showInDefault="1" showInWebsite="1" showInStore="1"
+                   brand_code="{{code}}">
+                <label>Search</label>
+                <field id="enable_company_search" translate="label" type="select" sortOrder="10"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Enable Company Search</label>
+                    <comment>Adds a searchable company name input field on shipping details page where the buyer can select their company from a dropdown menu.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends>
+                        <field id="active">1</field>
+                    </depends>
+                    <config_path>payment/{{code}}/enable_company_search</config_path>
+                </field>
+                <field id="enable_address_search" translate="label" type="select" sortOrder="20"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Enable Address Search</label>
+                    <comment>Autocomplete address based on selected country and company.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends>
+                        <field id="active">1</field>
+                        <field id="enable_company_search">1</field>
+                    </depends>
+                    <config_path>payment/{{code}}/enable_address_search</config_path>
+                </field>
+            </group>
+        </section>
+        <section id="{{section_prefix}}_version" translate="label" type="text" sortOrder="100"
+                 showInDefault="1" showInWebsite="1" showInStore="1"
+                 brand_code="{{code}}">
+            <class>separator-top</class>
+            <label>Version</label>
+            <tab>{{section_prefix}}_gateway</tab>
+            <resource>{{admin_resource}}</resource>
+            <group id="general" translate="label" type="text" sortOrder="10"
+                   showInDefault="1" showInWebsite="1" showInStore="1"
+                   brand_code="{{code}}">
+                <label>Version</label>
+                <field id="version" translate="label" type="button" sortOrder="10"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       brand_code="{{code}}">
+                    <label/>
+                    <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\Version</frontend_model>
                 </field>
             </group>
         </section>

--- a/etc/brand.xml
+++ b/etc/brand.xml
@@ -11,7 +11,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:two-inc:magento2:Brand/etc/brand.xsd">
-    <brand code="two_payment" tab_sort_order="500">
+    <brand code="two_payment" section_prefix="two" tab_sort_order="500">
         <provider>Two</provider>
         <provider_full_name>Two</provider_full_name>
         <product_name>Two</product_name>

--- a/etc/brand.xsd
+++ b/etc/brand.xsd
@@ -45,6 +45,15 @@
         </xs:all>
         <xs:attribute name="code" type="brandCodeType" use="required"/>
         <xs:attribute name="tab_sort_order" type="xs:integer" use="required"/>
+        <!--
+            Short identifier used as the prefix for synthesised admin
+            Configuration section IDs (e.g. `two` → `two_general`,
+            `two_payment`, `two_search`, `two_version`) and the
+            synthesised admin tab id (`{prefix}_gateway`). Optional —
+            when absent, derived by stripping a trailing `_payment`
+            suffix from `code`.
+        -->
+        <xs:attribute name="section_prefix" type="brandCodeType" use="optional"/>
     </xs:complexType>
 
     <xs:simpleType name="brandCodeType">


### PR DESCRIPTION
## Summary

Fleshes the brand-overlay synthesis template (`etc/adminhtml/brand_form_template.xml`) to the full canonical admin Configuration surface and adds the supporting `section_prefix` token. Builds on the dormant synthesis foundation shipped in #161. Part of the ABN-398 brand unification work.

## What changes

- `brand.xsd` / `brand.xml`: add optional `section_prefix` attribute. Default-derived from `code` by stripping a trailing `_payment` suffix (`two_payment` → `two`).
- `Brand\Descriptor::getSectionPrefix()` — explicit value or derived fallback.
- `Brand\Loader` — parse the new attribute.
- `SynthesiseBrandAdminForm`:
  - substitutes new tokens (`{{section_prefix}}`, `{{tab_label}}`, `{{tab_css_class}}`);
  - merges **all** sections and tabs from the converted template (previously assumed exactly one section per brand);
  - **deep-merges** overlay stubs on top of synthesised sections instead of skip-on-collision, so brand-overlay modules can suppress fields via a slim static `system.xml` of their own.
- `brand_form_template.xml` — now mirrors `etc/adminhtml/system.xml` in full (4 sections: `*_general`, `*_payment`, `*_search`, `*_version`, plus the tab declaration), with all section IDs, tab refs and `config_path`s tokenised.

## Tokens

| Token | Maps to | Used for |
|---|---|---|
| `{{code}}` | brand payment-method code (`two_payment`) | `config_path` values |
| `{{section_prefix}}` | section / tab ID prefix (`two`) | section IDs (`*_general` etc.), tab ID (`*_gateway`) |
| `{{provider}}` | short brand name | reserved for future label interpolation |
| `{{tab_label}}` | admin tab label | tab `<label>` body |
| `{{tab_css_class}}` | admin tab CSS class | tab `class` attribute |
| `{{tab_sort_order}}` | admin tab `sortOrder` | tab `sortOrder` attribute |
| `{{admin_resource}}` | ACL resource string | section `<resource>` |

## Why deep-merge instead of relying on slim suppression XML alone

Pre-implementation I framed Option B as "synthesised canonical section + slim suppression-only static system.xml in overlay, merged via Magento's native machinery, zero new plugin code". Verifying the load order proves that framing wrong:

Magento merges static `system.xml` across all modules at the file-resolver level **before** our `Reader::read` `afterRead` plugin fires. An overlay's slim `<section id="abn_payment" showInDefault="0"/>` stub therefore lands in the merged Structure first. With the original skip-by-collision invariant, synthesis would then skip the section entirely and the brand's admin form would be empty.

Deep-merge inverts the precedence: synthesised content is the base, overlay scalar attributes win per-field. Overlays **cannot add** fields via this mechanism — the canonical template remains the source of truth for what controls exist; the overlay's job is purely to hide.

## Behavioural impact

Synthesis remains dormant. The flag `system/two_brand_synthesis/admin_form/enabled` is still `0` by default. Even with the flag flipped, the Two brand has static `*_general/payment/search/version` sections, so deep-merge sees its own static body as the overlay; synthesised content equals the static body, so no visible change.

The deep-merge mechanism is what brand-overlay modules will use post-strip-down to hide specific controls. See the companion magento-abn-plugin PR for the live consumer.

## v1.14 ABN suppression list (consumed by the companion PR)

Per audit against `abn-1.14.1`'s `etc/adminhtml/system.xml`, the canonical Two brand admin surface differs from what ABN merchants actually saw by exactly four field-level suppressions, all inside `abn_payment/payment_terms`:

1. `payment_terms_duration_days` — "Custom Payment Term (days)"
2. `payment_terms_type` — "Payment Terms Type" select
3. `surcharge_differential` — "Surcharge Calculation Basis"
4. `surcharge_line_description` — "Surcharge Line Description"

Structural delta worth flagging: v1.14 ABN folded the version button into `abn_general/general`; this PR keeps the canonical layout (separate `*_version` section). Functionally equivalent, layout-cosmetic only.

## Test plan

- [ ] CI green
- [ ] Deploy to staging vanilla; admin Configuration → Sales → Two tab renders identically to pre-merge (synthesis still dormant)
- [ ] Flip `system/two_brand_synthesis/admin_form/enabled` to 1 on staging vanilla via the bootstrap-PHP incantation; admin form still renders identically (deep-merge is a no-op for the Two brand because synthesised body equals static body)
- [ ] After the companion magento-abn-plugin PR lands and is deployed to ABN staging: admin Configuration → Sales → ABN tab renders with the four suppressed fields hidden and all other controls intact
