### PR TITLE
ABN-433/followup: locale-aware tax rate + fees rendering

### DIFF
--- a/Block/Adminhtml/System/Config/Field/PaymentTermsCheckboxes.php
+++ b/Block/Adminhtml/System/Config/Field/PaymentTermsCheckboxes.php
@@ -14,6 +14,7 @@ use Magento\Framework\Data\Form\Element\AbstractElement;
 use Magento\Store\Model\StoreManagerInterface;
 use Two\Gateway\Api\BrandRegistryInterface;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
+use Two\Gateway\Service\Locale\AdminDecimalFormatter;
 
 /**
  * Renders payment terms as individual checkboxes instead of a multiselect.
@@ -38,17 +39,22 @@ class PaymentTermsCheckboxes extends Field
     /** @var ScopeConfigInterface */
     private $scopeConfig;
 
+    /** @var AdminDecimalFormatter */
+    private $decimalFormatter;
+
     public function __construct(
         Context $context,
         BrandRegistryInterface $brandRegistry,
         StoreManagerInterface $storeManager,
         ScopeConfigInterface $scopeConfig,
+        AdminDecimalFormatter $decimalFormatter,
         array $data = []
     ) {
         parent::__construct($context, $data);
         $this->brandRegistry = $brandRegistry;
         $this->storeManager = $storeManager;
         $this->scopeConfig = $scopeConfig;
+        $this->decimalFormatter = $decimalFormatter;
     }
 
     /**
@@ -148,6 +154,16 @@ class PaymentTermsCheckboxes extends Field
      * returns amounts in the merchant's contractual currency; JS
      * appends a degraded-currency suffix when they differ.
      */
