### PR TITLE
ABN-410/fix: re-key i18n CSVs from "Surcharge Strategy" to "Surcharge Method"

### DIFF
--- a/i18n/nb_NO.csv
+++ b/i18n/nb_NO.csv
@@ -129,7 +129,7 @@ Standard,Standard
 "Optional. Enter a custom number of days to offer alongside the selected terms above.","Valgfritt. Angi et egendefinert antall dager å tilby sammen med de valgte vilkårene ovenfor."
 "Default Payment Term","Standard betalingsvilkår"
 "Select the payment term that will be automatically selected for your customer.","Velg betalingsvilkåret som automatisk blir valgt for kunden din."
-"Surcharge Strategy","Tilleggsstrategi"
+"Surcharge Method","Tilleggsstrategi"
 "No surcharge applied","Ingen tillegg"
 "Select a method to surcharge your customer.","Velg en metode for å belaste kunden din."
 No,Nei

--- a/i18n/nl_NL.csv
+++ b/i18n/nl_NL.csv
@@ -129,7 +129,7 @@ Standard,Standaard
 "Optional. Enter a custom number of days to offer alongside the selected terms above.","Optioneel. Voer een aangepast aantal dagen in om aan te bieden naast de hierboven geselecteerde termijnen."
 "Default Payment Term","Standaard betaaltermijn"
 "Select the payment term that will be automatically selected for your customer.","Kies de betaaltermijn die automatisch wordt geselecteerd voor je klant."
-"Surcharge Strategy","Toeslagstrategie"
+"Surcharge Method","Toeslagstrategie"
 "No surcharge applied","Geen toeslag toegepast"
 "Select a method to surcharge your customer.","Kies een methode om kosten door te berekenen aan je klant."
 No,Nee

--- a/i18n/sv_SE.csv
+++ b/i18n/sv_SE.csv
@@ -129,7 +129,7 @@ Standard,Standard
 "Optional. Enter a custom number of days to offer alongside the selected terms above.","Valfritt. Ange ett anpassat antal dagar att erbjuda tillsammans med de valda villkoren ovan."
 "Default Payment Term","Standard betalningsvillkor"
 "Select the payment term that will be automatically selected for your customer.","Välj det betalningsvillkor som automatiskt väljs för din kund."
-"Surcharge Strategy","Tilläggsstrategi"
+"Surcharge Method","Tilläggsstrategi"
 "No surcharge applied","Inget tillägg"
 "Select a method to surcharge your customer.","Välj en metod för att debitera din kund."
 No,Nej


### PR DESCRIPTION
## Context

ABN-401 row F5 surfaced that the admin label `Surcharge Strategy → Surcharge Payment Method` rename ask (ABN-335) had drifted:
- Current source label is `Surcharge Method` (system.xml:167, brand_form_template.xml:239), not the spec'd `Surcharge Payment Method`. Doug confirmed "Surcharge Method" reads cleaner and is the intended final label; the test spec wording will be amended to match.
- Translation CSVs (nl_NL, sv_SE, nb_NO) still key off the pre-rename `Surcharge Strategy` source string. Magento `__()` does exact-string lookup, so once the source moved, those rows stopped resolving and NL/SV/NO admin started seeing the untranslated EN label.

## Changes

Re-key row 132 of three CSVs from `"Surcharge Strategy"` to `"Surcharge Method"`. Translated values unchanged.

## Scope / Non-goals

- Translated nouns left as-is. NL `"Toeslagstrategie"`, SV `"Tilläggsstrategi"`, NB `"Tilleggsstrategi"` still semantically read "strategy" in the target language. A copy follow-up to switch them to method-equivalents (e.g. `Toeslagmethode`, `Tilläggsmetod`, `Tilleggsmetode`) should be raised separately if/when product wants the target-language wording to track the source rename. Out of scope here to avoid a non-native-speaker rewrite landing without copy review.
- No changes to source labels or other CSVs (en_US has no row 132 — it inherits the source).

## Validation

- `grep -n "Surcharge Strategy" i18n/*.csv` returns empty.
- `grep -n "Surcharge Method" i18n/{nl_NL,sv_SE,nb_NO}.csv` shows the re-keyed rows at line 132.
- No code changes — the CSVs are install-time data only, no DI / compile impact.

## Ticket

- https://linear.app/tillit/issue/ABN-410