### PR TITLE
ABN-356/feat: per-term merchant fees beside Payment Terms checkboxes (brand-hideable)

### DIFF
--- a/Api/BrandRegistryInterface.php
+++ b/Api/BrandRegistryInterface.php
@@ -89,6 +89,15 @@ interface BrandRegistryInterface
     public function getCode(): string;
 
     /**
+     * Whether the admin Payment Terms checkbox list should render the
+     * per-term merchant fee inline beside each checkbox (e.g.
+     * "30 days (1.50% + 0.50)"). Default true. Brand overlays return
+     * false to hide the inline fee preview when their pricing contract
+     * makes the per-term cost unhelpful to surface in admin.
+     */
+    public function getInlineTermFees(): bool;
+
+    /**
      * Ordered label => module-name map for the admin Version panel
      * (Stores → Configuration → ABN/Two AMRO → Version). Brand
      * overlays append their theme modules to the parent runtime

--- a/Block/Adminhtml/System/Config/Field/PaymentTermsCheckboxes.php
+++ b/Block/Adminhtml/System/Config/Field/PaymentTermsCheckboxes.php
@@ -9,7 +9,9 @@ namespace Two\Gateway\Block\Adminhtml\System\Config\Field;
 
 use Magento\Backend\Block\Template\Context;
 use Magento\Config\Block\System\Config\Form\Field;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Data\Form\Element\AbstractElement;
+use Magento\Store\Model\StoreManagerInterface;
 use Two\Gateway\Api\BrandRegistryInterface;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
 
@@ -30,13 +32,23 @@ class PaymentTermsCheckboxes extends Field
     /** @var BrandRegistryInterface */
     private $brandRegistry;
 
+    /** @var StoreManagerInterface */
+    private $storeManager;
+
+    /** @var ScopeConfigInterface */
+    private $scopeConfig;
+
     public function __construct(
         Context $context,
         BrandRegistryInterface $brandRegistry,
+        StoreManagerInterface $storeManager,
+        ScopeConfigInterface $scopeConfig,
         array $data = []
     ) {
         parent::__construct($context, $data);
         $this->brandRegistry = $brandRegistry;
+        $this->storeManager = $storeManager;
+        $this->scopeConfig = $scopeConfig;
     }
 
     /**
@@ -82,5 +94,76 @@ class PaymentTermsCheckboxes extends Field
     {
         $element = $this->getData('element');
         return $element ? $element->getHtmlId() : '';
+    }
+
+    /**
+     * Whether to render an inline merchant-fee span beside each
+     * checkbox. Brand overlays return false to hide.
+     */
+    public function showInlineFees(): bool
+    {
+        return $this->brandRegistry->getInlineTermFees();
+    }
+
+    /**
+     * Admin URL the inline-fees JS hits to fetch merchant fees.
+     */
+    public function getFeesUrl(): string
+    {
+        return $this->getUrl('two/config/fees');
+    }
+
+    /**
+     * Current Configuration scope (default / websites / stores).
+     */
+    public function getScope(): string
+    {
+        $element = $this->getData('element');
+        if ($element) {
+            $form = $element->getForm();
+            if ($form) {
+                $scope = (string)$form->getScope();
+                if ($scope !== '') {
+                    return $scope;
+                }
+            }
+        }
+        return 'default';
+    }
+
+    public function getScopeId(): int
+    {
+        $element = $this->getData('element');
+        if ($element) {
+            $form = $element->getForm();
+            if ($form) {
+                return (int)$form->getScopeId();
+            }
+        }
+        return 0;
+    }
+
+    /**
+     * Base currency code of the active scope. The Fees controller
+     * returns amounts in the merchant's contractual currency; JS
+     * appends a degraded-currency suffix when they differ.
+     */
+    public function getBaseCurrency(): string
+    {
+        try {
+            $scope = $this->getScope();
+            $scopeId = $this->getScopeId();
+            if ($scopeId > 0) {
+                if ($scope === 'stores') {
+                    return (string)$this->storeManager->getStore($scopeId)->getBaseCurrencyCode();
+                }
+                if ($scope === 'websites') {
+                    return (string)$this->storeManager->getWebsite($scopeId)->getBaseCurrencyCode();
+                }
+            }
+            return (string)($this->scopeConfig->getValue('currency/options/base') ?: 'EUR');
+        } catch (\Exception $e) {
+            return '';
+        }
     }
 }

