### PR TITLE
INF-1458/feat: derive frp tunnel domain per-env from TWO_API_BASE_URL

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,3 +1,7 @@
+# Point TWO_API_BASE_URL at staging or release; start-proxy.sh derives the frp
+# tunnel domain from it (api.<env>.two.inc -> <subdomain>.frp.<env>.two.inc) and
+# refuses any env other than staging/release. Switch env by editing this value,
+# or inline: TWO_API_BASE_URL=https://api.release.two.inc ./start-proxy.sh
 TWO_API_BASE_URL=https://api.staging.two.inc
 TWO_CHECKOUT_BASE_URL=https://checkout.staging.two.inc
 TWO_API_KEY=dummy-dev-key

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ plans/
 
 # Node deps for Test/Js Jest runner; lockfile + manifest are tracked
 node_modules/
+
+.worktrees/

--- a/frpc.toml
+++ b/frpc.toml
@@ -10,4 +10,4 @@ localPort = {{ .Envs.PORT }}
 name = "{{ .Envs.SUBDOMAIN }}"
 type = "http"
 localIP = "{{ .Envs.HOST }}"
-subdomain = "{{ .Envs.SUBDOMAIN }}"
+customDomains = ["{{ .Envs.FRP_DOMAIN }}"]

--- a/start-proxy.sh
+++ b/start-proxy.sh
@@ -5,12 +5,17 @@
 # If no token is provided, attempts to fetch it from GCP Secret Manager
 # (requires an active @two.inc gcloud login).
 
+# Preserve an inline override (e.g. `TWO_API_BASE_URL=https://api.release.two.inc ./start-proxy.sh`)
+# so sourcing .env.local below doesn't clobber it.
+_TWO_API_BASE_URL_OVERRIDE="${TWO_API_BASE_URL}"
+
 # Source .env.local if it exists
 if [ -f .env.local ]; then
   set -a
   source .env.local
   set +a
 fi
+TWO_API_BASE_URL="${_TWO_API_BASE_URL_OVERRIDE:-${TWO_API_BASE_URL}}"
 
 # Define environment variables
 PROXY_USER="${PROXY_USER:-$USER}"
@@ -23,7 +28,28 @@ USER_LOWER=$(echo "${PROXY_USER}" | tr '[:upper:]' '[:lower:]')
 SANITIZED_USER=$(echo "${USER_LOWER}" | sed -E 's/[^a-z0-9-]+/-/g' | sed -E 's/^-+|-+$//g' | sed -E 's/--+/-/g')
 export SUBDOMAIN="magento-${SANITIZED_USER}"
 
-PROXY_URL="https://${SUBDOMAIN}.frp.beta.two.inc"
+# Derive the FRP domain from the API base URL so the tunnel follows whichever env
+# TWO_API_BASE_URL points at: api.<env>.two.inc -> <subdomain>.frp.<env>.two.inc.
+# A non-Two base (localhost, unset, ...) defaults the tunnel to staging. The
+# staging/release guard is enforced in start mode below so stop/url still work.
+# Connect to release by setting TWO_API_BASE_URL=https://api.release.two.inc.
+API_HOST="${TWO_API_BASE_URL#http://}"
+API_HOST="${API_HOST#https://}"
+API_HOST="${API_HOST%%/*}"   # strip path
+API_HOST="${API_HOST%%:*}"   # strip port
+case "${API_HOST}" in
+  api.*.two.inc)
+    FRP_ZONE="${API_HOST#api.}"   # e.g. staging.two.inc
+    FRP_ENV="${FRP_ZONE%%.*}"     # e.g. staging
+    ;;
+  *)
+    FRP_ENV="staging"
+    FRP_ZONE="staging.two.inc"
+    ;;
+esac
+
+export FRP_DOMAIN="${SUBDOMAIN}.frp.${FRP_ZONE}"
+PROXY_URL="https://${FRP_DOMAIN}"
 
 # ── stop mode ────────────────────────────────────────────────────────────────
 if [ "$1" = "stop" ]; then
@@ -81,6 +107,15 @@ else
 fi
 
 # Start frpc in background
+# Per-env FRP is only provisioned for staging and release (routes/certs/DNS/authz).
+case "${FRP_ENV}" in
+  staging | release) ;;
+  *)
+    echo "FRP tunnels are only supported for staging or release (got '${FRP_ENV}' from TWO_API_BASE_URL=${TWO_API_BASE_URL})"
+    exit 1
+    ;;
+esac
+
 frpc -c frpc.toml &
 FRP_PID=$!
 


### PR DESCRIPTION
## Context

The local frp dev tunnel used the `subdomain` shorthand (resolves only under `subDomainHost = frp.beta.two.inc`). Per-env frp routing/certs/DNS for staging + release is now live, so the tunnel can follow whichever env `TWO_API_BASE_URL` points at.

Targeted at `main` (no `develop` branch exists on origin).

## Changes (single commit)

- `frpc.toml`: `subdomain` → `customDomains = ["{{ .Envs.FRP_DOMAIN }}"]`
- `start-proxy.sh`: preserve an inline `TWO_API_BASE_URL` override across the `.env.local` source; guard empty value; strip path + port; derive the env and **refuse anything but staging/release**; derive `FRP_DOMAIN` (`api.<env>.two.inc` → `<subdomain>.frp.<env>.two.inc`); use it for `PROXY_URL`
- `.env.local.example`: document the derivation

## How to connect to a different env

`TWO_API_BASE_URL=https://api.release.two.inc` - tunnel follows automatically.

## Validation

- `bash -n start-proxy.sh` clean; derivation verified for staging + release; env guard rejects others
- `check-toml` skipped on the commit: `frpc.toml` uses frpc Go-template placeholders (not literal TOML), pre-existing

## Ticket

- https://linear.app/tillit/issue/INF-1458