### PR TITLE
ABN-443/fix: stop double-counting surcharge VAT on invoice + credit memo

### DIFF
--- a/Model/Total/Creditmemo/Surcharge.php
+++ b/Model/Total/Creditmemo/Surcharge.php
@@ -91,9 +91,6 @@ class Surcharge extends AbstractTotal
         $baseAmount = min($baseAmount, $baseMaxRefundable);
         $baseTaxAmount = round($taxAmount / $rate, 6);
 
-        $grossAmount = round($amount + $taxAmount, 6);
-        $baseGrossAmount = round($baseAmount + $baseTaxAmount, 6);
-
         $creditmemo->setTwoSurchargeAmount($amount);
         $creditmemo->setBaseTwoSurchargeAmount($baseAmount);
         $creditmemo->setTwoSurchargeTaxAmount($taxAmount);
@@ -101,10 +98,14 @@ class Surcharge extends AbstractTotal
         $creditmemo->setTwoSurchargeDescription((string)$order->getTwoSurchargeDescription());
         $creditmemo->setTwoSurchargeTaxRate($taxRatePercent);
 
-        $creditmemo->setGrandTotal((float)$creditmemo->getGrandTotal() + $grossAmount);
-        $creditmemo->setBaseGrandTotal((float)$creditmemo->getBaseGrandTotal() + $baseGrossAmount);
-        $creditmemo->setTaxAmount((float)$creditmemo->getTaxAmount() + $taxAmount);
-        $creditmemo->setBaseTaxAmount((float)$creditmemo->getBaseTaxAmount() + $baseTaxAmount);
+        // Add ONLY the surcharge net to the grand total. The surcharge VAT is
+        // already carried in the credit-memo's tax_amount/grand_total via
+        // Magento's native propagation of the order/invoice tax, so re-adding
+        // it here double-counts the VAT — which pushes the refund total past
+        // the order's paid total and makes Magento reject the refund with "The
+        // most money available to refund is ..." (ABN-443).
+        $creditmemo->setGrandTotal((float)$creditmemo->getGrandTotal() + $amount);
+        $creditmemo->setBaseGrandTotal((float)$creditmemo->getBaseGrandTotal() + $baseAmount);
 
         // NOTE: do NOT mutate $order->setTwoSurchargeRefunded here. collect()
         // runs on prepareCreditmemo and again on save/register — mutating the

--- a/Model/Total/Invoice/Surcharge.php
+++ b/Model/Total/Invoice/Surcharge.php
@@ -43,13 +43,12 @@ class Surcharge extends AbstractTotal
 
         $orderTax = (float)$order->getTwoSurchargeTaxAmount();
         $baseOrderTax = (float)$order->getBaseTwoSurchargeTaxAmount();
-        // Tax follows the same proportion as the net amount remaining.
+        // Tax follows the same proportion as the net amount remaining. Kept for
+        // the descriptor fields below; NOT re-applied to the invoice tax total
+        // (see grand-total note).
         $proportion = $orderSurcharge > 0 ? $remaining / $orderSurcharge : 1.0;
         $taxAmount = round($orderTax * $proportion, 6);
         $baseTaxAmount = round($baseOrderTax * $proportion, 6);
-
-        $grossAmount = $remaining + $taxAmount;
-        $baseGrossAmount = $baseRemaining + $baseTaxAmount;
 
         $invoice->setTwoSurchargeAmount($remaining);
         $invoice->setBaseTwoSurchargeAmount($baseRemaining);
@@ -58,10 +57,14 @@ class Surcharge extends AbstractTotal
         $invoice->setTwoSurchargeDescription((string)$order->getTwoSurchargeDescription());
         $invoice->setTwoSurchargeTaxRate((float)$order->getTwoSurchargeTaxRate());
 
