### PR TITLE
ABN-433/followup: render saved surcharge values with admin-locale decimal separator

### DIFF
--- a/Block/Adminhtml/System/Config/Field/SurchargeGrid.php
+++ b/Block/Adminhtml/System/Config/Field/SurchargeGrid.php
@@ -11,6 +11,7 @@ use Magento\Backend\Block\Template\Context;
 use Magento\Config\Block\System\Config\Form\Field;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Data\Form\Element\AbstractElement;
+use Magento\Framework\Locale\ResolverInterface as LocaleResolverInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Two\Gateway\Api\BrandRegistryInterface;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
@@ -40,6 +41,9 @@ class SurchargeGrid extends Field
     /** @var BrandRegistryInterface */
     private $brandRegistry;
 
+    /** @var LocaleResolverInterface */
+    private $localeResolver;
+
     /** @var string */
     private $scope = 'default';
 
@@ -52,6 +56,7 @@ class SurchargeGrid extends Field
         StoreManagerInterface $storeManager,
         CurrencyRatesProviderInterface $ratesProvider,
         BrandRegistryInterface $brandRegistry,
+        LocaleResolverInterface $localeResolver,
         array $data = []
     ) {
         parent::__construct($context, $data);
@@ -59,6 +64,7 @@ class SurchargeGrid extends Field
         $this->storeManager = $storeManager;
         $this->ratesProvider = $ratesProvider;
         $this->brandRegistry = $brandRegistry;
+        $this->localeResolver = $localeResolver;
     }
 
     /**
@@ -108,12 +114,35 @@ class SurchargeGrid extends Field
     }
 
     /**
-     * Get the saved surcharge value for a given term and field.
+     * Get the saved surcharge value for a given term and field,
+     * formatted with the admin locale's decimal separator (e.g.
+     * "5,3" under nl_NL, "5.3" under en_US).
+     *
+     * Storage is canonical period-decimal (the backend model
+     * normalises comma → period on save), so display formatting
+     * is the inverse: swap the period for the locale separator
+     * before emitting into the input's value attribute.
      */
     public function getSavedValue(int $days, string $field): string
     {
         $value = $this->getConfigValue($this->path(sprintf('surcharge_%d_%s', $days, $field)));
-        return $value !== null ? (string)$value : '';
+        if ($value === null || $value === '') {
+            return '';
+        }
+        return str_replace('.', $this->decimalSeparator(), (string)$value);
+    }
+
+    /**
+     * Decimal separator for the current admin locale. Derived from
+     * ICU via NumberFormatter so it matches whatever $.mage.parseNumber
+     * accepts on the JS side (both read the same locale data).
+     */
+    private function decimalSeparator(): string
+    {
+        $locale = (string)$this->localeResolver->getLocale() ?: 'en_US';
+        $formatter = new \NumberFormatter($locale, \NumberFormatter::DECIMAL);
+        $separator = $formatter->getSymbol(\NumberFormatter::DECIMAL_SEPARATOR_SYMBOL);
+        return $separator !== false && $separator !== '' ? $separator : '.';
     }
 
     /**


### PR DESCRIPTION
## Context

ABN-433 ships in two passes. PR #189 fixed the input side: a Dutch
admin typing `5,3` no longer gets the comma rewritten to a period
mid-typing. But the load side was still emitting the raw stored
value as `5.3` — so on reload nl_NL admins saw a period back in the
box, inconsistent with the rest of the admin UI and with what they
typed.

Backend storage is canonical period-decimal (the backend model
normalises comma → period on save), so this is a display-only
concern.

## Changes

- Inject `Magento\Framework\Locale\ResolverInterface` into the
  surcharge-grid block.
- `getSavedValue()` looks up the admin locale's decimal separator
  via `NumberFormatter` and swaps `.` for it before returning the
  string the template emits as `value="…"`.
- ICU is the same data source `$.mage.parseNumber` reads on the JS
  side, so display and validation agree on what counts as a
  decimal separator under the active locale.

## Scope / Non-goals

- No storage-format change. Canonical period-decimal stays.
- No JS change. Dynamic rows are rendered with empty values.
- `getFixedLimitLabel()` still uses `number_format(..., '.', '')`
  for the helper-text label (e.g. "EUR 25.50"). User-visible and
  arguably wants the same treatment, but it is a label not an
  input — tracked separately rather than bundled here.

## Validation

- Chrome on `magento.staging.achterafbetalen.co` admin in nl_NL,
  pre-fix: row-60 fixed input loads as `5.3`.
- After deploy, expect: same input loads as `5,3`; typing `2,5`
  retains the comma through blur (still works as in PR #189); save
  round-trips back to `5,3` on reload.

## Ticket

- <https://linear.app/tillit/issue/ABN-433>