### PR TITLE
ABN-445/feat: push overlay-only NL/NO/SE translations into base + fix errors

### DIFF
--- a/i18n/nb_NO.csv
+++ b/i18n/nb_NO.csv
@@ -9,7 +9,7 @@
 "%1 requires whole order to be shipped before it can be fulfilled.","%1 krever at hele bestillingen sendes før den kan oppfylles."
 "%1 terms and conditions","%1 vilkår og betingelser"
 "* Required Fields","* Obligatoriske felter"
-"API Key",API-nøkkel
+"API Key","API-nøkkel"
 "API Key is missing","API-nøkkel mangler"
 "API Key is not valid","API-nøkkel er ikke gyldig"
 "API Key is valid","API-nøkkel er gyldig"
@@ -18,31 +18,31 @@
 "Add Order Note Field","Legg til bestillingsnotatfelt"
 "Add Project Field","Legg til felt for prosjekt"
 "Allowed Countries","Tillatte land"
-"Choose whether to enable this payment method for all allowed countries or only specific ones.","Velg om du vil aktivere denne betalingsmetoden for alle tillatte land eller bare bestemte."
+"Choose whether to enable this payment method for all allowed countries or only specific ones.","Velg om du vil aktivere denne betalingsmetoden for alle tillatte land eller noen spesifikke."
 "Country Availability","Landtilgjengelighet"
 "Select the countries where this payment method should be available.","Velg landene der denne betalingsmetoden skal være tilgjengelig."
 "Amount is missing","Beløp mangler"
-Branding,Merkevarebygging
-"Business Invoice",Bedriftsfaktura
+"Branding","Merkevarebygging"
+"Business Invoice","Bedriftsfaktura"
 "Buy now, receive your goods, pay your invoice later.","Kjøp nå, motta varene dine, betal fakturaen senere."
 "Check last 100 debug log records","Sjekk siste 100 feilsøkingsloggposter"
 "Check last 100 error log records","Sjekk siste 100 feilloggposter"
-"City",By
+"City","By"
 "%1 is not valid.","%1 er ikke gyldig."
 "%1: %2.","%1: %2."
 "Click here to log in or sign up as a Sole Trader.","Klikk her for å logge inn eller registrere deg som eneforhandler."
-"Company Number",Organisasjonsnummer
-"Company Name",Selskapsnavn
+"Company Number","Organisasjonsnummer"
+"Company Name","Selskapsnavn"
 "Could not initiate capture with %1","Kunne ikke starte fangst med %1"
 "Could not initiate refund with %1","Kunne ikke starte refusjon med %1"
 "Could not update %1 order status to cancelled. Please contact support with order ID %2. Error: %3","Kunne ikke oppdatere %1 ordrestatus til kansellert. Ta kontakt med brukerstøtten med ordre-ID %2. Feil: %3"
-"Country",Land
-"Credit Note",Kreditnota
-"Debug Mode",Feilsøkingsmodus
-Department,Avdeling
-Download,"Last ned"
+"Country","Land"
+"Credit Note","Kreditnota"
+"Debug Mode","Feilsøkingsmodus"
+"Department","Avdeling"
+"Download","Last ned"
 "Download as .txt file","Last ned som .txt-fil"
-"Email Address",E-postadresse
+"Email Address","E-postadresse"
 "Enable Address Search","Aktiver adressesøk"
 "Enable Company Search","Aktiver firmasøk"
 "Enable Order Intent","Aktiver ordrehensikt"
@@ -50,55 +50,55 @@ Download,"Last ned"
 "Enable Tax Subtotals","Aktiver delsummer for avgifter"
 "Enter company name to search","Skriv inn firmanavn for å søke"
 "Enter details manually","Skriv inn detaljer manuelt"
-Environment,Miljø
+"Environment","Miljø"
 "Failed to refund order with %1. Reason: %2","Kunne ikke refundere bestillingen med %1. Årsak: %2"
 "Failed to update %1 customer address: %2","Kunne ikke oppdatere %1 kundeadresse: %2"
 "Find out more","Finn ut mer"
-"First Name",Fornavn
+"First Name","Fornavn"
 "Fulfilment Order Status","Oppfyllelse av ordrestatus"
 "Fulfilment Trigger","Oppfyllelse utløser"
-General,Generelt
+"General","Generelt"
 "Invalid API response from %1.","Ugyldig API-svar fra %1."
-Invoice,Faktura
+"Invoice","Faktura"
 "Invoice purchase with %1 is not available for this order.","Fakturakjøp med %1 er ikke tilgjengelig for denne bestillingen."
 "Last 100 debug log lines","Siste 100 feilsøkingslogglinjer"
 "Last 100 error log records","Siste 100 feilloggposter"
-"Last Name",Etternavn
+"Last Name","Etternavn"
 "Log is empty","Loggen er tom"
-OK,OK
+"OK","OK"
 "On Completion","Ved ferdigstillelse"
 "On Invoice","På faktura"
 "On Shipment","På forsendelse"
-"Order ID",Bestillings-ID
-"Order Note",Bestillingsmerknad
+"Order ID","Bestillings-ID"
+"Order Note","Bestillingsmerknad"
 "Order edit request was accepted by %1","Bestillingsredigeringsforespørsel ble akseptert av %1"
-"PO Number",PO-nummer
-Payment,Betaling
-"Payment Method",Betalingsmetode
-"Phone Number",Telefonnummer
+"PO Number","PO-nummer"
+"Payment","Betaling"
+"Payment Method","Betalingsmetode"
+"Phone Number","Telefonnummer"
 "Place Order","Plasser ordre"
 "Please try again later.","Vennligst prøv igjen senere."
-Production,Produksjon
-Project,Prosjekt
+"Production","Produksjon"
+"Project","Prosjekt"
 "Registered Organisation","Registrert organisasjon"
-Sandbox,Sandbox
-Search,Søk
+"Sandbox","Sandbox"
+"Search","Søk"
 "Search for company","Søk etter selskap"
 "Sign up now","Registrer deg nå"
-"Sole Trader",Eneforhandler
+"Sole Trader","Eneforhandler"
 "Something went wrong with your request to %1. %2","Noe gikk galt med forespørselen din til %1. %2"
-"Sort Order",Sorteringsrekkefølge
-"Street Address",Gateadresse
+"Sort Order","Sorteringsrekkefølge"
+"Street Address","Gateadresse"
 "Successfully refunded order with %1 for order ID: %2. Refund reference: %3","Vellykket refundert bestilling med %1 for bestillings-ID: %2. Refusjonsreferanse: %3"
