### PR TITLE
ABN-439/fix: always preselect the single available payment term

### DIFF
--- a/Model/Config/Repository.php
+++ b/Model/Config/Repository.php
@@ -494,11 +494,16 @@ class Repository implements RepositoryInterface
      */
     public function getDefaultPaymentTerm(?int $storeId = null): int
     {
+        $terms = $this->getAllBuyerTerms($storeId);
         $default = (int)$this->getConfig($this->path('default_payment_term'), $storeId);
-        if ($default > 0) {
+        // Only honour the configured default if it's actually an available
+        // buyer term. Otherwise fall back to the lowest available term so the
+        // buyer always lands on a real, selectable term — in particular a
+        // single available term is always the default (and thus preselected),
+        // even if a stale default_payment_term points elsewhere (ABN-439).
+        if ($default > 0 && in_array($default, $terms, true)) {
             return $default;
         }
-        $terms = $this->getAllBuyerTerms($storeId);
         return $terms ? min($terms) : 30;
     }
 

--- a/Test/Unit/Model/Config/RepositoryPaymentTermsTest.php
+++ b/Test/Unit/Model/Config/RepositoryPaymentTermsTest.php
@@ -176,6 +176,31 @@ class RepositoryPaymentTermsTest extends TestCase
         $this->assertEquals(30, $this->repository->getDefaultPaymentTerm());
     }
 
+    public function testGetDefaultPaymentTermPreselectsSingleAvailableTermDespiteStaleDefault(): void
+    {
+        // ABN-439: with a single available term, that term must always be the
+        // default (and therefore preselected), even if a stale
+        // default_payment_term points at a term that's no longer available.
+        $this->stubConfig([
+            'payment/two_payment/default_payment_term' => '30', // stale, not available
+            'payment/two_payment/payment_terms' => '90',        // only 90 available
+            'payment/two_payment/payment_terms_duration_days' => '',
+        ]);
+        $this->assertEquals(90, $this->repository->getDefaultPaymentTerm());
+    }
+
+    public function testGetDefaultPaymentTermIgnoresDefaultOutsideAvailableTerms(): void
+    {
+        // A configured default that isn't among the available terms falls back
+        // to the lowest available term rather than returning an unselectable one.
+        $this->stubConfig([
+            'payment/two_payment/default_payment_term' => '14', // not available
+            'payment/two_payment/payment_terms' => '30,60,90',
+            'payment/two_payment/payment_terms_duration_days' => '',
+        ]);
+        $this->assertEquals(30, $this->repository->getDefaultPaymentTerm());
+    }
+
     // ── getSurchargeType ─────────────────────────────────────────────
 
     public function testGetSurchargeTypeReturnsNoneByDefault(): void


### PR DESCRIPTION
`getDefaultPaymentTerm` returned the configured `default_payment_term` without checking it's an available buyer term, so a single available term wasn't guaranteed preselected (and a stale default could surface an unselectable term). Now clamps the default into the available set (honour-if-available else lowest available). A single term is always the default → preselected on **both** Luma and Hyva via the shared config. Unit tests added. Refs ABN-439