### PR TITLE
ABN-414/fix: restore End-of-Month option in payment-terms-type source

### DIFF
--- a/Model/Config/Source/PaymentTermsType.php
+++ b/Model/Config/Source/PaymentTermsType.php
@@ -22,12 +22,17 @@ class PaymentTermsType implements OptionSourceInterface
 
     /**
      * @inheritDoc
+     *
+     * Both options are always returned. Brands that don't offer
+     * End-of-Month suppress the whole field via their brand.xml
+     * `<suppressed_fields>` (e.g. ABN), so per-brand filtering on
+     * this list is unnecessary.
      */
     public function toOptionArray(): array
     {
-        // Filter to the brand's supported payment term types via BrandRegistryInterface.
         return [
-            ['value' => self::STANDARD, 'label' => __('Standard')]
+            ['value' => self::STANDARD, 'label' => __('Standard')],
+            ['value' => self::END_OF_MONTH, 'label' => __('End of Month')]
         ];
     }
 }

--- a/Test/Unit/Model/Config/Source/PaymentTermsTypeTest.php
+++ b/Test/Unit/Model/Config/Source/PaymentTermsTypeTest.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Model\Config\Source;
+
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Model\Config\Source\PaymentTermsType;
+
+class PaymentTermsTypeTest extends TestCase
+{
+    public function testOptionArrayIncludesStandardAndEndOfMonth(): void
+    {
+        $source = new PaymentTermsType();
+        $values = array_column($source->toOptionArray(), 'value');
+        $this->assertContains(PaymentTermsType::STANDARD, $values);
+        $this->assertContains(PaymentTermsType::END_OF_MONTH, $values);
+    }
+}


### PR DESCRIPTION
## Context

ABN-414 — Two admin: End-of-Month option missing from `payment_terms_type` dropdown despite helper text describing both Standard and End-of-Month modes.

Root cause located in `Model/Config/Source/PaymentTermsType.php`: TWO-24485 (brand-aware rewrite) removed `END_OF_MONTH` from the option array with a comment "Filter to the brand's supported payment term types via BrandRegistryInterface". That filter was never implemented, so the source emits Standard only — for every brand, including Two which is supposed to offer both.

The ComposeOrder + SurchargeCalculator runtimes both still check for `end_of_month` (no dead code), so functionality is intact — just unreachable via admin.

## Changes

- Restore END_OF_MONTH to the option list, unconditionally.
- Add docstring explaining the design choice: brands that don't offer EoM suppress the whole field via brand.xml `<suppressed_fields>` (ABN does this), so no per-brand option filtering is needed at the source level.
- Add unit test pinning both options into the option array.

## Scope / Non-goals

- No change to the `PaymentTermsType` value constants — they were never removed.
- ABN's `<suppressed_fields>` already hides the whole `payment_terms_type` row; this PR doesn't touch ABN's brand overlay.

## Validation

- Local: `vendor/bin/phpunit Test/Unit/Model/Config/Source/PaymentTermsTypeTest.php`
- Staging: deploy + admin → Stores → Configuration → Sales → Two → Payment Method → Payment Terms — dropdown should show both Standard and End of Month options.

## Ticket

- https://linear.app/tillit/issue/ABN-414