-TWO,TWO
+"TWO","TWO"
 "The %1 payment plugin for Magento simplifies B2B shopping, making it easy and safe for merchants to offer invoices as a payment method.<br>The payment method lives next to other payment methods in your existing checkout, and offers a variety of configuration options to suit your businesses needs.<br>If you would like to know more about how to configure the plugin, check out our <a href=""%2"" target=""_blank"">step by step guide</a>.","%1 betalingsplugin for Magento forenkler B2B shopping, og gjør det enkelt og trygt for selgere å tilby fakturaer som betalingsmåte. <br> Betalingsmetoden lever ved siden av andre betalingsmetoder i din eksisterende kassen, og tilbyr en rekke konfigurasjonsalternativer for å passe bedriftens behov. <br> Hvis du vil vite mer om hvordan du konfigurerer programtillegget, sjekk ut vår <a href=""%2"" target=""_blank""> trinnvise veiledning </a> ."
 "The buyer and the seller are the same company.","Kjøper og selger er samme selskap."
 "The capture action is not available.","Opptakshandlingen er ikke tilgjengelig."
-Title,Tittel
+"Title","Tittel"
 "Two is a payment solution for B2B purchases online, allowing you to buy from your favourite merchants and suppliers on trade credit. Using Two, you can access flexible trade credit instantly to make purchasing simple.","Two er en betalingsløsning for B2B-kjøp på nettet, som lar deg kjøpe fra dine favorittforhandlere og leverandører på handelskreditt. Med Two kan du få tilgang til fleksibel handelskreditt umiddelbart for å gjøre innkjøp enkelt."
 "Unable to confirm %1 order with %2 state.","Kan ikke bekrefte %1 bestilling med %2 status."
 "Unable to find the requested %1 order","Kan ikke finne den forespurte bestillingen %1"
-Version,Versjon
+"Version","Versjon"
 "You must accept %1 to place order.","Du må akseptere %1 for å legge inn bestillingen."
 "You will be redirected to %1 when you place order.","Du vil bli omdirigert til %1 når du legger inn bestilling."
 "Your invoice purchase with %1 could not be processed. The cart will be restored.","Fakturaen din med %1 kunne ikke behandles. Handlevognen vil bli gjenopprettet."
@@ -108,7 +108,7 @@ Version,Versjon
 "Your invoice purchase with %1 is likely to be accepted subject to additional checks.","Fakturakjøpet ditt med %1 vil sannsynligvis bli akseptert med forbehold om ytterligere kontroller."
 "Your request to %1 failed. Reason: %2","Din forespørsel til %1 mislyktes. Årsak: %2"
 "Your sole trader account could not be verified.","Din eneforhandlerkonto kunne ikke bekreftes."
-"Zip/Postal Code",Postnummer
+"Zip/Postal Code","Postnummer"
 "Invoice email address","E-postadresse for faktura"
 "Please ensure that your invoice email address list only contains valid email addresses separated by commas.","Sørg for at listen over e-postadresser for faktura bare inneholder gyldige e-postadresser atskilt med komma."
 "Please enter 3 or more characters","Vennligst skriv inn 3 eller flere tegn"
@@ -117,8 +117,8 @@ Version,Versjon
 "Payment Terms Duration","Betalingsvilkårs varighet"
 "Hyva Extension","Hyva-utvidelse"
 "Checkout Fields","Kassefelt"
-Advanced,Avansert
-Standard,Standard
+"Advanced","Avansert"
+"Standard","Standard"
 "End of Month","Slutten av måneden"
 "%1 days","%1 dager"
 "Controls the position of this payment method relative to other payment methods at checkout. Lower numbers appear first. Default is empty (no specific order).","Styrer plasseringen av denne betalingsmetoden i forhold til andre betalingsmetoder ved utsjekking. Lavere tall vises først. Standard er tom (ingen spesifikk rekkefølge)."
@@ -131,8 +131,8 @@ Standard,Standard
 "Surcharge Method","Tilleggsstrategi"
 "No surcharge applied","Ingen tillegg"
 "Select a method to surcharge your customer.","Velg en metode for å belaste kunden din."
-No,Nei
-Percentage,Prosent
+"No","Nei"
+"Percentage","Prosent"
 "Fixed fee","Fast beløp"
 "Fixed fee and percentage","Fast beløp og prosent"
 "Surcharge Calculation Basis","Grunnlag for tilleggsberegning"
@@ -155,8 +155,8 @@ Percentage,Prosent
 "default","standard"
 "No payment terms selected. Select payment terms above to configure surcharges.","Ingen betalingsvilkår valgt. Velg betalingsvilkår ovenfor for å konfigurere tillegg."
 "Payment Term","Betalingsvilkår"
-days,dager
-day,dag
+"days","dager"
+"day","dag"
 "Selected payment terms","Valgte betalingsvilkår"
 "Selected payment term is not available.","Valgt betalingsvilkår er ikke tilgjengelig."
 "Could not update payment term.","Kunne ikke oppdatere betalingsvilkår."
@@ -183,3 +183,46 @@ day,dag
 "Adds a searchable company name input field on shipping details page where the buyer can select their company from a dropdown menu.","Legger til et søkbart firmanavnfelt på leveringsdetaljsiden der kjøperen kan velge sitt firma fra en nedtrekksmeny."
 "Autocomplete address based on selected country and company.","Autofyll adresse basert på valgt land og firma."
 "If fulfilment trigger is On Completion, select one or more order statuses which can trigger fulfilment.","Hvis oppfyllelsestrigger er «Ved fullføring», velg én eller flere ordrestatuser som kan utløse oppfyllelse."
