### PR TITLE
ABN-440/fix: surcharge grid scope resolution + grid-level inherit

### DIFF
--- a/Block/Adminhtml/System/Config/Field/SurchargeGrid.php
+++ b/Block/Adminhtml/System/Config/Field/SurchargeGrid.php
@@ -10,6 +10,7 @@ namespace Two\Gateway\Block\Adminhtml\System\Config\Field;
 use Magento\Backend\Block\Template\Context;
 use Magento\Config\Block\System\Config\Form\Field;
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Data\Form\Element\AbstractElement;
 use Magento\Store\Model\StoreManagerInterface;
 use Two\Gateway\Api\BrandRegistryInterface;
@@ -44,6 +45,9 @@ class SurchargeGrid extends Field
     /** @var AdminDecimalFormatter */
     private $decimalFormatter;
 
+    /** @var ResourceConnection */
+    private $resource;
+
     /** @var string */
     private $scope = 'default';
 
@@ -57,6 +61,7 @@ class SurchargeGrid extends Field
         CurrencyRatesProviderInterface $ratesProvider,
         BrandRegistryInterface $brandRegistry,
         AdminDecimalFormatter $decimalFormatter,
+        ResourceConnection $resource,
         array $data = []
     ) {
         parent::__construct($context, $data);
@@ -65,6 +70,7 @@ class SurchargeGrid extends Field
         $this->ratesProvider = $ratesProvider;
         $this->brandRegistry = $brandRegistry;
         $this->decimalFormatter = $decimalFormatter;
+        $this->resource = $resource;
     }
 
     /**
@@ -343,29 +349,44 @@ class SurchargeGrid extends Field
     }
 
     /**
-     * Get the "inherit" checkbox name for scope override.
+     * Name of the hidden grid-level "inherit" sentinel posted with the
+     * grid value. Nested under [value] (not Magento's native [inherit])
+     * on purpose: keeping it inside the value array means the backend
+     * model's afterSave() always runs, so it can purge the per-term rows
+     * itself. Magento's native field [inherit] flag would instead delete
+     * the synthetic surcharge_grid path and skip the backend, leaving the
+     * flat surcharge_NN_* rows orphaned (the ABN-440 root cause).
      */
-    public function getInheritName(int $days, string $field): string
+    public function getInheritFieldName(): string
     {
-        return sprintf(
-            'groups[payment_terms][fields][surcharge_grid][inherit][%d][%s]',
-            $days,
-            $field
-        );
+        return 'groups[payment_terms][fields][surcharge_grid][value][__inherit]';
     }
 
     /**
-     * Check if a field is using the inherited (default/website) value at current scope.
+     * Whether an explicit surcharge override exists at the current scope.
+     *
+     * Tests for the presence of a stored per-term cell row
+     * (surcharge_{days}_{fixed|percentage|limit}) rather than comparing
+     * resolved values against the parent scope — value-equality can't
+     * tell "no override" from "override that happens to equal the
+     * parent", and it can't see an orphaned row whose value matches.
+     * Drives the grid-level "Use Website/Default" checkbox: checked
+     * (inheriting) when no override row exists.
      */
