### PR TITLE
docs(admin): correct stale config-path reference in PaymentTermsCheckboxes

### DIFF
--- a/Block/Adminhtml/System/Config/Field/PaymentTermsCheckboxes.php
+++ b/Block/Adminhtml/System/Config/Field/PaymentTermsCheckboxes.php
@@ -16,8 +16,11 @@ use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
 /**
  * Renders payment terms as individual checkboxes instead of a multiselect.
  *
- * Stores the selected terms as a comma-separated string in the existing
- * config path (payment/two_payment/payment_terms).
+ * Stores the selected terms as a comma-separated string at whatever config
+ * path the field's `<config_path>` element in `system.xml` binds. The block
+ * is path-agnostic — it reads the value via `$element->getValue()` and the
+ * System Config framework supplies the bound element. Brand overlays vary
+ * the path via their own `system.xml` without needing to touch this block.
  */
 class PaymentTermsCheckboxes extends Field
 {


### PR DESCRIPTION
## Summary

The docstring on `PaymentTermsCheckboxes` hardcoded `payment/two_payment/payment_terms` as the config path. The block doesn't actually know its config path — it reads via `$element->getValue()` and the System Config framework binds whatever element the field's `<config_path>` in `system.xml` says.

The vanilla `system.xml` happens to bind `payment/two_payment/payment_terms`; brand overlays bind their own paths (ABN uses `payment/abn_payment/payment_terms`). The block works correctly for both. Just the docstring was stale.

Comment-only change. No behavioural difference. Caught during the post-brand-overlay-refactor audit recipe sweep.

## Test plan

- [ ] CI green (docs-only change, no test surface affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