+"For all companies.","For alle bedrifter."
+"Two Surcharge","Betalingstillegg"
+"%1 days - %2: value cannot be negative.","%1 dager - %2: verdien kan ikke være negativ."
+"%1 days - fixed amount: maximum is %2.","%1 dager - fast beløp: maksimum er %2."
+"%1 days - percentage: maximum is %2.","%1 dager - prosent: maksimum er %2."
+"30 days","30 dager"
+"Add optional tax_subtotals metadata to order creation payload to enforce additional validation (recommended).","Legg til valgfri tax_subtotals-metadata i ordreopprettelsens innhold for å håndheve ytterligere validering (anbefalt)."
+"All Allowed Countries","Alle tillatte land"
+"Amounts are shown in %1.","Beløpet vises i %1."
+"Cannot convert surcharge from %1 to %2.","Kan ikke konvertere gebyr fra %1 til %2."
+"City is not valid.","By er ikke gyldig."
+"Country is not valid.","Land er ikke gyldig."
+"Developed by Magmodules.","Utviklet av Magmodules."
+"Email Address is not valid.","E-postadresse er ikke gyldig."
+"Enter a limit amount (in %1) if you do not want to charge your customer more than a specific amount.","Skriv inn et maksbeløp (i %1) hvis du ikke vil belaste kunden mer enn et bestemt beløp."
+"Enter the amount and percentage of the fee you want to charge your customer. Max %1 / %2.","Skriv inn beløpet og prosentandelen av gebyret du vil belaste kunden. Maks %1 / %2."
+"Enter the amount you want to charge your customer. Max %1.","Skriv inn beløpet du vil belaste kunden. Maks %1."
+"Enter the percentage of the fee you want to charge your customer. Max: %1.","Skriv inn prosentandelen av gebyret du vil belaste kunden. Maks: %1."
+"First Name is not valid.","Fornavn er ikke gyldig."
+"Fulfilment can be triggered by either initializing shipping or creating an invoice in the Magento admin","Fulfillment kan utløses enten ved å starte forsendelse eller ved å opprette en faktura i Magento-admin"
+"I accept the %1 and authorize %2 to process my data automatically.","Jeg aksepterer %1 og gir %2 tillatelse til å behandle mine data automatisk."
+"Company number is not valid.","Organisasjonsnummer er ikke gyldig."
+"Last Name is not valid.","Etternavn er ikke gyldig."
+"Payment Surcharge Configuration","Konfigurasjon av betalingstillegg"
+"Payment Terms %1 days","Betalingsvilkårs %1 dager"
+"Perform a check during checkout to inform the buyer whether an order is likely to be accepted before being placed (recommended).","Utfør en sjekk under utsjekk for å informere kjøperen om en bestilling sannsynligvis vil bli akseptert før den legges inn (anbefalt)."
+"Phone Number is not valid.","Telefonnummer er ikke gyldig."
+"Specific Countries","Spesifikke land"
+"Street Address is not valid.","Gateadresse er ikke gyldig."
+"Yes","Ja"
+"Zip/Postal Code is not valid.","Postnummer er ikke gyldig."
+"payment terms","betalingsvilkår"
+"60 days","60 dager"
+"90 days","90 dager"
+"Debug mode","Feilsøkingsmodus"
+"Max refundable: %1","Maks refunderbart: %1"
+"No extra costs","Ingen ekstra kostnader"
+"Order on invoice","Bestill på faktura"
+"Pay within 30 days","Betal innen 30 dager"
+"Refund Two Surcharge","Refunder tilleggsavgift"
+"Select the payment term(s) you want to offer.","Velg betalingsvilkår du vil tilby."
+"Warning: The fixed fee limit of %1 %2 cannot be enforced correctly because no exchange rate is configured from %3 to %4. Configure exchange rates in Stores → Currency → Currency Rates.","Advarsel: Den faste avgiftsgrensen %1 %2 kan ikke håndheves korrekt fordi ingen valutakurs er konfigurert fra %3 til %4. Konfigurer valutakurser i Stores → Currency → Currency Rates."
+

--- a/i18n/nl_NL.csv
+++ b/i18n/nl_NL.csv
@@ -9,96 +9,96 @@
 "%1 requires whole order to be shipped before it can be fulfilled.","%1 vereist dat de gehele bestelling wordt verzonden voordat deze kan worden uitgevoerd."
 "%1 terms and conditions","%1 voorwaarden en condities"
 "* Required Fields","* Verplichte velden"
-"API Key",API-sleutel
+"API Key","API-sleutel"
 "API key is missing","API-sleutel ontbreekt"
 "API key is not valid","API-sleutel is niet geldig"
 "API key is valid","API-sleutel is geldig"
-"Add PO Number Field","PO-nummer veld toevoegen"
+"Add PO Number Field","PO-nummerveld toevoegen"
 "Add Department Field","Afdelingsveld toevoegen"
-"Add Order Note Field","Bestelnotitie veld toevoegen"
+"Add Order Note Field","Bestelnotitieveld toevoegen"
 "Add Project Field","Projectveld toevoegen"
 "Allowed Countries","Toegestane landen"
-"Choose whether to enable this payment method for all allowed countries or only specific ones.","Kies of je deze betaalmethode wilt inschakelen voor alle toegestane landen of alleen voor specifieke."
+"Choose whether to enable this payment method for all allowed countries or only specific ones.","Kies of je de betaalmethode voor alle toegestane of specifieke landen wilt inschakelen."
 "Country Availability","Beschikbaarheid per land"
 "Select the countries where this payment method should be available.","Selecteer de landen waar deze betaalmethode beschikbaar moet zijn."
 "Amount is missing","Bedrag ontbreekt"
-Branding,Merknaam
+"Branding","Merknaam"
 "Business Invoice","Zakelijke factuur"
 "Buy now, receive your goods, pay your invoice later.","Koop nu, ontvang uw goederen, betaal uw factuur later."
 "Check last 100 debug log records","Controleer de laatste 100 debug-logboek records"
 "Check last 100 error log records","Controleer de laatste 100 foutenlogboek records"
-"City",Stad
+"City","Stad"
 "%1 is not valid.","%1 is niet geldig."
 "%1: %2.","%1: %2."
 "Click here to log in or sign up as a Sole Trader.","Klik hier om in te loggen of u aan te melden als zelfstandig ondernemer."
-"Company Number",Bedrijfsnummer
-"Company Name",Bedrijfsnaam
+"Company Number","Bedrijfsnummer"
+"Company Name","Bedrijfsnaam"
 "Could not initiate capture with %1","Kon geen vastlegging starten met %1"
 "Could not initiate refund with %1","Kon geen terugbetaling starten met %1"
 "Could not update %1 order status to cancelled. Please contact support with order ID %2. Error: %3","Kon %1 orderstatus niet updaten naar geannuleerd. Neem contact op met support met bestelnummer %2. Fout: %3"
-"Country",Land
-"Credit Note",Creditnota
-"Debug Mode",Debug-modus
-Department,Afdeling
-Download,Download
+"Country","Land"
+"Credit Note","Creditnota"
+"Debug Mode","Debug-modus"
+"Department","Afdeling"
+"Download","Download"
 "Download as .txt file","Downloaden als .txt-bestand"
