### PR TITLE
fix(Two): bind isAvailable active+api-key to method _code (Hyva/Luma dual-render regression)

### DIFF
--- a/Model/Two.php
+++ b/Model/Two.php
@@ -666,14 +666,22 @@ class Two extends AbstractMethod
 
     /**
      * @inheritDoc
+     *
+     * The active + api-key check must be method-code-bound (`_code`), not
+     * brand-aware. Both `two_payment` and an overlay's method (e.g.
+     * `abn_payment`) can be registered side-by-side; routing this method's
+     * self-check through the brand-aware ConfigRepository would make Two's
+     * instance answer with the overlay's config (because the brand-aware
+     * fallback resolves to the install's active brand, not this instance's
+     * `_code`). Use Magento's base `_code`-bound `isAvailable()` for the
+     * active flag and read api_key directly off `_code` for the same reason.
      */
     public function isAvailable(?CartInterface $quote = null)
     {
-        if (!$this->configRepository->isActive()
-            || $this->configRepository->getApiKey() == '') {
+        if (!parent::isAvailable($quote)) {
             return false;
         }
-
-        return parent::isAvailable($quote);
+        $apiKey = $this->_scopeConfig->getValue('payment/' . $this->_code . '/api_key');
+        return $apiKey !== null && $apiKey !== '';
     }
 }


### PR DESCRIPTION
## Summary

Fixes a regression introduced by #163 (brand-aware runtime resolution). On the ABN staging install, the Hyva checkout payment box renders labels but no chips/inputs — and the same form has been observed duplicated on Luma. Root cause: `Two\Gateway\Model\Two::isAvailable()` was using the brand-aware ConfigRepository for the method's own active + api-key check, which on a brand overlay resolves to the overlay's method-code (`abn_payment`) instead of Two's own (`two_payment`). Both methods then declared themselves active and Magento rendered both payment forms, which both define `var paymentFieldsInitialized` at module scope. The redeclaration `SyntaxError` aborted Alpine.data() registration for `abnGatewayHyvaPaymentMethodBase` and siblings, leaving the form template with `x-data="abnGatewayHyva*"` bindings that Alpine's CSP build couldn't interpret.

## What changes

`Model/Two.php::isAvailable()`:

- Drop `$this->configRepository->isActive()` / `getApiKey()` short-circuit.
- Use `parent::isAvailable($quote)` (Magento's `AbstractMethod` checks `payment/{_code}/active` via its own `_code`).
- Read api_key directly off `'payment/' . $this->_code . '/api_key'`.

`AbnPayment` is a virtualType of `Two\Gateway\Model\Two` with `_code = 'abn_payment'`, so it gets the same correct method-code-bound check through inheritance. No changes to `magento-abn-plugin` needed.

## Why this is the right cut

There are two distinct questions ConfigRepository was being asked:

1. **"What install is this?"** — single answer per install, brand-aware fallback is correct. All callers other than `Two::isAvailable` ask this: `Service/Api/Adapter` (X-API-Key on outbound calls), `ApiKeyCheck` admin block, `ConfigProvider` storefront block, `AbnApiTranslator`.

2. **"What method is this instance?"** — method-code-bound, per-instance. Only `Two::isAvailable` asks this, because it runs once per registered payment-method instance and answers about that specific instance.

#163 collapsed both onto the brand-aware Repository. This PR keeps that simplification for (1) and uses Magento's own `_code`-bound mechanism for (2). `AbnConfigRepository` virtualType stays retired.

## Test plan

- [ ] CI green
- [ ] Deploy to ABN staging; on `/hyva/checkout/`: payment box renders term chips (30/60/90), KvK input, company-search input, etc. No duplicate `paymentFieldsInitialized` console error.
- [ ] Place an ABN Hyva order end-to-end; admin order view renders payment info correctly.
- [ ] Vanilla Two staging `/hyva/checkout/`: payment box still renders identically (only `two_payment` registered, parent::isAvailable returns true on `payment/two_payment/active=1`).
- [ ] `/default/checkout/` (Luma) on ABN: only one payment-method renderer for `abn_payment`, no duplication.