-        $invoice->setGrandTotal((float)$invoice->getGrandTotal() + $grossAmount);
-        $invoice->setBaseGrandTotal((float)$invoice->getBaseGrandTotal() + $baseGrossAmount);
-        $invoice->setTaxAmount((float)$invoice->getTaxAmount() + $taxAmount);
-        $invoice->setBaseTaxAmount((float)$invoice->getBaseTaxAmount() + $baseTaxAmount);
+        // Add ONLY the surcharge net to the grand total. The surcharge VAT is
+        // booked into order.tax_amount at placement and Magento's native tax
+        // collector propagates it onto the invoice before this collector runs,
+        // so it is already present in tax_amount/grand_total. Adding it again
+        // here double-counts the VAT, inflating the invoice (and the order's
+        // paid total) by one surcharge-VAT and breaking refunds (ABN-443).
+        $invoice->setGrandTotal((float)$invoice->getGrandTotal() + $remaining);
+        $invoice->setBaseGrandTotal((float)$invoice->getBaseGrandTotal() + $baseRemaining);
 
         // NOTE: do NOT mutate $order->setTwoSurchargeInvoiced here. collect()
         // runs once on prepareInvoice and again on register() — mutating the

--- a/Test/Stubs/SalesModels.php
+++ b/Test/Stubs/SalesModels.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Stubs for the Magento sales models the surcharge Total collectors operate
+ * on (Invoice, Creditmemo, Order). The collectors type-hint the concrete
+ * Magento classes, so unit tests need instances of those exact classes — the
+ * bootstrap catch-all autoloader only produces empty, method-less classes.
+ *
+ * These stubs reproduce just enough of Magento\Framework\DataObject to be
+ * faithful: a backing data array plus get/set/has/uns magic with the same
+ * CamelCase -> snake_case key conversion Magento uses, so that
+ * getGrandTotal() and getData('grand_total') address the same slot. That
+ * fidelity matters for the Creditmemo collector, which mixes magic getters
+ * with explicit getData('two_surcharge_amount')/hasData() calls.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Stubs;
+
+/**
+ * Minimal faithful re-implementation of Magento\Framework\DataObject's
+ * data access — enough for the surcharge collectors under test.
+ */
+abstract class AbstractSalesModelStub
+{
+    /** @var array */
+    protected $_data = [];
+
+    public function setData($key, $value = null): self
+    {
+        $this->_data[$key] = $value;
+        return $this;
+    }
+
+    public function getData($key = '', $index = null)
+    {
+        if ($key === '') {
+            return $this->_data;
+        }
+        return $this->_data[$key] ?? null;
+    }
+
+    public function hasData($key = ''): bool
+    {
+        if ($key === '') {
+            return !empty($this->_data);
+        }
+        return array_key_exists($key, $this->_data);
+    }
+
+    public function __call($method, $args)
+    {
+        $prefix = substr($method, 0, 3);
+        $key = $this->_underscore(substr($method, 3));
+        switch ($prefix) {
+            case 'get':
+                return $this->_data[$key] ?? null;
+            case 'set':
+                $this->_data[$key] = $args[0] ?? null;
+                return $this;
+            case 'has':
+                return array_key_exists($key, $this->_data);
+            case 'uns':
+                unset($this->_data[$key]);
+                return $this;
+        }
+        return null;
+    }
+
+    /**
+     * CamelCase -> snake_case, matching Magento\Framework\DataObject.
+     */
+    protected function _underscore(string $name): string
+    {
+        return strtolower(preg_replace('/(.)([A-Z])/', '$1_$2', $name));
+    }
+}
+
+namespace Magento\Sales\Model\Order;
+
+use Two\Gateway\Test\Stubs\AbstractSalesModelStub;
+
+if (!class_exists(Invoice::class, false)) {
+    class Invoice extends AbstractSalesModelStub
+    {
+        private $order;
+
+        public function setOrder($order): self
+        {
+            $this->order = $order;
+            return $this;
+        }
+
+        public function getOrder()
+        {
+            return $this->order;
+        }
+    }
+}
+
+if (!class_exists(Creditmemo::class, false)) {
+    class Creditmemo extends AbstractSalesModelStub
+    {
+        private $order;
+
+        public function setOrder($order): self
+        {
+            $this->order = $order;
+            return $this;
+        }
+
+        public function getOrder()
+        {
+            return $this->order;
+        }
+    }
+}
+
+namespace Magento\Sales\Model;
+
+use Two\Gateway\Test\Stubs\AbstractSalesModelStub;
+
+if (!class_exists(Order::class, false)) {
+    // The order is untyped in the collectors; a plain data bag suffices.
+    class Order extends AbstractSalesModelStub
+    {
+    }
+}

