### PR TITLE
ABN-398/fix: derive active brand from DOM in checkout JS

### DIFF
--- a/Test/Js/amd-harness.js
+++ b/Test/Js/amd-harness.js
@@ -104,9 +104,27 @@ function defaultMocks() {
         },
         'Magento_Catalog/js/price-utils': { formatPrice: function (n) { return String(n); } },
         'Two_Gateway/js/model/surcharge': makeSurchargeMock(),
-        'Two_Gateway/js/model/brand-config': function (code) {
-            return ((typeof window !== 'undefined' && window.checkoutConfig && window.checkoutConfig.payment) || {})[code] || {};
-        },
+        'Two_Gateway/js/model/brand-config': (function () {
+            function getBrandConfig(code) {
+                return ((typeof window !== 'undefined' && window.checkoutConfig && window.checkoutConfig.payment) || {})[code] || {};
+            }
+            getBrandConfig.getActiveTwoBrandCode = function () {
+                var payment = (typeof window !== 'undefined' && window.checkoutConfig && window.checkoutConfig.payment) || {};
+                for (var code in payment) {
+                    if (Object.prototype.hasOwnProperty.call(payment, code)
+                        && payment[code]
+                        && payment[code].redirectUrlCookieCode) {
+                        return code;
+                    }
+                }
+                return null;
+            };
+            getBrandConfig.getActiveTwoBrandConfig = function () {
+                var code = getBrandConfig.getActiveTwoBrandCode();
+                return code ? getBrandConfig(code) : {};
+            };
+            return getBrandConfig;
+        }()),
         'Two_Gateway/select2-4.1.0/js/select2.min': function () {}
     };
 }

--- a/Test/Js/brand-config.test.js
+++ b/Test/Js/brand-config.test.js
@@ -61,4 +61,67 @@ describe('Two_Gateway/js/model/brand-config', () => {
         expect(getBrandConfig('two_payment').paymentTermsMessage).toBe('Two');
         expect(getBrandConfig('abn_payment').paymentTermsMessage).toBe('ABN');
     });
+
+    describe('getActiveTwoBrandCode', () => {
+        it('returns null when checkoutConfig is absent', () => {
+            expect(getBrandConfig.getActiveTwoBrandCode()).toBeNull();
+        });
+
+        it('returns null when no payment subtree has redirectUrlCookieCode', () => {
+            window.checkoutConfig = {
+                payment: {
+                    checkmo: { title: 'Check / Money order' },
+                    free: { title: 'No Payment Information Required' }
+                }
+            };
+            expect(getBrandConfig.getActiveTwoBrandCode()).toBeNull();
+        });
+
+        it('returns the vanilla two_payment code when its subtree carries the sentinel', () => {
+            window.checkoutConfig = {
+                payment: {
+                    checkmo: { title: 'Check / Money order' },
+                    two_payment: { redirectUrlCookieCode: 'two_redirect_url', brand: 'two' }
+                }
+            };
+            expect(getBrandConfig.getActiveTwoBrandCode()).toBe('two_payment');
+        });
+
+        it('returns the brand-overlay code (abn_payment) on an ABN install', () => {
+            window.checkoutConfig = {
+                payment: {
+                    checkmo: { title: 'Check / Money order' },
+                    abn_payment: { redirectUrlCookieCode: 'abn_redirect_url', brand: 'abn' }
+                }
+            };
+            expect(getBrandConfig.getActiveTwoBrandCode()).toBe('abn_payment');
+        });
+
+        it('ignores subtrees with a falsy redirectUrlCookieCode', () => {
+            window.checkoutConfig = {
+                payment: {
+                    two_payment: { redirectUrlCookieCode: '' },
+                    abn_payment: { redirectUrlCookieCode: 'abn_redirect_url' }
+                }
+            };
+            expect(getBrandConfig.getActiveTwoBrandCode()).toBe('abn_payment');
+        });
+    });
+
+    describe('getActiveTwoBrandConfig', () => {
+        it('returns an empty object when no Two-family brand is active', () => {
+            window.checkoutConfig = { payment: { checkmo: { title: 'cm' } } };
+            expect(getBrandConfig.getActiveTwoBrandConfig()).toEqual({});
+        });
+
+        it('returns the active brand subtree by reference', () => {
+            const abnSubtree = {
+                redirectUrlCookieCode: 'abn_redirect_url',
+                checkoutApiUrl: 'https://abn.example/api',
+                brand: 'abn'
+            };
+            window.checkoutConfig = { payment: { abn_payment: abnSubtree } };
+            expect(getBrandConfig.getActiveTwoBrandConfig()).toBe(abnSubtree);
+        });
+    });
 });

--- a/view/frontend/web/js/model/brand-config.js
+++ b/view/frontend/web/js/model/brand-config.js
@@ -12,6 +12,22 @@
  * Returns an empty object when the requested subtree is absent so
  * callers can safely property-access without null checks.
  *
