### PR TITLE
ABN-408/fix: brand-aware payment method title

### DIFF
--- a/Model/Two.php
+++ b/Model/Two.php
@@ -273,14 +273,18 @@ class Two extends AbstractMethod
     }
 
     /**
-     * Title for admin order display.
+     * Title for storefront payment-method list, admin order display
+     * and order/invoice/creditmemo line items.
      *
-     * Returns "Business Invoice" optionally suffixed with the buyer's
-     * selected term in days (e.g. "Business Invoice - 60 days").
-     * DataAssignObserver stores the chosen term under the `selectedTerm`
-     * key as a scalar. The noun and the duration are translated as two
-     * separate __() lookups so each half can use the existing "%1 days"
-     * translation alongside the locale-specific "Business Invoice".
+     * Resolution order:
+     *   1. `payment/<code>/title` from CCD (admin-saved override).
+     *   2. BrandRegistry::getProductName() (brand overlay fallback).
+     *
+     * Optionally suffixed with the buyer's selected term in days
+     * (e.g. "Zakelijk op Rekening - 60 days"). DataAssignObserver
+     * stores the chosen term under the `selectedTerm` key as a
+     * scalar; the duration is wrapped in a separate __() call so the
+     * existing "%1 days" CSV entry handles localisation.
      */
     public function getTitle()
     {
@@ -290,7 +294,10 @@ class Two extends AbstractMethod
         } catch (\Exception $e) {
             $days = 0;
         }
-        $noun = __('Business Invoice');
+        $configured = (string)$this->getConfigData('title');
+        $noun = $configured !== ''
+            ? __($configured)
+            : __($this->brandRegistry->getProductName());
         if ($days > 0) {
             return sprintf('%s - %s', $noun, __('%1 days', $days));
         }


### PR DESCRIPTION
## Context

`Two::getTitle()` hardcoded `__('Business Invoice')`, so the storefront payment-method list ignored both the admin-saved `payment/<code>/title` and the brand registry. On NL locale, the literal hit the i18n CSV mapping `"Business Invoice" → "Zakelijke factuur"` — both vanilla and ABN-overlay pods rendered "Zakelijke factuur" regardless of config or brand. Caught during ABN-401 QA cycle by checking `/rest/V1/guest-carts/{cart}/payment-methods` on ABN pod (DB title `Zakelijk op Rekening`, REST response `Zakelijke factuur`).

## Changes

- `Model/Two.php` — `getTitle()` resolves in two steps:
  1. `payment/<code>/title` from CCD (merchant admin override).
  2. `BrandRegistry::getProductName()` fallback.
- Still wraps in `__()` for opportunistic translation; still appends `" - %1 days"` when `selectedTerm` is set.

## Scope / Non-goals

- No change to the term-suffix behaviour.
- No change to vanilla / ABN brand definitions.
- No new tests — bug-fix, existing TwoErrorHandlingTest unaffected.

## Validation

- ABN staging pod: `/rest/V1/guest-carts/{cart}/payment-methods` with `Accept-Language: nl-NL` returns `"title":"Zakelijk op Rekening"` post-deploy.
- Vanilla staging pod: title remains the admin-saved value (`Two - Buy Now Pay Later on Invoice Terms`).
- Spot-check Hyva + Luma payment list visually after rollout.

## Ticket

- https://linear.app/tillit/issue/ABN-408