### PR TITLE
ABN-443/fix: credit-memo surcharge override row above Tax line

### DIFF
--- a/Block/Adminhtml/Creditmemo/SurchargeOverride.php
+++ b/Block/Adminhtml/Creditmemo/SurchargeOverride.php
@@ -59,7 +59,7 @@ class SurchargeOverride extends Template
                 'block_name' => 'two_surcharge_override',
                 'strong'     => false,
             ]),
-            'grand_total'
+            'tax'
         );
         return $this;
     }

--- a/Test/Unit/Block/Adminhtml/Creditmemo/SurchargeOverrideTest.php
+++ b/Test/Unit/Block/Adminhtml/Creditmemo/SurchargeOverrideTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Block\Adminhtml\Creditmemo;
+
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Block\Adminhtml\Creditmemo\SurchargeOverride;
+
+/**
+ * The editable surcharge override row on the credit-memo create form must sit
+ * directly above the Tax line — same ordering as the read-only row elsewhere
+ * (ABN-443 follow-up). The block removes the static row and re-adds an
+ * editable placeholder; that re-add must anchor before `tax`, not
+ * `grand_total`.
+ */
+class SurchargeOverrideTest extends TestCase
+{
+    public function testEditableRowIsInsertedAboveTax(): void
+    {
+        $capture = new \stdClass();
+        $parent = new class($capture) {
+            private $cap;
+            public function __construct($cap)
+            {
+                $this->cap = $cap;
+            }
+            public function removeTotal($code)
+            {
+                $this->cap->removed = $code;
+                return $this;
+            }
+            public function addTotalBefore($total, $before)
+            {
+                $this->cap->total = $total;
+                $this->cap->before = $before;
+                return $this;
+            }
+        };
+
+        $block = new class($parent) extends SurchargeOverride {
+            private $p;
+            public function __construct($p)
+            {
+                $this->p = $p;
+            }
+            public function getParentBlock()
+            {
+                return $this->p;
+            }
+            public function shouldDisplay(): bool
+            {
+                return true;
+            }
+        };
+
+        $block->initTotals();
+
+        $this->assertSame('two_surcharge', $capture->removed ?? null, 'static row must be removed first');
+        $this->assertSame('two_surcharge_override', $capture->total->getData('block_name'));
+        $this->assertSame(
+            'tax',
+            $capture->before ?? null,
+            'editable surcharge override row must be inserted above the Tax line'
+        );
+    }
+}


### PR DESCRIPTION
Follow-up to #203. The editable surcharge-override row on the credit-memo create form was re-added before `grand_total` (below Tax); anchor it before `tax` to match the read-only ordering. Display-only. Unit test added. Refs ABN-443