### PR TITLE
ABN-440/feat: brand-supplied checkout subtitle (vanilla renders none)

### DIFF
--- a/Api/BrandRegistryInterface.php
+++ b/Api/BrandRegistryInterface.php
@@ -70,6 +70,15 @@ interface BrandRegistryInterface
     public function getBrandTag(): string;
 
     /**
+     * i18n source key for the checkout payment-method subtitle, or '' when
+     * the brand defines none. The vanilla Two brand returns ''; brand
+     * overlays supply one via <checkout_subtitle> in brand.xml. Renderers
+     * must treat '' as "no subtitle" and never pass it to the translator,
+     * so an unmapped key can never leak into the storefront.
+     */
+    public function getCheckoutSubtitle(): string;
+
+    /**
      * Merchant sign-up URL shown on the admin config header block.
      */
     public function getSignUpUrl(): string;

--- a/Brand/DescriptorBackedBrandRegistry.php
+++ b/Brand/DescriptorBackedBrandRegistry.php
@@ -71,6 +71,11 @@ class DescriptorBackedBrandRegistry implements BrandRegistryInterface
         return $this->activeBrandResolver->resolve()->getBrandTag();
     }
 
+    public function getCheckoutSubtitle(): string
+    {
+        return $this->activeBrandResolver->resolve()->getCheckoutSubtitle();
+    }
+
     public function getCode(): string
     {
         return $this->activeBrandResolver->resolve()->getCode();

--- a/Model/Brand.php
+++ b/Model/Brand.php
@@ -44,6 +44,8 @@ class Brand implements BrandRegistryInterface
     private $documentationUrl;
     /** @var string */
     private $brandTag;
+    /** @var string */
+    private $checkoutSubtitle;
 
     /**
      * @param int[] $availablePaymentTerms
@@ -58,7 +60,8 @@ class Brand implements BrandRegistryInterface
         ?array $surchargeFixedMax = null,
         string $signUpUrl = '',
         string $documentationUrl = '',
-        string $brandTag = ''
+        string $brandTag = '',
+        string $checkoutSubtitle = ''
     ) {
         $this->provider = $provider;
         $this->providerFullName = $providerFullName;
@@ -69,6 +72,7 @@ class Brand implements BrandRegistryInterface
         $this->signUpUrl = $signUpUrl;
         $this->documentationUrl = $documentationUrl;
         $this->brandTag = $brandTag;
+        $this->checkoutSubtitle = $checkoutSubtitle;
     }
 
     public function getProvider(): string
@@ -114,6 +118,11 @@ class Brand implements BrandRegistryInterface
     public function getBrandTag(): string
     {
         return $this->brandTag;
+    }
+
+    public function getCheckoutSubtitle(): string
+    {
+        return $this->checkoutSubtitle;
     }
 
     /**

--- a/Model/Brand/Descriptor.php
+++ b/Model/Brand/Descriptor.php
@@ -69,7 +69,8 @@ final class Descriptor
         private readonly array $allowedCountries,
         private readonly array $extraHttpHeaders,
         private readonly array $suppressedFields = [],
-        private readonly bool $inlineTermFees = true
+        private readonly bool $inlineTermFees = true,
+        private readonly string $checkoutSubtitle = ''
     ) {
     }
 
@@ -161,6 +162,18 @@ final class Descriptor
     public function getBrandTag(): string
     {
         return $this->brandTag;
+    }
+
+    /**
+     * i18n source key for the checkout payment-method subtitle, or '' when
+     * the brand defines none. The vanilla Two brand returns ''; brand
+     * overlays set <checkout_subtitle> in brand.xml. Empty means the
+     * renderers emit no subtitle text — the key is never passed to the
+     * translator, so no untranslated key can leak into the storefront.
+     */
+    public function getCheckoutSubtitle(): string
+    {
+        return $this->checkoutSubtitle;
     }
 
     public function getSignUpUrl(): string

--- a/Model/Brand/Loader.php
+++ b/Model/Brand/Loader.php
@@ -188,7 +188,8 @@ class Loader
             $allowedCountries,
             $extraHttpHeaders,
             $suppressedFields,
-            $inlineTermFees
+            $inlineTermFees,
+            (string)($brand->checkout_subtitle ?? '')
         );
     }
 }

--- a/Model/Ui/ConfigProvider.php
+++ b/Model/Ui/ConfigProvider.php
@@ -143,6 +143,7 @@ class ConfigProvider implements ConfigProviderInterface
                     'selectedPaymentTerm' => (int)$this->checkoutSession->getTwoSelectedTerm()
                         ?: $this->configRepository->getDefaultPaymentTerm(),
                     'currencySymbol' => $this->getCurrencySymbol(),