-"Email Address",E-mailadres
+"Email Address","E-mailadres"
 "Enable Address Search","Adres zoeken inschakelen"
 "Enable Company Search","Bedrijf zoeken inschakelen"
 "Enable Order Intent","Bestelintentie inschakelen"
 "Enable Payment Method","Betaalmethode inschakelen"
-"Enable Tax Subtotals","Btw subtotalen inschakelen"
+"Enable Tax Subtotals","BTW-subtotalen inschakelen"
 "Enter company name to search","Voer bedrijfsnaam in om te zoeken"
 "Enter details manually","Gegevens handmatig invoeren"
-Environment,Omgeving
+"Environment","Omgeving"
 "Failed to refund order with %1. Reason: %2","Het is niet gelukt om de bestelling met %1 terug te betalen. Reden: %2"
 "Failed to update %1 customer address: %2","Kon het adres van klant %1 niet bijwerken: %2"
 "Find out more","Meer informatie"
-"First Name",Voornaam
+"First Name","Voornaam"
 "Fulfilment Order Status","Status van vervulling bestelling"
 "Fulfilment Trigger","Trigger voor vervulling"
-General,Algemeen
+"General","Algemeen"
 "Invalid API response from %1.","Ongeldige API-respons van %1."
-Invoice,Factuur
+"Invoice","Factuur"
 "Invoice purchase with %1 is not available for this order.","Aankoop op factuur met %1 is niet beschikbaar voor deze bestelling."
 "Last 100 debug log lines","Laatste 100 debug-logregels"
 "Last 100 error log records","Laatste 100 foutenlogboek records"
-"Last Name",Achternaam
+"Last Name","Achternaam"
 "Log is empty","Logboek is leeg"
-OK,OK
+"OK","OK"
 "On Completion","Bij voltooiing"
 "On Invoice","Op factuur"
 "On Shipment","Bij verzending"
-"Order ID",Bestelnummer
-"Order Note",Bestelnotitie
+"Order ID","Bestelnummer"
+"Order Note","Bestelnotitie"
 "Order edit request was accepted by %1","Bestellingswijzigingsverzoek is geaccepteerd door %1"
-"PO Number",PO-nummer
-Payment,Betaling
-"Payment Method",Betaalmethode
-"Phone Number",Telefoonnummer
+"PO Number","PO-nummer"
+"Payment","Betaling"
+"Payment Method","Betaalmethode"
+"Phone Number","Telefoonnummer"
 "Place Order","Bestelling plaatsen"
 "Please try again later.","Probeer het later opnieuw."
-Production,Productie
-Project,Project
+"Production","Productie"
+"Project","Project"
 "Registered Organisation","Geregistreerde organisatie"
-Sandbox,Zandbak
-Search,Zoekopdracht
+"Sandbox","Zandbak"
+"Search","Zoekopdracht"
 "Search for company","Zoek naar bedrijf"
 "Sign up now","Meld u nu aan"
-"Sole Trader",Eenmanszaak
+"Sole Trader","Eenmanszaak"
 "Something went wrong with your request to %1. %2","Er is iets misgegaan met uw verzoek aan %1. %2"
-"Sort Order",Sorteervolgorde
-"Street Address",Straatadres
+"Sort Order","Sorteervolgorde"
+"Street Address","Straatadres"
 "Successfully refunded order with %1 for order ID: %2. Refund reference: %3","Bestelling succesvol terugbetaald met %1 voor bestelnummer: %2. Terugbetalingsreferentie: %3"
-TWO,TWO
+"TWO","TWO"
 "The %1 payment plugin for Magento simplifies B2B shopping, making it easy and safe for merchants to offer invoices as a payment method.<br>The payment method lives next to other payment methods in your existing checkout, and offers a variety of configuration options to suit your businesses needs.<br>If you would like to know more about how to configure the plugin, check out our <a href=""%2"" target=""_blank"">step by step guide</a>.","De %1-betaalplug-in voor Magento vereenvoudigt B2B-shoppen en maakt het voor verkopers eenvoudig en veilig om facturen als betaalmethode aan te bieden. <br> De betaalmethode staat naast andere betaalmethoden in je bestaande kassa en biedt een verscheidenheid aan configuratieopties die aansluiten op de behoeften van je bedrijf. <br> Als je meer wilt weten over het configureren van de plug-in, bekijk dan onze <a href=""%2"" target=""_blank""> stapsgewijze handleiding </a> ."
 "The buyer and the seller are the same company.","De koper en de verkoper zijn hetzelfde bedrijf."
 "The capture action is not available.","De vastleg actie is niet beschikbaar."
-Title,Titel
+"Title","Titel"
 "Two is a payment solution for B2B purchases online, allowing you to buy from your favourite merchants and suppliers on trade credit. Using Two, you can access flexible trade credit instantly to make purchasing simple.","Two is een betalingsoplossing voor online B2B-aankopen, waarmee u op handelskrediet kunt kopen bij uw favoriete handelaren en leveranciers. Met Two heeft u direct toegang tot flexibel handelskrediet om het aankopen eenvoudig te maken."
 "Unable to confirm %1 order with %2 state.","Kan %1 bestelling met %2 status niet bevestigen."
 "Unable to find the requested %1 order","Kan de gevraagde %1 bestelling niet vinden"
-Version,Versie
+"Version","Versie"
 "You must accept %1 to place order.","U moet %1 accepteren om de bestelling te plaatsen."
 "You will be redirected to %1 when you place order.","U wordt doorgestuurd naar %1 wanneer u een bestelling plaatst."
 "Your invoice purchase with %1 could not be processed. The cart will be restored.","Uw factuuraankoop met %1 kon niet worden verwerkt. De winkelwagen wordt hersteld."
@@ -108,17 +108,17 @@ Version,Versie
 "Your invoice purchase with %1 is likely to be accepted subject to additional checks.","Uw aankoop op factuur met %1 wordt waarschijnlijk geaccepteerd, mits er aanvullende controles worden uitgevoerd."
 "Your request to %1 failed. Reason: %2","Uw verzoek aan %1 is mislukt. Reden: %2"
 "Your sole trader account could not be verified.","Uw eenmanszaakaccount kon niet worden geverifieerd."
-"Zip/Postal Code",Postcode
+"Zip/Postal Code","Postcode"
 "Invoice email address","E-mailadres factuur"
 "Please ensure that your invoice email address list only contains valid email addresses separated by commas.","Zorg ervoor dat uw factuur-e-mailadreslijst alleen geldige e-mailadressen bevat, gescheiden door komma's."
 "Please enter 3 or more characters","Voer 3 of meer tekens in"
 "Enable Invoice Emails","Factuur-e-mails inschakelen"
