### PR TITLE
fix(brand-overlay): keep {{}} tokens out of synthesis template docs comment

### DIFF
--- a/etc/adminhtml/brand_form_template.xml
+++ b/etc/adminhtml/brand_form_template.xml
@@ -13,21 +13,29 @@
  * through Magento's Config\Structure\Converter, then merges the
  * converted tabs and sections into the Structure result.
  *
- * Tokens:
+ * Tokens (named without the `{{ }}` braces in this docs block —
+ * SynthesiseBrandAdminForm::substitute() does a naive `strtr` against
+ * the whole template string, so any `{{token}}` here would be rewritten
+ * in this XML comment too, and tokens whose substituted value contains
+ * `--` would corrupt the comment and fail re-parse):
  *
- *   {{code}}             Brand payment-method code, e.g. "two_payment".
- *                        Used in CCD config_path values.
- *   {{section_prefix}}   Short brand prefix, e.g. "two", "abn". Used
- *                        for tab id (`{prefix}_gateway`) and section
- *                        ids (`{prefix}_general`/`_payment`/`_search`/
- *                        `_version`).
- *   {{provider}}         Short brand name. Currently unused at the
- *                        admin-XML level but reserved for label
- *                        interpolation in follow-ups.
- *   {{tab_label}}        Admin Configuration tab label.
- *   {{tab_css_class}}    CSS class on the admin tab `<li>`.
- *   {{tab_sort_order}}   Admin tab sortOrder for this brand.
- *   {{admin_resource}}   ACL resource string for the brand's section.
+ *   code             Brand payment-method code, e.g. "two_payment".
+ *                    Used in CCD config_path values.
+ *   section_prefix   Short brand prefix, e.g. "two", "abn". Used
+ *                    for tab id (`{prefix}_gateway`) and section
+ *                    ids (`{prefix}_general`/`_payment`/`_search`/
+ *                    `_version`).
+ *   provider         Short brand name. Currently unused at the
+ *                    admin-XML level but reserved for label
+ *                    interpolation in follow-ups.
+ *   tab_label        Admin Configuration tab label.
+ *   tab_css_class    CSS class on the admin tab `<li>`. Some brands
+ *                    use BEM `block__elem--modifier`; that double-
+ *                    hyphen is fine in the rendered `class=` attr
+ *                    but would corrupt this XML comment if
+ *                    substitution reached here.
+ *   tab_sort_order   Admin tab sortOrder for this brand.
+ *   admin_resource   ACL resource string for the brand's section.
  *
  * The `brand_code` attribute on `<section>`/`<group>`/`<field>` is
  * preserved by the Converter (verified by PR #160's §3.5 probe) and

--- a/etc/adminhtml/brand_form_template.xml
+++ b/etc/adminhtml/brand_form_template.xml
@@ -17,7 +17,8 @@
  * SynthesiseBrandAdminForm::substitute() does a naive `strtr` against
  * the whole template string, so any brace-wrapped token name here would
  * be rewritten in this XML comment too, and tokens whose substituted
- * value contains `--` would corrupt the comment and fail re-parse):
+ * value contains XML control character sequences would corrupt the
+ * comment and fail re-parse):
  *
  *   code             Brand payment-method code, e.g. "two_payment".
  *                    Used in CCD config_path values.
@@ -30,9 +31,9 @@
  *                    interpolation in follow-ups.
  *   tab_label        Admin Configuration tab label.
  *   tab_css_class    CSS class on the admin tab `<li>`. Some brands
- *                    use BEM `block__elem--modifier`; that double-
- *                    hyphen is fine in the rendered `class=` attr
- *                    but would corrupt this XML comment if
+ *                    use values that contain double hyphens (BEM
+ *                    modifier syntax); fine in the rendered `class=`
+ *                    attr but would corrupt this XML comment if
  *                    substitution reached here.
  *   tab_sort_order   Admin tab sortOrder for this brand.
  *   admin_resource   ACL resource string for the brand's section.

--- a/etc/adminhtml/brand_form_template.xml
+++ b/etc/adminhtml/brand_form_template.xml
@@ -13,11 +13,11 @@
  * through Magento's Config\Structure\Converter, then merges the
  * converted tabs and sections into the Structure result.
  *
- * Tokens (named without the `{{ }}` braces in this docs block —
+ * Tokens (named without double curly braces in this docs block —
  * SynthesiseBrandAdminForm::substitute() does a naive `strtr` against
- * the whole template string, so any `{{token}}` here would be rewritten
- * in this XML comment too, and tokens whose substituted value contains
- * `--` would corrupt the comment and fail re-parse):
+ * the whole template string, so any brace-wrapped token name here would
+ * be rewritten in this XML comment too, and tokens whose substituted
+ * value contains `--` would corrupt the comment and fail re-parse):
  *
  *   code             Brand payment-method code, e.g. "two_payment".
  *                    Used in CCD config_path values.


### PR DESCRIPTION
## Summary

`SynthesiseBrandAdminForm::substitute()` does a naive `strtr` over the entire `brand_form_template.xml` string. The file's leading docs comment named each token as `{{name}}` for readability — which meant naive substitution rewrote those token references in the XML comment block too. For brands whose `tab_css_class` uses BEM `block__elem--modifier`, the substituted comment contained `--`, which is invalid inside an XML comment. Re-parse failed with:

> Comment must not contain '--' (double-hyphen)

…and the synthesis plugin logged `leaving Structure unchanged for this brand`. The active brand on ABN staging (ABN itself, no BEM in its `tab_css_class`) synthesised cleanly. The parent Two brand (`tab_css_class="two-extension two-extension--no-caption"`) failed silently — visible-on-staging impact was minor because the parent brand's admin tab is hidden anyway on overlay installs (`HidePaymentSection` plugin). Latent risk: any future overlay brand whose token values contain `--` would fail synthesis the same way.

## Fix

Name the tokens bare (without braces) in the docs comment. The plugin's `strtr` table matches the literal strings `{{code}}`, `{{section_prefix}}`, `{{provider}}`, `{{tab_label}}`, `{{tab_css_class}}`, `{{tab_sort_order}}`, `{{admin_resource}}`. Names not wrapped in braces are inert.

The comment now also explains *why* the names are bare, so the next maintainer doesn't re-introduce braces without thinking about it.

## Considered and rejected

Harden `substitute()` to skip XML comments before applying `strtr` (preg_replace_callback on `<!--…-->` blocks, then re-stitch). More robust against future templates, but:

- The docs comment is currently the only place tokens appear outside attribute values.
- "Don't reference tokens in the docs comment with braces" is a cheap permanent rule.
- Adding comment-aware string surgery to the plugin pulls in another fragile mode of failure (regex tripping on `-->` inside CDATA, etc.).

If we ever want to lift this rule, that hardening is a separate PR.

## Test plan

- [ ] CI green
- [ ] Deploy to ABN staging; check `var/log/system.log` for absence of `failed to synthesise template for brand "two_payment"` after a fresh admin Configuration page load.
- [ ] Confirm synthesised tabs/sections set includes `two_*` for the parent brand alongside `abn_*` (`grep two_brand_admin_form var/log/system.log`).
- [ ] Vanilla Two staging admin Configuration still renders cleanly (no spurious effect — vanilla has only the Two brand registered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
