### PR TITLE
fix(brand-overlay): flip admin_form synthesis default 0 -> 1

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -87,12 +87,16 @@
                 per brand. Skips any brand whose intended section id
                 already exists statically (so a brand whose overlay
                 module still ships its own etc/adminhtml/system.xml
-                stays on the static surface — first-writer-wins). The
-                strip-down PR flips this flag to 1 in lockstep with
-                deleting overlay system.xml files.
+                stays on the static surface — first-writer-wins).
+                Default 1 since the magento-abn-plugin strip-down: the
+                overlay no longer ships its own system.xml, so synthesis
+                is the sole source of the per-brand admin tab. Flip to
+                0 only to debug — vanilla Two installs have no overlay
+                brands registered, so synthesis is a no-op for them
+                regardless.
             -->
             <admin_form>
-                <enabled>0</enabled>
+                <enabled>1</enabled>
             </admin_form>
         </two_brand_synthesis>
     </default>


### PR DESCRIPTION
## Summary

Promote `two_brand_synthesis/admin_form/enabled` default from `0` to `1` in `magento-plugin/etc/config.xml`.

## Why

The admin_form synthesis layer ships dormant (default 0). Activation on staging has been via a bootstrap-PHP `WriterInterface::save` row in `core_config_data`, set out-of-band. Tonight that row went missing across a redeploy and the ABN admin "Zakelig Op Rekening" tab disappeared from the staging Configuration page — login worked, all Magento tabs visible, only our synthesized tab gone.

The fix is permanent: flip the default so the flag is on without anyone needing to remember the bootstrap-PHP incantation after each deploy. The original config.xml comment already pencilled in this flip ("the strip-down PR flips this flag to 1 in lockstep with deleting overlay system.xml files"); the magento-abn-plugin overlay has been strip-down for a while now, so the precondition holds.

## Why it's safe

- **Vanilla Two installs** have no overlay brands registered (no `etc/brand.xml` in any installed module). `SynthesiseBrandAdminForm` iterates the brand registry, finds nothing, no-ops. The flag flip is invisible to them.
- **ABN install**: synthesis is now the sole source of the per-brand admin tab (magento-abn-plugin no longer ships its own `etc/adminhtml/system.xml`). Without this flag at 1 by default, the tab disappears on any deploy that doesn't carry the manually-written `core_config_data` row.
- **The flag stays present** as a per-layer debug knob — set to 0 to disable synthesis without uninstalling. Just no longer needed on for normal use.

## Scope

Only the `admin_form` layer. Sibling synthesis flags stay at default `0`:

- `checkout_renderers/enabled` — separate readiness criteria; renderer synthesis hasn't been live-tested at the same scale yet
- `payment_xml/enabled` — same
- `csp/enabled` — same

Those are separate flips and can ride their own PRs.

## Test plan

- [ ] CI green
- [ ] Deploy to ABN staging; admin Configuration → ABN section "Zakelig Op Rekening" tab visible after a fresh pod-init, without any bootstrap-PHP intervention
- [ ] Vanilla Two staging admin Configuration → no spurious extra tab; Two_Gateway tab renders identically to pre-flip

🤖 Generated with [Claude Code](https://claude.com/claude-code)