-"Payment Terms Type","Betalingsvoorwaarden type"
-"Payment Terms Duration","Betalingsvoorwaarden duur"
+"Payment Terms Type","Type betaaltermijnen"
+"Payment Terms Duration","Duur betaaltermijnen"
 "Hyva Extension","Hyva-extensie"
-"Checkout Fields","Afrekenveldenst"
-Advanced,Geavanceerd
-Standard,Standaard
+"Checkout Fields","Afrekenvelden"
+"Advanced","Geavanceerd"
+"Standard","Standaard"
 "End of Month","Einde van de maand"
 "%1 days","%1 dagen"
 "Controls the position of this payment method relative to other payment methods at checkout. Lower numbers appear first. Default is empty (no specific order).","Bepaalt de positie van deze betaalmethode ten opzichte van andere betaalmethoden bij het afrekenen. Lagere nummers verschijnen eerst. Standaard is leeg (geen specifieke volgorde)."
@@ -129,10 +129,10 @@ Standard,Standaard
 "Default Payment Term","Standaard betaaltermijn"
 "Select the payment term that will be automatically selected for your customer.","Kies de betaaltermijn die automatisch wordt geselecteerd voor je klant."
 "Surcharge Method","Toeslagstrategie"
-"No surcharge applied","Geen toeslag toegepast"
+"No surcharge applied","Geen toeslag"
 "Select a method to surcharge your customer.","Kies een methode om kosten door te berekenen aan je klant."
-No,Nee
-Percentage,Percentage
+"No","Nee"
+"Percentage","Percentage"
 "Fixed fee","Vast bedrag"
 "Fixed fee and percentage","Vast bedrag en percentage"
 "Surcharge Calculation Basis","Basis voor toeslagberekening"
@@ -140,7 +140,7 @@ Percentage,Percentage
 "Fee difference vs default payment term","Verschil ten opzichte van standaard betaaltermijn"
 "Surcharge Line Description","Omschrijving toeslagregel"
 "Description shown to the buyer for the surcharge line item.","Omschrijving die aan de koper wordt getoond voor de toeslagregel."
-"Payment terms fee","Betaaltermijn toeslag"
+"Payment terms fee","Toeslag betaaltermijnen"
 "Payment terms fee - %1 days","Betaaltermijn toeslag - %1 dagen"
 "Surcharge Tax Rate (%)","BTW-tarief toeslag (%)"
 "Leave empty to use your store's default tax rate (%1%). Enter 0 for tax-exempt.","Laat leeg om het standaard BTW-tarief van je winkel te gebruiken (%1%). Voer 0 in voor BTW-vrijstelling."
@@ -155,8 +155,8 @@ Percentage,Percentage
 "default","standaard"
 "No payment terms selected. Select payment terms above to configure surcharges.","Geen betaaltermijnen geselecteerd. Selecteer hierboven betaaltermijnen om toeslagen te configureren."
 "Payment Term","Betaaltermijn"
-days,dagen
-day,dag
+"days","dagen"
+"day","dag"
 "Selected payment terms","Gewenste betaaltermijn"
 "Selected payment term is not available.","Geselecteerde betaaltermijn is niet beschikbaar."
 "Could not update payment term.","Kan betaaltermijn niet bijwerken."
@@ -180,3 +180,45 @@ day,dag
 "Adds a searchable company name input field on shipping details page where the buyer can select their company from a dropdown menu.","Voegt een veld toe op de verzenddetails pagina waar de koper het bedrijf kan kiezen uit een dropdown menu."
 "Autocomplete address based on selected country and company.","Automatisch invullen van adres gebaseerd op geselecteerd land en bedrijf."
 "If fulfilment trigger is On Completion, select one or more order statuses which can trigger fulfilment.","Als de vervullingstrigger op Bij voltooiing staat, selecteer dan een of meer orderstatussen die vervulling kunnen triggeren."
+"For all companies.","Voor alle bedrijven."
+"Two Surcharge","Betalingstoeslag"
+"%1 days - %2: value cannot be negative.","%1 dagen - %2: waarde mag niet negatief zijn."
+"%1 days - fixed amount: maximum is %2.","%1 dagen - vast bedrag: maximum is %2."
+"%1 days - percentage: maximum is %2.","%1 dagen - percentage: maximum is %2."
+"30 days","30 dagen"
+"60 days","60 dagen"
+"90 days","90 dagen"
+"Add optional tax_subtotals metadata to order creation payload to enforce additional validation (recommended).","Voeg optionele BTW-subtotalen toe aan order creatie data om extra validatie toe te passen (aanbevolen)."
+"All Allowed Countries","Alle toegestane landen"
+"Amounts are shown in %1.","Bedragen worden getoond in %1."
+"City is not valid.","Stad is niet geldig."
+"Country is not valid.","Land is niet geldig."
+"Debug mode","Debug-modus"
+"Developed by Magmodules.","Ontwikkeld door Magmodules."
+"Email Address is not valid.","E-mailadres is niet geldig."
+"Enter the amount you want to charge your customer. Max %1.","Vul het bedrag in dat je bij je klant in rekening wilt brengen. Max %1."
+"Enter the amount and percentage of the fee you want to charge your customer. Max %1 / %2.","Vul het bedrag en het percentage van de fee in dat je bij je klant in rekening wilt brengen. Max %1 / %2."
+"Enter the percentage of the fee you want to charge your customer. Max: %1.","Vul het percentage van de fee in dat je bij je klant in rekening wilt brengen. Max: %1."
+"Enter a limit amount (in %1) if you do not want to charge your customer more than a specific amount.","Vul een limietbedrag (in %1) in als je je klant niet meer dan een specifiek bedrag in rekening wilt brengen."
+"First Name is not valid.","Voornaam is niet geldig."
+"Fulfilment can be triggered by either initializing shipping or creating an invoice in the Magento admin","Vervulling kan getriggerd worden door verzending of door een factuur aan te maken in het Magento portaal"
+"I accept the %1 and authorize %2 to process my data automatically.","Ik accepteer de %1 en geef toestemming aan %2 voor automatische verwerking van mijn gegevens."
+"Company number is not valid.","KVK-nummer is niet geldig."
+"Last Name is not valid.","Achternaam is niet geldig."
+"No extra costs","Geen extra kosten"
+"Order on invoice","Op rekening bestellen"
+"Pay within 30 days","Betaal binnen 30 dagen"
+"Payment Surcharge Configuration","Configuratie van toeslagen"
+"Payment Terms %1 days","Betaaltermijn %1 dagen"
+"Perform a check during checkout to inform the buyer whether an order is likely to be accepted before being placed (recommended).","Doe een controle tijdens checkout om de koper te informeren of de bestelling waarschijnlijk geaccepteerd zal worden voordat deze geplaatst wordt (aanbevolen)."
+"Phone Number is not valid.","Telefoonnummer is niet geldig."
+"Select the payment term(s) you want to offer.","Selecteer de betaaltermijn(en) die je wilt aanbieden."
+"Specific Countries","Specifieke landen"
+"Street Address is not valid.","Adres is niet geldig."
+"Warning: The fixed fee limit of %1 %2 cannot be enforced correctly because no exchange rate is configured from %3 to %4. Configure exchange rates in Stores → Currency → Currency Rates.","Waarschuwing: de vaste toeslaglimiet van %1 %2 kan niet correct worden toegepast omdat er geen wisselkoers is geconfigureerd van %3 naar %4. Configureer wisselkoersen in Winkels → Valuta → Valutakoersen."
+"Yes","Ja"
+"Zip/Postal Code is not valid.","Postcode is niet geldig."
+"payment terms","betaalvoorwaarden"
+"Refund Two Surcharge","Toeslag terugbetalen"
+"Max refundable: %1","Maximaal terugbetaalbaar: %1"
+