+ * Default export is a callable function (`getBrandConfig(code)`) so
+ * the gateway_method renderer keeps its existing usage. Two
+ * additional properties resolve the active Two-family brand at
+ * runtime for callers that don't already know the method code:
+ *
+ *   getBrandConfig.getActiveTwoBrandCode()
+ *     → scans `window.checkoutConfig.payment` and returns the first
+ *       key whose subtree has a truthy `redirectUrlCookieCode`
+ *       (emitted only by Two_Gateway's ConfigProvider, so it's a
+ *       reliable Two-family sentinel). Returns `null` if none.
+ *
+ *   getBrandConfig.getActiveTwoBrandConfig()
+ *     → shorthand for `getBrandConfig(getActiveTwoBrandCode())`.
+ *       Always returns an object (empty if no Two-family brand is
+ *       active) so callers can property-access without guards.
+ *
  * UMD wrapper supports both AMD (in-browser, Magento RequireJS) and
  * CommonJS (Jest test runner under Node).
  */
@@ -27,8 +43,41 @@
 }(typeof self !== 'undefined' ? self : this, function () {
     'use strict';
 
-    return function getBrandConfig(code) {
+    function getBrandConfig(code) {
         var checkoutConfig = (typeof window !== 'undefined' && window.checkoutConfig) || {};
         return (checkoutConfig.payment || {})[code] || {};
+    }
+
+    /**
+     * Returns the payment-method code for the currently-active Two-family
+     * brand (two_payment, abn_payment, …) by scanning checkoutConfig.payment
+     * for a subtree with a truthy `redirectUrlCookieCode`. That field is
+     * emitted only by Two_Gateway's Model/Ui/ConfigProvider, so its presence
+     * is a reliable Two-family sentinel that does not collide with other
+     * Magento payment methods.
+     */
+    getBrandConfig.getActiveTwoBrandCode = function () {
+        var checkoutConfig = (typeof window !== 'undefined' && window.checkoutConfig) || {};
+        var payment = checkoutConfig.payment || {};
+        for (var code in payment) {
+            if (Object.prototype.hasOwnProperty.call(payment, code)
+                && payment[code]
+                && payment[code].redirectUrlCookieCode) {
+                return code;
+            }
+        }
+        return null;
     };
+
+    /**
+     * Returns the config subtree for the active Two-family brand, or an
+     * empty object if none is active. Always object-typed so callers can
+     * property-access without null checks.
+     */
+    getBrandConfig.getActiveTwoBrandConfig = function () {
+        var code = getBrandConfig.getActiveTwoBrandCode();
+        return code ? getBrandConfig(code) : {};
+    };
+
+    return getBrandConfig;
 }));

