### PR TITLE
ABN-440/fix: gate surcharge grid on effective type, not inherit state

### DIFF
--- a/view/adminhtml/web/js/payment-terms-config.js
+++ b/view/adminhtml/web/js/payment-terms-config.js
@@ -44,10 +44,12 @@ define(['jquery', 'mage/translate', 'domReady!'], function ($, $t) {
         }
 
         function getSurchargeType() {
-            var $inherit = $('#' + prefix + 'surcharge_type_inherit');
-            if ($inherit.length && $inherit.is(':checked')) {
-                return 'none';
-            }
+            // Effective (resolved) type, scope-aware. When the type field's
+            // "Use Website/Default" is ticked the <select> is disabled but
+            // still carries the inherited value, so read it directly. An
+            // inherited Percentage type must still surface the surcharge
+            // fields; returning 'none' on inherit (the old behaviour) hid
+            // them at store scope (ABN-440).
             return $surchargeType.val() || 'none';
         }
 

--- a/view/adminhtml/web/js/surcharge-grid.js
+++ b/view/adminhtml/web/js/surcharge-grid.js
@@ -65,10 +65,13 @@ define(['jquery', 'mage/translate', 'domReady!'], function ($, $t) {
         }
 
         function getSurchargeType() {
-            var $inherit = $('#' + prefix + 'surcharge_type_inherit');
-            if ($inherit.length && $inherit.is(':checked')) {
-                return 'none';
-            }
+            // Effective (resolved) type, scope-aware. When the type field's
+            // "Use Website/Default" is ticked the <select> is disabled but
+            // still carries the inherited value, so read it directly. An
+            // inherited Percentage type must still render the grid; returning
+            // 'none' on inherit (the old behaviour) hid the grid at store
+            // scope and stranded any store-scope override out of sight
+            // (ABN-440).
             return $surchargeType.val() || 'none';
         }
 


### PR DESCRIPTION
## Context

ABN-440: on Hyva checkout, the 60-day buyer surcharge showed €0.84 while Luma showed €2.30 for the same €1188 cart. Investigation (checkout-api logs, two-beta staging) proved:

- The pricing API is correct — `5.5% × fee / (1−feerate)` grosses up to €2.30; €0.84 is the API's correct answer for `percentage: 2`.
- The Hyva storefront runs on store view `store_id=2` (`hyva`), which carries a **stale `stores/2 surcharge_60_percentage = 2.00`** override; Luma runs on `store_id=1` reading the default `5.5`.
- That override is **invisible in the admin grid** but **live at runtime** — because the grid is hidden whenever the Toeslagmethode field inherits ("Use Website"), even though the effective type is Percentage.

Root cause of the invisibility: `getSurchargeType()` returned `'none'` when the type field's inherit checkbox was ticked, so `updateContainerVisibility()` hid the whole grid.

## Changes

- `view/adminhtml/web/js/surcharge-grid.js` and `view/adminhtml/web/js/payment-terms-config.js`: `getSurchargeType()` now returns the effective type from the `<select>` (which carries the inherited value even when disabled), instead of short-circuiting to `'none'` on inherit.

Result: an inherited Percentage type renders the grid, which shows the actual store-scope value with each cell's "Use Website" checkbox reflecting whether an override exists (`isInherited`).

## Scope / Non-goals

- **Render-side visibility only.** This deliberately does NOT change save behaviour or auto-correct the stale data — the point is to make the override *visible* first.
- Save-side hardening (purge orphaned `surcharge_NN_*` rows when the grid is inherited at a scope) and the `isInherited()` value-equality smell are left for a follow-up.
- Hyva subtitle text fix is a separate PR (magento-hyva-extension #35).

## Validation

- `npx jest --config Test/Js/jest.config.js` → **28 passed**. The AMD-in-Jest harness stubs jQuery as a no-op, so both DOM modules early-return under it (load-only smoke tests); no behavioural JS unit test is feasible without building a faithful jQuery mock — disproportionate for a 2-line resolver change.
- **Behavioural acceptance: browser check on staging** — on Hyva Checkout (store 2) scope, abn_payment surcharge section, the grid is now visible and shows the real `2%` with "Use Website" unticked (override exposed, not auto-fixed).

## Ticket

- https://linear.app/tillit/issue/ABN-440