--- a/i18n/sv_SE.csv
+++ b/i18n/sv_SE.csv
@@ -9,11 +9,11 @@
 "%1 requires whole order to be shipped before it can be fulfilled.","%1 kräver att hela beställningen skickas innan den kan uppfyllas."
 "%1 terms and conditions","%1 villkor och bestämmelser"
 "* Required Fields","* Obligatoriska fält"
-"API Key",API-nyckel
+"API Key","API-nyckel"
 "API key is missing","API-nyckel saknas"
 "API key is not valid","API-nyckeln är inte giltig"
 "API key is valid","API-nyckeln är giltig"
-"Add PO Number Field","Lägg till PO-nummerfält"
+"Add PO Number Field","Lägg till fält för PO-nummer"
 "Add Department Field","Lägg till fält för avdelning"
 "Add Order Note Field","Lägg till orderanteckningsfält"
 "Add Project Field","Lägg till fält för projekt"
@@ -22,27 +22,27 @@
 "Country Availability","Landstillgänglighet"
 "Select the countries where this payment method should be available.","Välj de länder där denna betalningsmetod ska vara tillgänglig."
 "Amount is missing","Belopp saknas"
-Branding,Branding
-"Business Invoice",Företagsfaktura
+"Branding","Branding"
+"Business Invoice","Företagsfaktura"
 "Buy now, receive your goods, pay your invoice later.","Köp nu, få dina varor, betala din faktura senare."
 "Check last 100 debug log records","Kontrollera de senaste 100 felsökningsloggposterna"
 "Check last 100 error log records","Kontrollera de senaste 100 felloggposterna"
-"City",Stad
+"City","Stad"
 "%1 is not valid.","%1 är inte giltigt."
 "%1: %2.","%1: %2."
 "Click here to log in or sign up as a Sole Trader.","Klicka här för att logga in eller registrera dig som enskild näringsidkare."
-"Company Number",Organisationsnummer
-"Company Name",Företagsnamn
+"Company Number","Organisationsnummer"
+"Company Name","Företagsnamn"
 "Could not initiate capture with %1","Kunde inte initiera debitering med %1"
 "Could not initiate refund with %1","Kunde inte initiera återbetalning med %1"
 "Could not update %1 order status to cancelled. Please contact support with order ID %2. Error: %3","Kunde inte uppdatera %1 orderstatus till annullerad. Kontakta supporten med beställnings-ID %2. Fel: %3"
-"Country",Land
-"Credit Note",Kreditnota
-"Debug Mode",Felsökningsläge
-Department,Avdelning
-Download,"Ladda ner"
+"Country","Land"
+"Credit Note","Kreditnota"
+"Debug Mode","Felsökningsläge"
+"Department","Avdelning"
+"Download","Ladda ner"
 "Download as .txt file","Ladda ner som .txt-fil"
-"Email Address",E-postadress
+"Email Address","E-postadress"
 "Enable Address Search","Aktivera adresssökning"
 "Enable Company Search","Aktivera företagssökning"
 "Enable Order Intent","Aktivera orderavsikt"
@@ -50,55 +50,55 @@ Download,"Ladda ner"
 "Enable Tax Subtotals","Aktivera delsummor för skatt"
 "Enter company name to search","Ange företagsnamn för att söka"
 "Enter details manually","Ange detaljer manuellt"
-Environment,Miljö
+"Environment","Miljö"
 "Failed to refund order with %1. Reason: %2","Det gick inte att återbetala beställningen med %1. Orsak: %2"
 "Failed to update %1 customer address: %2","Misslyckades med att uppdatera %1 kundadress: %2"
 "Find out more","Ta reda på mer"
-"First Name",Förnamn
+"First Name","Förnamn"
 "Fulfilment Order Status","Uppfyllande orderstatus"
 "Fulfilment Trigger","Uppfyllelse trigger"
-General,Generellt
+"General","Generellt"
 "Invalid API response from %1.","Ogiltigt API-svar från %1."
-Invoice,Faktura
+"Invoice","Faktura"
 "Invoice purchase with %1 is not available for this order.","Fakturaköp med %1 är inte tillgängligt för den här beställningen."
 "Last 100 debug log lines","Senaste 100 felsökningsloggraderna"
 "Last 100 error log records","Senaste 100 felloggposter"
-"Last Name",Efternamn
+"Last Name","Efternamn"
 "Log is empty","Loggen är tom"
-OK,OK
+"OK","OK"
 "On Completion","Vid färdigställande"
 "On Invoice","På faktura"
 "On Shipment","Vid leverans"
-"Order ID",Beställnings-ID
-"Order Note",Beställningsanmärkning
+"Order ID","Beställnings-ID"
+"Order Note","Beställningsanmärkning"
 "Order edit request was accepted by %1","Begäran om beställningsredigering accepterades av %1"
-"PO Number",PO-nummer
-Payment,Betalning
-"Payment Method",Betalningsmetod
-"Phone Number",Telefonnummer
-"Place Order",Beställa
+"PO Number","PO-nummer"
+"Payment","Betalning"
+"Payment Method","Betalningsmetod"
+"Phone Number","Telefonnummer"
+"Place Order","Beställa"
 "Please try again later.","Försök igen senare."
