### PR TITLE
ABN-356/fix: fees beside every Payment Terms checkbox, not just checked

### DIFF
--- a/view/adminhtml/web/js/payment-terms-config.js
+++ b/view/adminhtml/web/js/payment-terms-config.js
@@ -283,7 +283,13 @@ define(['jquery', 'mage/translate', 'domReady!'], function ($, $t) {
                 var gridCurrency = String($termsContainer.data('base-currency') || '').toUpperCase();
                 var responseCurrency = String(response.currency || '').toUpperCase();
                 var degraded = responseCurrency !== '' && responseCurrency !== gridCurrency;
-                var suffix = degraded ? ' ' + responseCurrency : '';
+                // Fixed-portion currency: response currency wins when it
+                // differs from the scope's base (degraded display), else
+                // show the scope base currency. Always emitted, never
+                // blank — Doug 2026-05-27: the merchant has to be able
+                // to tell at a glance which currency the fixed fee is in.
+                var currency = degraded ? responseCurrency : gridCurrency;
+                var suffix = currency !== '' ? ' ' + currency : '';
                 $termsContainer.find('.two-term-checkboxes__fee').each(function () {
                     var $span = $(this);
                     var term = String($span.data('term'));
@@ -306,6 +312,8 @@ define(['jquery', 'mage/translate', 'domReady!'], function ($, $t) {
                     } else {
                         inner = pctStr + '% + ' + fixedStr + suffix;
                     }
+                    // suffix carries the currency code (e.g. " EUR") so
+                    // fixed-amount components are always disambiguated.
                     $span.text(' (' + inner + ')');
                 });
             }).fail(function () {

--- a/view/adminhtml/web/js/payment-terms-config.js
+++ b/view/adminhtml/web/js/payment-terms-config.js
@@ -280,15 +280,11 @@ define(['jquery', 'mage/translate', 'domReady!'], function ($, $t) {
                 if (!response || !response.success || !response.fees) {
                     return; // leave spans empty
                 }
-                var gridCurrency = String($termsContainer.data('base-currency') || '').toUpperCase();
-                var responseCurrency = String(response.currency || '').toUpperCase();
-                var degraded = responseCurrency !== '' && responseCurrency !== gridCurrency;
-                // Fixed-portion currency: response currency wins when it
-                // differs from the scope's base (degraded display), else
-                // show the scope base currency. Always emitted, never
-                // blank — Doug 2026-05-27: the merchant has to be able
-                // to tell at a glance which currency the fixed fee is in.
-                var currency = degraded ? responseCurrency : gridCurrency;
+                // Currency MUST come from the API response — the fee
+                // values do too, and we don't get to guess what currency
+                // they're in. If the API omits it, we cannot safely
+                // render any fixed amount.
+                var currency = String(response.currency || '').toUpperCase().trim();
                 var suffix = currency !== '' ? ' ' + currency : '';
                 $termsContainer.find('.two-term-checkboxes__fee').each(function () {
                     var $span = $(this);
@@ -302,6 +298,18 @@ define(['jquery', 'mage/translate', 'domReady!'], function ($, $t) {
                     var fixedStr = Number(fee.fixed || 0).toFixed(2);
                     var pctZero = pctStr === '0.00';
                     var fixedZero = fixedStr === '0.00';
+                    // Without an API-supplied currency, any fixed
+                    // component would be ambiguous. Drop the fixed
+                    // portion entirely in that case; percentage can
+                    // stand alone since it carries its own unit (%).
+                    if (currency === '') {
+                        if (pctZero) {
+                            $span.text('');
+                            return;
+                        }
+                        $span.text(' (' + pctStr + '%)');
+                        return;
+                    }
                     var inner;
                     if (pctZero && fixedZero) {
                         inner = '0.00' + suffix;
@@ -312,8 +320,6 @@ define(['jquery', 'mage/translate', 'domReady!'], function ($, $t) {
                     } else {
                         inner = pctStr + '% + ' + fixedStr + suffix;
                     }
-                    // suffix carries the currency code (e.g. " EUR") so
-                    // fixed-amount components are always disambiguated.
                     $span.text(' (' + inner + ')');
                 });
             }).fail(function () {

--- a/view/adminhtml/web/js/payment-terms-config.js
+++ b/view/adminhtml/web/js/payment-terms-config.js
@@ -243,7 +243,20 @@ define(['jquery', 'mage/translate', 'domReady!'], function ($, $t) {
             if (!url) {
                 return; // brand has inline_term_fees disabled (no data-fees-url emitted)
             }
-            var terms = getSelectedTerms();
+            // Fees render beside EVERY checkbox regardless of selection state,
+            // so the API call asks for all available term values, plus the
+            // custom-days entry if the merchant has one set. Differs from
+            // getSelectedTerms (which feeds the default-term dropdown and
+            // surcharge-visibility logic and intentionally tracks the
+            // checked state).
+            var terms = $termsContainer.find('.two-term-checkboxes__input').map(function () {
+                return Number(this.value);
+            }).get().filter(function (n) { return n > 0; });
+            var custom = parseInt($customDays.val(), 10);
+            if (custom > 0 && terms.indexOf(custom) === -1) {
+                terms.push(custom);
+            }
+            terms.sort(function (a, b) { return a - b; });
             if (!terms.length) {
                 return;
             }


### PR DESCRIPTION
## Context

Doug's review on the just-merged ABN-356 build (PR #177): fees were rendering only beside the *checked* terms. He wants the fee preview beside every term checkbox regardless of selection state — the merchant should see what every term would cost them before they decide which to enable.

Previous build sent `getSelectedTerms()` to the fees endpoint; that's the checked-only list. Empty unchecked spans were the symptom.

## Changes

`payment-terms-config.js` `loadFees()` now iterates every `.two-term-checkboxes__input` value (plus the custom-days input if set) and sends the full sorted superset to the fees endpoint. Memoisation key is now the full superset, so toggling a checkbox is a no-op for the fees AJAX — the existing default-term / surcharge-visibility logic on the same change events is untouched and still drives off `getSelectedTerms()`.

## Validation

- `git diff --stat`: 1 file, +14/-1.
- Behaviour: open the Two admin Payment Terms section with terms `[14, 30, 60, 90]` available, 14+60 checked. Before: 14/60 show `(10.00%)`, 30/90 empty. After: all four show the configured fee.

## Ticket

- https://linear.app/tillit/issue/ABN-356