### PR TITLE
fix(admin): make surcharge-grid.js brand-agnostic (recover prefix from DOM)

### DIFF
--- a/view/adminhtml/web/js/surcharge-grid.js
+++ b/view/adminhtml/web/js/surcharge-grid.js
@@ -3,11 +3,34 @@ define(['jquery', 'mage/translate', 'domReady!'], function ($, $t) {
 
     return function (config, element) {
         var $container = $(element);
-        var $termsContainer = $('#two_payment_payment_terms_payment_terms_checkboxes');
-        var $customDays = $('#two_payment_payment_terms_payment_terms_duration_days');
-        var $surchargeType = $('#two_payment_payment_terms_surcharge_type');
-        var $differential = $('#two_payment_payment_terms_surcharge_differential');
-        var $defaultTerm = $('#two_payment_payment_terms_default_payment_term');
+
+        // Derive the section-id prefix from the DOM (same approach as
+        // payment-terms-config.js). The phtml template renders the term
+        // checkboxes container with id `{section}_payment_terms_payment_terms_checkboxes`
+        // — strip the suffix to recover the section id and build every
+        // other selector against it. Keeps the file brand-agnostic:
+        // `two_payment` on vanilla, `abn_payment` on an ABN overlay
+        // install, etc. The previous hardcoded `two_payment_*` selectors
+        // matched nothing on overlay installs, so $surchargeType.val()
+        // returned undefined → getSurchargeType() defaulted to 'none' →
+        // updateContainerVisibility() hid the grid's row immediately on
+        // load.
+        var $termsContainer = $('.two-term-checkboxes').first();
+        if (!$termsContainer.length) {
+            return;
+        }
+        var containerSuffix = '_payment_terms_payment_terms_checkboxes';
+        var termsContainerId = $termsContainer.attr('id') || '';
+        if (termsContainerId.slice(-containerSuffix.length) !== containerSuffix) {
+            return;
+        }
+        var section = termsContainerId.slice(0, -containerSuffix.length);
+        var prefix = section + '_payment_terms_';
+
+        var $customDays = $('#' + prefix + 'payment_terms_duration_days');
+        var $surchargeType = $('#' + prefix + 'surcharge_type');
+        var $differential = $('#' + prefix + 'surcharge_differential');
+        var $defaultTerm = $('#' + prefix + 'default_payment_term');
         var $table = $container.find('.surcharge-grid');
         var $noTermsMsg = $container.find('.surcharge-grid__no-terms');
         var $currencyNote = $container.find('.surcharge-grid__currency-note');
@@ -42,7 +65,7 @@ define(['jquery', 'mage/translate', 'domReady!'], function ($, $t) {
         }
 
         function getSurchargeType() {
-            var $inherit = $('#two_payment_payment_terms_surcharge_type_inherit');
+            var $inherit = $('#' + prefix + 'surcharge_type_inherit');
             if ($inherit.length && $inherit.is(':checked')) {
                 return 'none';
             }
@@ -242,7 +265,7 @@ define(['jquery', 'mage/translate', 'domReady!'], function ($, $t) {
         $surchargeType.on('change', update);
         $differential.on('change', update);
         $defaultTerm.on('change', update);
-        $('#two_payment_payment_terms_surcharge_type_inherit').on('change', update);
+        $('#' + prefix + 'surcharge_type_inherit').on('change', update);
 
         // ── Fee column (read-only, fetched from Two API via admin proxy) ─
 


### PR DESCRIPTION
## Summary

Fixes the "surcharge grid appears for ~1 second then disappears" regression on the ABN staging admin's `abn_payment` configuration section.

## Root cause

`view/adminhtml/web/js/surcharge-grid.js` hardcoded `two_payment_payment_terms_*` element ids for the term checkboxes, custom-days input, surcharge type/differential/default-term selects, and the surcharge_type_inherit checkbox. On a vanilla Two install those ids match the rendered DOM. On an ABN overlay install the synthesised admin section uses `abn_payment_payment_terms_*`, so every hardcoded jQuery lookup returned an empty jQuery object.

On first `update()` call, `getSurchargeType()` does:

```js
return $surchargeType.val() || 'none';
```

`$surchargeType` is empty → `.val()` is undefined → falls back to `'none'`. `updateContainerVisibility()` then runs:

```js
var hasSurcharge = type !== 'none';
$container.closest('tr').toggle(hasSurcharge);
```

…and hides the entire `<tr>` containing the grid. The grid's server-rendered HTML was fine — that's why we saw it briefly before `domReady` fired.

Verified live on the ABN admin Configuration tab: `document.getElementById('two_payment_payment_terms_surcharge_type')` returned `null`, while `document.getElementById('abn_payment_payment_terms_surcharge_type').value` returned `'percentage'` as expected.

## Fix

Derive the section-id prefix from the DOM the same way `payment-terms-config.js` already does: find the `.two-term-checkboxes` container, strip the known `_payment_terms_payment_terms_checkboxes` suffix, and build every selector against the recovered prefix.

This is the canonical brand-agnostic pattern for this part of the admin UI; the sibling file (`payment-terms-config.js`) was correctly refactored to use it in #163, surcharge-grid.js got missed in that pass.

## Test plan

- [ ] CI green
- [ ] Deploy to ABN staging; on /admin Configuration → ABN AMRO Zakelijk op Rekening → Betaling, the "Payment Surcharge Configuration" row stays visible after page load; chosen surcharge_type (percentage) shows the right columns.
- [ ] Toggle surcharge_type between none/percentage/fixed/fixed_and_percentage — grid hides on "none", reappears for others, column visibility updates correctly.
- [ ] Vanilla Two staging admin Configuration → Two → Betaling — surcharge grid still renders identically (selectors recover `two_payment` prefix from DOM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