--- a/view/frontend/web/js/model/surcharge.js
+++ b/view/frontend/web/js/model/surcharge.js
@@ -18,11 +18,18 @@ define([
     'ko',
     'jquery',
     'Magento_Checkout/js/model/quote',
-    'mage/url'
-], function (ko, $, quote, url) {
+    'mage/url',
+    'Two_Gateway/js/model/brand-config'
+], function (ko, $, quote, url, brandConfig) {
     'use strict';
 
-    var config = (window.checkoutConfig.payment || {}).two_payment || {};
+    // Resolve the active Two-family brand subtree from checkoutConfig
+    // rather than hardcoding `.two_payment`. The brand-overlay 2.0
+    // architecture lets each overlay (abn_payment, …) ship its own
+    // ConfigProvider subtree under the brand's payment-method code,
+    // so this module needs to discover which is active rather than
+    // assuming vanilla.
+    var config = brandConfig.getActiveTwoBrandConfig();
 
     var selectedTerm = ko.observable(config.selectedPaymentTerm || config.defaultPaymentTerm || 0);
     // Empty by default — template renders loader until the latest loadFees() resolves.

--- a/view/frontend/web/js/view/address-autocomplete.js
+++ b/view/frontend/web/js/view/address-autocomplete.js
@@ -9,11 +9,17 @@ define([
     'Magento_Ui/js/form/form',
     'Magento_Customer/js/customer-data',
     'Magento_Checkout/js/model/step-navigator',
-    'uiRegistry'
-], function ($, $t, _, Component, customerData, stepNavigator, uiRegistry) {
+    'uiRegistry',
+    'Two_Gateway/js/model/brand-config'
+], function ($, $t, _, Component, customerData, stepNavigator, uiRegistry, brandConfig) {
     'use strict';
 
-    const config = (window.checkoutConfig.payment || {}).two_payment || {};
+    // Resolve the active Two-family brand subtree so overlays
+    // (abn_payment, …) get their own checkoutApiUrl /
+    // isCompanySearchEnabled / companySearchLimit instead of falling
+    // through to an empty object when the vanilla `two_payment` key
+    // isn't present.
+    const config = brandConfig.getActiveTwoBrandConfig();
 
     return Component.extend({
         countrySelector: '#shipping-new-address-form select[name="country_id"]',

--- a/view/frontend/web/js/view/checkout/summary/surcharge.js
+++ b/view/frontend/web/js/view/checkout/summary/surcharge.js
@@ -7,8 +7,9 @@
 define([
     'Magento_Checkout/js/view/summary/abstract-total',
     'Magento_Checkout/js/model/quote',
-    'Magento_Checkout/js/model/totals'
-], function (Component, quote, totals) {
+    'Magento_Checkout/js/model/totals',
+    'Two_Gateway/js/model/brand-config'
+], function (Component, quote, totals, brandConfig) {
     'use strict';
 
     return Component.extend({
@@ -19,8 +20,13 @@ define([
         isDisplayed: function () {
             var segment = totals.getSegment('two_surcharge');
             var method = quote.paymentMethod();
+            // Match against the active Two-family brand code rather
+            // than the hardcoded vanilla `two_payment`, so brand
+            // overlays (abn_payment, …) display the surcharge line
+            // when their own payment method is selected.
+            var activeCode = brandConfig.getActiveTwoBrandCode();
             return segment && parseFloat(segment.value) > 0
-                && method && method.method === 'two_payment';
+                && method && activeCode && method.method === activeCode;
         },
 
         getValue: function () {


### PR DESCRIPTION
## Context

Three checkout-frontend modules — the surcharge model, the order-summary surcharge line, and the address-autocomplete component — read their config out of `window.checkoutConfig.payment.two_payment` directly. That worked when the only Two-family payment method on the storefront was vanilla `two_payment`, but the brand-overlay 2.0 architecture ships each overlay (`abn_payment`, etc.) under its own payment-method key with its own ConfigProvider subtree. On an ABN install there is no `two_payment` key, so:

- `surcharge.js` module-load resolves to `{}` → loader hangs, no `currencySymbol`, no `defaultPaymentTerm`.
- `summary/surcharge.js` compares `method.method === 'two_payment'` → always false for ABN buyers, so the surcharge line never renders even when the segment is non-zero.
- `address-autocomplete.js` resolves `config.checkoutApiUrl` / `config.isCompanySearchEnabled` to undefined → company-name select2 dropdown never wires up.

`brand-config.js` already exposed `getBrandConfig(code)` but the three callsites had no way to discover which `code` was active.

## Changes

- `view/frontend/web/js/model/brand-config.js` — extend the helper with two properties on the default export:
  - `getActiveTwoBrandCode()` — scans `window.checkoutConfig.payment` and returns the first key whose subtree carries `redirectUrlCookieCode` (the Two-family sentinel; `grep` across the magento-plugin / magento-abn-plugin / magento-hyva-extension repos confirms only `Two_Gateway`'s `Model/Ui/ConfigProvider.php` emits this field).
  - `getActiveTwoBrandConfig()` — shorthand for `getBrandConfig(getActiveTwoBrandCode())`; returns `{}` when no Two-family brand is active.
  - Default export stays a callable function so the existing `gateway_method.js` renderer and the existing brand-config Jest test are byte-unaffected. New helpers are attached as properties on the function rather than re-shaping into an object.
- `view/frontend/web/js/model/surcharge.js` — depend on `brand-config`; replace the hardcoded `.two_payment` lookup at module load with `brandConfig.getActiveTwoBrandConfig()`.
- `view/frontend/web/js/view/checkout/summary/surcharge.js` — depend on `brand-config`; compare `method.method` against `brandConfig.getActiveTwoBrandCode()` with a null guard.
- `view/frontend/web/js/view/address-autocomplete.js` — depend on `brand-config`; replace the hardcoded `.two_payment` lookup with `brandConfig.getActiveTwoBrandConfig()`.
- `Test/Js/amd-harness.js` — mock updated to expose `getActiveTwoBrandCode` / `getActiveTwoBrandConfig` so `all-js-modules.test.js` continues to AMD-load the three updated modules.
- `Test/Js/brand-config.test.js` — added unit coverage for the two new properties (5 cases for `getActiveTwoBrandCode`, 2 for `getActiveTwoBrandConfig`).

No PHP / DI / config-XML changes — pure JS fix. The vanilla `two_payment` path is preserved by virtue of the same sentinel-scan logic; vanilla installs return `two_payment` just as ABN installs return `abn_payment`.

## Scope / Non-goals

- Not touching the `gateway_method.js` renderer — it already does the right thing via `getBrandConfig(this.getCode())`.
- Not renaming the `two_surcharge` totals-segment code — that's a server-side identifier on persisted quotes and out of scope for a JS-only fix.
- Not adding tests for the three callsites themselves — brief said not to expand the test framework. The `all-js-modules.test.js` AMD-load smoke is sufficient to catch dep-array breakage.

## Validation

- `npm run test:js` → 28/28 passing locally (3 suites: `gateway-method-this-context`, `brand-config`, `all-js-modules`).
- Pre-merge: staging deploy + manual storefront check on both vanilla (`magento.staging.two.inc`) and ABN (`magento.staging.achterafbetalen.co`) — confirm surcharge line item shows when the brand's payment method is selected, chip strip has `€` prefix from the `currencySymbol` config, and the company-name select2 dropdown wires up. Chrome verification via the two-platform-chrome-from-wsl skill.

## Ticket

[ABN-398](https://linear.app/tillit/issue/ABN-398)

🤖 Generated with [Claude Code](https://claude.com/claude-code)