### PR TITLE
ABN-428/followup: drop orphan 'By checking this box…' T&C source phrase

### DIFF
--- a/i18n/nb_NO.csv
+++ b/i18n/nb_NO.csv
@@ -25,7 +25,6 @@
 Branding,Merkevarebygging
 "Business Invoice",Bedriftsfaktura
 "Buy now, receive your goods, pay your invoice later.","Kjøp nå, motta varene dine, betal fakturaen senere."
-"By checking this box, I confirm that I have read and agree to %1.","Ved å merke av i denne boksen, bekrefter jeg at jeg har lest og godtar %1."
 "Check last 100 debug log records","Sjekk siste 100 feilsøkingsloggposter"
 "Check last 100 error log records","Sjekk siste 100 feilloggposter"
 "City",By

--- a/i18n/nl_NL.csv
+++ b/i18n/nl_NL.csv
@@ -25,7 +25,6 @@
 Branding,Merknaam
 "Business Invoice","Zakelijke factuur"
 "Buy now, receive your goods, pay your invoice later.","Koop nu, ontvang uw goederen, betaal uw factuur later."
-"By checking this box, I confirm that I have read and agree to %1.","Door dit vakje aan te vinken, bevestig ik dat ik de %1 heb gelezen en ermee akkoord ga."
 "Check last 100 debug log records","Controleer de laatste 100 debug-logboek records"
 "Check last 100 error log records","Controleer de laatste 100 foutenlogboek records"
 "City",Stad

--- a/i18n/sv_SE.csv
+++ b/i18n/sv_SE.csv
@@ -25,7 +25,6 @@
 Branding,Branding
 "Business Invoice",Företagsfaktura
 "Buy now, receive your goods, pay your invoice later.","Köp nu, få dina varor, betala din faktura senare."
-"By checking this box, I confirm that I have read and agree to %1.","Genom att kryssa i denna ruta bekräftar jag att jag har läst och godkänner %1."
 "Check last 100 debug log records","Kontrollera de senaste 100 felsökningsloggposterna"
 "Check last 100 error log records","Kontrollera de senaste 100 felloggposterna"
 "City",Stad


### PR DESCRIPTION
## Context

Companion to the ABN-428 follow-up PR set. The Hyva module's `TwoBrandedHyvaViewModel` no longer emits the source phrase `"By checking this box, I confirm that I have read and agree to %1."` — that copy has been replaced with Luma's existing `"I accept the %1 and authorize %2 to process my data automatically."` pattern, eliminating the Luma↔Hyva copy divergence for Two brand. The NL / NO / SE translations of the retired source phrase are now orphan.

## Changes

- `i18n/nl_NL.csv`, `i18n/nb_NO.csv`, `i18n/sv_SE.csv`: remove the single line for `"By checking this box, I confirm that I have read and agree to %1."` in each file.

## Cross-repo coordination

- **`two-inc/magento-hyva-extension` branch `doug/abn-428-followup-align-hyva-tc-with-luma-v2`** — retires the source phrase from `TwoBrandedHyvaViewModel`.
- **`two-inc/magento-abn-plugin` branch `doug/abn-428-followup-abn-link-wrap`** — matches the Luma pattern for ABN brand.

Recommended merge order: ABN brand PR → hyva-extension PR → this PR (only safe to drop translations once nothing emits the source phrase).

## Ticket

- https://linear.app/tillit/issue/ABN-428