--- a/Test/Unit/Model/Total/Creditmemo/SurchargeTest.php
+++ b/Test/Unit/Model/Total/Creditmemo/SurchargeTest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Model\Total\Creditmemo;
+
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Creditmemo;
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Model\Total\Creditmemo\Surcharge;
+
+/**
+ * Regression coverage for ABN-443 on the refund path.
+ *
+ * Same root cause as the invoice collector: the surcharge VAT is already
+ * carried in the credit-memo's tax_amount/grand_total (Magento propagates the
+ * order/invoice tax onto the credit memo natively) before this collector
+ * runs. Re-adding it here inflates the credit-memo grand total past the
+ * order's paid total, so Magento's CreditmemoService rejects the refund with
+ * "The most money available to refund is ...". This collector must add only
+ * the surcharge NET to the grand total and must not touch tax_amount.
+ *
+ * Full proportional refund of production order #2000000014:
+ *   net 58.09, VAT 21.5% = 12.48935.
+ *   Native credit-memo pre-state: grand 1071.48935, tax 12.48935.
+ *   Correct result: grand 1129.57935, tax 12.48935.
+ *   Buggy result:   grand 1142.06870, tax 24.97870  (VAT counted twice).
+ */
+class SurchargeTest extends TestCase
+{
+    private const NET = 58.09;
+    private const TAX_RATE = 21.5;
+    private const SURCHARGE_TAX = 12.48935; // round(58.09 * 0.215, 6)
+    private const SUBTOTAL = 1049.0;
+
+    private const NATIVE_GRAND = 1071.48935;
+    private const NATIVE_TAX = 12.48935;
+
+    private function makeOrder(): Order
+    {
+        $order = new Order();
+        $order->setData('two_surcharge_amount', self::NET);
+        $order->setData('base_two_surcharge_amount', self::NET);
+        $order->setData('two_surcharge_refunded', 0.0);
+        $order->setData('base_two_surcharge_refunded', 0.0);
+        $order->setData('two_surcharge_tax_rate', self::TAX_RATE);
+        $order->setData('two_surcharge_description', 'Zakelijk op Rekening - 90 dagen');
+        $order->setData('subtotal', self::SUBTOTAL);
+        $order->setData('base_to_order_rate', 1.0);
+        return $order;
+    }
+
+    private function makeCreditmemo(Order $order): Creditmemo
+    {
+        $creditmemo = new Creditmemo();
+        $creditmemo->setOrder($order);
+        // Full refund: credit-memo subtotal == order subtotal -> proportion 1.0.
+        $creditmemo->setData('subtotal', self::SUBTOTAL);
+        // State left by Magento's native collectors (incl. surcharge VAT).
+        $creditmemo->setData('grand_total', self::NATIVE_GRAND);
+        $creditmemo->setData('base_grand_total', self::NATIVE_GRAND);
+        $creditmemo->setData('tax_amount', self::NATIVE_TAX);
+        $creditmemo->setData('base_tax_amount', self::NATIVE_TAX);
+        return $creditmemo;
+    }
+
+    public function testAddsOnlyNetSurchargeToGrandTotal(): void
+    {
+        $order = $this->makeOrder();
+        $creditmemo = $this->makeCreditmemo($order);
+
+        (new Surcharge())->collect($creditmemo);
+
+        $this->assertEqualsWithDelta(
+            self::NATIVE_GRAND + self::NET,
+            (float)$creditmemo->getGrandTotal(),
+            0.0001,
+            'Credit-memo grand total must increase by the surcharge NET only; '
+            . 're-adding the VAT pushes the refund past the order paid total (ABN-443).'
+        );
+    }
+
+    public function testDoesNotReAddSurchargeVatToTaxAmount(): void
+    {
+        $order = $this->makeOrder();
+        $creditmemo = $this->makeCreditmemo($order);
+
+        (new Surcharge())->collect($creditmemo);
+
+        $this->assertEqualsWithDelta(
+            self::NATIVE_TAX,
+            (float)$creditmemo->getTaxAmount(),
+            0.0001,
+            'Credit-memo tax_amount must be unchanged: the surcharge VAT is already '
+            . 'present from native tax propagation (ABN-443).'
+        );
+    }
+
+    public function testStillRecordsSurchargeDescriptorFields(): void
+    {
+        $order = $this->makeOrder();
+        $creditmemo = $this->makeCreditmemo($order);
+
+        (new Surcharge())->collect($creditmemo);
+
+        $this->assertEqualsWithDelta(self::NET, (float)$creditmemo->getTwoSurchargeAmount(), 0.0001);
+        $this->assertEqualsWithDelta(
+            self::SURCHARGE_TAX,
+            (float)$creditmemo->getTwoSurchargeTaxAmount(),
+            0.0001
+        );
+        $this->assertSame(
+            'Zakelijk op Rekening - 90 dagen',
+            $creditmemo->getTwoSurchargeDescription()
+        );
+    }
+}