-Production,Produktion
-Project,Projekt
+"Production","Produktion"
+"Project","Projekt"
 "Registered Organisation","Registrerad organisation"
-Sandbox,Sandbox
-Search,Sök
+"Sandbox","Sandbox"
+"Search","Sök"
 "Search for company","Sök efter företag"
 "Sign up now","Registrera nu"
 "Sole Trader","Enskild näringsidkare"
 "Something went wrong with your request to %1. %2","Något gick fel med din begäran till %1. %2"
-"Sort Order",Sorteringsordning
-"Street Address",Gatuadress
+"Sort Order","Sorteringsordning"
+"Street Address","Gatuadress"
 "Successfully refunded order with %1 for order ID: %2. Refund reference: %3","Återbetalad beställning med %1 för beställnings-ID: %2. Återbetalningsreferens: %3"
-TWO,TWO
+"TWO","TWO"
 "The %1 payment plugin for Magento simplifies B2B shopping, making it easy and safe for merchants to offer invoices as a payment method.<br>The payment method lives next to other payment methods in your existing checkout, and offers a variety of configuration options to suit your businesses needs.<br>If you would like to know more about how to configure the plugin, check out our <a href=""%2"" target=""_blank"">step by step guide</a>.","Betalningspluginet %1 för Magento förenklar B2B-shopping, vilket gör det enkelt och säkert för handlare att erbjuda fakturor som betalningsmetod. <br> Betalningsmetoden finns bredvid andra betalningsmetoder i din befintliga kassa, och erbjuder en mängd olika konfigurationsalternativ för att passa ditt företags behov. <br> Om du vill veta mer om hur du konfigurerar plugin-programmet, kolla in vår <a href=""%2"" target=""_blank""> steg-för-steg-guide </a> ."
 "The buyer and the seller are the same company.","Köparen och säljaren är samma företag."
 "The capture action is not available.","Infångningsåtgärden är inte tillgänglig."
-Title,Titel
+"Title","Titel"
 "Two is a payment solution for B2B purchases online, allowing you to buy from your favourite merchants and suppliers on trade credit. Using Two, you can access flexible trade credit instantly to make purchasing simple.","Two är en betalningslösning för B2B-köp online, som låter dig köpa från dina favorithandlare och leverantörer på handelskredit. Med Two får du omedelbar tillgång till flexibel handelskredit för att göra inköp enkelt."
 "Unable to confirm %1 order with %2 state.","Kan inte bekräfta %1 beställning med %2 status."
 "Unable to find the requested %1 order","Det gick inte att hitta den begärda beställningen %1"
-Version,Version
+"Version","Version"
 "You must accept %1 to place order.","Du måste acceptera %1 för att göra en beställning."
 "You will be redirected to %1 when you place order.","Du kommer att omdirigeras till %1 när du beställer."
 "Your invoice purchase with %1 could not be processed. The cart will be restored.","Ditt fakturaköp med %1 kunde inte behandlas. Varukorgen kommer att återställas."
@@ -108,7 +108,7 @@ Version,Version
 "Your invoice purchase with %1 is likely to be accepted subject to additional checks.","Ditt fakturaköp med %1 kommer sannolikt att accepteras under förutsättning av ytterligare kontroller."
 "Your request to %1 failed. Reason: %2","Din begäran till %1 misslyckades. Orsak: %2"
 "Your sole trader account could not be verified.","Ditt enskild näringsidkarekonto kunde inte verifieras."
-"Zip/Postal Code",Postnummer
+"Zip/Postal Code","Postnummer"
 "Invoice email address","E-postadress för faktura"
 "Please ensure that your invoice email address list only contains valid email addresses separated by commas.","Se till att din e-postadresslista för faktura endast innehåller giltiga e-postadresser separerade med kommatecken."
 "Please enter 3 or more characters","Ange 3 eller fler tecken"
@@ -117,8 +117,8 @@ Version,Version
 "Payment Terms Duration","Betalningsvillkors varaktighet"
 "Hyva Extension","Hyva-tillägg"
 "Checkout Fields","Kassafält"
-Advanced,Avancerat
-Standard,Standard
+"Advanced","Avancerat"
+"Standard","Standard"
 "End of Month","Månadsskifte"
 "%1 days","%1 dagar"
 "Controls the position of this payment method relative to other payment methods at checkout. Lower numbers appear first. Default is empty (no specific order).","Styr positionen för denna betalningsmetod i förhållande till andra betalningsmetoder vid kassan. Lägre nummer visas först. Standard är tom (ingen specifik ordning)."
@@ -129,10 +129,10 @@ Standard,Standard
 "Default Payment Term","Standard betalningsvillkor"
 "Select the payment term that will be automatically selected for your customer.","Välj det betalningsvillkor som automatiskt väljs för din kund."
 "Surcharge Method","Tilläggsstrategi"
-"No surcharge applied","Inget tillägg"
+"No surcharge applied","Ingen tilläggsavgift appliceras"
 "Select a method to surcharge your customer.","Välj en metod för att debitera din kund."
-No,Nej
-Percentage,Procent
+"No","Nej"
+"Percentage","Procent"
 "Fixed fee","Fast belopp"
 "Fixed fee and percentage","Fast belopp och procent"
 "Surcharge Calculation Basis","Grund för tilläggsberäkning"
@@ -155,8 +155,8 @@ Percentage,Procent
 "default","standard"
 "No payment terms selected. Select payment terms above to configure surcharges.","Inga betalningsvillkor valda. Välj betalningsvillkor ovan för att konfigurera tillägg."
 "Payment Term","Betalningsvillkor"
-days,dagar
-day,dag
+"days","dagar"
+"day","dag"
 "Selected payment terms","Valda betalningsvillkor"
 "Selected payment term is not available.","Valt betalningsvillkor är inte tillgängligt."
 "Could not update payment term.","Kunde inte uppdatera betalningsvillkor."
@@ -180,3 +180,46 @@ day,dag
 "Adds a searchable company name input field on shipping details page where the buyer can select their company from a dropdown menu.","Lägger till ett sökbart företagsnamnsfält på leveransdetaljsidan där köparen kan välja sitt företag från en rullgardinsmeny."
 "Autocomplete address based on selected country and company.","Autofyll adress baserat på valt land och företag."
 "If fulfilment trigger is On Completion, select one or more order statuses which can trigger fulfilment.","Om uppfyllnadstrigger är ”Vid slutförande”, välj en eller flera orderstatusar som kan utlösa uppfyllnad."
