### PR TITLE
docs(AGENTS): guardrail against adminhtml-only Structure plugin registration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,3 +26,31 @@ disabled by `make install`** — point them at the README section,
 which includes the commands to re-enable PageBuilder for testing
 brand content that relies on it. Same applies to anything
 analytics-driven (e.g. NewRelic dashboards, GA events).
+
+## DI registration scope for Structure / Config Reader plugins
+
+**Plugins that target `Magento\Config\Model\Config\Structure\Reader`
+(or any class whose output gets cached under an area-specific cache
+key like `adminhtml::backend_system_configuration_structure`) MUST
+be registered in `etc/di.xml` (global), NOT `etc/adminhtml/di.xml`.**
+
+Reason: CLI invocations of `bin/magento` (`config:set`,
+`app:config:import`, `deploy:mode:set`, `admin:user:create`, etc.)
+populate the adminhtml-scoped Structure cache but bootstrap with
+the CLI process's DI graph — which loads `etc/di.xml` +
+`etc/crontab/di.xml` and does **NOT** load `etc/adminhtml/di.xml`.
+Plugins registered only under adminhtml therefore never fire for
+CLI-driven cache writes; the cache lands incomplete, and subsequent
+admin web requests read the broken cached Structure from
+`Scoped::_loadScopedData`.
+
+This is exactly how ABN-415 ("ABN admin tab vanishes after pod
+restart") happened — `SynthesiseBrandAdminForm` was originally
+registered under adminhtml; every CLI command in the init/setup
+hooks repopulated the cache without invoking synthesis.
+
+If your plugin's `afterRead` body only mutates the adminhtml shape,
+firing in other areas is harmless (wasted parse on a payload no
+consumer reads). The cost of registering globally is essentially
+zero; the cost of getting this wrong is a recurring restart-time
+production bug that masks itself behind cache-flush workarounds.


### PR DESCRIPTION
Adds an AGENTS.md section explaining why plugins on Structure\Reader (and similar area-cached classes) must be registered globally, not under etc/adminhtml/di.xml. Companion to ABN-415's fix in PR #182.

The guardrail captures the actual root-cause mechanism we discovered today: CLI bin/magento invocations populate the adminhtml-scoped Structure cache but don't load adminhtml-area plugins, so plugins registered there never fire for CLI cache writes — and the resulting broken cache then served admin web requests, manifesting as the ABN admin tab vanishing post-restart.

## Ticket

- https://linear.app/tillit/issue/ABN-415

🤖 Generated with [Claude Code](https://claude.com/claude-code)