--- a/Test/Unit/Model/Total/Invoice/SurchargeTest.php
+++ b/Test/Unit/Model/Total/Invoice/SurchargeTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Model\Total\Invoice;
+
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Invoice;
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Model\Total\Invoice\Surcharge;
+
+/**
+ * Regression coverage for ABN-443.
+ *
+ * The Two payment surcharge VAT is booked into the order's tax total at
+ * quote/placement time. Magento's native invoice Tax collector then
+ * propagates that order tax onto the invoice before this collector runs.
+ * Therefore the surcharge VAT is ALREADY present in the invoice's
+ * tax_amount/grand_total when collect() executes; this collector must add
+ * only the surcharge NET to the grand total and must NOT touch tax_amount.
+ *
+ * Numbers mirror the production order #2000000014 that exposed the bug:
+ *   net 58.09, VAT 21.5% = 12.48935, gross 70.58.
+ *   Native invoice pre-state: grand 1071.48935, tax 12.48935.
+ *   Correct result: grand 1129.57935, tax 12.48935.
+ *   Buggy result:   grand 1142.06870, tax 24.97870  (VAT counted twice).
+ */
+class SurchargeTest extends TestCase
+{
+    private const NET = 58.09;
+    private const TAX_RATE = 21.5;
+    private const SURCHARGE_TAX = 12.48935; // round(58.09 * 0.215, 6)
+
+    // Native-collected invoice pre-state (subtotal 1049 + shipping 10 + VAT).
+    private const NATIVE_GRAND = 1071.48935;
+    private const NATIVE_TAX = 12.48935;
+
+    private function makeOrder(): Order
+    {
+        $order = new Order();
+        $order->setData('two_surcharge_amount', self::NET);
+        $order->setData('base_two_surcharge_amount', self::NET);
+        $order->setData('two_surcharge_invoiced', 0.0);
+        $order->setData('base_two_surcharge_invoiced', 0.0);
+        $order->setData('two_surcharge_tax_amount', self::SURCHARGE_TAX);
+        $order->setData('base_two_surcharge_tax_amount', self::SURCHARGE_TAX);
+        $order->setData('two_surcharge_tax_rate', self::TAX_RATE);
+        $order->setData('two_surcharge_description', 'Zakelijk op Rekening - 90 dagen');
+        return $order;
+    }
+
+    private function makeInvoice(Order $order): Invoice
+    {
+        $invoice = new Invoice();
+        $invoice->setOrder($order);
+        // State left by Magento's native collectors (incl. surcharge VAT).
+        $invoice->setData('grand_total', self::NATIVE_GRAND);
+        $invoice->setData('base_grand_total', self::NATIVE_GRAND);
+        $invoice->setData('tax_amount', self::NATIVE_TAX);
+        $invoice->setData('base_tax_amount', self::NATIVE_TAX);
+        return $invoice;
+    }
+
+    public function testAddsOnlyNetSurchargeToGrandTotal(): void
+    {
+        $order = $this->makeOrder();
+        $invoice = $this->makeInvoice($order);
+
+        (new Surcharge())->collect($invoice);
+
+        $this->assertEqualsWithDelta(
+            self::NATIVE_GRAND + self::NET,
+            (float)$invoice->getGrandTotal(),
+            0.0001,
+            'Invoice grand total must increase by the surcharge NET only; '
+            . 'the VAT is already in the grand total via native tax propagation.'
+        );
+    }
+
+    public function testDoesNotReAddSurchargeVatToTaxAmount(): void
+    {
+        $order = $this->makeOrder();
+        $invoice = $this->makeInvoice($order);
+
+        (new Surcharge())->collect($invoice);
+
+        $this->assertEqualsWithDelta(
+            self::NATIVE_TAX,
+            (float)$invoice->getTaxAmount(),
+            0.0001,
+            'Invoice tax_amount must be unchanged: the surcharge VAT is already '
+            . 'present from native propagation of order.tax_amount (ABN-443).'
+        );
+    }
+
+    public function testStillRecordsSurchargeDescriptorFields(): void
+    {
+        $order = $this->makeOrder();
+        $invoice = $this->makeInvoice($order);
+
+        (new Surcharge())->collect($invoice);
+
+        $this->assertEqualsWithDelta(self::NET, (float)$invoice->getTwoSurchargeAmount(), 0.0001);
+        $this->assertEqualsWithDelta(
+            self::SURCHARGE_TAX,
+            (float)$invoice->getTwoSurchargeTaxAmount(),
+            0.0001
+        );
+        $this->assertSame('Zakelijk op Rekening - 90 dagen', $invoice->getTwoSurchargeDescription());
+    }
+}

