### PR TITLE
ABN-398/fix: append two_surcharge segment in CartTotalRepository::get

### DIFF
--- a/Plugin/Magento/Quote/Model/Cart/CartTotalRepositoryAppendSurcharge.php
+++ b/Plugin/Magento/Quote/Model/Cart/CartTotalRepositoryAppendSurcharge.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Plugin\Magento\Quote\Model\Cart;
+
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Api\CartTotalRepositoryInterface;
+use Magento\Quote\Api\Data\TotalsInterface;
+use Magento\Quote\Api\Data\TotalSegmentInterfaceFactory;
+use Magento\Framework\Phrase;
+
+/**
+ * Append the `two_surcharge` total segment to the cart-totals API response
+ * whenever the active quote address has a non-zero `two_surcharge_amount`.
+ *
+ * Why this plugin exists:
+ *
+ * Magento's `CartTotalRepository::get($cartId)` for non-virtual quotes
+ * reads the segments via `$quote->getShippingAddress()->getTotals()`,
+ * which is the in-memory `_totals` array populated only when
+ * `Quote::collectTotals()` has been called on THAT quote instance.
+ * Hyvä's PriceSummary view-model does call `collectTotals()` (via
+ * `reCollectTotalsInTotalSegments` workaround) but on a SEPARATE
+ * `sessionCheckout->getQuote()` instance — `CartTotalRepository::get()`
+ * then loads a fresh quote via `quoteRepository->getActive($cartId)`
+ * whose `_totals` is empty. Magento's standard segments (subtotal /
+ * discount / shipping / tax / grand_total) survive this round-trip
+ * because they are persisted as DB columns on `quote_address` and
+ * synthesised back into segments by other layers; our `two_surcharge`
+ * segment is NOT synthesised that way and silently goes missing.
+ *
+ * The Hyva-rendered order summary shows correct grand total (which
+ * includes the surcharge persisted as the `two_surcharge_amount`
+ * column) but no surcharge line. Buyer sees a mismatch.
+ *
+ * Fix: an `after` plugin on `CartTotalRepositoryInterface::get` that
+ * checks the relevant quote address for `two_surcharge_amount > 0`
+ * and appends a `two_surcharge` segment to the returned totals if
+ * one is not already present. Idempotent: pre-existing segment is
+ * left untouched.
+ */
+class CartTotalRepositoryAppendSurcharge
+{
+    public function __construct(
+        private readonly CartRepositoryInterface $quoteRepository,
+        private readonly TotalSegmentInterfaceFactory $totalSegmentFactory
+    ) {
+    }
+
+    /**
+     * @param mixed $cartId
+     */
+    public function afterGet(
+        CartTotalRepositoryInterface $subject,
+        TotalsInterface $result,
+        $cartId
+    ): TotalsInterface {
+        try {
+            $quote = $this->quoteRepository->getActive($cartId);
+        } catch (\Exception $e) {
+            return $result;
+        }
+
+        $address = $quote->isVirtual()
+            ? $quote->getBillingAddress()
+            : $quote->getShippingAddress();
+
+        if (!$address) {
+            return $result;
+        }
+
+        $surchargeAmount = (float) $address->getData('two_surcharge_amount');
+        if ($surchargeAmount <= 0) {
+            return $result;
+        }
+
+        $segments = $result->getTotalSegments() ?? [];
+        foreach ($segments as $segment) {
+            if ($segment->getCode() === 'two_surcharge') {
+                return $result;
+            }
+        }
+
+        $title = (string) $address->getData('two_surcharge_description');
+        if ($title === '') {
+            $title = (string) (new Phrase('Payment terms fee'));
+        }
+
+        $segment = $this->totalSegmentFactory->create();
+        $segment->setData([
+            'code'  => 'two_surcharge',
+            'title' => $title,
+            'value' => $surchargeAmount,
+            'area'  => null,
+        ]);
+
+        $segments[] = $segment;
+        $result->setTotalSegments($segments);
+
+        return $result;
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -133,6 +133,22 @@
     </type>
 
     <!--
+        Append the `two_surcharge` total segment to CartTotalRepository::get
+        whenever the quote address has `two_surcharge_amount > 0`. Required
+        because Hyvä's PriceSummary view-model loads the segments via the
+        repository, which on non-virtual quotes reads from `_totals` array
+        on a freshly-loaded quote (empty unless collectTotals() ran on that
+        exact instance). Standard segments (subtotal / shipping / tax /
+        grand_total) survive via quote_address DB columns; our custom
+        segment doesn't. See the plugin class docblock for the full trace.
+    -->
+    <type name="Magento\Quote\Api\CartTotalRepositoryInterface">
+        <plugin name="two_gateway_append_surcharge_segment"
+                type="Two\Gateway\Plugin\Magento\Quote\Model\Cart\CartTotalRepositoryAppendSurcharge"
+                sortOrder="10"/>
+    </type>
+
+    <!--
         Brand-overlay v6 synthesis plugins. Each is gated by its own
         flag under system/two_brand_synthesis/<layer>/enabled in
         etc/config.xml (default 0 in this PR — see header there).


### PR DESCRIPTION
## Context

After the ABN-398 cleanup landed, Doug spotted a remaining bug on Hyva checkout: surcharge line item missing from the order summary even though Grand Total is correct (includes the surcharge amount).

## Root cause

Magento's \`CartTotalRepository::get(\$cartId)\` for non-virtual quotes reads segments via \`\$quote->getShippingAddress()->getTotals()\` — the in-memory \`_totals\` array populated only when \`Quote::collectTotals()\` has been called on THAT quote instance.

Hyvä's \`PriceSummary\` view-model DOES force a collectTotals via the \`reCollectTotalsInTotalSegments\` workaround (verified true on staging), but on \`sessionCheckout->getQuote()\` — a different instance from the one \`CartTotalRepository::get\` loads via \`quoteRepository->getActive(\$cartId)\`.

Standard segments (subtotal / discount / shipping / tax / grand_total) survive this instance-divergence because they're persisted as DB columns on \`quote_address\` and synthesised back into segments elsewhere in Magento. Our \`two_surcharge\` segment is NOT synthesised that way → silently dropped from API output even though the underlying \`two_surcharge_amount\` column IS persisted (which is why Grand Total stays correct).

Verified live on quote 1050:

\`\`\`
\$quote->getShippingAddress()->getData('two_surcharge_amount')  → 32.07
\$cartTotalRepository->get(1050)->getTotalSegments()             → 5 segments, no two_surcharge
\$quote->collectTotals(); \$quote->getShippingAddress()->getTotals()  → 6 segments INCLUDING two_surcharge
\`\`\`

## Fix

An after-plugin on \`Magento\Quote\Api\CartTotalRepositoryInterface::get\` that:
1. Loads the active quote
2. Checks the relevant address (shipping for non-virtual, billing for virtual) for \`two_surcharge_amount > 0\`
3. Appends a \`two_surcharge\` segment to the returned totals if not already present
4. Idempotent: pre-existing segment is left untouched (so paths that ARE running collect+fetch correctly remain unaffected)

## Scope / Non-goals

- Lives in vanilla \`magento-plugin\`, so it benefits both Two vanilla Hyva AND ABN overlay Hyva checkouts.
- Does not change collect/fetch behaviour — the underlying surcharge calculation pipeline is untouched.
- Does not alter Luma rendering (Luma uses a different KO-driven summary path that already works).

## Validation

- Verified plugin logic against live quote 1050 state on ABN staging.
- Pending live Hyva checkout test post-deploy.

## Ticket

- https://linear.app/tillit/issue/ABN-398