### PR TITLE
ABN-443/fix: keep checkout loader up until Two redirect completes

### DIFF
--- a/Test/Js/gateway-method-afterplaceorder.test.js
+++ b/Test/Js/gateway-method-afterplaceorder.test.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+'use strict';
+
+const { loadAmdModule } = require('./amd-harness');
+
+describe('gateway_method afterPlaceOrder redirect', () => {
+    function loadComponent(seq, redirectUrl) {
+        const loader = {
+            startLoader: function () { seq.push('startLoader'); },
+            stopLoader: function () { seq.push('stopLoader'); }
+        };
+        function $() { return {}; }
+        $.mage = {
+            cookies: { get: function () { return redirectUrl; } },
+            redirect: function () { seq.push('redirect'); }
+        };
+        const component = loadAmdModule(
+            'view/frontend/web/js/view/payment/method-renderer/gateway_method.js',
+            {
+                jquery: $,
+                'Magento_Checkout/js/model/full-screen-loader': loader
+            }
+        );
+        return component;
+    }
+
+    test('keeps the full-screen loader up until the redirect navigates away', function () {
+        const seq = [];
+        const component = loadComponent(seq, 'https://checkout.example/redirect');
+
+        component.afterPlaceOrder.call({ _brandConfig: { redirectUrlCookieCode: 'two_redirect' } });
+
+        // The loader must be (re)started before the redirect fires, so the
+        // overlay stays visible for the seconds the browser takes to navigate.
+        expect(seq).toEqual(['startLoader', 'redirect']);
+    });
+
+    test('does nothing when there is no redirect cookie', function () {
+        const seq = [];
+        const component = loadComponent(seq, null);
+
+        component.afterPlaceOrder.call({ _brandConfig: { redirectUrlCookieCode: 'two_redirect' } });
+
+        expect(seq).toEqual([]);
+    });
+});

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -301,6 +301,13 @@ define([
         afterPlaceOrder: function () {
             const url = $.mage.cookies.get(this._brandConfig.redirectUrlCookieCode);
             if (url) {
+                // Magento's place-order action stops the full-screen loader the
+                // moment the AJAX resolves — which leaves the checkout bare for
+                // the few seconds the redirect to the Two/ABN checkout takes,
+                // making buyers think nothing happened. Re-show the loader so
+                // the overlay stays up until the browser actually navigates
+                // away (the new page discards it).
+                fullScreenLoader.startLoader();
                 $.mage.redirect(url);
             }
         },


### PR DESCRIPTION
On Place Order, Magento stops the full-screen loader when the AJAX resolves, but `afterPlaceOrder` then redirects to the Two/ABN checkout (takes a few seconds). The bare page between made buyers think nothing happened. Re-show the loader right before the redirect so the overlay persists until the browser navigates. Jest test added. Refs ABN-443