-    public function isInherited(int $days, string $field): bool
+    public function hasScopeOverride(): bool
     {
         if ($this->scope === 'default') {
             return false;
         }
-        $path = $this->path(sprintf('surcharge_%d_%s', $days, $field));
-        $value = $this->scopeConfig->getValue($path, $this->scope, $this->scopeId);
-        $defaultValue = $this->scopeConfig->getValue($path);
-        return $value === $defaultValue;
+        $conn = $this->resource->getConnection();
+        $select = $conn->select()
+            ->from($conn->getTableName('core_config_data'), 'config_id')
+            ->where('scope = ?', $this->scope)
+            ->where('scope_id = ?', $this->scopeId)
+            ->where('path LIKE ?', 'payment/' . $this->methodCode() . '/surcharge%')
+            ->where('path REGEXP ?', 'surcharge_[0-9]+_(fixed|percentage|limit)$')
+            ->limit(1);
+        return (bool)$conn->fetchOne($select);
     }
 
     /**
@@ -417,14 +438,46 @@ class SurchargeGrid extends Field
         return $this->decimalFormatter->getSeparator();
     }
 
+    /**
+     * Resolve the config scope of the page being rendered.
+     *
+     * Reads the canonical `store` / `website` request params (the same
+     * source Magento's config save pipeline uses to scope writes) and
+     * normalises them through StoreManager so a code *or* an id both
+     * resolve. The previous implementation read $element->getForm()->
+     * getScope(), but the Data\Form object never carries scope, so it
+     * always fell back to 'default' — the grid then rendered default-
+     * scope values at every scope and never surfaced store/website
+     * overrides (ABN-440).
+     */
     private function resolveScope(AbstractElement $element): void
     {
-        $form = $element->getForm();
-        if ($form) {
-            $scope = (string)$form->getScope();
-            $this->scope = ($scope !== '') ? $scope : 'default';
-            $this->scopeId = (int)$form->getScopeId();
+        $request = $this->getRequest();
+        $store = $request->getParam('store');
+        $website = $request->getParam('website');
+
+        if ($store !== null && $store !== '') {
+            try {
+                $this->scope = 'stores';
+                $this->scopeId = (int)$this->storeManager->getStore($store)->getId();
+                return;
+            } catch (\Exception $e) {
+                // fall through to default
+            }
         }
+
+        if ($website !== null && $website !== '') {
+            try {
+                $this->scope = 'websites';
+                $this->scopeId = (int)$this->storeManager->getWebsite($website)->getId();
+                return;
+            } catch (\Exception $e) {
+                // fall through to default
+            }
+        }
+
+        $this->scope = 'default';
+        $this->scopeId = 0;
     }
 
     private function getConfigValue(string $path)

--- a/Model/Config/Backend/SurchargeGrid.php
+++ b/Model/Config/Backend/SurchargeGrid.php
@@ -10,6 +10,7 @@ namespace Two\Gateway\Model\Config\Backend;
 use Magento\Framework\App\Config\Value;
 use Magento\Framework\App\Config\Storage\WriterInterface;
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Model\Context;
 use Magento\Framework\Registry;
@@ -44,6 +45,9 @@ class SurchargeGrid extends Value
     /** @var BrandRegistryInterface */
     private $brandRegistry;
 
+    /** @var ResourceConnection */
+    private $resourceConnection;
+
     public function __construct(
         Context $context,
         Registry $registry,
@@ -53,6 +57,7 @@ class SurchargeGrid extends Value
         StoreManagerInterface $storeManager,
         CurrencyRatesProviderInterface $ratesProvider,
         BrandRegistryInterface $brandRegistry,
+        ResourceConnection $resourceConnection,
         ?AbstractResource $resource = null,
         ?AbstractDb $resourceCollection = null,
         array $data = []
@@ -62,6 +67,7 @@ class SurchargeGrid extends Value
         $this->storeManager = $storeManager;
         $this->ratesProvider = $ratesProvider;
         $this->brandRegistry = $brandRegistry;
+        $this->resourceConnection = $resourceConnection;
     }
 
     /**
@@ -100,13 +106,21 @@ class SurchargeGrid extends Value
             return parent::afterSave();
         }
 
-        $inheritData = [];
-        if (isset($groups['payment_terms']['fields']['surcharge_grid']['inherit'])) {
-            $inheritData = $groups['payment_terms']['fields']['surcharge_grid']['inherit'];
-        }
-
         $scope = $this->getScope();
         $scopeId = (int)$this->getScopeId();
+
+        // Grid-level "Use Website/Default": a single checkbox inherits the
+        // whole grid. Purge every per-term cell row at this scope so none
+        // is left orphaned — invisible to the admin grid but still read at
+        // runtime, which is the ABN-440 root cause. The flag rides inside
+        // [value] (not Magento's native [inherit]) so this afterSave still
+        // runs and can do the purge itself.
+        if (!empty($gridValues['__inherit'])) {
+            $this->deleteScopeCells($scope, $scopeId);
+            return parent::afterSave();
+        }
+        unset($gridValues['__inherit']);
+
         $maxFixed = $this->getConvertedFixedMax($scope, $scopeId);
         $maxPercentage = ConfigRepository::SURCHARGE_PERCENTAGE_MAX;
 
@@ -122,11 +136,6 @@ class SurchargeGrid extends Value
                 }
 
                 $path = sprintf('payment/%s/surcharge_%d_%s', $this->methodCode(), $days, $type);
-
-                if (isset($inheritData[$days][$type]) && $inheritData[$days][$type]) {
-                    $this->configWriter->delete($path, $scope, $scopeId);
-                    continue;
-                }
 
                 $value = (string)$value;
                 if ($value === '') {
@@ -158,6 +167,29 @@ class SurchargeGrid extends Value
         );
 
         return parent::afterSave();
+    }
+
+    /**
+     * Delete every per-term surcharge cell row plus the base-currency
+     * marker at the given scope. Used when the grid inherits, so an
+     * inherited grid leaves no orphaned surcharge_* override behind.
+     */
+    private function deleteScopeCells(string $scope, int $scopeId): void
+    {
+        $conn = $this->resourceConnection->getConnection();
+        $method = $this->methodCode();
+        $paths = $conn->fetchCol(
+            $conn->select()
+                ->from($conn->getTableName('core_config_data'), 'path')
+                ->where('scope = ?', $scope)
+                ->where('scope_id = ?', $scopeId)
+                ->where('path LIKE ?', 'payment/' . $method . '/surcharge%')
+                ->where('path REGEXP ?', 'surcharge_[0-9]+_(fixed|percentage|limit)$')
+        );
+        $paths[] = sprintf('payment/%s/surcharge_fixed_currency', $method);
+        foreach (array_unique($paths) as $path) {
+            $this->configWriter->delete($path, $scope, $scopeId);
+        }
     }
 
     /**

--- a/Test/Unit/Model/Config/Backend/SurchargeGridTest.php
+++ b/Test/Unit/Model/Config/Backend/SurchargeGridTest.php
@@ -84,23 +84,17 @@ class SurchargeGridTest extends TestCase
         $this->assertEquals(['payment/two_payment/surcharge_30_percentage'], $saved);
     }
 
-    public function testInheritFlagDeletesConfig(): void
+    public function testInheritFlagPurgesAllScopeOverrides(): void
     {
+        // Grid-level inherit: the __inherit sentinel rides inside the value
+        // array. Every per-term cell row plus the currency marker is purged
+        // at this scope, and nothing is written (the grid inherits the
+        // parent). This is the ABN-440 fix — no orphaned override survives.
         $this->model->setTestValue([
+            '__inherit' => '1',
             30 => ['fixed' => '10', 'percentage' => '25', 'limit' => '50'],
         ]);
         $this->model->setTestScope('websites', 1);
-        $this->model->setTestGroups([
-            'payment_terms' => [
-                'fields' => [
-                    'surcharge_grid' => [
-                        'inherit' => [
-                            30 => ['fixed' => '1', 'percentage' => '0', 'limit' => '1'],
-                        ],
-                    ],
-                ],
-            ],
-        ]);
 
         $deleted = [];
         $this->configWriter->method('delete')->willReturnCallback(
@@ -119,8 +113,10 @@ class SurchargeGridTest extends TestCase
         $this->model->callAfterSave();
 
         $this->assertContains('payment/two_payment/surcharge_30_fixed', $deleted);
+        $this->assertContains('payment/two_payment/surcharge_30_percentage', $deleted);
         $this->assertContains('payment/two_payment/surcharge_30_limit', $deleted);
-        $this->assertEquals(['payment/two_payment/surcharge_30_percentage'], $saved);
+        $this->assertContains('payment/two_payment/surcharge_fixed_currency', $deleted);
+        $this->assertEmpty($saved, 'an inheriting grid writes nothing at the scope');
     }
 
     public function testRejectsNegativeValue(): void
@@ -200,7 +196,6 @@ class SurchargeGridTestable
     private $value;
     private $scope = 'default';
     private $scopeId = 0;
-    private $groups = [];
 
     public function __construct(WriterInterface $configWriter)
     {
@@ -218,52 +213,64 @@ class SurchargeGridTestable
         $this->scopeId = $scopeId;
     }
 
-    public function setTestGroups(array $groups): void
-    {
-        $this->groups = $groups;
-    }
-
     public function callAfterSave(): void
     {
         if (!is_array($this->value)) {
             return;
         }
 
-        $inheritData = [];
-        if (isset($this->groups['payment_terms']['fields']['surcharge_grid']['inherit'])) {
-            $inheritData = $this->groups['payment_terms']['fields']['surcharge_grid']['inherit'];
+        $value = $this->value;
+
+        // Grid-level inherit: purge every per-term cell + currency marker
+        // at this scope, write nothing. Mirrors deleteScopeCells() (which
+        // in production queries core_config_data for the live rows).
+        if (!empty($value['__inherit'])) {
+            foreach ($value as $days => $fields) {
+                if ($days === '__inherit' || !is_array($fields)) {
+                    continue;
+                }
+                foreach (self::FIELDS as $type) {
+                    $this->configWriter->delete(
+                        sprintf('payment/two_payment/surcharge_%d_%s', (int)$days, $type),
+                        $this->scope,
+                        $this->scopeId
+                    );
+                }
+            }
+            $this->configWriter->delete(
+                'payment/two_payment/surcharge_fixed_currency',
+                $this->scope,
+                $this->scopeId
+            );
+            return;
         }
+        unset($value['__inherit']);
 
         // Hard-coded to the test brand's surcharge bound — see
         // BrandRegistryInterface::getSurchargeFixedMax().
         $maxFixed = 25;
         $maxPercentage = ConfigRepository::SURCHARGE_PERCENTAGE_MAX;
 
-        foreach ($this->value as $days => $fields) {
+        foreach ($value as $days => $fields) {
             if (!is_array($fields)) {
                 continue;
             }
             $days = (int)$days;
 
-            foreach ($fields as $type => $value) {
+            foreach ($fields as $type => $cellValue) {
                 if (!in_array($type, self::FIELDS, true)) {
                     continue;
                 }
 
                 $path = sprintf('payment/two_payment/surcharge_%d_%s', $days, $type);
 
-                if (isset($inheritData[$days][$type]) && $inheritData[$days][$type]) {
+                $cellValue = (string)$cellValue;
+                if ($cellValue === '') {
                     $this->configWriter->delete($path, $this->scope, $this->scopeId);
                     continue;
                 }
 
-                $value = (string)$value;
-                if ($value === '') {
-                    $this->configWriter->delete($path, $this->scope, $this->scopeId);
-                    continue;
-                }
-
-                $numericValue = (float)$value;
+                $numericValue = (float)$cellValue;
                 if ($numericValue < 0) {
                     throw new LocalizedException(
                         __('%1 days - %2: value cannot be negative.', $days, $type)
@@ -280,7 +287,7 @@ class SurchargeGridTestable
                     );
                 }
 
-                $this->configWriter->save($path, $value, $this->scope, $this->scopeId);
+                $this->configWriter->save($path, $cellValue, $this->scope, $this->scopeId);
             }
         }
     }

--- a/view/adminhtml/templates/system/config/field/surcharge-grid.phtml
+++ b/view/adminhtml/templates/system/config/field/surcharge-grid.phtml
@@ -11,6 +11,13 @@ $maxFixed = $block->getMaxFixed();
 $maxPercentage = $block->getMaxPercentage();
 $defaultTerm = $block->getDefaultTerm();
 $isNonDefault = $block->isNonDefaultScope();
+// One inherit control for the whole grid (not per-cell). Checked = the
+// grid inherits the parent scope; unchecked = the grid is overridden
+// here. hasScopeOverride() reflects whether an actual override row
+// exists, so the checkbox starts in the right state.
+$hasOverride  = $isNonDefault && $block->hasScopeOverride();
+$inheriting   = $isNonDefault && !$hasOverride;
+$inheritLabel = $block->getScope() === 'stores' ? __('Use Website Value') : __('Use Default Value');
 $surchargeType = $block->getSurchargeType();
 $currencyCode = $block->getBaseCurrencyCode();
 $columns = ['fixed', 'percentage', 'limit'];
@@ -38,6 +45,23 @@ $columnLabels = [
         <span><?= $block->escapeHtml(__('No payment terms selected. Select payment terms above to configure surcharges.')) ?></span>
     </p>
 
+    <?php if ($isNonDefault): ?>
+        <div class="surcharge-grid__inherit-control">
+            <label>
+                <input type="checkbox"
+                       class="surcharge-grid__inherit-toggle"
+                       <?= $inheriting ? 'checked="checked"' : '' ?>
+                />
+                <?= $block->escapeHtml($inheritLabel) ?>
+            </label>
+            <input type="hidden"
+                   name="<?= $block->escapeHtmlAttr($block->getInheritFieldName()) ?>"
+                   class="surcharge-grid__inherit-sentinel"
+                   value="<?= $inheriting ? '1' : '0' ?>"
+            />
+        </div>
+    <?php endif; ?>
+
     <table class="admin__table-secondary surcharge-grid" cellspacing="0" <?= empty($terms) ? 'style="display:none"' : '' ?>>
         <thead>
             <tr>
@@ -45,9 +69,6 @@ $columnLabels = [
                 <th class="surcharge-grid__fixed"><?= $block->escapeHtml($columnLabels['fixed']) ?></th>
                 <th class="surcharge-grid__percentage"><?= $block->escapeHtml($columnLabels['percentage']) ?></th>
                 <th class="surcharge-grid__limit"><?= $block->escapeHtml($columnLabels['limit']) ?></th>
-                <?php if ($isNonDefault): ?>
-                    <th class="surcharge-grid__inherit"><?= $block->escapeHtml(__('Use Default')) ?></th>
-                <?php endif; ?>
             </tr>
         </thead>
         <tbody>
@@ -64,8 +85,6 @@ $columnLabels = [
                         <?php
                         $value = $block->getSavedValue($days, $col);
                         $name = $block->getFieldName($days, $col);
-                        $inheritName = $block->getInheritName($days, $col);
-                        $inherited = $isNonDefault && $block->isInherited($days, $col);
                         $max = ($col === 'fixed') ? $maxFixed : (($col === 'percentage') ? $maxPercentage : null);
                         // validate-number is intentionally NOT in this list.
                         // Its regex is locale-blind (period-only) and would
@@ -93,35 +112,10 @@ $columnLabels = [
                                    data-column="<?= $col ?>"
                                    data-term="<?= (int)$days ?>"
                                    data-validate='{<?= $block->escapeHtmlAttr(implode(',', $validateRules)) ?>}'
-                                   <?= $inherited ? 'disabled="disabled"' : '' ?>
+                                   <?= $inheriting ? 'disabled="disabled"' : '' ?>
                             />
-                            <?php if ($isNonDefault): ?>
-                                <input type="hidden"
-                                       name="<?= $block->escapeHtmlAttr($inheritName) ?>"
-                                       value="<?= $inherited ? '1' : '0' ?>"
-                                       class="surcharge-grid__inherit-flag"
-                                       data-column="<?= $col ?>"
-                                       data-term="<?= (int)$days ?>"
-                                />
-                            <?php endif; ?>
                         </td>
                     <?php endforeach; ?>
-                    <?php if ($isNonDefault): ?>
-                        <td class="surcharge-grid__inherit">
-                            <?php foreach ($columns as $col): ?>
-                                <?php $inherited = $block->isInherited($days, $col); ?>
-                                <label class="surcharge-grid__inherit-label">
-                                    <input type="checkbox"
-                                           class="surcharge-grid__inherit-checkbox"
-                                           data-column="<?= $col ?>"
-                                           data-term="<?= (int)$days ?>"
-                                           <?= $inherited ? 'checked="checked"' : '' ?>
-                                    />
-                                    <?= $block->escapeHtml($columnLabels[$col]) ?>
-                                </label>
-                            <?php endforeach; ?>
-                        </td>
-                    <?php endif; ?>
                 </tr>
             <?php endforeach; ?>
         </tbody>

--- a/view/adminhtml/web/js/surcharge-grid.js
+++ b/view/adminhtml/web/js/surcharge-grid.js
@@ -34,6 +34,10 @@ define(['jquery', 'mage/translate', 'domReady!'], function ($, $t) {
         var $table = $container.find('.surcharge-grid');
         var $noTermsMsg = $container.find('.surcharge-grid__no-terms');
         var $currencyNote = $container.find('.surcharge-grid__currency-note');
+        // Grid-level inherit ("Use Website/Default"). Present only at a
+        // non-default scope; absent at default scope.
+        var $inheritToggle = $container.find('.surcharge-grid__inherit-toggle');
+        var $inheritSentinel = $container.find('.surcharge-grid__inherit-sentinel');
         // maxFixed === null when the brand has no upper bound on fixed-fee
         // surcharges. Template emits `data-max-fixed=""` in that case;
         // parseInt('', 10) is NaN, so we explicitly track "no bound" and
@@ -233,22 +237,24 @@ define(['jquery', 'mage/translate', 'domReady!'], function ($, $t) {
             $container.closest('tr').toggle(hasSurcharge);
         }
 
-        // ── Inherit checkboxes ───────────────────────────────────────────
+        // ── Grid-level inherit ("Use Website/Default") ─────────────────────
 
-        function initInheritCheckboxes() {
-            $container.on('change', '.surcharge-grid__inherit-checkbox', function () {
-                var $cb = $(this);
-                var col = $cb.data('column');
-                var term = $cb.data('term');
-                var inherited = $cb.is(':checked');
-                var $row = $container.find('.surcharge-grid__row[data-term="' + term + '"]');
-
-                var $input = $row.find('.surcharge-grid__input[data-column="' + col + '"]');
-                $input.prop('disabled', inherited).data('inherit-disabled', inherited);
-
-                var $flag = $row.find('.surcharge-grid__inherit-flag[data-column="' + col + '"]');
-                $flag.val(inherited ? '1' : '0');
-            });
+        // One checkbox inherits or overrides the whole grid. Checked →
+        // the grid inherits the parent scope: all inputs disabled and the
+        // hidden sentinel posts '1' so the backend purges every per-term
+        // override row at this scope. Unchecked → editable override, and
+        // the differential rule reapplies (it owns the default-term row).
+        function applyGridInherit() {
+            if (!$inheritToggle.length) {
+                return; // default scope — no inherit control rendered
+            }
+            var inherit = $inheritToggle.is(':checked');
+            $inheritSentinel.val(inherit ? '1' : '0');
+            $container.find('.surcharge-grid__input').prop('disabled', inherit);
+            $table.toggleClass('surcharge-grid--inherited', inherit);
+            if (!inherit) {
+                updateDifferentialState();
+            }
         }
 
         // ── Master update ────────────────────────────────────────────────
@@ -259,6 +265,10 @@ define(['jquery', 'mage/translate', 'domReady!'], function ($, $t) {
             updateColumnVisibility();
             updateDifferentialState();
             updateHelperText();
+            // Last: grid-level inherit has final say on input disabled
+            // state, overriding column/differential toggles when the whole
+            // grid is inheriting.
+            applyGridInherit();
             // Fee-preview column removed (ABN-356 / ABN-401-F12); skip the
             // loadFees() AJAX whose response would have no cells to populate.
         }
@@ -271,6 +281,7 @@ define(['jquery', 'mage/translate', 'domReady!'], function ($, $t) {
         $differential.on('change', update);
         $defaultTerm.on('change', update);
         $('#' + prefix + 'surcharge_type_inherit').on('change', update);
+        $inheritToggle.on('change', applyGridInherit);
 
         // ── Fee column (read-only, fetched from Two API via admin proxy) ─
 
@@ -281,7 +292,6 @@ define(['jquery', 'mage/translate', 'domReady!'], function ($, $t) {
         // loadFees() writes during init.
         var lastFeesKey = null;
 
-        initInheritCheckboxes();
         update();
 
         function loadFees() {


### PR DESCRIPTION
## Context

Follow-up to #194. While verifying the visibility fix in the browser, we found two deeper bugs in the surcharge grid at non-default (store/website) scope:

1. **Scope resolution (display).** `SurchargeGrid` block read `$element->getForm()->getScope()`; the `Data\Form` never carries scope, so it always fell back to `'default'`. The grid rendered default-scope values at *every* scope and never surfaced store/website overrides — while the runtime `ConfigRepository` read the real store row. That's the whole ABN-440 mystery: Hyva store view (`store_id=2`) had a stale `surcharge_60_percentage=2.00` (checkout €0.84) while admin + Luma showed `5.5` (€2.30).
2. **Grid-level inherit (management).** Per-cell inherit checkboxes, and a whole-field inherit left the flat `surcharge_NN_*` rows orphaned (the recurring scope-drift). Replaced with one "Use Website/Default" checkbox for the whole grid.

## Changes

- **`Block/.../SurchargeGrid.php`**: `resolveScope()` reads the canonical `store`/`website` request params via `StoreManager`. Adds `hasScopeOverride()` (row-existence check, not the old value-equality `isInherited()`) to drive the checkbox state. Drops `isInherited()` / `getInheritName()`.
- **`view/.../surcharge-grid.phtml`**: single grid-level inherit control + a hidden `__inherit` sentinel nested inside `[value]`; per-cell checkboxes/flags removed; inputs disabled when inheriting.
- **`view/.../surcharge-grid.js`**: toggle disables/enables the whole grid and sets the sentinel; per-cell inherit handling removed.
- **`Model/Config/Backend/SurchargeGrid.php`**: `afterSave()` — `__inherit` set → `deleteScopeCells()` purges every per-term cell row + currency marker at the scope; else writes all cells. Fixes the early-return-leaves-orphan path.

### Why the sentinel lives inside `[value]`

Magento's native field `[inherit]` flag would delete the synthetic `surcharge_grid` path and **skip** the backend model, leaving the flat `surcharge_NN_*` rows orphaned. Nesting `__inherit` inside `[value]` keeps `afterSave()` running so it can purge them.

## Scope / Non-goals

- Builds on #194 (visibility gate). Hyva subtitle text is separate (hyva-extension #35).

## Validation

- `npx jest --config Test/Js/jest.config.js` → **28 passed**.
- Backend unit test updated to the grid-level contract (inherit purges all cells incl. percentage + currency; writes nothing). `php -l` clean on all changed files.
- **Browser acceptance on staging**: at Hyva Checkout (store 2) scope the grid shows the real `2,00` with the grid-level "Use Website" unticked; ticking + save inherits `5,5`; checkout → €2.30.

## Ticket

- https://linear.app/tillit/issue/ABN-440