### PR TITLE
TWO-24742/fix: Move frpc serverAddr from hardcoded toml to start-proxy.sh

### DIFF
--- a/frpc.toml
+++ b/frpc.toml
@@ -1,4 +1,4 @@
-serverAddr = "frp.beta.two.inc"
+serverAddr = "{{ .Envs.FRP_SERVER_ADDR }}"
 serverPort = 7000
 auth.token = "{{ .Envs.FRP_AUTH_TOKEN }}"
 

--- a/start-proxy.sh
+++ b/start-proxy.sh
@@ -51,6 +51,12 @@ esac
 export FRP_DOMAIN="${SUBDOMAIN}.frp.${FRP_ZONE}"
 PROXY_URL="https://${FRP_DOMAIN}"
 
+# frpc control-plane address. The frps server is shared across envs (INF-1458):
+# per-env routing happens via customDomains/FRP_DOMAIN through the istio gateway,
+# while the client always dials the single frps instance in beta. Overridable so
+# a per-env frps can be adopted here without touching frpc.toml again.
+export FRP_SERVER_ADDR="${FRP_SERVER_ADDR:-frp.beta.two.inc}"
+
 # ── stop mode ────────────────────────────────────────────────────────────────
 if [ "$1" = "stop" ]; then
   if [ -f "$PIDFILE" ]; then


### PR DESCRIPTION
## What

Templates `serverAddr` in `frpc.toml` (`{{ .Envs.FRP_SERVER_ADDR }}`) and exports `FRP_SERVER_ADDR` from `start-proxy.sh` next to the existing `FRP_DOMAIN` derivation, defaulting to the shared frps server.

## Why — and a premise correction on the ticket

TWO-24742 asks to derive `serverAddr` per-env "using the same environment detection logic already applied to the domain names". **That literal derivation would break every tunnel:** per INF-1458's design the frps control-plane server is intentionally *shared* across envs — per-env behaviour lives entirely in `customDomains`, routed through the istio gateway (`*.frp.<env>.two.inc` wildcards → 35.228.119.192). There is no per-env frps: `frp.staging.two.inc` and `frp.release.two.inc` have **no A records**; the only control-plane record is `frp.beta.two.inc` → 35.228.187.200.

So this PR delivers the defensible core of the ticket: the hardcode moves out of `frpc.toml` into `start-proxy.sh` where the env detection lives, as an overridable export with a comment documenting the shared-server design. If a per-env frps is ever provisioned, the derivation slots in there without touching the toml.

The same hardcode exists in prestashop, admin-portal, portals, and checkout-page — if we want this seam everywhere, that's a follow-up sweep.

## Verification

`bash -n start-proxy.sh` clean. Tunnel behaviour unchanged: frpc dials the same server with the same rendered config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)