+                    'subtitleHtml' => $this->getSubtitleHtml(),
                     'surchargeDescription' => $this->configRepository->getSurchargeLineDescription(),
                     'isPaymentTermsEnabled' => true,
                     'orderIntentApprovedMessage' => __(
@@ -186,6 +187,22 @@ class ConfigProvider implements ConfigProviderInterface
         } catch (\Exception $e) {
             return '';
         }
+    }
+
+    /**
+     * Resolve the brand's checkout subtitle for the storefront renderer.
+     *
+     * The string is brand data (BrandRegistryInterface::getCheckoutSubtitle,
+     * sourced from brand.xml). The vanilla Two brand returns '' → no
+     * subtitle. We only pass a non-empty key to the translator, so an
+     * unmapped locale falls back to the (brand-owned) source key rather
+     * than ever leaking a vanilla key. May contain HTML (e.g. a link);
+     * the KO template binds it via `html:`.
+     */
+    private function getSubtitleHtml(): string
+    {
+        $key = $this->brandRegistry->getCheckoutSubtitle();
+        return $key === '' ? '' : (string)__($key);
     }
 
     /**

--- a/etc/brand.xsd
+++ b/etc/brand.xsd
@@ -29,6 +29,7 @@
             <xs:element name="product_name" type="xs:string"/>
             <xs:element name="tab_label" type="xs:string"/>
             <xs:element name="tab_css_class" type="xs:string" minOccurs="0"/>
+            <xs:element name="checkout_subtitle" type="xs:string" minOccurs="0"/>
             <xs:element name="checkout_url_template" type="xs:string"/>
             <xs:element name="brand_tag" type="xs:string" minOccurs="0"/>
             <xs:element name="sign_up_url" type="xs:string" minOccurs="0"/>

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -46,7 +46,11 @@ define([
             template: 'Two_Gateway/payment/gateway_method'
         },
         redirectAfterPlaceOrder: false,
-        twoSubtitleHtml: $t('For all companies.'),
+        // Brand-supplied checkout subtitle; populated in initialize() from
+        // the brand's checkoutConfig subtree. Empty ('') for the vanilla
+        // Two brand → the template renders no subtitle text. Brand overlays
+        // (ABN, …) supply the string + its translations.
+        twoSubtitleHtml: '',
         isPaymentTermsAccepted: ko.observable(false),
         soleTraderCountryCodes: ['gb'],
         formSelector: 'form#two_gateway_form',
@@ -84,6 +88,7 @@ define([
             this._brandConfig = getBrandConfig(this.getCode());
             var config = this._brandConfig;
 
+            this.twoSubtitleHtml = config.subtitleHtml || '';
             this.paymentTermsMessage = config.paymentTermsMessage;
             this.termsNotAcceptedMessage = config.termsNotAcceptedMessage;
             this.isPaymentTermsEnabled = config.isPaymentTermsEnabled;


### PR DESCRIPTION
## Context

Follow-up to #194/#195. The Luma payment renderer hardcoded `$t('For all companies.')` as the subtitle under the payment title — an **ABN-specific string baked into the vanilla repo**, which also rendered under the vanilla "Two – Buy Now Pay Later…" caption. Subtitle text must be brand data: empty for vanilla Two, supplied + translated by a brand overlay.

## Changes

- **`etc/brand.xsd`**: new optional `<checkout_subtitle>` element (an i18n *source key*).
- **`Descriptor` / `Loader` / `BrandRegistryInterface` / `DescriptorBackedBrandRegistry` / `Model\Brand`**: `getCheckoutSubtitle()`, defaulting to `''`.
- **Luma `ConfigProvider`**: exposes `subtitleHtml` — `__()`'d **only when non-empty**, so an unmapped locale falls back to the brand-owned source key, never a vanilla key.
- **`gateway_method.js`**: reads `config.subtitleHtml` in `initialize()` instead of the hardcoded literal.

Vanilla Two now renders an **empty** subtitle (element present, no text). Brand overlays set `<checkout_subtitle>` and own translations.

## Why source-key-from-brand beats per-language blanking

The translator only leaks a key when one is *passed* and a locale lacks a mapping. Here vanilla passes `''` → `__()` is never called → nothing to leak. Only the brand that supplies a key (ABN) renders it, and falling back to its English source for an unmapped locale is correct.

## Scope / Non-goals

- Part 1 of 3 (parent). ABN brand.xml node + Hyva consumption land in `magento-abn-plugin` and `magento-hyva-extension`. Supersedes the hardcode in hyva-extension #35.

## Validation

- `php -l` clean on all changed files; brand.xsd well-formed; JS suite **28 passed**.
- Vanilla behaviour (empty subtitle) + ABN (renders its subtitle) verified end-to-end in browser after the 3-repo deploy.

## Ticket

- https://linear.app/tillit/issue/ABN-440