### PR TITLE
ABN-443/test: guard line-item VAT preserved by surcharge collectors

### DIFF
--- a/Test/Unit/Model/Total/Creditmemo/SurchargeTest.php
+++ b/Test/Unit/Model/Total/Creditmemo/SurchargeTest.php
@@ -117,4 +117,43 @@ class SurchargeTest extends TestCase
             $creditmemo->getTwoSurchargeDescription()
         );
     }
+
+    /**
+     * Guards that the fix only de-duplicates the surcharge VAT and never
+     * disturbs legitimate line-item VAT: when the native tax total carries
+     * both a line-item VAT component and the surcharge VAT, collect() must
+     * leave tax_amount exactly as-is (line VAT intact, surcharge VAT not
+     * re-added) and add only the surcharge net to the grand total.
+     */
+    public function testPreservesLineItemVatAndDoesNotReAddSurchargeVat(): void
+    {
+        $order = $this->makeOrder();
+
+        $lineItemVat = 200.0;
+        $nativeTax = $lineItemVat + self::SURCHARGE_TAX; // line VAT + surcharge VAT, both via native propagation
+        $nativeGrand = 1000.0 + $nativeTax;              // goods + all VAT; surcharge net not yet added
+
+        $creditmemo = new Creditmemo();
+        $creditmemo->setOrder($order);
+        $creditmemo->setData('subtotal', self::SUBTOTAL);
+        $creditmemo->setData('grand_total', $nativeGrand);
+        $creditmemo->setData('base_grand_total', $nativeGrand);
+        $creditmemo->setData('tax_amount', $nativeTax);
+        $creditmemo->setData('base_tax_amount', $nativeTax);
+
+        (new Surcharge())->collect($creditmemo);
+
+        $this->assertEqualsWithDelta(
+            $nativeGrand + self::NET,
+            (float)$creditmemo->getGrandTotal(),
+            0.0001,
+            'Grand total must grow by the surcharge net only.'
+        );
+        $this->assertEqualsWithDelta(
+            $nativeTax,
+            (float)$creditmemo->getTaxAmount(),
+            0.0001,
+            'tax_amount must be untouched: line-item VAT preserved AND surcharge VAT not re-added.'
+        );
+    }
 }

--- a/Test/Unit/Model/Total/Invoice/SurchargeTest.php
+++ b/Test/Unit/Model/Total/Invoice/SurchargeTest.php
@@ -111,4 +111,42 @@ class SurchargeTest extends TestCase
         );
         $this->assertSame('Zakelijk op Rekening - 90 dagen', $invoice->getTwoSurchargeDescription());
     }
+
+    /**
+     * Guards that the fix only de-duplicates the surcharge VAT and never
+     * disturbs legitimate line-item VAT: when the native tax total carries
+     * both a line-item VAT component and the surcharge VAT, collect() must
+     * leave tax_amount exactly as-is (line VAT intact, surcharge VAT not
+     * re-added) and add only the surcharge net to the grand total.
+     */
+    public function testPreservesLineItemVatAndDoesNotReAddSurchargeVat(): void
+    {
+        $order = $this->makeOrder();
+
+        $lineItemVat = 200.0;
+        $nativeTax = $lineItemVat + self::SURCHARGE_TAX; // line VAT + surcharge VAT, both via native propagation
+        $nativeGrand = 1000.0 + $nativeTax;              // goods + all VAT; surcharge net not yet added
+
+        $invoice = new Invoice();
+        $invoice->setOrder($order);
+        $invoice->setData('grand_total', $nativeGrand);
+        $invoice->setData('base_grand_total', $nativeGrand);
+        $invoice->setData('tax_amount', $nativeTax);
+        $invoice->setData('base_tax_amount', $nativeTax);
+
+        (new Surcharge())->collect($invoice);
+
+        $this->assertEqualsWithDelta(
+            $nativeGrand + self::NET,
+            (float)$invoice->getGrandTotal(),
+            0.0001,
+            'Grand total must grow by the surcharge net only.'
+        );
+        $this->assertEqualsWithDelta(
+            $nativeTax,
+            (float)$invoice->getTaxAmount(),
+            0.0001,
+            'tax_amount must be untouched: line-item VAT preserved AND surcharge VAT not re-added.'
+        );
+    }
 }


### PR DESCRIPTION
Follow-up to #201 (ABN-443 surcharge VAT double-count fix).

Adds a regression test to both the invoice and credit-memo surcharge `Total`
collector test classes covering the **both-VAT** case: the document's native
tax total carries a line-item VAT component **and** the surcharge VAT.

Asserts `collect()`:
- leaves `tax_amount` exactly untouched — line-item VAT preserved, surcharge VAT not re-added;
- grows the grand total by the surcharge **net** only.

The #201 tests seeded only surcharge VAT; these lock in that legitimate
line-item VAT is never disturbed by the fix. Would fail on pre-#201 code
(which did `tax_amount += surchargeVAT`). 142 tests pass locally.

Refs ABN-443