+    /**
+     * Decimal separator for the active admin locale, emitted as a
+     * data attribute on the container so the inline-fees JS can
+     * render fetched amounts with the matching separator.
+     */
+    public function getDecimalSeparator(): string
+    {
+        return $this->decimalFormatter->getSeparator();
+    }
+
     public function getBaseCurrency(): string
     {
         try {

--- a/Block/Adminhtml/System/Config/Field/SurchargeGrid.php
+++ b/Block/Adminhtml/System/Config/Field/SurchargeGrid.php
@@ -11,11 +11,11 @@ use Magento\Backend\Block\Template\Context;
 use Magento\Config\Block\System\Config\Form\Field;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Data\Form\Element\AbstractElement;
-use Magento\Framework\Locale\ResolverInterface as LocaleResolverInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Two\Gateway\Api\BrandRegistryInterface;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
 use Two\Gateway\Api\CurrencyRatesProviderInterface;
+use Two\Gateway\Service\Locale\AdminDecimalFormatter;
 
 /**
  * Renders a grid of surcharge inputs (fixed, percentage, limit) per payment term.
@@ -41,8 +41,8 @@ class SurchargeGrid extends Field
     /** @var BrandRegistryInterface */
     private $brandRegistry;
 
-    /** @var LocaleResolverInterface */
-    private $localeResolver;
+    /** @var AdminDecimalFormatter */
+    private $decimalFormatter;
 
     /** @var string */
     private $scope = 'default';
@@ -56,7 +56,7 @@ class SurchargeGrid extends Field
         StoreManagerInterface $storeManager,
         CurrencyRatesProviderInterface $ratesProvider,
         BrandRegistryInterface $brandRegistry,
-        LocaleResolverInterface $localeResolver,
+        AdminDecimalFormatter $decimalFormatter,
         array $data = []
     ) {
         parent::__construct($context, $data);
@@ -64,7 +64,7 @@ class SurchargeGrid extends Field
         $this->storeManager = $storeManager;
         $this->ratesProvider = $ratesProvider;
         $this->brandRegistry = $brandRegistry;
-        $this->localeResolver = $localeResolver;
+        $this->decimalFormatter = $decimalFormatter;
     }
 
     /**
@@ -132,17 +132,9 @@ class SurchargeGrid extends Field
         return str_replace('.', $this->decimalSeparator(), (string)$value);
     }
 
-    /**
-     * Decimal separator for the current admin locale. Derived from
-     * ICU via NumberFormatter so it matches whatever $.mage.parseNumber
-     * accepts on the JS side (both read the same locale data).
-     */
     private function decimalSeparator(): string
     {
-        $locale = (string)$this->localeResolver->getLocale() ?: 'en_US';
-        $formatter = new \NumberFormatter($locale, \NumberFormatter::DECIMAL);
-        $separator = $formatter->getSymbol(\NumberFormatter::DECIMAL_SEPARATOR_SYMBOL);
-        return $separator !== false && $separator !== '' ? $separator : '.';
+        return $this->decimalFormatter->getSeparator();
     }
 
     /**
@@ -412,6 +404,17 @@ class SurchargeGrid extends Field
     public function getScopeId(): int
     {
         return $this->scopeId;
+    }
+
+
+    /**
+     * Decimal separator for the active admin locale, exposed so
+     * the grid's data attributes can carry it through to the JS
+     * fees-formatting routine.
+     */
+    public function getDecimalSeparator(): string
+    {
+        return $this->decimalFormatter->getSeparator();
     }
 
     private function resolveScope(AbstractElement $element): void

--- a/Block/Adminhtml/System/Config/Field/SurchargeTaxRate.php
+++ b/Block/Adminhtml/System/Config/Field/SurchargeTaxRate.php
@@ -10,8 +10,8 @@ namespace Two\Gateway\Block\Adminhtml\System\Config\Field;
 use Magento\Backend\Block\Template\Context;
 use Magento\Config\Block\System\Config\Form\Field;
 use Magento\Framework\Data\Form\Element\AbstractElement;
-use Magento\Framework\Locale\ResolverInterface as LocaleResolverInterface;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
+use Two\Gateway\Service\Locale\AdminDecimalFormatter;
 
 class SurchargeTaxRate extends Field
 {
@@ -20,18 +20,18 @@ class SurchargeTaxRate extends Field
      */
     private $configRepository;
 
-    /** @var LocaleResolverInterface */
-    private $localeResolver;
+    /** @var AdminDecimalFormatter */
+    private $decimalFormatter;
 
     public function __construct(
         Context $context,
         ConfigRepository $configRepository,
-        LocaleResolverInterface $localeResolver,
+        AdminDecimalFormatter $decimalFormatter,
         array $data = []
     ) {
         parent::__construct($context, $data);
         $this->configRepository = $configRepository;
-        $this->localeResolver = $localeResolver;
+        $this->decimalFormatter = $decimalFormatter;
     }
 
     /**
@@ -40,12 +40,13 @@ class SurchargeTaxRate extends Field
     protected function _getElementHtml(AbstractElement $element): string
     {
         $defaultRate = $this->configRepository->getDefaultTaxRate();
+        $separator = $this->decimalFormatter->getSeparator();
 
         if ($defaultRate > 0) {
             $element->setComment(
                 (string)__(
                     'Leave empty to use your store\'s default tax rate (%1%). Enter 0 for tax-exempt.',
-                    number_format($defaultRate, 1, $this->decimalSeparator(), '')
+                    number_format($defaultRate, 1, $separator, '')
                 )
             );
         } else {
@@ -68,19 +69,18 @@ class SurchargeTaxRate extends Field
             );
         }
 
-        return parent::_getElementHtml($element);
-    }
+        // Locale-format the stored value (canonical "21.5") into
+        // the admin's separator (e.g. "21,5" under nl_NL) before
+        // it renders into the input's value attribute. The
+        // validate-zero-or-greater validator routes through
+        // $.mage.parseNumber, which is locale-aware, so the
+        // comma round-trips. Save-side normalisation happens
+        // in the LocaleDecimal backend model.
+        $value = $element->getValue();
+        if (is_string($value) && $value !== '') {
+            $element->setValue(str_replace('.', $separator, $value));
+        }
 
-    /**
-     * Decimal separator for the current admin locale. Mirrors the
-     * SurchargeGrid block helper — kept duplicated rather than
-     * factored out because there are only two consumers.
-     */
-    private function decimalSeparator(): string
-    {
-        $locale = (string)$this->localeResolver->getLocale() ?: 'en_US';
-        $formatter = new \NumberFormatter($locale, \NumberFormatter::DECIMAL);
-        $separator = $formatter->getSymbol(\NumberFormatter::DECIMAL_SEPARATOR_SYMBOL);
-        return $separator !== false && $separator !== '' ? $separator : '.';
+        return parent::_getElementHtml($element);
     }
 }

--- a/Model/Config/Backend/LocaleDecimal.php
+++ b/Model/Config/Backend/LocaleDecimal.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Model\Config\Backend;
+
+use Magento\Framework\App\Config\Value;
+
+/**
+ * Backend model for numeric config fields that should accept the
+ * admin locale's decimal separator on input. Storage stays
+ * canonical period-decimal; this normalises comma → period on
+ * save so downstream (float) casts see "21.5" not "21," (which
+ * PHP truncates to 21).
+ *
+ * Mirrors the comma → period pass already performed in
+ * Two\Gateway\Model\Config\Backend\SurchargeGrid::afterSave(),
+ * but for single scalar fields (no per-term iteration).
+ */
+class LocaleDecimal extends Value
+{
+    /**
+     * @inheritDoc
+     */
+    public function beforeSave()
+    {
+        $value = $this->getValue();
+        if (is_string($value)) {
+            $this->setValue(str_replace(',', '.', $value));
+        }
+        return parent::beforeSave();
+    }
+}

--- a/Service/Locale/AdminDecimalFormatter.php
+++ b/Service/Locale/AdminDecimalFormatter.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Service\Locale;
+
+use Magento\Framework\Locale\ResolverInterface as LocaleResolverInterface;
+
+/**
+ * Resolves the decimal separator for the active admin locale via ICU.
+ * Shared by the surcharge-grid block, the surcharge-tax-rate block,
+ * and the payment-terms-checkboxes block — all of which need to
+ * render canonical period-decimal storage with the admin's separator
+ * (e.g. "21.5" → "21,5" under nl_NL).
+ *
+ * Storage stays period-canonical; this is display-formatting only.
+ */
+class AdminDecimalFormatter
+{
+    /** @var LocaleResolverInterface */
+    private $localeResolver;
+
+    public function __construct(LocaleResolverInterface $localeResolver)
+    {
+        $this->localeResolver = $localeResolver;
+    }
+
+    /**
+     * Decimal separator for the current admin locale. Same ICU
+     * data that $.mage.parseNumber reads on the JS side, so what
+     * we render is what the locale-aware validators accept.
+     */
+    public function getSeparator(): string
+    {
+        $locale = (string)$this->localeResolver->getLocale() ?: 'en_US';
+        $formatter = new \NumberFormatter($locale, \NumberFormatter::DECIMAL);
+        $separator = $formatter->getSymbol(\NumberFormatter::DECIMAL_SEPARATOR_SYMBOL);
+        return $separator !== false && $separator !== '' ? $separator : '.';
+    }
+}

--- a/etc/adminhtml/brand_form_template.xml
+++ b/etc/adminhtml/brand_form_template.xml
@@ -260,7 +260,8 @@
                        canRestore="1" brand_code="{{code}}">
                     <label>Surcharge Tax Rate (%)</label>
                     <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\SurchargeTaxRate</frontend_model>
-                    <validate>validate-number validate-zero-or-greater</validate>
+                    <backend_model>Two\Gateway\Model\Config\Backend\LocaleDecimal</backend_model>
+                    <validate>validate-zero-or-greater</validate>
                     <config_path>payment/{{code}}/surcharge_tax_rate</config_path>
                 </field>
                 <field id="surcharge_grid" translate="label" type="text" sortOrder="100"

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -186,7 +186,8 @@
                        showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Surcharge Tax Rate (%)</label>
                     <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\SurchargeTaxRate</frontend_model>
-                    <validate>validate-number validate-zero-or-greater</validate>
+                    <backend_model>Two\Gateway\Model\Config\Backend\LocaleDecimal</backend_model>
+                    <validate>validate-zero-or-greater</validate>
                     <config_path>payment/two_payment/surcharge_tax_rate</config_path>
                 </field>
                 <!-- Per-term surcharge grid (fixed, percentage, limit per term) -->

--- a/view/adminhtml/templates/system/config/field/payment-terms-checkboxes.phtml
+++ b/view/adminhtml/templates/system/config/field/payment-terms-checkboxes.phtml
@@ -23,6 +23,7 @@ $showFees = $block->showInlineFees();
      data-scope="<?= $block->escapeHtmlAttr($block->getScope()) ?>"
      data-scope-id="<?= (int)$block->getScopeId() ?>"
      data-base-currency="<?= $block->escapeHtmlAttr($block->getBaseCurrency()) ?>"
+     data-decimal-separator="<?= $block->escapeHtmlAttr($block->getDecimalSeparator()) ?>"
      <?php endif; ?>>
     <?php foreach ($terms as $days): ?>
         <?php

--- a/view/adminhtml/templates/system/config/field/surcharge-grid.phtml
+++ b/view/adminhtml/templates/system/config/field/surcharge-grid.phtml
@@ -31,7 +31,8 @@ $columnLabels = [
      data-fees-url="<?= $block->escapeHtmlAttr($block->getFeesUrl()) ?>"
      data-scope="<?= $block->escapeHtmlAttr($block->getScope()) ?>"
      data-scope-id="<?= (int)$block->getScopeId() ?>"
-     data-base-currency="<?= $block->escapeHtmlAttr($currencyCode) ?>">
+     data-base-currency="<?= $block->escapeHtmlAttr($currencyCode) ?>"
+     data-decimal-separator="<?= $block->escapeHtmlAttr($block->getDecimalSeparator()) ?>">
 
     <p class="surcharge-grid__no-terms note" <?= !empty($terms) ? 'style="display:none"' : '' ?>>
         <span><?= $block->escapeHtml(__('No payment terms selected. Select payment terms above to configure surcharges.')) ?></span>

--- a/view/adminhtml/web/js/payment-terms-config.js
+++ b/view/adminhtml/web/js/payment-terms-config.js
@@ -286,6 +286,15 @@ define(['jquery', 'mage/translate', 'domReady!'], function ($, $t) {
                 // render any fixed amount.
                 var currency = String(response.currency || '').toUpperCase().trim();
                 var suffix = currency !== '' ? ' ' + currency : '';
+                // Admin locale's decimal separator, sourced server-side
+                // from ICU (matches what the surcharge-grid display path
+                // uses). Falls back to '.' on legacy renders that didn't
+                // emit the attribute.
+                var decimalSep = String($termsContainer.data('decimal-separator') || '.');
+                function formatAmount(n) {
+                    var s = Number(n).toFixed(2);
+                    return decimalSep === '.' ? s : s.replace('.', decimalSep);
+                }
                 $termsContainer.find('.two-term-checkboxes__fee').each(function () {
                     var $span = $(this);
                     var term = String($span.data('term'));
@@ -294,10 +303,11 @@ define(['jquery', 'mage/translate', 'domReady!'], function ($, $t) {
                         $span.text('');
                         return;
                     }
-                    var pctStr = Number(fee.percentage || 0).toFixed(2);
-                    var fixedStr = Number(fee.fixed || 0).toFixed(2);
-                    var pctZero = pctStr === '0.00';
-                    var fixedZero = fixedStr === '0.00';
+                    var pctStr = formatAmount(fee.percentage || 0);
+                    var fixedStr = formatAmount(fee.fixed || 0);
+                    var zero = formatAmount(0);
+                    var pctZero = pctStr === zero;
+                    var fixedZero = fixedStr === zero;
                     // Without an API-supplied currency, any fixed
                     // component would be ambiguous. Drop the fixed
                     // portion entirely in that case; percentage can
@@ -312,7 +322,7 @@ define(['jquery', 'mage/translate', 'domReady!'], function ($, $t) {
                     }
                     var inner;
                     if (pctZero && fixedZero) {
-                        inner = '0.00' + suffix;
+                        inner = zero + suffix;
                     } else if (pctZero) {
                         inner = fixedStr + suffix;
                     } else if (fixedZero) {

--- a/view/adminhtml/web/js/surcharge-grid.js
+++ b/view/adminhtml/web/js/surcharge-grid.js
@@ -314,6 +314,12 @@ define(['jquery', 'mage/translate', 'domReady!'], function ($, $t) {
                 var responseCurrency = String(response.currency || '').toUpperCase();
                 var degraded = responseCurrency !== '' && responseCurrency !== gridCurrency;
                 var suffix = degraded ? ' ' + responseCurrency : '';
+                var decimalSep = String($container.data('decimal-separator') || '.');
+                function formatAmount(n) {
+                    var s = Number(n).toFixed(2);
+                    return decimalSep === '.' ? s : s.replace('.', decimalSep);
+                }
+                var zero = formatAmount(0);
                 $container.find('td.surcharge-grid__fee').each(function () {
                     var $cell = $(this);
                     var term = String($cell.data('term'));
@@ -321,13 +327,13 @@ define(['jquery', 'mage/translate', 'domReady!'], function ($, $t) {
                     if (!fee) {
                         return;
                     }
-                    var pctStr = Number(fee.percentage || 0).toFixed(2);
-                    var fixedStr = Number(fee.fixed || 0).toFixed(2);
-                    var pctZero = pctStr === '0.00';
-                    var fixedZero = fixedStr === '0.00';
+                    var pctStr = formatAmount(fee.percentage || 0);
+                    var fixedStr = formatAmount(fee.fixed || 0);
+                    var pctZero = pctStr === zero;
+                    var fixedZero = fixedStr === zero;
                     var text;
                     if (pctZero && fixedZero) {
-                        text = '0.00' + suffix;
+                        text = zero + suffix;
                     } else if (pctZero) {
                         text = fixedStr + suffix;
                     } else if (fixedZero) {


### PR DESCRIPTION
## Context

Two more nl_NL admin spots still hardcoded \`.\` after PRs #189 / #190 / #191:

1. **Surcharge Tax Rate input** — typing \`21,5\` was rejected by the
   \`validate-number\` validator. Even if accepted, no backend model meant
   the raw \`21,\` would land in \`core_config_data\` and \`(float)\` truncate
   it to 21.
2. **Inline fees** beside payment-term checkboxes (and surcharge grid
   Fee column) used \`Number(n).toFixed(2)\` → \`1.50\` regardless of locale.

## Changes

**Tax rate input**
- Drop \`validate-number\` from \`system.xml\` and
  \`brand_form_template.xml\` (\`validate-zero-or-greater\` already
  routes through locale-aware \`\$.mage.parseNumber\`).
- New \`Two\\Gateway\\Model\\Config\\Backend\\LocaleDecimal\` —
  generic scalar backend model that normalises comma → period in
  \`beforeSave()\`. Wired as \`backend_model\` for \`surcharge_tax_rate\`.
- \`SurchargeTaxRate\` block locale-formats the loaded element value
  before \`parent::_getElementHtml()\` emits the input.

**Inline fees JS**
- \`payment-terms-config.js\` and \`surcharge-grid.js\` now read a new
  \`data-decimal-separator\` attribute on the container and rewrite
  \`.\` → admin locale's separator after \`toFixed\`.

**Refactor**
- Three blocks (\`SurchargeGrid\`, \`SurchargeTaxRate\`,
  \`PaymentTermsCheckboxes\`) all wanted the same ICU lookup. Extracted
  to \`Two\\Gateway\\Service\\Locale\\AdminDecimalFormatter\` and
  injected into each, replacing the duplicated private helpers from
  #190 and #191.

## Scope / Non-goals

- Storage stays canonical period-decimal.
- API/serialisation paths in \`Service/Order\` and the
  \`Invoice/Creditmemo\` observers untouched.

## Validation

- Pre-fix in nl_NL admin: typing \`21,5\` in Surcharge Tax Rate
  triggers \"Please enter a valid number\"; inline fees render as
  \`(1.50% + 0.50 EUR)\`.
- After deploy, expect: \`21,5\` accepted, saved as canonical
  \`21.5\`, reloaded as \`21,5\`; inline fees render as
  \`(1,50% + 0,50 EUR)\`.

## Ticket

- <https://linear.app/tillit/issue/ABN-433>