### PR TITLE
ABN-423/feat: cross-deployment cache-staleness hardening (M4 + M5)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,3 +54,9 @@ firing in other areas is harmless (wasted parse on a payload no
 consumer reads). The cost of registering globally is essentially
 zero; the cost of getting this wrong is a recurring restart-time
 production bug that masks itself behind cache-flush workarounds.
+
+The inverse trap applies to `etc/crontab/di.xml`: a plugin registered
+ONLY there fires in CLI processes (cron, indexer) but NOT in HTTP
+requests. If you find yourself reaching for crontab-scope DI, ask
+whether the symmetric case (HTTP request misses the plugin) would
+break correctness — almost always yes; register globally instead.

--- a/Setup/Recurring.php
+++ b/Setup/Recurring.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Two\Gateway\Setup;
+
+use Magento\Framework\App\Cache\TypeListInterface;
+use Magento\Framework\Setup\InstallSchemaInterface;
+use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\Framework\Setup\SchemaSetupInterface;
+
+/**
+ * Fires on every `bin/magento setup:upgrade`. Ensures that runtime
+ * caches survive a plugin DI change cleanly:
+ *
+ *   - config, layout, translate, full_page caches are flushed so
+ *     they re-build against the freshly-compiled interceptor list.
+ *     Without this, Magento's persistent cache backends (Redis,
+ *     file) keep serving rendered output that pre-dates the plugin
+ *     update, which is the cross-deployment-path manifestation of
+ *     ABN-415's bug class.
+ *
+ *   - opcache_reset() is called best-effort. In CLI it only clears
+ *     the CLI process's opcache (mostly cosmetic), but it does no
+ *     harm. FPM-worker opcache is handled separately by the helm
+ *     post-rotation hook on our k8s deployments; merchants on
+ *     stock prod / Cloud / Docker should follow the install README
+ *     guidance.
+ */
+class Recurring implements InstallSchemaInterface
+{
+    private TypeListInterface $cacheTypeList;
+
+    public function __construct(TypeListInterface $cacheTypeList)
+    {
+        $this->cacheTypeList = $cacheTypeList;
+    }
+
+    public function install(SchemaSetupInterface $setup, ModuleContextInterface $context): void
+    {
+        foreach (['config', 'layout', 'translate', 'full_page'] as $type) {
+            $this->cacheTypeList->cleanType($type);
+        }
+
+        if (function_exists('opcache_reset')) {
+            @opcache_reset();
+        }
+    }
+}


### PR DESCRIPTION
## Context

ABN-423 bundles the mitigations against ABN-415-class bugs across deployment paths beyond our k8s/gitsync model. This PR ships the two trivial-to-low-risk items: M4 (AGENTS guardrail extension) and M5 (auto-firing cache flush on \`setup:upgrade\`).

The two higher-effort items in ABN-423 — M1 (synthesis emit-all-brands) and M3 (install-time smoke test) — are NOT in this PR. They land separately.

## Changes

### M4 — AGENTS.md guardrail extension

The existing guardrail covers \`etc/adminhtml/di.xml\` (the ABN-415 case). Added the symmetric note for \`etc/crontab/di.xml\` — the inverse trap where a plugin registered there fires in CLI but not in HTTP requests. Future contributors need both rules to make the right scope decision.

### M5 — Setup/Recurring.php (auto-firing cache flush)

New \`Setup/Recurring.php\` implementing \`InstallSchemaInterface\` — fires on every \`bin/magento setup:upgrade\`.

Flushes 4 cache types that survive plugin DI changes and otherwise leave Redis serving pre-update payloads:

- \`config\` — system config tree (the ABN-415 family)
- \`layout\` — layout XML compile (interceptor list)
- \`translate\` — i18n strings
- \`full_page\` — when merchant uses Magento's FPC backend, this also bans Varnish (Magento's Varnish integration listens for full_page cache invalidations)

Best-effort \`opcache_reset()\` included. In CLI it only clears the CLI process's opcache (mostly cosmetic), but harmless. FPM-worker opcache is handled separately by the magento-helm post-rotation hook (ABN-423 M2, separate PR); merchants on stock Magento prod / Cloud / Docker should follow install README guidance.

## Scope / Non-goals

- **Not in this PR**: M1 synthesis emit-all-brands (multi-store hardening — needs careful synthesis-layer change, separate PR with the ABN-423 diagnostic harness still active).
- **Not in this PR**: M2 opcache_reset in helm post-rotation hook (separate magento-helm PR).
- **Not in this PR**: M3 install-time smoke test (CI + README addition, separate PR).

## Validation

- \`Setup/Recurring.php\` follows the existing Setup/Patch/Data pattern (constructor DI, single public method).
- AGENTS.md addition is plain prose, mirrors the existing guardrail's voice.
- No DI registration needed — Magento auto-discovers \`Setup/Recurring.php\` via \`InstallSchemaInterface\`.
- Cache type list constructor-injected, no service-locator anti-pattern.

## Risks

- **Cache flush on every upgrade is a behaviour change.** Merchants currently see no auto-flush on plugin updates — they may be relying on cached layout/config surviving. But this is exactly the cross-deployment bug class ABN-415 surfaced; making the flush automatic is the correct default.
- **Auto-running cache flush adds ~3-5 s to \`setup:upgrade\` runtime.** Trivial vs the upgrade itself.

## Ticket

- https://linear.app/tillit/issue/ABN-423

🤖 Generated with [Claude Code](https://claude.com/claude-code)