### PR TITLE
ABN-415/fix: register SynthesiseBrandAdminForm globally (not adminhtml)

### DIFF
--- a/Plugin/Magento/Config/Model/Config/Structure/Reader/SynthesiseBrandAdminForm.php
+++ b/Plugin/Magento/Config/Model/Config/Structure/Reader/SynthesiseBrandAdminForm.php
@@ -35,16 +35,32 @@ use Two\Gateway\Model\Brand\Loader;
  *
  * Synthesis is unconditional. The previous `system/two_brand_synthesis/
  * admin_form/enabled` flag-gate was a transition kill-switch from
- * before strip-down; it has been removed because it created a
- * cold-cache race (ABN-415): if ScopeConfig couldn't resolve the
- * flag during the first admin request after a pod restart, the
- * plugin no-op'd, the un-synthesised Reader output was cached
- * under `adminhtml::backend_system_configuration_structure`, and
- * the ABN admin tab disappeared for the lifetime of the PHP-FPM
- * worker. Always synthesising removes the race entirely; the
- * existing skip-if-already-declared logic still protects against
- * collision with static overlays for any brand that later opts
- * into a stub system.xml.
+ * before strip-down. It was removed in PR #181 because we suspected
+ * a cold-cache race on the flag was the cause of ABN-415 (admin tab
+ * vanishes post-restart). That fix closed a real race but the
+ * symptom kept recurring.
+ *
+ * Evidence-driven follow-up (ABN-423 diagnostic harness on staging)
+ * showed the actual root cause: this plugin used to be registered
+ * in `etc/adminhtml/di.xml`. CLI invocations of bin/magento
+ * (`config:set`, `app:config:import`, `deploy:mode:set`, and similar)
+ * populate the `adminhtml::backend_system_configuration_structure`
+ * cache file but bootstrap with the CLI process's DI graph, which
+ * loads `etc/di.xml` + `etc/crontab/di.xml` and NOT
+ * `etc/adminhtml/di.xml`. The afterRead chain on `Structure\Reader`
+ * therefore omitted this plugin for every CLI-driven cache write —
+ * the cache landed un-synthesised, and subsequent admin web requests
+ * read it via `Scoped::_loadScopedData` and saw the broken Structure.
+ *
+ * Registration moved to `etc/di.xml` (global) so the plugin fires
+ * on every Reader::read regardless of which area the caller
+ * bootstrapped under. The afterRead body only adds tabs and sections
+ * to the adminhtml Structure shape, so firing in other areas is
+ * harmless (at worst, a wasted parse on a payload no consumer reads).
+ *
+ * The skip-if-already-declared logic still protects against collision
+ * with static overlays for any brand that later opts into a stub
+ * system.xml.
  *
  * Design v6 §3.5 verified: `brand_code` survives Converter conversion
  * at section / group / field levels (PR #160's probe). Synthesised

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -29,16 +29,14 @@
                 sortOrder="10"/>
     </type>
     <!--
-        Layer C/3: synthesise per-brand admin Configuration sections
-        from a tokenised template + the brand registry. Skips brands
-        whose intended section id already exists statically, so the
-        plugin is a no-op while overlay modules still ship their own
-        etc/adminhtml/system.xml. Activates at the strip-down PR when
-        overlay system.xml files are deleted and the flag flips to 1.
+        SynthesiseBrandAdminForm is registered globally in etc/di.xml,
+        not here. CLI commands (bin/magento config:set, app:config:import,
+        deploy:mode:set, etc.) populate the adminhtml-scoped structure
+        cache key but bootstrap with the CLI process's DI graph — which
+        loaded only etc/di.xml + etc/crontab/di.xml (or similar), not
+        etc/adminhtml/di.xml. Registering the plugin here meant CLI-driven
+        cache writes never invoked synthesis; the cache then served the
+        un-synthesised result to subsequent admin web requests and the
+        ABN admin tab disappeared (ABN-415).
     -->
-    <type name="Magento\Config\Model\Config\Structure\Reader">
-        <plugin name="two-synthesise-brand-admin-form"
-                type="Two\Gateway\Plugin\Magento\Config\Model\Config\Structure\Reader\SynthesiseBrandAdminForm"
-                sortOrder="10"/>
-    </type>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -166,4 +166,19 @@
                 type="Two\Gateway\Plugin\Magento\Csp\Model\Collector\SynthesiseBrandOrigins"
                 sortOrder="10"/>
     </type>
+    <!--
+        Synthesise per-brand admin Configuration sections (Layer C/3).
+        MUST be registered globally (not under etc/adminhtml/di.xml) —
+        CLI invocations of bin/magento populate the adminhtml-scoped
+        structure cache key using the CLI process's DI graph, which
+        doesn't load adminhtml-area plugins. Cache then serves the
+        un-synthesised result to admin web requests and the ABN admin
+        tab vanishes (ABN-415). The plugin's `afterRead` is a no-op
+        on non-Reader read paths; safe to register globally.
+    -->
+    <type name="Magento\Config\Model\Config\Structure\Reader">
+        <plugin name="two-synthesise-brand-admin-form"
+                type="Two\Gateway\Plugin\Magento\Config\Model\Config\Structure\Reader\SynthesiseBrandAdminForm"
+                sortOrder="10"/>
+    </type>
 </config>


### PR DESCRIPTION
## Context

The \"ABN admin tab vanishes after pod restart\" symptom kept recurring in staging despite #181 removing the suspected cold-cache race on the ScopeConfig flag. Today's evidence-driven diagnostic (ABN-423 harness in platform-tools) revealed the actual mechanism.

## The actual root cause (proven)

`SynthesiseBrandAdminForm` was registered in `etc/adminhtml/di.xml`. CLI invocations of bin/magento (`config:set`, `app:config:import`, `deploy:mode:set`, `admin:user:create`, and similar) populate the `adminhtml::backend_system_configuration_structure` cache file — but CLI processes bootstrap with the CLI DI graph, which loads `etc/di.xml` + `etc/crontab/di.xml` and **NOT** `etc/adminhtml/di.xml`. The afterRead chain on `Structure\\Reader` therefore omitted this plugin for every CLI-driven cache write. The cache landed un-synthesised; subsequent admin web requests read it via `Scoped::_loadScopedData` and saw an admin Structure with no ABN sections.

Reproduced cleanly on staging today:

\`\`\`
# wipe structure cache file
rm /var/www/html/var/cache/mage--*/mage---*_ADMINHTML__BACKEND_SYSTEM_CONFIGURATION_STRUCTURE
# trigger via CLI
runuser -u www-data -- bin/magento config:show payment/two_payment/title
# cache file rebuilt — but:
grep -c abn_payment /var/www/html/var/cache/mage--*/mage---*_ADMINHTML__BACKEND_SYSTEM_CONFIGURATION_STRUCTURE
# -> 0
# and no [two_brand_admin_form] line in system.log
\`\`\`

## Why our prior fixes appeared to work and then stopped

- **#181** (isEnabled removal): closed a separate cold-cache race, but the bug was never primarily that.
- **magento-helm#18** (cache:flush after di:compile in init-setup): wipes the bad cache. But init-setup runs more CLI commands afterwards (`maintenance:disable`, postSetup's `app:config:import`, `config:set ...`, `indexer:reindex`, `cache:flush`), which re-poison the cache **before** any admin web request lands.
- **Kick scripts / manual fix-magento-admin**: wipe cache and exit before any other CLI hits it; next admin web request rebuilds correctly. \"Worked\" but fragile.

## Changes

- `etc/adminhtml/di.xml`: drop the `<type name=\"Magento\\Config\\Model\\Config\\Structure\\Reader\">` registration. Leave a comment recording why.
- `etc/di.xml`: add the same registration (global). Aligns with the existing `SynthesiseBrandMethods` and `SynthesiseBrandOrigins` plugins which are already global for the same reason.
- `SynthesiseBrandAdminForm.php`: docstring rewritten to record the actual mechanism so the next person looking at this code isn't misled by the old \"ScopeConfig race\" explanation.

## Scope / Non-goals

- The plugin's afterRead body is unchanged.
- Synthesis output is unchanged.
- No effect on overlay/brand-overlay registration paths.
- Doesn't replace the kick-script or cache:flush workarounds that are already deployed — they remain available as belt-and-braces.

## Validation

Local:

- XML parsed cleanly.
- `grep -rn SynthesiseBrandAdminForm etc/` shows registration only in `etc/di.xml`.

Staging (post-merge + ArgoCD reconcile):

1. Pod rolls with new plugin position.
2. Reproduce the CLI-driven cache write that was broken before:
   \`\`\`
   rm <structure cache file>
   bin/magento config:show payment/two_payment/title
   grep -c abn_payment <structure cache file>  # expect: > 0
   \`\`\`
3. Check `var/log/system.log` for a `[two_brand_admin_form] synthesised tabs ... sections ...` line generated by that CLI invocation.
4. Hit `/admin/admin/system_config/edit/section/abn_payment` and confirm the section renders.
5. Restart pod, confirm admin tab is present without any kick-script intervention.

## Ticket

- https://linear.app/tillit/issue/ABN-415

🤖 Generated with [Claude Code](https://claude.com/claude-code)