### PR TITLE
ABN-443/fix: surcharge on invoice/credit-memo PDF + shipping before tax

### DIFF
--- a/Model/Pdf/Total/Surcharge.php
+++ b/Model/Pdf/Total/Surcharge.php
@@ -30,7 +30,7 @@ class Surcharge extends DefaultTotal
         }
 
         $label = $source->getDataUsingMethod('two_surcharge_description')
-            ?: (string)__('Two Surcharge');
+            ?: (string)__('Surcharge');
 
         // NET surcharge — its VAT is shown in the Tax line, matching the
         // on-screen totals, the checkout, and the grand total.

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -91,24 +91,6 @@
             </argument>
         </arguments>
     </virtualType>
-    <type name="Magento\Sales\Model\Order\Pdf\Config">
-        <arguments>
-            <argument name="data" xsi:type="array">
-                <item name="renderers" xsi:type="array">
-                    <item name="invoice" xsi:type="array">
-                        <item name="two_surcharge" xsi:type="array">
-                            <item name="class" xsi:type="string">Two\Gateway\Model\Pdf\Total\Surcharge</item>
-                        </item>
-                    </item>
-                    <item name="creditmemo" xsi:type="array">
-                        <item name="two_surcharge" xsi:type="array">
-                            <item name="class" xsi:type="string">Two\Gateway\Model\Pdf\Total\Surcharge</item>
-                        </item>
-                    </item>
-                </item>
-            </argument>
-        </arguments>
-    </type>
     <type name="Magento\Config\Model\Config\TypePool">
         <arguments>
             <argument name="environment" xsi:type="array">

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -10,6 +10,7 @@
 	<module name="Two_Gateway" setup_version="1.3.0">
 		<sequence>
             <module name="Magento_Sales"/>
+            <module name="Magento_Tax"/>
             <module name="Magento_Payment"/>
             <module name="Magento_Checkout"/>
             <module name="Magento_Directory" />

--- a/etc/pdf.xml
+++ b/etc/pdf.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Sales:etc/pdf_file.xsd">
+    <totals>
+        <!--
+            Move Shipping & Handling ahead of Tax on invoice/credit-memo PDFs.
+            Core (Magento_Sales) places shipping at 400 and Magento_Tax places
+            tax at 300, so shipping prints AFTER tax — but shipping is part of
+            the tax base, and the on-screen totals already show it before tax.
+            Re-sort to keep the document consistent and intuitive.
+        -->
+        <total name="shipping">
+            <sort_order>250</sort_order>
+        </total>
+        <!--
+            Render the Two surcharge (NET) on invoice + credit-memo PDFs,
+            directly above the Tax line (its VAT is in the Tax total). This is
+            a totals MODEL — the renderer builds the row and its label from the
+            order's surcharge fields. The surcharge previously never appeared
+            on PDFs because it was registered under item-renderers, not totals.
+        -->
+        <total name="two_surcharge">
+            <title translate="true">Surcharge</title>
+            <source_field>two_surcharge_amount</source_field>
+            <model>Two\Gateway\Model\Pdf\Total\Surcharge</model>
+            <font_size>7</font_size>
+            <display_zero>false</display_zero>
+            <sort_order>280</sort_order>
+        </total>
+    </totals>
+</config>


### PR DESCRIPTION
Invoice/credit-memo **PDF** fixes:
1. **Surcharge now renders** — it was mis-registered under PDF item-renderers, never as a total. Registered as a totals `<model>` (etc/pdf.xml, sort_order 280) → prints the NET surcharge directly above the Tax line.
2. **Shipping before Tax** — core/Tax order has tax (300) before shipping (400); shipping is part of the tax base and the on-screen totals show it first. Re-sorted shipping to 250.

Also: dropped the dead di.xml item-renderer entry, added Magento_Tax to module sequence (deterministic pdf.xml merge), brand-neutral fallback label. PHPUnit 153 green. Verify by rendering an invoice + credit-memo PDF. Refs ABN-443