### PR TITLE
INF/docs: Pluralise xdebug ini comment in dev/install-xdebug

### DIFF
--- a/dev/install-xdebug
+++ b/dev/install-xdebug
@@ -16,7 +16,7 @@ if [ -z "$XDEBUG_SO" ]; then
     exit 1
 fi
 
-# Disable the apt-installed ini (it defaults to mode=develop)
+# Disable the apt-installed ini files (they default to mode=develop)
 find /etc/php/${PHP_VERSION} -name '*xdebug*' -exec rm -f {} + 2>/dev/null
 
 # Write our config to both CLI and FPM conf.d (mode=off, activated by make debug)


### PR DESCRIPTION
## Context

`dev/install-xdebug` removes every `*xdebug*` ini file under `/etc/php/${PHP_VERSION}` via `find -exec rm -f {} +`. The adjacent comment used the singular form ("the apt-installed ini... it defaults"), which understated what the line actually does. On systems with both CLI and FPM SAPI inis (the common case) the find removes multiple files.

This is a tiny docs-only correction so that future readers don't second-guess whether only one file is being removed.

## Changes

- `dev/install-xdebug`: switch comment to plural — "the apt-installed ini files (they default to mode=develop)".

## Scope / Non-goals

- No behavioural change. The `find … -exec rm` line is untouched.
- No change to xdebug config written below.

## Validation

- `git diff staging...HEAD` → 1 line changed, comment only.
- `make install` path unchanged; no impact on CI.

## Ticket

Trivial doc tweak — no Linear ticket required.