### PR TITLE
ABN-409/chore: marketing-friendly default for Two title

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -27,7 +27,7 @@
                 -->
                 <hide_when_overlay_installed>1</hide_when_overlay_installed>
                 <version>2.0.0-dev</version>
-                <title>Two</title>
+                <title>Two - Buy Now Pay Later on Invoice Terms</title>
                 <sort_order>-10</sort_order>
                 <mode>sandbox</mode>
                 <invoice_type>FUNDED_INVOICE</invoice_type>


### PR DESCRIPTION
## Context

Pairs with the staging postSetup-hook removal in `platform-tools` (separate PR). On the vanilla pod, the helm hook hardcoded:

```bash
mage config:set payment/two_payment/title "Business invoice - 30 days"
```

…which fired on every pod restart and clobbered any admin save. With the hook line gone, the title falls back to `etc/config.xml`'s default whenever no admin override exists. The previous default — bare brand product_name `Two` — is too terse to ship as the storefront-visible label.

## Changes

- `etc/config.xml` — bump `payment/two_payment/title` default from `Two` → `Two - Buy Now Pay Later on Invoice Terms` (the marketing form that's been living in core_config_data).

## Scope / Non-goals

- No code path changes. `Two::getTitle()` already prefers admin-saved value over default.
- ABN overlay is untouched — `magento-abn-plugin/plugin/etc/config.xml` already defaults to `Zakelijk op Rekening`.

## Validation

- After platform-tools companion PR merges + staging rolls: fresh pod with no admin override → REST `payment-methods` returns `Two - Buy Now Pay Later on Invoice Terms` on Two storefront.
- Admin saves persist between resets.

## Ticket

- https://linear.app/tillit/issue/ABN-409