--- a/Test/bootstrap.php
+++ b/Test/bootstrap.php
@@ -58,6 +58,12 @@ if (!class_exists(\Magento\Bundle\Model\Product\Price::class)) {
 if (!class_exists(\Magento\Catalog\Model\Product\Type::class)) {
     require_once __DIR__ . '/Stubs/ProductType.php';
 }
+// Sales models (Invoice, Creditmemo, Order) with faithful DataObject
+// semantics — required before the catch-all below so the surcharge Total
+// collectors operate on real data bags, not empty method-less stubs.
+if (!class_exists(\Magento\Sales\Model\Order\Invoice::class, false)) {
+    require_once __DIR__ . '/Stubs/SalesModels.php';
+}
 
 // Catch-all autoloader for remaining Magento classes/interfaces.
 // Creates empty stubs so that type hints, extends, and implements resolve.


### PR DESCRIPTION
## Problem (ABN-443)

Refunds of **any surcharge-bearing order** fail in the Magento admin with
*"The most money available to refund is € 1.142,07"*. Surfaced by QA on
ABN staging refunding order #2000000014 (HK Interieur & Design B.V.).

## Root cause

The invoice and credit-memo surcharge `Total` collectors add the surcharge
**VAT** into the document `tax_amount` / `grand_total`. But the surcharge
VAT is booked into `order.tax_amount` at placement, and Magento's **native**
tax collector already propagates that onto each invoice/credit memo before
our collector runs. The surcharge **net** is Magento-invisible (added once —
correct); the **VAT** gets counted twice.

Traced on order #2000000014 (net €58.09, VAT 21.5% = €12.49):

| Doc | Correct | Actual (bug) |
|-----|---------|--------------|
| Order grand total | 1129.58 | 1129.58 ✓ |
| Invoice grand / `base_total_paid` | 1129.58 | **1142.07** (VAT ×2) |
| Full credit-memo grand total | 1129.58 | **1154.56** (VAT ×3) |

Magento's `CreditmemoService` guard rejects the refund because the inflated
credit-memo total (1154.56) exceeds the inflated paid total (1142.07).

## Fix

Add **only the surcharge net** to the grand total in both collectors; leave
`tax_amount` to Magento's native propagation. Descriptor fields
(`two_surcharge_tax_amount`, etc.) are still recorded.

## Tests

New unit coverage for both collectors (`Test/Unit/Model/Total/...`),
reproducing the production figures. Verified RED on the old code
(1142.07 / 24.98) → GREEN after the fix. Full suite: 140 passed.

A faithful `Magento\Sales\Model\Order\{Invoice,Creditmemo,Order}` stub was
added (`Test/Stubs/SalesModels.php`) since the harness has no Magento vendor.

## Follow-ups

- Manual test plan: adding row **H15** to ABN-401 (invoice/refund VAT
  reconciliation for surcharge orders).
- Note for finance: the invoice double-count also mis-stated invoice VAT/grand
  total on the books (€1142.07 vs true €1129.58), independent of refunds.
- End-to-end Chrome verification on ABN staging admin to follow.

Fixes ABN-443