--- a/Brand/DescriptorBackedBrandRegistry.php
+++ b/Brand/DescriptorBackedBrandRegistry.php
@@ -76,6 +76,11 @@ class DescriptorBackedBrandRegistry implements BrandRegistryInterface
         return $this->activeBrandResolver->resolve()->getCode();
     }
 
+    public function getInlineTermFees(): bool
+    {
+        return $this->activeBrandResolver->resolve()->getInlineTermFees();
+    }
+
     public function getModuleLabelChain(): array
     {
         $chain = [];

--- a/Model/Brand.php
+++ b/Model/Brand.php
@@ -148,4 +148,17 @@ class Brand implements BrandRegistryInterface
             . 'via ActiveBrandResolver.'
         );
     }
+
+    /**
+     * @deprecated 2.0.0 See note on getCode().
+     */
+    public function getInlineTermFees(): bool
+    {
+        throw new \LogicException(
+            'Two\\Gateway\\Model\\Brand is deprecated; consume '
+            . 'BrandRegistryInterface via DescriptorBackedBrandRegistry instead. '
+            . 'Inline-term-fees flag now comes from brand.xml `<inline_term_fees>` '
+            . 'via ActiveBrandResolver.'
+        );
+    }
 }

--- a/Model/Brand/Descriptor.php
+++ b/Model/Brand/Descriptor.php
@@ -44,6 +44,7 @@ final class Descriptor
      * @param string[] $allowedCountries ISO codes; empty = unrestricted.
      * @param array<string,string> $extraHttpHeaders name=>value, decoration on outbound requests.
      * @param string[] $suppressedFields `section_suffix/group/field` paths to hide in the synthesised admin form.
