### PR TITLE
ABN-440/fix: unify Luma payment-block link styling

### DIFF
--- a/view/frontend/web/css/style.css
+++ b/view/frontend/web/css/style.css
@@ -52,7 +52,11 @@
     color: var(--color-brownie-vanilla);
 }
 
-.two-payment-subtitle a {
+/* All links inside the Two/ABN payment-method block render blue +
+   underlined (brand subtitle "lees meer", terms "betaalvoorwaarden", …).
+   Scoped to the block rather than a bare `a` so it stays out of the rest
+   of checkout and so the class+element specificity wins over resets. */
+.two-payment-method a {
     color: #0066cc;
     text-decoration: underline;
 }
@@ -90,10 +94,6 @@
     font-weight: 500;
 }
 
-.terms-text a {
-    text-decoration: none;
-    /* Style the anchor tags inside .terms-text */
-}
 
 .terms-container {
     margin-top: 1.5rem;


### PR DESCRIPTION
## Context
Links in the Two/ABN payment block were inconsistent: subtitle link blue+underlined, but the terms ("betaalvoorwaarden") link had `text-decoration:none` and the teal `.terms-text` colour. Companion to the Hyva fix.

## Changes
- `view/frontend/web/css/style.css`: replace `.two-payment-subtitle a` + `.terms-text a` with one block rule `.two-payment-method a { color:#0066cc; text-decoration:underline }`. Scoped to the payment block (not bare `a`) to avoid restyling the rest of checkout.

## Ticket
- https://linear.app/tillit/issue/ABN-440