### PR TITLE
ABN-436/fix: locale-format Luma term-tile surcharge labels

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -15,6 +15,7 @@ define([
     'Magento_Checkout/js/model/full-screen-loader',
     'Magento_Checkout/js/action/redirect-on-success',
     'mage/url',
+    'Magento_Catalog/js/price-utils',
     'Two_Gateway/js/model/surcharge',
     'Two_Gateway/js/model/brand-config',
     'Magento_Ui/js/lib/view/utils/async',
@@ -32,6 +33,7 @@ define([
     fullScreenLoader,
     redirectOnSuccessAction,
     url,
+    priceUtils,
     surchargeModel,
     getBrandConfig
 ) {
@@ -120,11 +122,10 @@ define([
                 if (amount < 0.005) {
                     return '';
                 }
-                return '+' + surchargeModel.currencySymbol + amount.toFixed(2);
+                return '+' + priceUtils.formatPrice(amount, quote.getPriceFormat());
             });
             this.termOptions = ko.pureComputed(function () {
                 var surcharges = surchargeModel.termSurcharges();
-                var symbol = surchargeModel.currencySymbol;
                 var isLoading = !surcharges || !Object.keys(surcharges).length;
                 var amounts = terms.map(function (days) {
                     return parseFloat(surcharges[days] || 0);
@@ -135,7 +136,7 @@ define([
                         days: days,
                         daysLabel: days + ' ' + $t('days'),
                         isLoading: isLoading,
-                        surchargeLabel: (isLoading || allZero) ? '' : '+' + symbol + amounts[i].toFixed(2)
+                        surchargeLabel: (isLoading || allZero) ? '' : '+' + priceUtils.formatPrice(amounts[i], quote.getPriceFormat())
                     };
                 });
             });


### PR DESCRIPTION
## Context

On the Luma checkout (`/default/checkout/`) under an nl_NL store view (ABN brand), the payment-term tile surcharge labels render with a period decimal — `+€7.61` — while everything else on the same page uses the Dutch comma (`€ 7,61`, `€ 0,00`, `€ 9.999,99`). The Hyva equivalent was already fixed under ABN-433 (PRs #190/#191/#192); the Luma path was missed and stayed locale-blind.

Found during the ABN-401 cycle. See ABN-436 for the full repro.

## Changes

- `view/frontend/web/js/view/payment/method-renderer/gateway_method.js`:
  - Add `Magento_Catalog/js/price-utils` to the RequireJS define
  - Route both tile label sites (`singleTermSurchargeLabel`, `termOptions.surchargeLabel`) through `priceUtils.formatPrice(amount, quote.getPriceFormat())` instead of the bare `toFixed(2)` + `currencySymbol` concat
  - Drop the now-unused `symbol` local

This is the same canonical formatter the surrounding summary surcharge line and shipping/totals already use (via `abstract-total.getFormattedPrice`).

## Scope / Non-goals

- Not touched: the JSON payload constructors lower in the file (`gross_amount`/`net_amount`/`tax_amount` `.toFixed(2)` calls). Those are API transport — must stay period-decimal.
- Not touched: Hyva equivalents (already fixed by ABN-433 family).
- Not touched: `surchargeModel.currencySymbol` itself (still consumed by other paths if any; not removed defensively).

## Validation

- Two brand Luma under en_GB: tile labels render `+£0.51` (no change — period decimal already correct).
- ABN brand Luma under nl_NL: tile labels render `+€ 7,61` after deploy, matching surcharge line + summary.
- Single-term layout under nl_NL also locale-correct (line 123 site).

## Ticket

- https://linear.app/tillit/issue/ABN-436

🤖 Generated with [Claude Code](https://claude.com/claude-code)