### PR TITLE
ABN-433/followup: locale-format the remaining admin decimal labels

### DIFF
--- a/Block/Adminhtml/System/Config/Field/SurchargeGrid.php
+++ b/Block/Adminhtml/System/Config/Field/SurchargeGrid.php
@@ -251,7 +251,7 @@ class SurchargeGrid extends Field
             $precision = $this->getCurrencyPrecision($baseCurrency);
             $factor = pow(10, $precision);
             $convertedMax = ceil($converted * $factor) / $factor;
-            $formatted = number_format($convertedMax, $precision, '.', '');
+            $formatted = number_format($convertedMax, $precision, $this->decimalSeparator(), '');
             return $baseCurrency . ' ' . $formatted . ' (' . $limitCurrency . ' ' . $limitAmount . ')';
         }
 

--- a/Block/Adminhtml/System/Config/Field/SurchargeTaxRate.php
+++ b/Block/Adminhtml/System/Config/Field/SurchargeTaxRate.php
@@ -10,14 +10,9 @@ namespace Two\Gateway\Block\Adminhtml\System\Config\Field;
 use Magento\Backend\Block\Template\Context;
 use Magento\Config\Block\System\Config\Form\Field;
 use Magento\Framework\Data\Form\Element\AbstractElement;
+use Magento\Framework\Locale\ResolverInterface as LocaleResolverInterface;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
 
-/**
- * Surcharge Tax Rate field with dynamic comment.
- *
- * Shows the store's default tax rate when available, or a red warning
- * when no tax rules are configured.
- */
 class SurchargeTaxRate extends Field
 {
     /**
@@ -25,13 +20,18 @@ class SurchargeTaxRate extends Field
      */
     private $configRepository;
 
+    /** @var LocaleResolverInterface */
+    private $localeResolver;
+
     public function __construct(
         Context $context,
         ConfigRepository $configRepository,
+        LocaleResolverInterface $localeResolver,
         array $data = []
     ) {
         parent::__construct($context, $data);
         $this->configRepository = $configRepository;
+        $this->localeResolver = $localeResolver;
     }
 
     /**
@@ -45,7 +45,7 @@ class SurchargeTaxRate extends Field
             $element->setComment(
                 (string)__(
                     'Leave empty to use your store\'s default tax rate (%1%). Enter 0 for tax-exempt.',
-                    number_format($defaultRate, 1)
+                    number_format($defaultRate, 1, $this->decimalSeparator(), '')
                 )
             );
         } else {
@@ -69,5 +69,18 @@ class SurchargeTaxRate extends Field
         }
 
         return parent::_getElementHtml($element);
+    }
+
+    /**
+     * Decimal separator for the current admin locale. Mirrors the
+     * SurchargeGrid block helper — kept duplicated rather than
+     * factored out because there are only two consumers.
+     */
+    private function decimalSeparator(): string
+    {
+        $locale = (string)$this->localeResolver->getLocale() ?: 'en_US';
+        $formatter = new \NumberFormatter($locale, \NumberFormatter::DECIMAL);
+        $separator = $formatter->getSymbol(\NumberFormatter::DECIMAL_SEPARATOR_SYMBOL);
+        return $separator !== false && $separator !== '' ? $separator : '.';
     }
 }


### PR DESCRIPTION
## Context

PR #190 locale-formatted surcharge-grid input values. Doug's least-
surprises principle: the surrounding labels should match. Two
stragglers in the surcharge admin UI still used hardcoded periods.

## Changes

- \`SurchargeGrid::getFixedLimitLabel()\`: the converted fixed-fee
  max helper text (e.g. \"EUR 25.50 (USD 28)\") now uses the locale
  separator via the existing \`decimalSeparator()\` helper.
- \`SurchargeTaxRate::_getElementHtml()\`: the \"default tax rate
  (21.0%)\" comment now uses the locale separator. Inject
  \`LocaleResolverInterface\` and duplicate the small helper rather
  than factor it out — only two consumers.

## Scope / Non-goals

- No storage-format changes.
- \`Service/Order\`, \`Observer/Invoice*\`, \`Observer/Creditmemo*\`
  still use \`number_format(..., '.', '')\` — those are API
  serialisation paths and must stay period-canonical.

## Validation

- Pre-fix in nl_NL admin: \"default tax rate (21.0%)\" and
  \"EUR 25.50 (USD 28)\" both show period.
- After deploy, expect: \"21,0%\" and \"EUR 25,50 (USD 28)\" under
  nl_NL; unchanged under en_US.

## Ticket

- <https://linear.app/tillit/issue/ABN-433>