+     * @param bool $inlineTermFees Whether to render the per-term merchant fee beside each Payment Terms checkbox in admin.
      */
     public function __construct(
         private readonly string $code,
@@ -67,8 +68,21 @@ final class Descriptor
         private readonly array $allowedCurrencies,
         private readonly array $allowedCountries,
         private readonly array $extraHttpHeaders,
-        private readonly array $suppressedFields = []
+        private readonly array $suppressedFields = [],
+        private readonly bool $inlineTermFees = true
     ) {
+    }
+
+    /**
+     * Whether the admin Payment Terms checkbox list should render the
+     * per-term merchant fee inline beside each checkbox. Default true.
+     * Brand overlays set `<inline_term_fees>false</inline_term_fees>` in
+     * brand.xml when their pricing contract makes the per-term cost
+     * unhelpful to surface in admin.
+     */
+    public function getInlineTermFees(): bool
+    {
+        return $this->inlineTermFees;
     }
 
     /**

--- a/Model/Brand/Loader.php
+++ b/Model/Brand/Loader.php
@@ -156,6 +156,15 @@ class Loader
             }
         }
 
+        $inlineTermFees = true;
+        if (isset($brand->inline_term_fees)) {
+            $inlineTermFees = filter_var(
+                (string)$brand->inline_term_fees,
+                FILTER_VALIDATE_BOOLEAN,
+                FILTER_NULL_ON_FAILURE
+            ) ?? true;
+        }
+
         return new Descriptor(
             $code,
             $sectionPrefix,
@@ -178,7 +187,8 @@ class Loader
             $allowedCurrencies,
             $allowedCountries,
             $extraHttpHeaders,
-            $suppressedFields
+            $suppressedFields,
+            $inlineTermFees
         );
     }
 }

--- a/etc/brand.xsd
+++ b/etc/brand.xsd
@@ -43,6 +43,15 @@
             <xs:element name="allowed_countries" type="allowedCountriesType" minOccurs="0"/>
             <xs:element name="extra_http_headers" type="extraHttpHeadersType" minOccurs="0"/>
             <xs:element name="suppressed_fields" type="suppressedFieldsType" minOccurs="0"/>
+            <!--
+                Show the per-term merchant fee inline beside each
+                Payment Terms checkbox in admin (e.g. "30 days (1.50%
+                + 0.50)"). Default true. Brand overlays set false to
+                hide the inline fee preview (e.g. when their pricing
+                contract makes the per-term cost noise rather than
+                signal for the merchant).
+            -->
+            <xs:element name="inline_term_fees" type="xs:boolean" minOccurs="0"/>
         </xs:all>
         <xs:attribute name="code" type="brandCodeType" use="required"/>
         <xs:attribute name="tab_sort_order" type="xs:integer" use="required"/>

--- a/view/adminhtml/templates/system/config/field/payment-terms-checkboxes.phtml
+++ b/view/adminhtml/templates/system/config/field/payment-terms-checkboxes.phtml
@@ -10,12 +10,20 @@ $terms = $block->getAvailableTerms();
 $selected = $block->getSelectedTerms();
 $fieldName = $block->getFieldName();
 $elementId = $block->getElementId();
+$showFees = $block->showInlineFees();
 ?>
 
 <?php // Hidden fallback — ensures the field posts even when nothing is checked ?>
 <input type="hidden" name="<?= $block->escapeHtmlAttr(rtrim($fieldName, '[]')) ?>" value=""/>
 
-<div id="<?= $block->escapeHtmlAttr($elementId) ?>_checkboxes" class="two-term-checkboxes">
+<div id="<?= $block->escapeHtmlAttr($elementId) ?>_checkboxes"
+     class="two-term-checkboxes<?= $showFees ? ' two-term-checkboxes--with-fees' : '' ?>"
+     <?php if ($showFees): ?>
+     data-fees-url="<?= $block->escapeHtmlAttr($block->getFeesUrl()) ?>"
+     data-scope="<?= $block->escapeHtmlAttr($block->getScope()) ?>"
+     data-scope-id="<?= (int)$block->getScopeId() ?>"
+     data-base-currency="<?= $block->escapeHtmlAttr($block->getBaseCurrency()) ?>"
+     <?php endif; ?>>
     <?php foreach ($terms as $days): ?>
         <?php
             $checked = in_array($days, $selected, true);
@@ -31,6 +39,9 @@ $elementId = $block->getElementId();
             />
             <label class="admin__field-label two-term-checkboxes__label"
                    for="<?= $block->escapeHtmlAttr($checkboxId) ?>"><?= (int)$days ?> <?= $block->escapeHtml(__('days')) ?></label>
+            <?php if ($showFees): ?>
+                <span class="two-term-checkboxes__fee" data-term="<?= (int)$days ?>"></span>
+            <?php endif; ?>
         </div>
     <?php endforeach; ?>
 </div>

--- a/view/adminhtml/web/js/payment-terms-config.js
+++ b/view/adminhtml/web/js/payment-terms-config.js
@@ -230,6 +230,84 @@ define(['jquery', 'mage/translate', 'domReady!'], function ($, $t) {
             $checkboxes.prop('disabled', $inherit.is(':checked'));
         }
 
+        // ── Inline merchant fees beside each checkbox ────────────────────
+
+        // Fetched async from admin proxy `two/config/fees` (same endpoint
+        // the old surcharge-grid Fee column used). Each `.two-term-
+        // checkboxes__fee` span is populated with text like " (1.50% + 0.50)"
+        // when the response arrives. On failure the span stays empty.
+        var lastFeesKey = null;
+
+        function loadFees() {
+            var url = $termsContainer.data('fees-url');
+            if (!url) {
+                return; // brand has inline_term_fees disabled (no data-fees-url emitted)
+            }
+            var terms = getSelectedTerms();
+            if (!terms.length) {
+                return;
+            }
+            var key = terms.join(',');
+            if (key === lastFeesKey) {
+                return;
+            }
+            lastFeesKey = key;
+            var $formKey = $('input[name="form_key"]').first();
+            $.ajax({
+                url: url,
+                type: 'POST',
+                dataType: 'json',
+                data: {
+                    form_key: $formKey.val() || (window.FORM_KEY || ''),
+                    terms: JSON.stringify(terms),
+                    scope: String($termsContainer.data('scope') || 'default'),
+                    scopeId: parseInt($termsContainer.data('scope-id'), 10) || 0
+                }
+            }).done(function (response) {
+                if (!response || !response.success || !response.fees) {
+                    return; // leave spans empty
+                }
+                var gridCurrency = String($termsContainer.data('base-currency') || '').toUpperCase();
+                var responseCurrency = String(response.currency || '').toUpperCase();
+                var degraded = responseCurrency !== '' && responseCurrency !== gridCurrency;
+                var suffix = degraded ? ' ' + responseCurrency : '';
+                $termsContainer.find('.two-term-checkboxes__fee').each(function () {
+                    var $span = $(this);
+                    var term = String($span.data('term'));
+                    var fee = response.fees[term];
+                    if (!fee) {
+                        $span.text('');
+                        return;
+                    }
+                    var pctStr = Number(fee.percentage || 0).toFixed(2);
+                    var fixedStr = Number(fee.fixed || 0).toFixed(2);
+                    var pctZero = pctStr === '0.00';
+                    var fixedZero = fixedStr === '0.00';
+                    var inner;
+                    if (pctZero && fixedZero) {
+                        inner = '0.00' + suffix;
+                    } else if (pctZero) {
+                        inner = fixedStr + suffix;
+                    } else if (fixedZero) {
+                        inner = pctStr + '%';
+                    } else {
+                        inner = pctStr + '% + ' + fixedStr + suffix;
+                    }
+                    $span.text(' (' + inner + ')');
+                });
+            }).fail(function () {
+                // Allow a retry on the same term-set after a transient error,
+                // and clear any half-populated spans.
+                lastFeesKey = null;
+                $termsContainer.find('.two-term-checkboxes__fee').text('');
+            });
+        }
+
+        // Additional handlers for fee refresh — fire alongside the term-set
+        // change handlers without disturbing their existing wiring.
+        $termsContainer.on('change', '.two-term-checkboxes__input', loadFees);
+        $customDays.on('change keyup', loadFees);
+
         // ── Initialize ───────────────────────────────────────────────────
 
         updateDefaultTermOptions();
@@ -237,6 +315,7 @@ define(['jquery', 'mage/translate', 'domReady!'], function ($, $t) {
         updateSurchargeVisibility();
         initInheritResetBehavior();
         initTermCheckboxInherit();
+        loadFees();
     }
 
     $(document).ready(function () {


### PR DESCRIPTION
## Context

ABN-401 row F12 / ABN-406 removed the per-term merchant-fee preview column from the admin surcharge grid (PR #173, 2026-05-26). That removal was wrong — Doug discussed it with the customer and they wanted the fees to remain visible. The fees were valuable data; the grid was the wrong location.

This PR puts the fees back, inline beside each Payment Terms checkbox — closer to where the merchant decides which terms to offer and what they pay for each.

## Changes

- Each Payment Terms checkbox now renders an adjacent empty `<span class="two-term-checkboxes__fee" data-term="…">`.
- `payment-terms-config.js` POSTs to the existing `two/config/fees` admin endpoint on init and on term-set change, and populates the spans with ` (1.50% + 0.50)` (or just `1.50%` / `0.50` / `0.00` depending on which components are non-zero).
- A trailing currency code is appended when the API response currency differs from the scope base — same degraded-display behaviour as the old grid column had.

## Brand-hideable

New optional `<inline_term_fees>` boolean on `brand.xml` (default true):

```xml
<brand code="my_brand">
    …
    <inline_term_fees>false</inline_term_fees>
</brand>
```

When false, the block omits the `data-fees-url` attribute and the `<span>` elements entirely. The JS short-circuits on missing URL, so no network call fires either. Vanilla Two ships without the element so fees show as before.

## Scope / Non-goals

- Doesn't touch the dead `loadFees()` in `surcharge-grid.js` left behind by PR #173 — that cleanup is independent and not worth bundling.
- No CSS added — fees are text-only adjacent to label, inherit Magento admin styling. Cosmetic styling can land separately if needed.
- ABN's `brand.xml` is unchanged — fees show on ABN too by default. Flip `<inline_term_fees>false</inline_term_fees>` over in the overlay repo when/if the customer asks to hide them.

## Validation

- `git diff --stat`: 8 files, +223/-3.
- Manual storefront/admin verification deferred to post-merge sync (staging will pick up the change via ArgoCD).
- Unit tests: no Descriptor mocks needed updating — the new ctor param has a `true` default, so existing test mocks continue to work.

## Ticket

- https://linear.app/tillit/issue/ABN-356
- Related: closed PR #173 (the wrong-place removal); test plan ABN-401 row F12