### PR TITLE
ABN-433/fix: accept Dutch comma decimal in admin surcharge grid

### DIFF
--- a/Model/Config/Backend/SurchargeGrid.php
+++ b/Model/Config/Backend/SurchargeGrid.php
@@ -134,6 +134,13 @@ class SurchargeGrid extends Value
                     continue;
                 }
 
+                // Accept the Dutch comma decimal separator. Front-end
+                // JS already normalises on input, but admins posting
+                // directly (curl, REST app:config:import, scripted
+                // setup:config:set chain) hit this code path without
+                // the JS pass; normalise server-side too.
+                $value = str_replace(',', '.', $value);
+
                 $numericValue = (float)$value;
                 $this->validateValue($type, $numericValue, $days, $maxFixed, $maxPercentage);
 

--- a/i18n/nl_NL.csv
+++ b/i18n/nl_NL.csv
@@ -170,3 +170,4 @@ day,dag
 "Optional field which enables the buyer to register the project the purchase is connected to. The information is eventually displayed on the invoice.","Optioneel veld waarmee de koper het project kan registreren waaraan de aankoop is gekoppeld. De informatie verschijnt uiteindelijk op de factuur."
 "Optional field which enables the buyer to register their purchase order number.","Optioneel veld waarmee de koper het inkoopordernummer kan registreren."
 "Let your buyer input additional emails to forward the invoice to on order fulfilment.","Laat uw koper aanvullende e-mailadressen invoeren om de factuur door te sturen bij bestellingsuitvoering."
+"Select your company from the dropdown to continue.","Selecteer uw bedrijf uit de lijst om door te gaan."

--- a/view/adminhtml/web/js/surcharge-grid.js
+++ b/view/adminhtml/web/js/surcharge-grid.js
@@ -265,6 +265,22 @@ define(['jquery', 'mage/translate', 'domReady!'], function ($, $t) {
         $defaultTerm.on('change', update);
         $('#' + prefix + 'surcharge_type_inherit').on('change', update);
 
+        // Accept the Dutch comma decimal separator on every surcharge
+        // input (Fixed, Percentage, Limit). Magento's stock
+        // validate-number rule is locale-blind and only accepts the
+        // period separator, so without normalisation a Dutch admin
+        // typing "10,50" trips the validator and cannot save. Replace
+        // commas with periods as the user types — the visible value
+        // updates in place, the validator passes, and the backend
+        // model receives a parsable string.
+        $container.on('input', '.surcharge-grid__input', function () {
+            var $input = $(this);
+            var value = $input.val();
+            if (typeof value === 'string' && value.indexOf(',') !== -1) {
+                $input.val(value.replace(/,/g, '.'));
+            }
+        });
+
         // ── Fee column (read-only, fetched from Two API via admin proxy) ─
 
         // Memoise the term-set we last fetched so rapid re-fires (keystrokes


### PR DESCRIPTION
## Context

Dutch-locale admins typing "10,50" into the Fixed / Percentage / Limit fields of the per-term surcharge grid could not save: Magento's stock `validate-number` jQuery rule is locale-blind and rejects any non-period decimal separator, so the form failed client-side validation before reaching the backend model. Reported via ABN as part of the ABN-422/424/428/429/433 bundle.

## Changes

- **`view/adminhtml/web/js/surcharge-grid.js`** — bind `input` on `.surcharge-grid__input` and swap commas → periods in place as the user types. The visible value updates immediately, `validate-number` passes, and the form posts a parsable string.
- **`Model/Config/Backend/SurchargeGrid::afterSave()`** — defence in depth: server-side `str_replace(',', '.', $value)` for admins who bypass the front-end (curl, `app:config:import`, scripted `setup:config:set` chains).

## Scope / Non-goals

- The fix is scoped to the **per-term surcharge grid** (Fixed / Percentage / Limit columns). Other admin numeric inputs (e.g. `surcharge_tax_rate`) are out of scope — only those used the per-grid template + backend model and were tested as comma-rejecting.
- No locale detection — commas are accepted unconditionally rather than only for Dutch locale. Surcharge values can't realistically use thousands-separator commas at the magnitudes involved (max 100s), so the unconditional swap is safe and matches the merchant-input model.

## Cross-repo coordination

- This PR is independent of the other ABN-422 bundle PRs (`two-inc/magento-hyva-extension#32` and the `magento-abn-plugin` ABN-424/428 PR). Merge order does not matter.

## Validation

- Local lint: `php` not installed in dev env — relies on CI.
- Manual admin test plan after deploy: open Stores → Configuration → Sales → Payment Methods → Two → Payment Surcharge Configuration in `nl_NL` admin locale, type `10,50` in any Fixed-cost cell, save — value should persist and reload as `10.50`.

## Ticket

- <https://linear.app/tillit/issue/ABN-433>