+"For all companies.","För alla företag."
+"Two Surcharge","Betalningsavgift"
+"%1 days - %2: value cannot be negative.","%1 dagar - %2: värdet får inte vara negativt."
+"%1 days - fixed amount: maximum is %2.","%1 dagar - fast belopp: maximum är %2."
+"%1 days - percentage: maximum is %2.","%1 dagar - procent: maximum är %2."
+"30 days","30 dagar"
+"Add optional tax_subtotals metadata to order creation payload to enforce additional validation (recommended).","Lägg till valfri tax_subtotals-metadata i orderskapandets payload för att tillämpa ytterligare validering (rekommenderas)."
+"All Allowed Countries","Alla tillåtna länder"
+"Amounts are shown in %1.","Belopp visas i %1."
+"Cannot convert surcharge from %1 to %2.","Kan inte konvertera tillägg från %1 till %2."
+"City is not valid.","Stad är inte giltig."
+"Country is not valid.","Land är inte giltigt."
+"Developed by Magmodules.","Utvecklad av Magmodules."
+"Email Address is not valid.","E-postadress är inte giltig."
+"Enter a limit amount (in %1) if you do not want to charge your customer more than a specific amount.","Ange ett maxbelopp (i %1) om du inte vill debitera din kund mer än ett specifikt belopp."
+"Enter the amount and percentage of the fee you want to charge your customer. Max %1 / %2.","Ange beloppet och procentandelen av avgiften du vill debitera din kund. Max %1 / %2."
+"Enter the amount you want to charge your customer. Max %1.","Ange beloppet du vill debitera din kund. Max %1."
+"Enter the percentage of the fee you want to charge your customer. Max: %1.","Ange procentandelen av avgiften du vill debitera din kund. Max: %1."
+"First Name is not valid.","Förnamn är inte giltigt."
+"Fulfilment can be triggered by either initializing shipping or creating an invoice in the Magento admin","Orderuppfyllelse kan utlösas antingen genom att initiera leverans eller genom att skapa en faktura i Magento-administrationen"
+"I accept the %1 and authorize %2 to process my data automatically.","Jag accepterar %1 och ger %2 tillstånd att behandla mina uppgifter automatiskt."
+"Company number is not valid.","Organisationsnummer är inte giltigt."
+"Last Name is not valid.","Efternamn är inte giltigt."
+"Payment Surcharge Configuration","Konfiguration av tilläggsavgift"
+"Payment Terms %1 days","Betalningsvillkors %1 dagar"
+"Perform a check during checkout to inform the buyer whether an order is likely to be accepted before being placed (recommended).","Gör en kontroll under kassan för att informera köparen om en order sannolikt kommer att accepteras innan den läggs (rekommenderas)."
+"Phone Number is not valid.","Telefonnummer är inte giltigt."
+"Specific Countries","Specifika länder"
+"Street Address is not valid.","Gatuadress är inte giltig."
+"Yes","Ja"
+"Zip/Postal Code is not valid.","Postnummer är inte giltigt."
+"payment terms","betalningsvillkor"
+"60 days","60 dagar"
+"90 days","90 dagar"
+"Debug mode","Felsökningsläge"
+"Max refundable: %1","Max återbetalningsbart: %1"
+"No extra costs","Inga extra kostnader"
+"Order on invoice","Beställ på faktura"
+"Pay within 30 days","Betala inom 30 dagar"
+"Refund Two Surcharge","Återbetala tilläggsavgift"
+"Select the payment term(s) you want to offer.","Välj betalningsvillkor du vill erbjuda."
+"Warning: The fixed fee limit of %1 %2 cannot be enforced correctly because no exchange rate is configured from %3 to %4. Configure exchange rates in Stores → Currency → Currency Rates.","Varning: Den fasta avgiftsgränsen %1 %2 kan inte upprätthållas korrekt eftersom ingen växelkurs är konfigurerad från %3 till %4. Konfigurera växelkurser i Stores → Currency → Currency Rates."
+


### PR DESCRIPTION
## What

Mechanical reconciliation of i18n drift between the ABN overlay and the base plugin. Items 1–4 from [ABN-445](https://linear.app/tillit/issue/ABN-445).

### Changes

**Push 39 nl_NL / 41 nb_NO / 41 sv_SE generic translations from overlay to base** — Two-branded merchants were missing these. Generic (no ABN brand strings); brand-specific overrides remain in the overlay.

**Fix 9 nl_NL base translation errors** where the overlay had the correct version:

| Key | Base (wrong) | Fixed |
|-----|-------------|-------|
| Checkout Fields | `Afrekenveldenst` ← typo | `Afrekenvelden` |
| Add Order Note Field | `Bestelnotitie veld toevoegen` | `Bestelnotitieveld toevoegen` (compound) |
| Add PO Number Field | `PO-nummer veld toevoegen` | `PO-nummerveld toevoegen` (compound) |
| Enable Tax Subtotals | `Btw subtotalen inschakelen` | `BTW-subtotalen inschakelen` (caps+hyphen) |
| Payment Terms Duration | `Betalingsvoorwaarden duur` | `Duur betaaltermijnen` (natural word order) |
| Payment Terms Type | `Betalingsvoorwaarden type` | `Type betaaltermijnen` |
| Payment terms fee | `Betaaltermijn toeslag` | `Toeslag betaaltermijnen` |
| Choose whether to enable… | truncated sentence | complete sentence |
| No surcharge applied | `Geen toeslag toegepast` | `Geen toeslag` |

Equivalent corrections applied to nb_NO / sv_SE where overlay held a better value.

**Add generic base entries for brand-specific overlay keys:**
- `For all companies.` → `Voor alle bedrijven.` / `For alle bedrifter.` / `För alla företag.`
- `Two Surcharge` → `Betalingstoeslag` / `Betalingstillegg` / `Betalningsavgift`

(ABN-branded override values remain in the overlay.)

## Not included

Item 5 — 12 nl_NL style/register conflicts — pending #languages native sign-off. Will come as a follow-up once the canonical NL decisions are in.

## Validation

- All 3 locale CSVs: 2-col clean, no bad rows.
- No brand strings leaked into base (debrand check).
- Pre-existing `Percentage` duplicate key in base CSVs is out of scope (noted in ABN-445).

Ref: ABN-445. Companion overlay PR: two-inc/magento-abn-plugin#128.

**Stop for Doug review before merge.**