### PR TITLE
TWO-24743/feat: Brand-driven minimum order gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@ Two's Magento 2 BNPL payment plugin. Brand-aware single-module
 extension; brand-specific identity values resolve through
 `Two\Gateway\Api\BrandRegistryInterface`. The default DI
 binding in `etc/di.xml` resolves to `Two\Gateway\Brand\TwoBrand`.
+Building a partner overlay or adding a brand-driven field:
+see docs/brand-overlay-guide.md.
 
 Standard Magento dev workflow: composer install, bin/magento
 setup:di:compile, setup:upgrade, cache:flush. PHPUnit under Test/.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,8 @@
 Two's Magento 2 BNPL payment plugin. Brand-aware single-module
 extension; brand-specific identity values resolve through
 `Two\Gateway\Api\BrandRegistryInterface`. The default DI
-binding in `etc/di.xml` resolves to `Two\Gateway\Brand\TwoBrand`.
+binding in `etc/di.xml` resolves to
+`Two\Gateway\Brand\DescriptorBackedBrandRegistry`.
 Building a partner overlay or adding a brand-driven field:
 see docs/brand-overlay-guide.md.
 

--- a/Api/BrandOverlayRegistryInterface.php
+++ b/Api/BrandOverlayRegistryInterface.php
@@ -47,7 +47,7 @@ interface BrandOverlayRegistryInterface
      * method" (observers, controllers, the order-reference lookup in
      * Service\Payment\OrderService) use this instead of the previous
      * pattern of `=== Two::CODE` which excluded overlay methods like
-     * `abn_payment` and produced "Unable to find the requested order"
+     * `acme_payment` and produced "Unable to find the requested order"
      * errors on overlay checkouts.
      */
     public function isTwoStackMethod(string $method): bool;

--- a/Api/BrandRegistryInterface.php
+++ b/Api/BrandRegistryInterface.php
@@ -104,7 +104,7 @@ interface BrandRegistryInterface
 
     /**
      * Magento payment-method code for the active brand (e.g.
-     * "two_payment", "abn_payment"). Used to build brand-aware
+     * "two_payment", "acme_payment"). Used to build brand-aware
      * `payment/<code>/*` CCD paths from a single shared codebase
      * — callers do not hold this value in their own constructor
      * args.

--- a/Api/BrandRegistryInterface.php
+++ b/Api/BrandRegistryInterface.php
@@ -61,15 +61,16 @@ interface BrandRegistryInterface
     public function getSurchargeFixedMax(): ?array;
 
     /**
-     * Minimum NET order value (basket total excluding tax) required for
-     * this brand's payment method to be offered at checkout, expressed
-     * in a specific currency — net, because the funding partner's
-     * server-side risk rule compares net. Returning null means there is
-     * no minimum - any order value is acceptable. Baskets in other
+     * Minimum order value required for this brand's payment method to
+     * be offered at checkout: amount + currency + basis ('net' = basket
+     * excluding tax, 'gross' = including; ABN AMRO defines its minimum
+     * net, matching the funding partner's server-side risk rule, while
+     * the platform's country defaults are gross — hence explicit).
+     * Returning null means there is no minimum. Baskets in other
      * currencies are converted to this currency via the store's
      * exchange rates before comparing.
      *
-     * @return array{amount: float, currency: string}|null
+     * @return array{amount: float, currency: string, basis: string}|null
      */
     public function getMinimumOrder(): ?array;
 

--- a/Api/BrandRegistryInterface.php
+++ b/Api/BrandRegistryInterface.php
@@ -63,9 +63,9 @@ interface BrandRegistryInterface
     /**
      * Minimum order value required for this brand's payment method to
      * be offered at checkout: amount + currency + basis ('net' = basket
-     * excluding tax, 'gross' = including; ABN AMRO defines its minimum
-     * net, matching the funding partner's server-side risk rule, while
-     * the platform's country defaults are gross — hence explicit).
+     * excluding tax, 'gross' = including). Basis is always explicit in
+     * brand.xml — funding-partner rules and platform country defaults
+     * may differ, so the brand declares its requirement unambiguously.
      * Returning null means there is no minimum. Baskets in other
      * currencies are converted to this currency via the store's
      * exchange rates before comparing.
@@ -122,7 +122,7 @@ interface BrandRegistryInterface
 
     /**
      * Ordered label => module-name map for the admin Version panel
-     * (Stores → Configuration → ABN/Two AMRO → Version). Brand
+     * (Stores → Configuration → [Brand] → Version). Brand
      * overlays append their theme modules to the parent runtime
      * rows; the Version block renders one row per ComponentRegistrar-
      * resolvable module and silently skips unregistered entries.

--- a/Api/BrandRegistryInterface.php
+++ b/Api/BrandRegistryInterface.php
@@ -61,6 +61,17 @@ interface BrandRegistryInterface
     public function getSurchargeFixedMax(): ?array;
 
     /**
+     * Minimum order value required for this brand's payment method to
+     * be offered at checkout, expressed in a specific currency.
+     * Returning null means there is no minimum - any order value is
+     * acceptable. Baskets in other currencies are converted to this
+     * currency via the store's exchange rates before comparing.
+     *
+     * @return array{amount: float, currency: string}|null
+     */
+    public function getMinimumOrder(): ?array;
+
+    /**
      * Short brand tag used to decorate non-production checkout URLs
      * (e.g. `?brand=<tag>`). Empty string ('') means do not decorate
      * — the URL host already conveys the brand. Implementations may

--- a/Api/BrandRegistryInterface.php
+++ b/Api/BrandRegistryInterface.php
@@ -61,11 +61,13 @@ interface BrandRegistryInterface
     public function getSurchargeFixedMax(): ?array;
 
     /**
-     * Minimum order value required for this brand's payment method to
-     * be offered at checkout, expressed in a specific currency.
-     * Returning null means there is no minimum - any order value is
-     * acceptable. Baskets in other currencies are converted to this
-     * currency via the store's exchange rates before comparing.
+     * Minimum NET order value (basket total excluding tax) required for
+     * this brand's payment method to be offered at checkout, expressed
+     * in a specific currency — net, because the funding partner's
+     * server-side risk rule compares net. Returning null means there is
+     * no minimum - any order value is acceptable. Baskets in other
+     * currencies are converted to this currency via the store's
+     * exchange rates before comparing.
      *
      * @return array{amount: float, currency: string}|null
      */

--- a/Block/Adminhtml/Creditmemo/SurchargeOverride.php
+++ b/Block/Adminhtml/Creditmemo/SurchargeOverride.php
@@ -143,7 +143,7 @@ class SurchargeOverride extends Template
     /**
      * Label for the row — mirrors the order's surcharge description so the
      * editable line on the creditmemo create form reads the same as the
-     * static line shown elsewhere (e.g. "Zakelijk op Rekening - 30 dagen"
+     * static line shown elsewhere (e.g. "Partner Product - 30 dagen"
      * prefixed with "Refund").
      */
     public function getLabel(): string

--- a/Block/Adminhtml/System/Config/Field/SurchargeGrid.php
+++ b/Block/Adminhtml/System/Config/Field/SurchargeGrid.php
@@ -490,7 +490,7 @@ class SurchargeGrid extends Field
 
     /**
      * Build a fully-qualified config path under the active brand's
-     * payment-method subtree (e.g. `payment/abn_payment/...` on an
+     * payment-method subtree (e.g. `payment/acme_payment/...` on an
      * ABN install). The brand code is resolved at call time from
      * BrandRegistryInterface, which routes through ActiveBrandResolver
      * to the active brand's brand.xml — no per-brand DI rebinding.

--- a/Brand/DescriptorBackedBrandRegistry.php
+++ b/Brand/DescriptorBackedBrandRegistry.php
@@ -56,6 +56,11 @@ class DescriptorBackedBrandRegistry implements BrandRegistryInterface
         return $this->activeBrandResolver->resolve()->getSurchargeFixedMax();
     }
 
+    public function getMinimumOrder(): ?array
+    {
+        return $this->activeBrandResolver->resolve()->getMinimumOrder();
+    }
+
     public function getSignUpUrl(): string
     {
         return $this->activeBrandResolver->resolve()->getSignUpUrl();

--- a/Model/Brand.php
+++ b/Model/Brand.php
@@ -46,6 +46,8 @@ class Brand implements BrandRegistryInterface
     private $brandTag;
     /** @var string */
     private $checkoutSubtitle;
+    /** @var array{amount: float, currency: string}|null */
+    private $minimumOrder;
 
     /**
      * @param int[] $availablePaymentTerms
@@ -61,7 +63,8 @@ class Brand implements BrandRegistryInterface
         string $signUpUrl = '',
         string $documentationUrl = '',
         string $brandTag = '',
-        string $checkoutSubtitle = ''
+        string $checkoutSubtitle = '',
+        ?array $minimumOrder = null
     ) {
         $this->provider = $provider;
         $this->providerFullName = $providerFullName;
@@ -73,6 +76,7 @@ class Brand implements BrandRegistryInterface
         $this->documentationUrl = $documentationUrl;
         $this->brandTag = $brandTag;
         $this->checkoutSubtitle = $checkoutSubtitle;
+        $this->minimumOrder = $minimumOrder;
     }
 
     public function getProvider(): string
@@ -103,6 +107,11 @@ class Brand implements BrandRegistryInterface
     public function getSurchargeFixedMax(): ?array
     {
         return $this->surchargeFixedMax;
+    }
+
+    public function getMinimumOrder(): ?array
+    {
+        return $this->minimumOrder;
     }
 
     public function getSignUpUrl(): string

--- a/Model/Brand/Descriptor.php
+++ b/Model/Brand/Descriptor.php
@@ -116,7 +116,7 @@ final class Descriptor
         if ($this->sectionPrefix !== '') {
             return $this->sectionPrefix;
         }
-        // Derive: `two_payment` → `two`, `abn_payment` → `abn`.
+        // Derive: `two_payment` → `two`, `acme_payment` → `acme`.
         // Strictly strip a TRAILING `_payment` suffix only; using
         // strstr() would incorrectly shorten a hypothetical
         // `foo_payment_method` to `foo`.

--- a/Model/Brand/Descriptor.php
+++ b/Model/Brand/Descriptor.php
@@ -45,6 +45,7 @@ final class Descriptor
      * @param array<string,string> $extraHttpHeaders name=>value, decoration on outbound requests.
      * @param string[] $suppressedFields `section_suffix/group/field` paths to hide in the synthesised admin form.
      * @param bool $inlineTermFees Whether to render the per-term merchant fee beside each Payment Terms checkbox in admin.
+     * @param array{amount:float,currency:string}|null $minimumOrder Minimum order value for the method to be offered; null = no minimum.
      */
     public function __construct(
         private readonly string $code,
@@ -70,7 +71,8 @@ final class Descriptor
         private readonly array $extraHttpHeaders,
         private readonly array $suppressedFields = [],
         private readonly bool $inlineTermFees = true,
-        private readonly string $checkoutSubtitle = ''
+        private readonly string $checkoutSubtitle = '',
+        private readonly ?array $minimumOrder = null
     ) {
     }
 
@@ -201,6 +203,12 @@ final class Descriptor
     public function getSurchargeFixedMax(): ?array
     {
         return $this->surchargeFixedMax;
+    }
+
+    /** @return array{amount:float,currency:string}|null */
+    public function getMinimumOrder(): ?array
+    {
+        return $this->minimumOrder;
     }
 
     /** @return string[] */

--- a/Model/Brand/Loader.php
+++ b/Model/Brand/Loader.php
@@ -113,28 +113,38 @@ class Loader
 
         $minimumOrder = null;
         if (isset($brand->minimum_order)) {
-            $amount = (float)$brand->minimum_order['amount'];
+            $rawAmount = trim((string)$brand->minimum_order['amount']);
             $currency = strtoupper(trim((string)$brand->minimum_order['currency']));
             $basis = strtolower(trim((string)$brand->minimum_order['basis']));
             // brand.xsd marks all three attributes required, but nothing
             // validates the schema at runtime (simplexml ignores the
-            // xsi:noNamespaceSchemaLocation hint). A typo'd amount would
-            // coerce to 0.0 and silently disable the gate, and an implied
-            // basis would silently flip net/gross semantics, so reject
-            // malformed declarations here like the empty-code guard above.
-            if ($amount <= 0 || $currency === '' || !in_array($basis, ['net', 'gross'], true)) {
+            // xsi:noNamespaceSchemaLocation hint). Validate the amount as a
+            // string before casting - a typo'd amount would otherwise coerce
+            // to 0.0 silently - and reject an implied basis, which would
+            // silently flip net/gross semantics.
+            if (!is_numeric($rawAmount)
+                || (float)$rawAmount < 0
+                || $currency === ''
+                || !in_array($basis, ['net', 'gross'], true)
+            ) {
                 throw new \DomainException(sprintf(
                     'brand.xml at %s declares <minimum_order> with invalid'
-                    . ' amount/currency/basis (amount > 0, currency non-empty,'
-                    . ' basis "net" or "gross")',
+                    . ' amount/currency/basis (amount a non-negative number,'
+                    . ' currency non-empty, basis "net" or "gross")',
                     $sourcePath
                 ));
             }
-            $minimumOrder = [
-                'amount' => $amount,
-                'currency' => $currency,
-                'basis' => $basis,
-            ];
+            $amount = (float)$rawAmount;
+            // An explicit zero means "no minimum" - same semantics as the
+            // checkout-api merchant config, where 0 is the escape hatch for
+            // overriding an inherited partner minimum.
+            if ($amount > 0) {
+                $minimumOrder = [
+                    'amount' => $amount,
+                    'currency' => $currency,
+                    'basis' => $basis,
+                ];
+            }
         }
 
         $cspOrigins = [];

--- a/Model/Brand/Loader.php
+++ b/Model/Brand/Loader.php
@@ -113,9 +113,23 @@ class Loader
 
         $minimumOrder = null;
         if (isset($brand->minimum_order)) {
+            $amount = (float)$brand->minimum_order['amount'];
+            $currency = strtoupper(trim((string)$brand->minimum_order['currency']));
+            // brand.xsd marks both attributes required, but nothing validates
+            // the schema at runtime (simplexml ignores the
+            // xsi:noNamespaceSchemaLocation hint). A typo'd amount would coerce
+            // to 0.0 and silently disable the gate, so reject malformed
+            // declarations here like the empty-code guard above.
+            if ($amount <= 0 || $currency === '') {
+                throw new \DomainException(sprintf(
+                    'brand.xml at %s declares <minimum_order> with invalid'
+                    . ' amount/currency (amount must be > 0, currency non-empty)',
+                    $sourcePath
+                ));
+            }
             $minimumOrder = [
-                'amount' => (float)$brand->minimum_order['amount'],
-                'currency' => (string)$brand->minimum_order['currency'],
+                'amount' => $amount,
+                'currency' => $currency,
             ];
         }
 

--- a/Model/Brand/Loader.php
+++ b/Model/Brand/Loader.php
@@ -115,21 +115,25 @@ class Loader
         if (isset($brand->minimum_order)) {
             $amount = (float)$brand->minimum_order['amount'];
             $currency = strtoupper(trim((string)$brand->minimum_order['currency']));
-            // brand.xsd marks both attributes required, but nothing validates
-            // the schema at runtime (simplexml ignores the
-            // xsi:noNamespaceSchemaLocation hint). A typo'd amount would coerce
-            // to 0.0 and silently disable the gate, so reject malformed
-            // declarations here like the empty-code guard above.
-            if ($amount <= 0 || $currency === '') {
+            $basis = strtolower(trim((string)$brand->minimum_order['basis']));
+            // brand.xsd marks all three attributes required, but nothing
+            // validates the schema at runtime (simplexml ignores the
+            // xsi:noNamespaceSchemaLocation hint). A typo'd amount would
+            // coerce to 0.0 and silently disable the gate, and an implied
+            // basis would silently flip net/gross semantics, so reject
+            // malformed declarations here like the empty-code guard above.
+            if ($amount <= 0 || $currency === '' || !in_array($basis, ['net', 'gross'], true)) {
                 throw new \DomainException(sprintf(
                     'brand.xml at %s declares <minimum_order> with invalid'
-                    . ' amount/currency (amount must be > 0, currency non-empty)',
+                    . ' amount/currency/basis (amount > 0, currency non-empty,'
+                    . ' basis "net" or "gross")',
                     $sourcePath
                 ));
             }
             $minimumOrder = [
                 'amount' => $amount,
                 'currency' => $currency,
+                'basis' => $basis,
             ];
         }
 

--- a/Model/Brand/Loader.php
+++ b/Model/Brand/Loader.php
@@ -111,6 +111,14 @@ class Loader
             ];
         }
 
+        $minimumOrder = null;
+        if (isset($brand->minimum_order)) {
+            $minimumOrder = [
+                'amount' => (float)$brand->minimum_order['amount'],
+                'currency' => (string)$brand->minimum_order['currency'],
+            ];
+        }
+
         $cspOrigins = [];
         if (isset($brand->csp_origins->origin)) {
             foreach ($brand->csp_origins->origin as $origin) {
@@ -189,7 +197,8 @@ class Loader
             $extraHttpHeaders,
             $suppressedFields,
             $inlineTermFees,
-            (string)($brand->checkout_subtitle ?? '')
+            (string)($brand->checkout_subtitle ?? ''),
+            $minimumOrder
         );
     }
 }

--- a/Model/Config/Backend/MerchantMinimumOrder.php
+++ b/Model/Config/Backend/MerchantMinimumOrder.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Model\Config\Backend;
+
+use Magento\Framework\App\Cache\TypeListInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\Config\Value;
+use Magento\Framework\Data\Collection\AbstractDb;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Model\Context;
+use Magento\Framework\Model\ResourceModel\AbstractResource;
+use Magento\Framework\Registry;
+use Two\Gateway\Api\BrandRegistryInterface;
+
+/**
+ * Merchant-set minimum order value. The platform/partner minimum (the
+ * brand's minimum_order) is the floor: a merchant may only RAISE the
+ * bar, never lower it below what the funding setup requires. The value
+ * is interpreted in the platform minimum's currency and basis when one
+ * exists, otherwise in the store base currency, gross.
+ */
+class MerchantMinimumOrder extends Value
+{
+    /**
+     * @var BrandRegistryInterface
+     */
+    private $brandRegistry;
+
+    public function __construct(
+        Context $context,
+        Registry $registry,
+        ScopeConfigInterface $config,
+        TypeListInterface $cacheTypeList,
+        BrandRegistryInterface $brandRegistry,
+        ?AbstractResource $resource = null,
+        ?AbstractDb $resourceCollection = null,
+        array $data = []
+    ) {
+        $this->brandRegistry = $brandRegistry;
+        parent::__construct($context, $registry, $config, $cacheTypeList, $resource, $resourceCollection, $data);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function beforeSave()
+    {
+        $value = trim((string)$this->getValue());
+        if ($value === '') {
+            return parent::beforeSave();
+        }
+
+        $normalised = str_replace(',', '.', $value);
+        if (!is_numeric($normalised) || (float)$normalised < 0) {
+            throw new LocalizedException(__('Minimum Order Value must be a non-negative number.'));
+        }
+        $this->setValue($normalised);
+
+        $platformMinimum = $this->brandRegistry->getMinimumOrder();
+        if ($platformMinimum !== null && (float)$normalised <= $platformMinimum['amount']) {
+            throw new LocalizedException(__(
+                'Minimum Order Value must exceed the platform minimum of %1 %2 (%3 tax).',
+                $platformMinimum['amount'],
+                $platformMinimum['currency'],
+                $platformMinimum['basis'] === 'gross' ? __('including') : __('excluding')
+            ));
+        }
+
+        return parent::beforeSave();
+    }
+}

--- a/Model/Config/Backend/MerchantMinimumOrder.php
+++ b/Model/Config/Backend/MerchantMinimumOrder.php
@@ -14,15 +14,21 @@ use Magento\Framework\Data\Collection\AbstractDb;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Model\Context;
 use Magento\Framework\Model\ResourceModel\AbstractResource;
+use Magento\Framework\Pricing\PriceCurrencyInterface;
 use Magento\Framework\Registry;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Store\Model\StoreManagerInterface;
 use Two\Gateway\Api\BrandRegistryInterface;
+use Two\Gateway\Api\CurrencyRatesProviderInterface;
 
 /**
- * Merchant-set minimum order value. The platform/partner minimum (the
- * brand's minimum_order) is the floor: a merchant may only RAISE the
- * bar, never lower it below what the funding setup requires. The value
- * is interpreted in the platform minimum's currency and basis when one
- * exists, otherwise in the store base currency, gross.
+ * Merchant-set minimum order value, interpreted in the STORE BASE
+ * currency. The platform/partner minimum (the brand's minimum_order)
+ * is the floor: a merchant may only RAISE the bar, never lower it
+ * below what the funding setup requires. The floor is converted into
+ * the store base currency for the comparison; when no exchange rate
+ * is configured the numeric floor check is skipped here — the
+ * checkout gate enforces both minima independently and fails closed.
  */
 class MerchantMinimumOrder extends Value
 {
@@ -31,17 +37,38 @@ class MerchantMinimumOrder extends Value
      */
     private $brandRegistry;
 
+    /**
+     * @var CurrencyRatesProviderInterface
+     */
+    private $ratesProvider;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var PriceCurrencyInterface
+     */
+    private $priceCurrency;
+
     public function __construct(
         Context $context,
         Registry $registry,
         ScopeConfigInterface $config,
         TypeListInterface $cacheTypeList,
         BrandRegistryInterface $brandRegistry,
+        CurrencyRatesProviderInterface $ratesProvider,
+        StoreManagerInterface $storeManager,
+        PriceCurrencyInterface $priceCurrency,
         ?AbstractResource $resource = null,
         ?AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         $this->brandRegistry = $brandRegistry;
+        $this->ratesProvider = $ratesProvider;
+        $this->storeManager = $storeManager;
+        $this->priceCurrency = $priceCurrency;
         parent::__construct($context, $registry, $config, $cacheTypeList, $resource, $resourceCollection, $data);
     }
 
@@ -62,15 +89,70 @@ class MerchantMinimumOrder extends Value
         $this->setValue($normalised);
 
         $platformMinimum = $this->brandRegistry->getMinimumOrder();
-        if ($platformMinimum !== null && (float)$normalised <= $platformMinimum['amount']) {
-            throw new LocalizedException(__(
-                'Minimum Order Value must exceed the platform minimum of %1 %2 (%3 tax).',
+        if ($platformMinimum === null) {
+            return parent::beforeSave();
+        }
+
+        $store = $this->resolveScopeStore();
+        $baseCurrency = $store !== null ? (string)$store->getBaseCurrencyCode() : '';
+        $storeId = $store !== null ? (int)$store->getId() : null;
+
+        $floor = $platformMinimum['amount'];
+        if ($baseCurrency !== '' && $baseCurrency !== $platformMinimum['currency']) {
+            $rate = $this->ratesProvider->getRate($platformMinimum['currency'], $baseCurrency, $storeId);
+            if ($rate === null || $rate <= 0) {
+                // Cannot express the floor in the store currency; accept the
+                // value — the checkout gate enforces both minima independently.
+                return parent::beforeSave();
+            }
+            $floor = round($floor * $rate, 2);
+        }
+
+        if ((float)$normalised <= $floor) {
+            $floorDisplay = $this->priceCurrency->format(
+                $floor,
+                false,
+                2,
+                $store,
+                $baseCurrency ?: $platformMinimum['currency']
+            );
+            $nativeDisplay = $this->priceCurrency->format(
                 $platformMinimum['amount'],
-                $platformMinimum['currency'],
+                false,
+                2,
+                $store,
+                $platformMinimum['currency']
+            );
+            throw new LocalizedException(__(
+                'Minimum Order Value must exceed the platform minimum of %1, %2 tax.',
+                $floorDisplay === $nativeDisplay ? $floorDisplay : sprintf('%s (%s)', $floorDisplay, $nativeDisplay),
                 $platformMinimum['basis'] === 'gross' ? __('including') : __('excluding')
             ));
         }
 
         return parent::beforeSave();
+    }
+
+    /**
+     * The store whose base currency the value is interpreted in, derived
+     * from the config scope being saved (store view, website default
+     * store, or the global default store).
+     *
+     * @return \Magento\Store\Api\Data\StoreInterface|null
+     */
+    private function resolveScopeStore()
+    {
+        try {
+            if ($this->getScope() === ScopeInterface::SCOPE_STORES) {
+                return $this->storeManager->getStore($this->getScopeId());
+            }
+            if ($this->getScope() === ScopeInterface::SCOPE_WEBSITES) {
+                $website = $this->storeManager->getWebsite($this->getScopeId());
+                return $this->storeManager->getStore($website->getDefaultGroup()->getDefaultStoreId());
+            }
+            return $this->storeManager->getStore();
+        } catch (\Exception $e) {
+            return null;
+        }
     }
 }

--- a/Model/Config/Backend/MerchantMinimumOrder.php
+++ b/Model/Config/Backend/MerchantMinimumOrder.php
@@ -138,6 +138,11 @@ class MerchantMinimumOrder extends Value
      * from the config scope being saved (store view, website default
      * store, or the global default store).
      *
+     * Counterpart: Comment\MerchantMinimumOrder::resolveScopeStore() resolves
+     * the same scope from request params (the comment renders at page load,
+     * before any model scope exists). Keep their store resolution in lockstep
+     * or the displayed floor and the validated floor can disagree.
+     *
      * @return \Magento\Store\Api\Data\StoreInterface|null
      */
     private function resolveScopeStore()

--- a/Model/Config/Comment/MerchantMinimumOrder.php
+++ b/Model/Config/Comment/MerchantMinimumOrder.php
@@ -8,12 +8,17 @@ declare(strict_types=1);
 namespace Two\Gateway\Model\Config\Comment;
 
 use Magento\Config\Model\Config\CommentInterface;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Pricing\PriceCurrencyInterface;
+use Magento\Store\Model\StoreManagerInterface;
 use Two\Gateway\Api\BrandRegistryInterface;
+use Two\Gateway\Api\CurrencyRatesProviderInterface;
 
 /**
  * Shows the merchant the platform/partner minimum their own value must
- * exceed (the brand's minimum_order), so the constraint on the field is
- * visible where they type.
+ * exceed (the brand's minimum_order), converted into the store base
+ * currency the field is interpreted in, with the platform's native
+ * value in brackets - e.g. "Platform minimum £215.73 (€250.00)".
  */
 class MerchantMinimumOrder implements CommentInterface
 {
@@ -22,9 +27,38 @@ class MerchantMinimumOrder implements CommentInterface
      */
     private $brandRegistry;
 
-    public function __construct(BrandRegistryInterface $brandRegistry)
-    {
+    /**
+     * @var CurrencyRatesProviderInterface
+     */
+    private $ratesProvider;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var PriceCurrencyInterface
+     */
+    private $priceCurrency;
+
+    /**
+     * @var RequestInterface
+     */
+    private $request;
+
+    public function __construct(
+        BrandRegistryInterface $brandRegistry,
+        CurrencyRatesProviderInterface $ratesProvider,
+        StoreManagerInterface $storeManager,
+        PriceCurrencyInterface $priceCurrency,
+        RequestInterface $request
+    ) {
         $this->brandRegistry = $brandRegistry;
+        $this->ratesProvider = $ratesProvider;
+        $this->storeManager = $storeManager;
+        $this->priceCurrency = $priceCurrency;
+        $this->request = $request;
     }
 
     /**
@@ -38,11 +72,63 @@ class MerchantMinimumOrder implements CommentInterface
                 'Hide the payment method below this order value (store base currency, including tax). Leave empty for no minimum.'
             );
         }
-        return (string)__(
-            'Platform minimum: %1 %2 (%3 tax). A value here must exceed it and is interpreted in the same currency and tax basis.',
+
+        $store = $this->resolveScopeStore();
+        $baseCurrency = $store !== null ? (string)$store->getBaseCurrencyCode() : '';
+        $nativeDisplay = $this->priceCurrency->format(
             $platformMinimum['amount'],
-            $platformMinimum['currency'],
+            false,
+            2,
+            $store,
+            $platformMinimum['currency']
+        );
+
+        $minimumDisplay = $nativeDisplay;
+        if ($baseCurrency !== '' && $baseCurrency !== $platformMinimum['currency']) {
+            $rate = $this->ratesProvider->getRate(
+                $platformMinimum['currency'],
+                $baseCurrency,
+                $store !== null ? (int)$store->getId() : null
+            );
+            if ($rate !== null && $rate > 0) {
+                $floorDisplay = $this->priceCurrency->format(
+                    round($platformMinimum['amount'] * $rate, 2),
+                    false,
+                    2,
+                    $store,
+                    $baseCurrency
+                );
+                $minimumDisplay = sprintf('%s (%s)', $floorDisplay, $nativeDisplay);
+            }
+        }
+
+        return (string)__(
+            'Platform minimum %1, %2 tax. A value here is interpreted in the store base currency on the same tax basis and must exceed it.',
+            $minimumDisplay,
             $platformMinimum['basis'] === 'gross' ? __('including') : __('excluding')
         );
+    }
+
+    /**
+     * The store whose base currency the field is interpreted in, derived
+     * from the admin config-scope selector (store param, website default
+     * store, or the global default store).
+     *
+     * @return \Magento\Store\Api\Data\StoreInterface|null
+     */
+    private function resolveScopeStore()
+    {
+        try {
+            if ($storeCode = $this->request->getParam('store')) {
+                return $this->storeManager->getStore($storeCode);
+            }
+            if ($websiteCode = $this->request->getParam('website')) {
+                $website = $this->storeManager->getWebsite($websiteCode);
+                return $this->storeManager->getStore($website->getDefaultGroup()->getDefaultStoreId());
+            }
+            return $this->storeManager->getStore();
+        } catch (\Exception $e) {
+            return null;
+        }
     }
 }

--- a/Model/Config/Comment/MerchantMinimumOrder.php
+++ b/Model/Config/Comment/MerchantMinimumOrder.php
@@ -114,6 +114,11 @@ class MerchantMinimumOrder implements CommentInterface
      * from the admin config-scope selector (store param, website default
      * store, or the global default store).
      *
+     * Counterpart: Backend\MerchantMinimumOrder::resolveScopeStore() resolves
+     * the same scope from the config model at save time. Keep their store
+     * resolution in lockstep or the displayed floor and the validated floor
+     * can disagree.
+     *
      * @return \Magento\Store\Api\Data\StoreInterface|null
      */
     private function resolveScopeStore()

--- a/Model/Config/Comment/MerchantMinimumOrder.php
+++ b/Model/Config/Comment/MerchantMinimumOrder.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Model\Config\Comment;
+
+use Magento\Config\Model\Config\CommentInterface;
+use Two\Gateway\Api\BrandRegistryInterface;
+
+/**
+ * Shows the merchant the platform/partner minimum their own value must
+ * exceed (the brand's minimum_order), so the constraint on the field is
+ * visible where they type.
+ */
+class MerchantMinimumOrder implements CommentInterface
+{
+    /**
+     * @var BrandRegistryInterface
+     */
+    private $brandRegistry;
+
+    public function __construct(BrandRegistryInterface $brandRegistry)
+    {
+        $this->brandRegistry = $brandRegistry;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getCommentText($elementValue)
+    {
+        $platformMinimum = $this->brandRegistry->getMinimumOrder();
+        if ($platformMinimum === null) {
+            return (string)__(
+                'Hide the payment method below this order value (store base currency, including tax). Leave empty for no minimum.'
+            );
+        }
+        return (string)__(
+            'Platform minimum: %1 %2 (%3 tax). A value here must exceed it and is interpreted in the same currency and tax basis.',
+            $platformMinimum['amount'],
+            $platformMinimum['currency'],
+            $platformMinimum['basis'] === 'gross' ? __('including') : __('excluding')
+        );
+    }
+}

--- a/Model/CurrencyRatesProvider.php
+++ b/Model/CurrencyRatesProvider.php
@@ -27,6 +27,15 @@ class CurrencyRatesProvider implements CurrencyRatesProviderInterface
     /** @var StoreManagerInterface */
     private $storeManager;
 
+    /**
+     * Rate-table loads memoised per base currency: getRate() sits on the
+     * payment-method isAvailable() hot path (many calls per page view)
+     * and the rate table is static within a request.
+     *
+     * @var array<string,\Magento\Directory\Model\Currency|null>
+     */
+    private $baseCurrencyCache = [];
+
     public function __construct(
         CurrencyFactory $currencyFactory,
         StoreManagerInterface $storeManager
@@ -84,10 +93,13 @@ class CurrencyRatesProvider implements CurrencyRatesProviderInterface
         if ($baseCurrency === '') {
             return null;
         }
+        if (array_key_exists($baseCurrency, $this->baseCurrencyCache)) {
+            return $this->baseCurrencyCache[$baseCurrency];
+        }
         try {
-            return $this->currencyFactory->create()->load($baseCurrency);
+            return $this->baseCurrencyCache[$baseCurrency] = $this->currencyFactory->create()->load($baseCurrency);
         } catch (\Exception $e) {
-            return null;
+            return $this->baseCurrencyCache[$baseCurrency] = null;
         }
     }
 }

--- a/Model/GenericPaymentMethod.php
+++ b/Model/GenericPaymentMethod.php
@@ -27,6 +27,7 @@ use Two\Gateway\Service\Api\Adapter;
 use Two\Gateway\Service\Order\ComposeCapture;
 use Two\Gateway\Service\Order\ComposeOrder;
 use Two\Gateway\Service\Order\ComposeRefund;
+use Two\Gateway\Service\Order\MinimumOrderGate;
 use Two\Gateway\Service\UrlCookie;
 
 /**
@@ -81,6 +82,7 @@ class GenericPaymentMethod extends Two
         OrderRepositoryInterface $orderRepository,
         Adapter $apiAdapter,
         LogRepository $logRepository,
+        MinimumOrderGate $minimumOrderGate,
         ?AbstractResource $resource = null,
         ?AbstractDb $resourceCollection = null,
         array $data = []
@@ -105,6 +107,7 @@ class GenericPaymentMethod extends Two
             $orderRepository,
             $apiAdapter,
             $logRepository,
+            $minimumOrderGate,
             $resource,
             $resourceCollection,
             $data

--- a/Model/GenericPaymentMethod.php
+++ b/Model/GenericPaymentMethod.php
@@ -50,7 +50,7 @@ use Two\Gateway\Service\UrlCookie;
  *   <virtualType name="ABN\Gateway\Model\AbnPayment"
  *                type="Two\Gateway\Model\GenericPaymentMethod">
  *       <arguments>
- *           <argument name="code" xsi:type="string">abn_payment</argument>
+ *           <argument name="code" xsi:type="string">acme_payment</argument>
  *           <argument name="brand" xsi:type="object">ABN\Gateway\Model\AbnBrand</argument>
  *       </arguments>
  *   </virtualType>
@@ -112,7 +112,7 @@ class GenericPaymentMethod extends Two
             $resourceCollection,
             $data
         );
-        // Brand-overlay payment-method code, e.g. 'abn_payment'. Replaces
+        // Brand-overlay payment-method code, e.g. 'acme_payment'. Replaces
         // the hardcoded `self::CODE` baked into the parent Two class so a
         // single class can back multiple brand-overlay virtualTypes.
         $this->_code = $code;

--- a/Model/Two.php
+++ b/Model/Two.php
@@ -715,7 +715,7 @@ class Two extends AbstractMethod
      *
      * The active + api-key check must be method-code-bound (`_code`), not
      * brand-aware. Both `two_payment` and an overlay's method (e.g.
-     * `abn_payment`) can be registered side-by-side; routing this method's
+     * `acme_payment`) can be registered side-by-side; routing this method's
      * self-check through the brand-aware ConfigRepository would make Two's
      * instance answer with the overlay's config (because the brand-aware
      * fallback resolves to the install's active brand, not this instance's

--- a/Model/Two.php
+++ b/Model/Two.php
@@ -320,7 +320,7 @@ class Two extends AbstractMethod
      *   2. BrandRegistry::getProductName() (brand overlay fallback).
      *
      * Optionally suffixed with the buyer's selected term in days
-     * (e.g. "Zakelijk op Rekening - 60 days"). DataAssignObserver
+     * (e.g. "Partner Product - 60 days"). DataAssignObserver
      * stores the chosen term under the `selectedTerm` key as a
      * scalar; the duration is wrapped in a separate __() call so the
      * existing "%1 days" CSV entry handles localisation.

--- a/Model/Two.php
+++ b/Model/Two.php
@@ -732,8 +732,9 @@ class Two extends AbstractMethod
             return false;
         }
         // Brand product minimum-order constraint (brand.xml <minimum_order/>)
-        // plus the merchant's own optional minimum (admin setting; validated
-        // on save to exceed the platform floor). The brand is passed in
+        // plus the merchant's own optional minimum (admin setting in the
+        // STORE BASE currency; validated on save to exceed the platform
+        // floor converted to that currency). The brand is passed in
         // rather than re-resolved by the gate; ActiveBrandResolver
         // guarantees one active brand per install.
         $merchantMinimum = null;
@@ -742,8 +743,7 @@ class Two extends AbstractMethod
             if ($merchantValue > 0) {
                 $platformMinimum = $this->brandRegistry->getMinimumOrder();
                 $store = $quote->getStore();
-                $currency = $platformMinimum['currency']
-                    ?? ($store !== null ? (string)$store->getBaseCurrencyCode() : '');
+                $currency = $store !== null ? (string)$store->getBaseCurrencyCode() : '';
                 if ($currency !== '') {
                     $merchantMinimum = [
                         'amount' => $merchantValue,

--- a/Model/Two.php
+++ b/Model/Two.php
@@ -239,6 +239,26 @@ class Two extends AbstractMethod
                 sprintf('Order was not accepted by %s', $this->brandRegistry->getProductName()),
                 $response
             );
+            // The backend's decline reason is opaque, but when the basket
+            // sits near the brand's minimum the likely cause is the
+            // minimum-order rule (the display gate and the backend convert
+            // with different FX rates) — tell the buyer something they can
+            // act on instead of only the generic decline.
+            $netAmount = (float)$order->getGrandTotal() - (float)$order->getTaxAmount();
+            if ($this->minimumOrderGate->isNearOrBelowMinimum(
+                $this->brandRegistry,
+                $netAmount,
+                (string)$order->getOrderCurrencyCode(),
+                $order->getStoreId() !== null ? (int)$order->getStoreId() : null
+            )) {
+                $minimumOrder = $this->brandRegistry->getMinimumOrder();
+                throw new LocalizedException(__(
+                    'Invoice purchase with %1 is not available for this order. Note: %1 requires a minimum order value of %2 %3 excluding tax.',
+                    $this->brandRegistry->getProductName(),
+                    $minimumOrder['amount'],
+                    $minimumOrder['currency']
+                ));
+            }
             throw new LocalizedException(
                 __('Invoice purchase with %1 is not available for this order.', $this->brandRegistry->getProductName())
             );

--- a/Model/Two.php
+++ b/Model/Two.php
@@ -700,9 +700,9 @@ class Two extends AbstractMethod
         if ($apiKey === null || $apiKey === '') {
             return false;
         }
-        // Brand product constraint (e.g. ABN AMRO's EUR 250 minimum). Uses
-        // this instance's brand binding so side-by-side method instances
-        // each gate on their own brand.
+        // Brand product minimum-order constraint (brand.xml <minimum_order/>).
+        // The brand is passed in rather than re-resolved by the gate;
+        // ActiveBrandResolver guarantees one active brand per install.
         return $this->minimumOrderGate->isSatisfied($this->brandRegistry, $quote);
     }
 }

--- a/Model/Two.php
+++ b/Model/Two.php
@@ -34,6 +34,7 @@ use Two\Gateway\Service\Api\Adapter;
 use Two\Gateway\Service\Order\ComposeCapture;
 use Two\Gateway\Service\Order\ComposeOrder;
 use Two\Gateway\Service\Order\ComposeRefund;
+use Two\Gateway\Service\Order\MinimumOrderGate;
 use Two\Gateway\Service\UrlCookie;
 use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
 
@@ -120,6 +121,10 @@ class Two extends AbstractMethod
      * @var LogRepository
      */
     private $logRepository;
+    /**
+     * @var MinimumOrderGate
+     */
+    private $minimumOrderGate;
 
     /**
      * Two constructor.
@@ -141,6 +146,7 @@ class Two extends AbstractMethod
      * @param OrderStatusHistoryRepositoryInterface $orderStatusHistoryRepository
      * @param Adapter $apiAdapter
      * @param LogRepository $logRepository
+     * @param MinimumOrderGate $minimumOrderGate
      * @param AbstractResource|null $resource
      * @param AbstractDb|null $resourceCollection
      * @param array $data
@@ -165,6 +171,7 @@ class Two extends AbstractMethod
         OrderRepositoryInterface $orderRepository,
         Adapter $apiAdapter,
         LogRepository $logRepository,
+        MinimumOrderGate $minimumOrderGate,
         ?AbstractResource $resource = null,
         ?AbstractDb $resourceCollection = null,
         array $data = []
@@ -193,6 +200,7 @@ class Two extends AbstractMethod
         $this->orderStatusHistoryRepository = $orderStatusHistoryRepository;
         $this->orderRepository = $orderRepository;
         $this->logRepository = $logRepository;
+        $this->minimumOrderGate = $minimumOrderGate;
     }
 
     /**
@@ -689,6 +697,12 @@ class Two extends AbstractMethod
             return false;
         }
         $apiKey = $this->_scopeConfig->getValue('payment/' . $this->_code . '/api_key');
-        return $apiKey !== null && $apiKey !== '';
+        if ($apiKey === null || $apiKey === '') {
+            return false;
+        }
+        // Brand product constraint (e.g. ABN AMRO's EUR 250 minimum). Uses
+        // this instance's brand binding so side-by-side method instances
+        // each gate on their own brand.
+        return $this->minimumOrderGate->isSatisfied($this->brandRegistry, $quote);
     }
 }

--- a/Model/Two.php
+++ b/Model/Two.php
@@ -239,25 +239,36 @@ class Two extends AbstractMethod
                 sprintf('Order was not accepted by %s', $this->brandRegistry->getProductName()),
                 $response
             );
-            // The backend's decline reason is opaque, but when the basket
-            // sits near the brand's minimum the likely cause is the
-            // minimum-order rule (the display gate and the backend convert
-            // with different FX rates) — tell the buyer something they can
-            // act on instead of only the generic decline.
-            $netAmount = (float)$order->getGrandTotal() - (float)$order->getTaxAmount();
-            if ($this->minimumOrderGate->isNearOrBelowMinimum(
-                $this->brandRegistry,
-                $netAmount,
-                (string)$order->getOrderCurrencyCode(),
-                $order->getStoreId() !== null ? (int)$order->getStoreId() : null
-            )) {
-                $minimumOrder = $this->brandRegistry->getMinimumOrder();
-                throw new LocalizedException(__(
-                    'Invoice purchase with %1 is not available for this order. Note: %1 requires a minimum order value of %2 %3 excluding tax.',
-                    $this->brandRegistry->getProductName(),
-                    $minimumOrder['amount'],
-                    $minimumOrder['currency']
-                ));
+            // Surface the minimum when the decline is attributable to it:
+            // primarily by the API's machine-readable decline reason
+            // (emitted by the platform's minimum-order rejection), with a
+            // strictly-below-minimum check on the order value as fallback
+            // while older backends carry only a generic reason.
+            $storeId = $order->getStoreId() !== null ? (int)$order->getStoreId() : null;
+            $orderCurrency = (string)$order->getOrderCurrencyCode();
+            $minimumOrder = $this->brandRegistry->getMinimumOrder();
+            $declinedOnMinimum = ($response['decline_reason'] ?? null) === 'ORDER_BELOW_MIN_INVOICE_AMOUNT';
+            if (!$declinedOnMinimum && $minimumOrder !== null) {
+                $orderValue = $minimumOrder['basis'] === 'gross'
+                    ? (float)$order->getGrandTotal()
+                    : (float)$order->getGrandTotal() - (float)$order->getTaxAmount();
+                $declinedOnMinimum = $this->minimumOrderGate->isBelowMinimum(
+                    $this->brandRegistry,
+                    $orderValue,
+                    $orderCurrency,
+                    $storeId
+                );
+            }
+            if ($declinedOnMinimum && $minimumOrder !== null) {
+                $display = $this->minimumOrderGate->getMinimumForDisplay($this->brandRegistry, $orderCurrency, $storeId);
+                if ($display !== null) {
+                    throw new LocalizedException(__(
+                        'Invoice purchase with %1 is not available for this order. Minimum order value is %2 %3 tax.',
+                        $this->brandRegistry->getProductName(),
+                        $order->getOrderCurrency()->formatTxt($display['amount']),
+                        $display['basis'] === 'gross' ? __('including') : __('excluding')
+                    ));
+                }
             }
             throw new LocalizedException(
                 __('Invoice purchase with %1 is not available for this order.', $this->brandRegistry->getProductName())
@@ -720,9 +731,28 @@ class Two extends AbstractMethod
         if ($apiKey === null || $apiKey === '') {
             return false;
         }
-        // Brand product minimum-order constraint (brand.xml <minimum_order/>).
-        // The brand is passed in rather than re-resolved by the gate;
-        // ActiveBrandResolver guarantees one active brand per install.
-        return $this->minimumOrderGate->isSatisfied($this->brandRegistry, $quote);
+        // Brand product minimum-order constraint (brand.xml <minimum_order/>)
+        // plus the merchant's own optional minimum (admin setting; validated
+        // on save to exceed the platform floor). The brand is passed in
+        // rather than re-resolved by the gate; ActiveBrandResolver
+        // guarantees one active brand per install.
+        $merchantMinimum = null;
+        if ($quote instanceof \Magento\Quote\Model\Quote) {
+            $merchantValue = (float)$this->getConfigData('merchant_minimum_order');
+            if ($merchantValue > 0) {
+                $platformMinimum = $this->brandRegistry->getMinimumOrder();
+                $store = $quote->getStore();
+                $currency = $platformMinimum['currency']
+                    ?? ($store !== null ? (string)$store->getBaseCurrencyCode() : '');
+                if ($currency !== '') {
+                    $merchantMinimum = [
+                        'amount' => $merchantValue,
+                        'currency' => $currency,
+                        'basis' => $platformMinimum['basis'] ?? 'gross',
+                    ];
+                }
+            }
+        }
+        return $this->minimumOrderGate->isSatisfied($this->brandRegistry, $quote, $merchantMinimum);
     }
 }

--- a/Model/Ui/ConfigProvider.php
+++ b/Model/Ui/ConfigProvider.php
@@ -23,7 +23,7 @@ use Two\Gateway\Model\Two;
  * Populates `window.checkoutConfig.payment[<code>]` with the runtime
  * config the gateway_method renderer needs. The `$code` constructor
  * argument decides which subtree of `payment` gets populated, so
- * brand-overlay packages (magento-abn-plugin) can declare a
+ * brand-overlay packages can declare a
  * virtualType of this class with `code='abn_payment'` and a
  * brand-bound BrandRegistryInterface to expose their own subtree
  * without re-implementing the body of getConfig().

--- a/Model/Ui/ConfigProvider.php
+++ b/Model/Ui/ConfigProvider.php
@@ -24,7 +24,7 @@ use Two\Gateway\Model\Two;
  * config the gateway_method renderer needs. The `$code` constructor
  * argument decides which subtree of `payment` gets populated, so
  * brand-overlay packages can declare a
- * virtualType of this class with `code='abn_payment'` and a
+ * virtualType of this class with `code='acme_payment'` and a
  * brand-bound BrandRegistryInterface to expose their own subtree
  * without re-implementing the body of getConfig().
  *

--- a/Plugin/Magento/Checkout/Block/LayoutProcessor/SynthesiseBrandRenderers.php
+++ b/Plugin/Magento/Checkout/Block/LayoutProcessor/SynthesiseBrandRenderers.php
@@ -21,9 +21,8 @@ use Two\Gateway\Model\Brand\Descriptor;
  * view/frontend/web/js/view/payment/two_payment.js file shipped
  * with magento-plugin. This plugin therefore only emits a synthesis
  * entry when the resolved active brand is something other than the
- * default Two brand (i.e. when an overlay package such as the
- * future data-only magento-abn-plugin is installed and contributes
- * its own etc/brand.xml).
+ * default Two brand (i.e. when a data-only brand overlay package
+ * is installed and contributes its own etc/brand.xml).
  *
  * Gated by the system/two_brand_synthesis/checkout_renderers/enabled
  * flag, default 0. While dormant, afterProcess is a pass-through.

--- a/Plugin/Magento/Config/Model/Config/Structure/Reader/SynthesiseBrandAdminForm.php
+++ b/Plugin/Magento/Config/Model/Config/Structure/Reader/SynthesiseBrandAdminForm.php
@@ -268,7 +268,7 @@ class SynthesiseBrandAdminForm
      * are declared) but renders as hidden in the admin form.
      *
      * @param array<string,mixed> $section
-     * @param string $sectionId Full section id, e.g. `abn_payment`.
+     * @param string $sectionId Full section id, e.g. `acme_payment`.
      * @param string $sectionPrefix Brand's section prefix, e.g. `abn`.
      * @param string[] $suppressedPaths `section_suffix/group/field` paths.
      * @return array<string,mixed>
@@ -281,7 +281,7 @@ class SynthesiseBrandAdminForm
     ): array {
         $expectedPrefix = $sectionPrefix . '_';
         // section_suffix is everything after the brand prefix in the
-        // section id, e.g. `payment` for `abn_payment`.
+        // section id, e.g. `payment` for `acme_payment`.
         if (strncmp($sectionId, $expectedPrefix, strlen($expectedPrefix)) !== 0) {
             return $section;
         }

--- a/Plugin/Model/Sales/AfterPlaceOrder.php
+++ b/Plugin/Model/Sales/AfterPlaceOrder.php
@@ -14,7 +14,7 @@ use Two\Gateway\Model\Two;
 /**
  * AfterPlaceOrder Plugin
  * Set Two-stack orders (parent-brand `two_payment` + any registered
- * brand overlays such as `abn_payment`) to status pending after place.
+ * brand overlays such as `acme_payment`) to status pending after place.
  */
 class AfterPlaceOrder
 {

--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ Install also runs:
 
 ### Brand overlays
 
-Brand-specific overlay packages (e.g. ABN AMRO's Zakelijk op Rekening) live in
-their own Composer packages and are installed separately from this plugin, not
-through `make install`. See `two-inc/magento-abn-plugin` for the ABN overlay.
+Brand-specific overlay packages live in their own Composer packages and are
+installed separately from this plugin, not through `make install`. See
+`docs/brand-overlay-guide.md` for how overlay modules are structured.
 
 ### Debugging
 

--- a/Service/Order/MinimumOrderGate.php
+++ b/Service/Order/MinimumOrderGate.php
@@ -19,11 +19,12 @@ use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
  * is offered at checkout.
  *
  * The minimum is declared per brand in brand.xml as
- * `<minimum_order amount="250" currency="EUR"/>` and compares the
- * basket's NET total (grand total minus tax) — the funding partner's
- * risk rule enforces the same net semantics server-side. Baskets in a
- * different currency are converted to the brand currency via the
- * store's exchange rates before comparing. When no rate is
+ * `<minimum_order amount="250" currency="EUR" basis="net"/>` and
+ * compares the basket's net (grand total minus tax) or gross value per
+ * the declared basis — ABN AMRO's funding-partner rule is net; the
+ * platform's country defaults are gross. Baskets in a different
+ * currency are converted to the brand currency via the store's
+ * exchange rates before comparing. When no rate is
  * configured the gate fails closed: the method is hidden rather
  * than offered on an order we cannot prove satisfies the brand's
  * product minimum.
@@ -73,63 +74,87 @@ class MinimumOrderGate
      *              cannot be resolved for a cross-currency basket
      *              (fail-closed).
      */
-    public function isSatisfied(BrandRegistryInterface $brand, ?CartInterface $quote): bool
-    {
-        $minimumOrder = $brand->getMinimumOrder();
-        if ($minimumOrder === null || !$quote instanceof Quote) {
+    public function isSatisfied(
+        BrandRegistryInterface $brand,
+        ?CartInterface $quote,
+        ?array $merchantMinimum = null
+    ): bool {
+        if (!$quote instanceof Quote) {
             return true;
         }
 
-        // Net basket value: the server-side funding-partner rule compares
-        // net, so the display gate must too — a gross-compared gate shows
-        // the method on baskets the credit check then declines.
-        $taxAmount = 0.0;
-        foreach ($quote->getAllAddresses() as $address) {
-            $taxAmount += (float)$address->getTaxAmount();
+        // The brand minimum is the platform/partner floor; the merchant
+        // minimum (admin setting, validated to exceed the floor on save)
+        // may only raise the bar — both must be satisfied.
+        foreach ([$brand->getMinimumOrder(), $merchantMinimum] as $minimum) {
+            if ($minimum !== null && !$this->satisfiesMinimum($quote, $minimum)) {
+                return false;
+            }
         }
-        $netTotal = (float)$quote->getGrandTotal() - $taxAmount;
+
+        return true;
+    }
+
+    /**
+     * @param array{amount: float, currency: string, basis: string} $minimum
+     */
+    private function satisfiesMinimum(Quote $quote, array $minimum): bool
+    {
+        $basketValue = $this->basketValue($quote, $minimum['basis']);
         $store = $quote->getStore();
         $quoteCurrency = (string)($quote->getQuoteCurrencyCode()
             ?: ($store !== null ? $store->getBaseCurrencyCode() : ''));
 
         if ($quoteCurrency === '') {
-            $this->reportFailClosed('(unresolved)', $minimumOrder['currency']);
+            $this->reportFailClosed('(unresolved)', $minimum['currency']);
             return false;
         }
 
-        if ($quoteCurrency === $minimumOrder['currency']) {
-            return $netTotal >= $minimumOrder['amount'];
+        if ($quoteCurrency === $minimum['currency']) {
+            return $basketValue >= $minimum['amount'];
         }
 
         $rate = $this->ratesProvider->getRate(
             $quoteCurrency,
-            $minimumOrder['currency'],
+            $minimum['currency'],
             $quote->getStoreId() !== null ? (int)$quote->getStoreId() : null
         );
         if ($rate === null || $rate <= 0) {
-            $this->reportFailClosed($quoteCurrency, $minimumOrder['currency']);
+            $this->reportFailClosed($quoteCurrency, $minimum['currency']);
             return false;
         }
 
         // Compare at currency precision: full-precision arithmetic,
         // rounded once at the decision boundary (the plugin-wide model).
-        return round($netTotal * $rate, 2) >= $minimumOrder['amount'];
+        return round($basketValue * $rate, 2) >= $minimum['amount'];
     }
 
     /**
-     * Whether a net amount sits below (or within a small band above) the
-     * brand's minimum — used to decide if a backend decline should carry
-     * the minimum-order hint. The band covers rate skew between this
-     * plugin's store FX rates and the risk engine's spot rates: a basket
-     * that passed the display gate here can still be marginally below
-     * the threshold by the backend's rates. Fail-soft: unresolvable
-     * conversion means no hint, never a blocked message.
-     *
-     * @param float $netAmount Net amount in $currency
+     * The basket value the minimum compares against, per the brand's
+     * declared basis (net = grand total minus tax, gross = grand total).
      */
-    public function isNearOrBelowMinimum(
+    private function basketValue(Quote $quote, string $basis): float
+    {
+        if ($basis === 'gross') {
+            return (float)$quote->getGrandTotal();
+        }
+        $taxAmount = 0.0;
+        foreach ($quote->getAllAddresses() as $address) {
+            $taxAmount += (float)$address->getTaxAmount();
+        }
+        return (float)$quote->getGrandTotal() - $taxAmount;
+    }
+
+    /**
+     * Whether an order value (in $currency, on the brand's basis) is
+     * strictly below the brand's minimum — the fallback signal for the
+     * decline hint when the API response carries no machine-readable
+     * decline reason. Fail-soft: unresolvable conversion means no hint,
+     * never a blocked message.
+     */
+    public function isBelowMinimum(
         BrandRegistryInterface $brand,
-        float $netAmount,
+        float $amount,
         string $currency,
         ?int $storeId
     ): bool {
@@ -143,10 +168,36 @@ class MinimumOrderGate
             if ($rate === null || $rate <= 0) {
                 return false;
             }
-            $netAmount = round($netAmount * $rate, 2);
+            $amount = round($amount * $rate, 2);
         }
 
-        return $netAmount < $minimumOrder['amount'] * 1.05;
+        return $amount < $minimumOrder['amount'];
+    }
+
+    /**
+     * The brand minimum expressed in $currency for buyer-facing display,
+     * or null when no minimum exists / no rate is available.
+     *
+     * @return array{amount: float, basis: string}|null
+     */
+    public function getMinimumForDisplay(
+        BrandRegistryInterface $brand,
+        string $currency,
+        ?int $storeId
+    ): ?array {
+        $minimumOrder = $brand->getMinimumOrder();
+        if ($minimumOrder === null) {
+            return null;
+        }
+        $amount = $minimumOrder['amount'];
+        if ($currency !== $minimumOrder['currency']) {
+            $rate = $this->ratesProvider->getRate($minimumOrder['currency'], $currency, $storeId);
+            if ($rate === null || $rate <= 0) {
+                return null;
+            }
+            $amount = round($amount * $rate, 2);
+        }
+        return ['amount' => $amount, 'basis' => $minimumOrder['basis']];
     }
 
     /**

--- a/Service/Order/MinimumOrderGate.php
+++ b/Service/Order/MinimumOrderGate.php
@@ -14,15 +14,14 @@ use Two\Gateway\Api\CurrencyRatesProviderInterface;
 use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
 
 /**
- * Enforces a brand's minimum order value (e.g. the ABN AMRO product
- * requires a €250 minimum) when deciding whether the payment method
- * is offered at checkout.
+ * Enforces a brand's minimum order value when deciding whether the
+ * payment method is offered at checkout.
  *
  * The minimum is declared per brand in brand.xml as
  * `<minimum_order amount="250" currency="EUR" basis="net"/>` and
  * compares the basket's net (grand total minus tax) or gross value per
- * the declared basis — ABN AMRO's funding-partner rule is net; the
- * platform's country defaults are gross. Baskets in a different
+ * the declared basis — always explicit, since funding-partner rules and
+ * platform country defaults may differ. Baskets in a different
  * currency are converted to the brand currency via the store's
  * exchange rates before comparing. When no rate is
  * configured the gate fails closed: the method is hidden rather

--- a/Service/Order/MinimumOrderGate.php
+++ b/Service/Order/MinimumOrderGate.php
@@ -117,6 +117,39 @@ class MinimumOrderGate
     }
 
     /**
+     * Whether a net amount sits below (or within a small band above) the
+     * brand's minimum — used to decide if a backend decline should carry
+     * the minimum-order hint. The band covers rate skew between this
+     * plugin's store FX rates and the risk engine's spot rates: a basket
+     * that passed the display gate here can still be marginally below
+     * the threshold by the backend's rates. Fail-soft: unresolvable
+     * conversion means no hint, never a blocked message.
+     *
+     * @param float $netAmount Net amount in $currency
+     */
+    public function isNearOrBelowMinimum(
+        BrandRegistryInterface $brand,
+        float $netAmount,
+        string $currency,
+        ?int $storeId
+    ): bool {
+        $minimumOrder = $brand->getMinimumOrder();
+        if ($minimumOrder === null) {
+            return false;
+        }
+
+        if ($currency !== $minimumOrder['currency']) {
+            $rate = $this->ratesProvider->getRate($currency, $minimumOrder['currency'], $storeId);
+            if ($rate === null || $rate <= 0) {
+                return false;
+            }
+            $netAmount = round($netAmount * $rate, 2);
+        }
+
+        return $netAmount < $minimumOrder['amount'] * 1.05;
+    }
+
+    /**
      * Failing closed hides the payment method outright — a revenue stop
      * if the cause is a missing exchange rate on a live store — so it
      * must land in the monitored error log, not the debug log.

--- a/Service/Order/MinimumOrderGate.php
+++ b/Service/Order/MinimumOrderGate.php
@@ -38,6 +38,16 @@ class MinimumOrderGate
      */
     private $logRepository;
 
+    /**
+     * Currency pairs already reported this request. The fail-closed
+     * condition is a stable store misconfiguration, not a per-quote
+     * event, and isAvailable() fires many times per page view — one
+     * log line per pair is the correct cardinality.
+     *
+     * @var array<string,true>
+     */
+    private $reportedPairs = [];
+
     public function __construct(
         CurrencyRatesProviderInterface $ratesProvider,
         LogRepository $logRepository
@@ -49,10 +59,17 @@ class MinimumOrderGate
     /**
      * Whether the quote satisfies the brand's minimum order value.
      *
-     * The brand is passed by the payment-method instance rather than
-     * resolved from DI so that side-by-side method instances (vanilla
-     * `two_payment` next to an overlay's method) each gate on their
-     * own brand binding.
+     * The brand is passed in by the payment-method instance rather than
+     * resolved from DI here, keeping the gate decoupled from brand
+     * resolution; ActiveBrandResolver guarantees a single active brand
+     * per install. Non-Quote CartInterface implementations pass the gate:
+     * every storefront/GraphQL/admin checkout flow hands the concrete
+     * Quote model to isAvailable(), and hiding the method on an unknown
+     * cart type would be a worse failure than skipping the minimum.
+     *
+     * @return bool false when the basket currency or an exchange rate
+     *              cannot be resolved for a cross-currency basket
+     *              (fail-closed).
      */
     public function isSatisfied(BrandRegistryInterface $brand, ?CartInterface $quote): bool
     {
@@ -62,8 +79,14 @@ class MinimumOrderGate
         }
 
         $grandTotal = (float)$quote->getGrandTotal();
+        $store = $quote->getStore();
         $quoteCurrency = (string)($quote->getQuoteCurrencyCode()
-            ?: $quote->getStore()->getBaseCurrencyCode());
+            ?: ($store !== null ? $store->getBaseCurrencyCode() : ''));
+
+        if ($quoteCurrency === '') {
+            $this->reportFailClosed('(unresolved)', $minimumOrder['currency']);
+            return false;
+        }
 
         if ($quoteCurrency === $minimumOrder['currency']) {
             return $grandTotal >= $minimumOrder['amount'];
@@ -74,17 +97,31 @@ class MinimumOrderGate
             $minimumOrder['currency'],
             $quote->getStoreId() !== null ? (int)$quote->getStoreId() : null
         );
-        if ($rate === null) {
-            $this->logRepository->addDebugLog(
-                'MinimumOrderGate: no exchange rate, hiding payment method',
-                [
-                    'from' => $quoteCurrency,
-                    'to' => $minimumOrder['currency'],
-                ]
-            );
+        if ($rate === null || $rate <= 0) {
+            $this->reportFailClosed($quoteCurrency, $minimumOrder['currency']);
             return false;
         }
 
-        return $grandTotal * $rate >= $minimumOrder['amount'];
+        // Compare at currency precision: full-precision arithmetic,
+        // rounded once at the decision boundary (the plugin-wide model).
+        return round($grandTotal * $rate, 2) >= $minimumOrder['amount'];
+    }
+
+    /**
+     * Failing closed hides the payment method outright — a revenue stop
+     * if the cause is a missing exchange rate on a live store — so it
+     * must land in the monitored error log, not the debug log.
+     */
+    private function reportFailClosed(string $from, string $to): void
+    {
+        $pair = $from . '->' . $to;
+        if (isset($this->reportedPairs[$pair])) {
+            return;
+        }
+        $this->reportedPairs[$pair] = true;
+        $this->logRepository->addErrorLog(
+            'MinimumOrderGate: cannot convert basket to brand currency, hiding payment method',
+            ['from' => $from, 'to' => $to]
+        );
     }
 }

--- a/Service/Order/MinimumOrderGate.php
+++ b/Service/Order/MinimumOrderGate.php
@@ -19,7 +19,9 @@ use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
  * is offered at checkout.
  *
  * The minimum is declared per brand in brand.xml as
- * `<minimum_order amount="250" currency="EUR"/>`. Baskets in a
+ * `<minimum_order amount="250" currency="EUR"/>` and compares the
+ * basket's NET total (grand total minus tax) — the funding partner's
+ * risk rule enforces the same net semantics server-side. Baskets in a
  * different currency are converted to the brand currency via the
  * store's exchange rates before comparing. When no rate is
  * configured the gate fails closed: the method is hidden rather
@@ -78,7 +80,14 @@ class MinimumOrderGate
             return true;
         }
 
-        $grandTotal = (float)$quote->getGrandTotal();
+        // Net basket value: the server-side funding-partner rule compares
+        // net, so the display gate must too — a gross-compared gate shows
+        // the method on baskets the credit check then declines.
+        $taxAmount = 0.0;
+        foreach ($quote->getAllAddresses() as $address) {
+            $taxAmount += (float)$address->getTaxAmount();
+        }
+        $netTotal = (float)$quote->getGrandTotal() - $taxAmount;
         $store = $quote->getStore();
         $quoteCurrency = (string)($quote->getQuoteCurrencyCode()
             ?: ($store !== null ? $store->getBaseCurrencyCode() : ''));
@@ -89,7 +98,7 @@ class MinimumOrderGate
         }
 
         if ($quoteCurrency === $minimumOrder['currency']) {
-            return $grandTotal >= $minimumOrder['amount'];
+            return $netTotal >= $minimumOrder['amount'];
         }
 
         $rate = $this->ratesProvider->getRate(
@@ -104,7 +113,7 @@ class MinimumOrderGate
 
         // Compare at currency precision: full-precision arithmetic,
         // rounded once at the decision boundary (the plugin-wide model).
-        return round($grandTotal * $rate, 2) >= $minimumOrder['amount'];
+        return round($netTotal * $rate, 2) >= $minimumOrder['amount'];
     }
 
     /**

--- a/Service/Order/MinimumOrderGate.php
+++ b/Service/Order/MinimumOrderGate.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Service\Order;
+
+use Magento\Quote\Api\Data\CartInterface;
+use Magento\Quote\Model\Quote;
+use Two\Gateway\Api\BrandRegistryInterface;
+use Two\Gateway\Api\CurrencyRatesProviderInterface;
+use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
+
+/**
+ * Enforces a brand's minimum order value (e.g. the ABN AMRO product
+ * requires a €250 minimum) when deciding whether the payment method
+ * is offered at checkout.
+ *
+ * The minimum is declared per brand in brand.xml as
+ * `<minimum_order amount="250" currency="EUR"/>`. Baskets in a
+ * different currency are converted to the brand currency via the
+ * store's exchange rates before comparing. When no rate is
+ * configured the gate fails closed: the method is hidden rather
+ * than offered on an order we cannot prove satisfies the brand's
+ * product minimum.
+ */
+class MinimumOrderGate
+{
+    /**
+     * @var CurrencyRatesProviderInterface
+     */
+    private $ratesProvider;
+
+    /**
+     * @var LogRepository
+     */
+    private $logRepository;
+
+    public function __construct(
+        CurrencyRatesProviderInterface $ratesProvider,
+        LogRepository $logRepository
+    ) {
+        $this->ratesProvider = $ratesProvider;
+        $this->logRepository = $logRepository;
+    }
+
+    /**
+     * Whether the quote satisfies the brand's minimum order value.
+     *
+     * The brand is passed by the payment-method instance rather than
+     * resolved from DI so that side-by-side method instances (vanilla
+     * `two_payment` next to an overlay's method) each gate on their
+     * own brand binding.
+     */
+    public function isSatisfied(BrandRegistryInterface $brand, ?CartInterface $quote): bool
+    {
+        $minimumOrder = $brand->getMinimumOrder();
+        if ($minimumOrder === null || !$quote instanceof Quote) {
+            return true;
+        }
+
+        $grandTotal = (float)$quote->getGrandTotal();
+        $quoteCurrency = (string)($quote->getQuoteCurrencyCode()
+            ?: $quote->getStore()->getBaseCurrencyCode());
+
+        if ($quoteCurrency === $minimumOrder['currency']) {
+            return $grandTotal >= $minimumOrder['amount'];
+        }
+
+        $rate = $this->ratesProvider->getRate(
+            $quoteCurrency,
+            $minimumOrder['currency'],
+            $quote->getStoreId() !== null ? (int)$quote->getStoreId() : null
+        );
+        if ($rate === null) {
+            $this->logRepository->addDebugLog(
+                'MinimumOrderGate: no exchange rate, hiding payment method',
+                [
+                    'from' => $quoteCurrency,
+                    'to' => $minimumOrder['currency'],
+                ]
+            );
+            return false;
+        }
+
+        return $grandTotal * $rate >= $minimumOrder['amount'];
+    }
+}

--- a/Test/Stubs/ComponentRegistrar.php
+++ b/Test/Stubs/ComponentRegistrar.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * ComponentRegistrar stub with the getPaths surface intact — required
+ * before the catch-all autoloader so Loader tests can mock module
+ * enumeration (the catch-all would stub an empty class without the
+ * method, and onlyMethods() refuses methods that don't exist).
+ *
+ * Must be required BEFORE the catch-all autoloader in bootstrap.php.
+ */
+declare(strict_types=1);
+
+namespace Magento\Framework\Component {
+    if (!class_exists(ComponentRegistrar::class, false)) {
+        class ComponentRegistrar
+        {
+            public const MODULE = 'module';
+
+            public function getPaths($type)
+            {
+                return [];
+            }
+        }
+    }
+}

--- a/Test/Stubs/QuoteModels.php
+++ b/Test/Stubs/QuoteModels.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Quote model stubs with the CartInterface relationship intact —
+ * required before the catch-all autoloader so type hints against
+ * CartInterface accept Quote mocks (the catch-all would otherwise
+ * stub Quote as an empty class implementing nothing).
+ */
+declare(strict_types=1);
+
+namespace Magento\Quote\Api\Data {
+    if (!interface_exists(CartInterface::class, false)) {
+        interface CartInterface
+        {
+        }
+    }
+}
+
+namespace Magento\Quote\Model {
+    if (!class_exists(Quote::class, false)) {
+        class Quote implements \Magento\Quote\Api\Data\CartInterface
+        {
+            public function getGrandTotal()
+            {
+                return null;
+            }
+
+            public function getQuoteCurrencyCode()
+            {
+                return null;
+            }
+
+            public function getStoreId()
+            {
+                return null;
+            }
+
+            public function getStore()
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/Test/Stubs/QuoteModels.php
+++ b/Test/Stubs/QuoteModels.php
@@ -4,6 +4,10 @@
  * required before the catch-all autoloader so type hints against
  * CartInterface accept Quote mocks (the catch-all would otherwise
  * stub Quote as an empty class implementing nothing).
+ *
+ * Must be required BEFORE the catch-all autoloader in bootstrap.php;
+ * if another stub for these classes appears later, the class_exists
+ * guards silently resolve the collision by require order.
  */
 declare(strict_types=1);
 
@@ -11,6 +15,18 @@ namespace Magento\Quote\Api\Data {
     if (!interface_exists(CartInterface::class, false)) {
         interface CartInterface
         {
+        }
+    }
+}
+
+namespace Magento\Store\Model {
+    if (!class_exists(Store::class, false)) {
+        class Store
+        {
+            public function getBaseCurrencyCode()
+            {
+                return null;
+            }
         }
     }
 }

--- a/Test/Stubs/QuoteModels.php
+++ b/Test/Stubs/QuoteModels.php
@@ -54,6 +54,11 @@ namespace Magento\Quote\Model {
             {
                 return null;
             }
+
+            public function getAllAddresses()
+            {
+                return [];
+            }
         }
     }
 }

--- a/Test/Unit/Model/Brand/LoaderTest.php
+++ b/Test/Unit/Model/Brand/LoaderTest.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Model\Brand;
+
+use Magento\Framework\Component\ComponentRegistrar;
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Model\Brand\Loader;
+
+class LoaderTest extends TestCase
+{
+    private function loaderFor(string $fixture): Loader
+    {
+        $registrar = $this->getMockBuilder(ComponentRegistrar::class)
+            ->onlyMethods(['getPaths'])
+            ->getMock();
+        $registrar->method('getPaths')->willReturn([__DIR__ . '/_files/' . $fixture]);
+        return new Loader($registrar);
+    }
+
+    public function testRejectsZeroMinimumOrderAmount(): void
+    {
+        // brand.xsd marks amount required but nothing validates the schema
+        // at runtime; a zero/typo'd amount would silently disable the gate,
+        // so the Loader must refuse to load it.
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessageMatches('/minimum_order/');
+
+        $this->loaderFor('invalid_minimum')->load();
+    }
+
+    public function testNormalisesMinimumOrderCurrency(): void
+    {
+        $brands = $this->loaderFor('lowercase_currency')->load();
+
+        // ' eur ' in the xml must not force the FX branch into permanent
+        // fail-closed against uppercase quote currency codes
+        $this->assertSame(
+            ['amount' => 250.0, 'currency' => 'EUR'],
+            $brands['two_payment']->getMinimumOrder()
+        );
+    }
+}

--- a/Test/Unit/Model/Brand/LoaderTest.php
+++ b/Test/Unit/Model/Brand/LoaderTest.php
@@ -18,15 +18,25 @@ class LoaderTest extends TestCase
         return new Loader($registrar);
     }
 
-    public function testRejectsZeroMinimumOrderAmount(): void
+    public function testRejectsNonNumericMinimumOrderAmount(): void
     {
         // brand.xsd marks amount required but nothing validates the schema
-        // at runtime; a zero/typo'd amount would silently disable the gate,
-        // so the Loader must refuse to load it.
+        // at runtime; a typo'd amount (here a comma decimal) would coerce
+        // to 0.0 and silently disable the gate, so the Loader must refuse
+        // to load it.
         $this->expectException(\DomainException::class);
         $this->expectExceptionMessageMatches('/minimum_order/');
 
         $this->loaderFor('invalid_minimum')->load();
+    }
+
+    public function testZeroMinimumOrderAmountMeansNoMinimum(): void
+    {
+        // An explicit zero is valid and means "no minimum" - same semantics
+        // as the checkout-api merchant config.
+        $brands = $this->loaderFor('zero_minimum')->load();
+
+        $this->assertNull($brands['two_payment']->getMinimumOrder());
     }
 
     public function testNormalisesMinimumOrderCurrency(): void

--- a/Test/Unit/Model/Brand/LoaderTest.php
+++ b/Test/Unit/Model/Brand/LoaderTest.php
@@ -36,7 +36,7 @@ class LoaderTest extends TestCase
         // ' eur ' in the xml must not force the FX branch into permanent
         // fail-closed against uppercase quote currency codes
         $this->assertSame(
-            ['amount' => 250.0, 'currency' => 'EUR'],
+            ['amount' => 250.0, 'currency' => 'EUR', 'basis' => 'net'],
             $brands['two_payment']->getMinimumOrder()
         );
     }

--- a/Test/Unit/Model/Brand/_files/invalid_minimum/etc/brand.xml
+++ b/Test/Unit/Model/Brand/_files/invalid_minimum/etc/brand.xml
@@ -10,6 +10,6 @@
             <term>30</term>
         </available_payment_terms>
         <admin_resource>Two_Gateway::config</admin_resource>
-        <minimum_order amount="0" currency="EUR"/>
+        <minimum_order amount="0" currency="EUR" basis="net"/>
     </brand>
 </config>

--- a/Test/Unit/Model/Brand/_files/invalid_minimum/etc/brand.xml
+++ b/Test/Unit/Model/Brand/_files/invalid_minimum/etc/brand.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<config>
+    <brand code="two_payment" tab_sort_order="100">
+        <provider>Two</provider>
+        <product_name>Two</product_name>
+        <tab_label>Two</tab_label>
+        <checkout_url_template>https://%s.two.inc</checkout_url_template>
+        <api_base_url>https://api.two.inc</api_base_url>
+        <available_payment_terms>
+            <term>30</term>
+        </available_payment_terms>
+        <admin_resource>Two_Gateway::config</admin_resource>
+        <minimum_order amount="0" currency="EUR"/>
+    </brand>
+</config>

--- a/Test/Unit/Model/Brand/_files/lowercase_currency/etc/brand.xml
+++ b/Test/Unit/Model/Brand/_files/lowercase_currency/etc/brand.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<config>
+    <brand code="two_payment" tab_sort_order="100">
+        <provider>Two</provider>
+        <product_name>Two</product_name>
+        <tab_label>Two</tab_label>
+        <checkout_url_template>https://%s.two.inc</checkout_url_template>
+        <api_base_url>https://api.two.inc</api_base_url>
+        <available_payment_terms>
+            <term>30</term>
+        </available_payment_terms>
+        <admin_resource>Two_Gateway::config</admin_resource>
+        <minimum_order amount="250" currency=" eur "/>
+    </brand>
+</config>

--- a/Test/Unit/Model/Brand/_files/lowercase_currency/etc/brand.xml
+++ b/Test/Unit/Model/Brand/_files/lowercase_currency/etc/brand.xml
@@ -10,6 +10,6 @@
             <term>30</term>
         </available_payment_terms>
         <admin_resource>Two_Gateway::config</admin_resource>
-        <minimum_order amount="250" currency=" eur "/>
+        <minimum_order amount="250" currency=" eur " basis=" NET "/>
     </brand>
 </config>

--- a/Test/Unit/Model/Brand/_files/zero_minimum/etc/brand.xml
+++ b/Test/Unit/Model/Brand/_files/zero_minimum/etc/brand.xml
@@ -10,6 +10,6 @@
             <term>30</term>
         </available_payment_terms>
         <admin_resource>Two_Gateway::config</admin_resource>
-        <minimum_order amount="250,00" currency="EUR" basis="net"/>
+        <minimum_order amount="0" currency="EUR" basis="net"/>
     </brand>
 </config>

--- a/Test/Unit/Service/Order/MinimumOrderGateTest.php
+++ b/Test/Unit/Service/Order/MinimumOrderGateTest.php
@@ -82,7 +82,7 @@ class MinimumOrderGateTest extends TestCase
 
     public function testSatisfiedWhenQuoteIsNull(): void
     {
-        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR', 'basis' => 'net']);
 
         $this->assertTrue($this->gate->isSatisfied($this->brand, null));
     }
@@ -91,21 +91,21 @@ class MinimumOrderGateTest extends TestCase
 
     public function testNotSatisfiedWhenEurTotalBelowEurMinimum(): void
     {
-        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR', 'basis' => 'net']);
 
         $this->assertFalse($this->gate->isSatisfied($this->brand, $this->quote(249.99, 'EUR')));
     }
 
     public function testSatisfiedWhenEurTotalEqualsEurMinimum(): void
     {
-        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR', 'basis' => 'net']);
 
         $this->assertTrue($this->gate->isSatisfied($this->brand, $this->quote(250.0, 'EUR')));
     }
 
     public function testComparesNetNotGross(): void
     {
-        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR', 'basis' => 'net']);
 
         // EUR 302.50 gross with EUR 52.50 tax is exactly EUR 250 net: satisfied
         $this->assertTrue($this->gate->isSatisfied($this->brand, $this->quote(302.50, 'EUR', null, 52.50)));
@@ -116,7 +116,7 @@ class MinimumOrderGateTest extends TestCase
 
     public function testSameCurrencySkipsRateLookup(): void
     {
-        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR', 'basis' => 'net']);
         $this->ratesProvider->expects($this->never())->method('getRate');
 
         $this->assertTrue($this->gate->isSatisfied($this->brand, $this->quote(300.0, 'EUR')));
@@ -124,7 +124,7 @@ class MinimumOrderGateTest extends TestCase
 
     public function testFallsBackToStoreBaseCurrencyWhenQuoteCurrencyMissing(): void
     {
-        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR', 'basis' => 'net']);
         $this->ratesProvider->expects($this->never())->method('getRate');
 
         $store = $this->createMock(Store::class);
@@ -135,7 +135,7 @@ class MinimumOrderGateTest extends TestCase
 
     public function testFailsClosedWhenBasketCurrencyUnresolvable(): void
     {
-        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR', 'basis' => 'net']);
 
         // No quote currency and no store: the gate cannot establish what
         // currency the basket is in, so it must not offer the method.
@@ -144,7 +144,7 @@ class MinimumOrderGateTest extends TestCase
 
     public function testPassesForNonQuoteCartInterface(): void
     {
-        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR', 'basis' => 'net']);
 
         // Deliberate: every real checkout flow passes the concrete Quote;
         // an unknown CartInterface impl skips the gate rather than hiding
@@ -156,7 +156,7 @@ class MinimumOrderGateTest extends TestCase
 
     public function testNotSatisfiedWhenConvertedGbpTotalBelowEurMinimum(): void
     {
-        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR', 'basis' => 'net']);
         $this->ratesProvider->method('getRate')
             ->with('GBP', 'EUR', 1)
             ->willReturn(1.17);
@@ -167,7 +167,7 @@ class MinimumOrderGateTest extends TestCase
 
     public function testSatisfiedWhenConvertedGbpTotalAboveEurMinimum(): void
     {
-        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR', 'basis' => 'net']);
         $this->ratesProvider->method('getRate')
             ->with('GBP', 'EUR', 1)
             ->willReturn(1.17);
@@ -178,7 +178,7 @@ class MinimumOrderGateTest extends TestCase
 
     public function testFailsClosedWhenNoExchangeRateConfigured(): void
     {
-        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR', 'basis' => 'net']);
         $this->ratesProvider->method('getRate')->willReturn(null);
 
         $this->assertFalse($this->gate->isSatisfied($this->brand, $this->quote(10000.0, 'SEK')));
@@ -186,7 +186,7 @@ class MinimumOrderGateTest extends TestCase
 
     public function testFailsClosedWhenRateIsZero(): void
     {
-        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR', 'basis' => 'net']);
         $this->ratesProvider->method('getRate')->willReturn(0.0);
 
         $this->assertFalse($this->gate->isSatisfied($this->brand, $this->quote(10000.0, 'SEK')));
@@ -194,7 +194,7 @@ class MinimumOrderGateTest extends TestCase
 
     public function testConvertedTotalComparedAtCurrencyPrecision(): void
     {
-        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR', 'basis' => 'net']);
         $this->ratesProvider->method('getRate')
             ->with('GBP', 'EUR', 1)
             ->willReturn(1.17);
@@ -204,32 +204,78 @@ class MinimumOrderGateTest extends TestCase
         $this->assertTrue($this->gate->isSatisfied($this->brand, $this->quote(213.675, 'GBP')));
     }
 
-    public function testNearOrBelowMinimumDrivesTheDeclineHint(): void
+    public function testBelowMinimumDrivesTheDeclineHintStrictly(): void
     {
-        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR', 'basis' => 'net']);
 
-        // Just above threshold but inside the rate-skew band: hint
-        $this->assertTrue($this->gate->isNearOrBelowMinimum($this->brand, 255.0, 'EUR', 1));
-        // Comfortably above: no hint (a risk decline must not be blamed
-        // on the minimum)
-        $this->assertFalse($this->gate->isNearOrBelowMinimum($this->brand, 400.0, 'EUR', 1));
+        $this->assertTrue($this->gate->isBelowMinimum($this->brand, 249.99, 'EUR', 1));
+        // No tolerance band: at or above the minimum is not "below"
+        $this->assertFalse($this->gate->isBelowMinimum($this->brand, 250.0, 'EUR', 1));
         // No minimum configured: never hint
         $this->brand = $this->createMock(BrandRegistryInterface::class);
         $this->brand->method('getMinimumOrder')->willReturn(null);
-        $this->assertFalse($this->gate->isNearOrBelowMinimum($this->brand, 10.0, 'EUR', 1));
+        $this->assertFalse($this->gate->isBelowMinimum($this->brand, 10.0, 'EUR', 1));
     }
 
-    public function testNearMinimumFailsSoftWithoutRate(): void
+    public function testBelowMinimumFailsSoftWithoutRate(): void
     {
-        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR', 'basis' => 'net']);
         $this->ratesProvider->method('getRate')->willReturn(null);
 
-        $this->assertFalse($this->gate->isNearOrBelowMinimum($this->brand, 10.0, 'SEK', 1));
+        $this->assertFalse($this->gate->isBelowMinimum($this->brand, 10.0, 'SEK', 1));
+    }
+
+    public function testMerchantMinimumRaisesTheBar(): void
+    {
+        // No platform minimum, merchant sets one: it gates alone
+        $this->stubMinimum(null);
+        $merchantMinimum = ['amount' => 500.0, 'currency' => 'EUR', 'basis' => 'gross'];
+
+        $this->assertFalse($this->gate->isSatisfied($this->brand, $this->quote(499.0, 'EUR'), $merchantMinimum));
+        $this->assertTrue($this->gate->isSatisfied($this->brand, $this->quote(500.0, 'EUR'), $merchantMinimum));
+    }
+
+    public function testMerchantMinimumAppliesOnTopOfThePlatformFloor(): void
+    {
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR', 'basis' => 'net']);
+        $merchantMinimum = ['amount' => 400.0, 'currency' => 'EUR', 'basis' => 'net'];
+
+        // Above the floor but below the merchant's own bar: hidden
+        $this->assertFalse($this->gate->isSatisfied($this->brand, $this->quote(300.0, 'EUR'), $merchantMinimum));
+        $this->assertTrue($this->gate->isSatisfied($this->brand, $this->quote(400.0, 'EUR'), $merchantMinimum));
+    }
+
+    public function testGrossBasisComparesGrandTotal(): void
+    {
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR', 'basis' => 'gross']);
+
+        // EUR 250 gross with tax included satisfies a GROSS minimum even
+        // though its net value is below
+        $this->assertTrue($this->gate->isSatisfied($this->brand, $this->quote(250.0, 'EUR', null, 43.39)));
+        $this->assertFalse($this->gate->isSatisfied($this->brand, $this->quote(249.99, 'EUR', null, 43.39)));
+    }
+
+    public function testMinimumForDisplayConvertsToOrderCurrency(): void
+    {
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR', 'basis' => 'net']);
+        $this->ratesProvider->method('getRate')
+            ->with('EUR', 'GBP', 1)
+            ->willReturn(0.86);
+
+        $this->assertSame(
+            ['amount' => 215.0, 'basis' => 'net'],
+            $this->gate->getMinimumForDisplay($this->brand, 'GBP', 1)
+        );
+        // No rate: no display value (caller falls back to the generic message)
+        $brand = $this->createMock(BrandRegistryInterface::class);
+        $brand->method('getMinimumOrder')->willReturn(['amount' => 250.0, 'currency' => 'EUR', 'basis' => 'net']);
+        $gate = new MinimumOrderGate($this->createMock(CurrencyRatesProviderInterface::class), $this->logRepository);
+        $this->assertNull($gate->getMinimumForDisplay($brand, 'SEK', 1));
     }
 
     public function testReportsMissingRateOncePerCurrencyPair(): void
     {
-        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR', 'basis' => 'net']);
         $this->ratesProvider->method('getRate')->willReturn(null);
         $this->logRepository->expects($this->once())->method('addErrorLog');
 

--- a/Test/Unit/Service/Order/MinimumOrderGateTest.php
+++ b/Test/Unit/Service/Order/MinimumOrderGateTest.php
@@ -1,0 +1,127 @@
+<?php
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Service\Order;
+
+use Magento\Quote\Model\Quote;
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Api\BrandRegistryInterface;
+use Two\Gateway\Api\CurrencyRatesProviderInterface;
+use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
+use Two\Gateway\Service\Order\MinimumOrderGate;
+
+class MinimumOrderGateTest extends TestCase
+{
+    /** @var BrandRegistryInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $brand;
+
+    /** @var CurrencyRatesProviderInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $ratesProvider;
+
+    /** @var MinimumOrderGate */
+    private $gate;
+
+    protected function setUp(): void
+    {
+        $this->brand = $this->createMock(BrandRegistryInterface::class);
+        $this->ratesProvider = $this->createMock(CurrencyRatesProviderInterface::class);
+
+        $this->gate = new MinimumOrderGate(
+            $this->ratesProvider,
+            $this->createMock(LogRepository::class)
+        );
+    }
+
+    /**
+     * @return Quote|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private function quote(float $grandTotal, string $currency)
+    {
+        $quote = $this->getMockBuilder(Quote::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getGrandTotal', 'getQuoteCurrencyCode', 'getStoreId'])
+            ->getMock();
+        $quote->method('getGrandTotal')->willReturn($grandTotal);
+        $quote->method('getQuoteCurrencyCode')->willReturn($currency);
+        $quote->method('getStoreId')->willReturn(1);
+        return $quote;
+    }
+
+    private function stubMinimum(?array $minimum): void
+    {
+        $this->brand->method('getMinimumOrder')->willReturn($minimum);
+    }
+
+    // ── No minimum configured (vanilla Two brand) ────────────────────
+
+    public function testSatisfiedRegardlessOfAmountWhenBrandHasNoMinimum(): void
+    {
+        $this->stubMinimum(null);
+        $this->ratesProvider->expects($this->never())->method('getRate');
+
+        $this->assertTrue($this->gate->isSatisfied($this->brand, $this->quote(0.01, 'EUR')));
+    }
+
+    public function testSatisfiedWhenQuoteIsNull(): void
+    {
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
+
+        $this->assertTrue($this->gate->isSatisfied($this->brand, null));
+    }
+
+    // ── Same-currency comparison ─────────────────────────────────────
+
+    public function testNotSatisfiedWhenEurTotalBelowEurMinimum(): void
+    {
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
+
+        $this->assertFalse($this->gate->isSatisfied($this->brand, $this->quote(249.99, 'EUR')));
+    }
+
+    public function testSatisfiedWhenEurTotalEqualsEurMinimum(): void
+    {
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
+
+        $this->assertTrue($this->gate->isSatisfied($this->brand, $this->quote(250.0, 'EUR')));
+    }
+
+    public function testSameCurrencySkipsRateLookup(): void
+    {
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
+        $this->ratesProvider->expects($this->never())->method('getRate');
+
+        $this->gate->isSatisfied($this->brand, $this->quote(300.0, 'EUR'));
+    }
+
+    // ── Cross-currency comparison via store FX rates ─────────────────
+
+    public function testNotSatisfiedWhenConvertedGbpTotalBelowEurMinimum(): void
+    {
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
+        $this->ratesProvider->method('getRate')
+            ->with('GBP', 'EUR', 1)
+            ->willReturn(1.17);
+
+        // £99 -> €115.83 < €250
+        $this->assertFalse($this->gate->isSatisfied($this->brand, $this->quote(99.0, 'GBP')));
+    }
+
+    public function testSatisfiedWhenConvertedGbpTotalAboveEurMinimum(): void
+    {
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
+        $this->ratesProvider->method('getRate')
+            ->with('GBP', 'EUR', 1)
+            ->willReturn(1.17);
+
+        // £1000 -> €1170 >= €250
+        $this->assertTrue($this->gate->isSatisfied($this->brand, $this->quote(1000.0, 'GBP')));
+    }
+
+    public function testFailsClosedWhenNoExchangeRateConfigured(): void
+    {
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
+        $this->ratesProvider->method('getRate')->willReturn(null);
+
+        $this->assertFalse($this->gate->isSatisfied($this->brand, $this->quote(10000.0, 'SEK')));
+    }
+}

--- a/Test/Unit/Service/Order/MinimumOrderGateTest.php
+++ b/Test/Unit/Service/Order/MinimumOrderGateTest.php
@@ -41,16 +41,27 @@ class MinimumOrderGateTest extends TestCase
     /**
      * @return Quote|\PHPUnit\Framework\MockObject\MockObject
      */
-    private function quote(float $grandTotal, ?string $currency, ?Store $store = null)
+    private function quote(float $grandTotal, ?string $currency, ?Store $store = null, float $taxAmount = 0.0)
     {
         $quote = $this->getMockBuilder(Quote::class)
             ->disableOriginalConstructor()
-            ->onlyMethods(['getGrandTotal', 'getQuoteCurrencyCode', 'getStoreId', 'getStore'])
+            ->onlyMethods(['getGrandTotal', 'getQuoteCurrencyCode', 'getStoreId', 'getStore', 'getAllAddresses'])
             ->getMock();
         $quote->method('getGrandTotal')->willReturn($grandTotal);
         $quote->method('getQuoteCurrencyCode')->willReturn($currency);
         $quote->method('getStoreId')->willReturn(1);
         $quote->method('getStore')->willReturn($store);
+        $address = new class ($taxAmount) {
+            public function __construct(private readonly float $taxAmount)
+            {
+            }
+
+            public function getTaxAmount(): float
+            {
+                return $this->taxAmount;
+            }
+        };
+        $quote->method('getAllAddresses')->willReturn([$address]);
         return $quote;
     }
 
@@ -90,6 +101,17 @@ class MinimumOrderGateTest extends TestCase
         $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
 
         $this->assertTrue($this->gate->isSatisfied($this->brand, $this->quote(250.0, 'EUR')));
+    }
+
+    public function testComparesNetNotGross(): void
+    {
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
+
+        // EUR 302.50 gross with EUR 52.50 tax is exactly EUR 250 net: satisfied
+        $this->assertTrue($this->gate->isSatisfied($this->brand, $this->quote(302.50, 'EUR', null, 52.50)));
+        // EUR 250 gross with tax is below EUR 250 net: the credit check would
+        // decline it, so the gate must hide the method
+        $this->assertFalse($this->gate->isSatisfied($this->brand, $this->quote(250.0, 'EUR', null, 43.39)));
     }
 
     public function testSameCurrencySkipsRateLookup(): void

--- a/Test/Unit/Service/Order/MinimumOrderGateTest.php
+++ b/Test/Unit/Service/Order/MinimumOrderGateTest.php
@@ -204,6 +204,29 @@ class MinimumOrderGateTest extends TestCase
         $this->assertTrue($this->gate->isSatisfied($this->brand, $this->quote(213.675, 'GBP')));
     }
 
+    public function testNearOrBelowMinimumDrivesTheDeclineHint(): void
+    {
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
+
+        // Just above threshold but inside the rate-skew band: hint
+        $this->assertTrue($this->gate->isNearOrBelowMinimum($this->brand, 255.0, 'EUR', 1));
+        // Comfortably above: no hint (a risk decline must not be blamed
+        // on the minimum)
+        $this->assertFalse($this->gate->isNearOrBelowMinimum($this->brand, 400.0, 'EUR', 1));
+        // No minimum configured: never hint
+        $this->brand = $this->createMock(BrandRegistryInterface::class);
+        $this->brand->method('getMinimumOrder')->willReturn(null);
+        $this->assertFalse($this->gate->isNearOrBelowMinimum($this->brand, 10.0, 'EUR', 1));
+    }
+
+    public function testNearMinimumFailsSoftWithoutRate(): void
+    {
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
+        $this->ratesProvider->method('getRate')->willReturn(null);
+
+        $this->assertFalse($this->gate->isNearOrBelowMinimum($this->brand, 10.0, 'SEK', 1));
+    }
+
     public function testReportsMissingRateOncePerCurrencyPair(): void
     {
         $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);

--- a/Test/Unit/Service/Order/MinimumOrderGateTest.php
+++ b/Test/Unit/Service/Order/MinimumOrderGateTest.php
@@ -3,7 +3,9 @@ declare(strict_types=1);
 
 namespace Two\Gateway\Test\Unit\Service\Order;
 
+use Magento\Quote\Api\Data\CartInterface;
 use Magento\Quote\Model\Quote;
+use Magento\Store\Model\Store;
 use PHPUnit\Framework\TestCase;
 use Two\Gateway\Api\BrandRegistryInterface;
 use Two\Gateway\Api\CurrencyRatesProviderInterface;
@@ -18,6 +20,9 @@ class MinimumOrderGateTest extends TestCase
     /** @var CurrencyRatesProviderInterface|\PHPUnit\Framework\MockObject\MockObject */
     private $ratesProvider;
 
+    /** @var LogRepository|\PHPUnit\Framework\MockObject\MockObject */
+    private $logRepository;
+
     /** @var MinimumOrderGate */
     private $gate;
 
@@ -25,25 +30,27 @@ class MinimumOrderGateTest extends TestCase
     {
         $this->brand = $this->createMock(BrandRegistryInterface::class);
         $this->ratesProvider = $this->createMock(CurrencyRatesProviderInterface::class);
+        $this->logRepository = $this->createMock(LogRepository::class);
 
         $this->gate = new MinimumOrderGate(
             $this->ratesProvider,
-            $this->createMock(LogRepository::class)
+            $this->logRepository
         );
     }
 
     /**
      * @return Quote|\PHPUnit\Framework\MockObject\MockObject
      */
-    private function quote(float $grandTotal, string $currency)
+    private function quote(float $grandTotal, ?string $currency, ?Store $store = null)
     {
         $quote = $this->getMockBuilder(Quote::class)
             ->disableOriginalConstructor()
-            ->onlyMethods(['getGrandTotal', 'getQuoteCurrencyCode', 'getStoreId'])
+            ->onlyMethods(['getGrandTotal', 'getQuoteCurrencyCode', 'getStoreId', 'getStore'])
             ->getMock();
         $quote->method('getGrandTotal')->willReturn($grandTotal);
         $quote->method('getQuoteCurrencyCode')->willReturn($currency);
         $quote->method('getStoreId')->willReturn(1);
+        $quote->method('getStore')->willReturn($store);
         return $quote;
     }
 
@@ -90,7 +97,37 @@ class MinimumOrderGateTest extends TestCase
         $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
         $this->ratesProvider->expects($this->never())->method('getRate');
 
-        $this->gate->isSatisfied($this->brand, $this->quote(300.0, 'EUR'));
+        $this->assertTrue($this->gate->isSatisfied($this->brand, $this->quote(300.0, 'EUR')));
+    }
+
+    public function testFallsBackToStoreBaseCurrencyWhenQuoteCurrencyMissing(): void
+    {
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
+        $this->ratesProvider->expects($this->never())->method('getRate');
+
+        $store = $this->createMock(Store::class);
+        $store->method('getBaseCurrencyCode')->willReturn('EUR');
+
+        $this->assertTrue($this->gate->isSatisfied($this->brand, $this->quote(300.0, null, $store)));
+    }
+
+    public function testFailsClosedWhenBasketCurrencyUnresolvable(): void
+    {
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
+
+        // No quote currency and no store: the gate cannot establish what
+        // currency the basket is in, so it must not offer the method.
+        $this->assertFalse($this->gate->isSatisfied($this->brand, $this->quote(300.0, null)));
+    }
+
+    public function testPassesForNonQuoteCartInterface(): void
+    {
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
+
+        // Deliberate: every real checkout flow passes the concrete Quote;
+        // an unknown CartInterface impl skips the gate rather than hiding
+        // the method (documented in MinimumOrderGate::isSatisfied()).
+        $this->assertTrue($this->gate->isSatisfied($this->brand, $this->createMock(CartInterface::class)));
     }
 
     // ── Cross-currency comparison via store FX rates ─────────────────
@@ -123,5 +160,35 @@ class MinimumOrderGateTest extends TestCase
         $this->ratesProvider->method('getRate')->willReturn(null);
 
         $this->assertFalse($this->gate->isSatisfied($this->brand, $this->quote(10000.0, 'SEK')));
+    }
+
+    public function testFailsClosedWhenRateIsZero(): void
+    {
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
+        $this->ratesProvider->method('getRate')->willReturn(0.0);
+
+        $this->assertFalse($this->gate->isSatisfied($this->brand, $this->quote(10000.0, 'SEK')));
+    }
+
+    public function testConvertedTotalComparedAtCurrencyPrecision(): void
+    {
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
+        $this->ratesProvider->method('getRate')
+            ->with('GBP', 'EUR', 1)
+            ->willReturn(1.17);
+
+        // £213.675 x 1.17 = €249.99975 raw; rounded once at the decision
+        // boundary it is €250.00 and satisfies the minimum.
+        $this->assertTrue($this->gate->isSatisfied($this->brand, $this->quote(213.675, 'GBP')));
+    }
+
+    public function testReportsMissingRateOncePerCurrencyPair(): void
+    {
+        $this->stubMinimum(['amount' => 250.0, 'currency' => 'EUR']);
+        $this->ratesProvider->method('getRate')->willReturn(null);
+        $this->logRepository->expects($this->once())->method('addErrorLog');
+
+        $this->gate->isSatisfied($this->brand, $this->quote(100.0, 'SEK'));
+        $this->gate->isSatisfied($this->brand, $this->quote(200.0, 'SEK'));
     }
 }

--- a/Test/bootstrap.php
+++ b/Test/bootstrap.php
@@ -64,6 +64,11 @@ if (!class_exists(\Magento\Catalog\Model\Product\Type::class)) {
 if (!class_exists(\Magento\Sales\Model\Order\Invoice::class, false)) {
     require_once __DIR__ . '/Stubs/SalesModels.php';
 }
+// Quote model with the CartInterface relationship intact - required so
+// type hints against CartInterface accept Quote mocks.
+if (!class_exists(\Magento\Quote\Model\Quote::class, false)) {
+    require_once __DIR__ . '/Stubs/QuoteModels.php';
+}
 
 // Catch-all autoloader for remaining Magento classes/interfaces.
 // Creates empty stubs so that type hints, extends, and implements resolve.

--- a/Test/bootstrap.php
+++ b/Test/bootstrap.php
@@ -45,6 +45,7 @@ if (!interface_exists(\Magento\Framework\App\Config\Storage\WriterInterface::cla
 }
 if (!class_exists(\Magento\Framework\HTTP\Client\Curl::class)) {
     require_once __DIR__ . '/Stubs/Curl.php';
+    require_once __DIR__ . '/Stubs/ComponentRegistrar.php';
 }
 if (!class_exists(\Magento\Framework\HTTP\Client\CurlFactory::class)) {
     require_once __DIR__ . '/Stubs/CurlFactory.php';

--- a/docs/brand-overlay-guide.md
+++ b/docs/brand-overlay-guide.md
@@ -1,9 +1,7 @@
 # Brand overlay guide
 
-How to build a brand overlay module on top of `Two_Gateway` — a partner
-edition (like the ABN AMRO plugin) that rebrands the payment method
-without forking any code. Reference implementation:
-[two-inc/magento-abn-plugin](https://github.com/two-inc/magento-abn-plugin).
+How to build a brand overlay module on top of `Two_Gateway` — a brand
+overlay edition that rebrands the payment method without forking any code.
 
 ## Architecture in one paragraph
 
@@ -72,10 +70,10 @@ Two things, both small:
      method. The brand's `code` is the only override; every other
      constructor argument resolves by type through the ObjectManager,
      so new required parent constructor params auto-inject. -->
-<virtualType name="ABN\Gateway\Model\AbnPayment"
+<virtualType name="Acme\Gateway\Model\AcmePayment"
              type="Two\Gateway\Model\GenericPaymentMethod">
     <arguments>
-        <argument name="code" xsi:type="string">abn_payment</argument>
+        <argument name="code" xsi:type="string">acme_payment</argument>
     </arguments>
 </virtualType>
 
@@ -83,7 +81,7 @@ Two things, both small:
 <type name="Two\Gateway\Model\BrandOverlayRegistry">
     <arguments>
         <argument name="overlays" xsi:type="array">
-            <item name="abn_payment" xsi:type="string">abn_payment</item>
+            <item name="acme_payment" xsi:type="string">acme_payment</item>
         </argument>
     </arguments>
 </type>
@@ -171,7 +169,7 @@ short-circuits the synthesised section ordering.
 
 ## Worked example: adding a brand-driven field (`minimum_order`)
 
-The €250 ABN minimum-order gate (TWO-24743) is the canonical recipe for
+The minimum-order gate (TWO-24743) — a €250 EUR floor — is the canonical recipe for
 extending `BrandRegistryInterface` with a new brand-driven value. Six
 touch points, in dependency order:
 
@@ -229,8 +227,8 @@ warning above), so verify the feature's behaviour (here: the
 ## Local development
 
 `make up` in this repo runs a vanilla Magento dev stack on port 1234;
-the ABN overlay repo's `make up` runs an ABN-flavoured stack on 1235 —
-both can co-run. The overlay repo's `dev/install.sh` supports
+a brand overlay repo's `make up` typically runs a brand-flavoured stack
+on a different port — both can co-run. The overlay repo's `dev/install.sh` supports
 `BASE=released|develop|tag:|sha:|ref:|path:` to test an overlay against
 any parent version, which is exactly what the release-ordering caveat
 above requires before shipping a new brand field.

--- a/docs/brand-overlay-guide.md
+++ b/docs/brand-overlay-guide.md
@@ -126,7 +126,7 @@ across modules). Elements may appear in any order (`xs:all`).
 | `api_base_url` | yes | string | Two API base for this brand. |
 | `available_payment_terms` | yes | `<term>` list | Day counts offered (positive integers). |
 | `surcharge_fixed_max` | no | `amount` + `currency` attrs | Cap on the fixed surcharge component. |
-| `minimum_order` | no | `amount` + `currency` attrs | Minimum NET basket value (excl. tax, matching the funding partner's server-side rule) for the method to be offered (worked example below). |
+| `minimum_order` | no | `amount` + `currency` + `basis` attrs | Minimum basket value for the method to be offered; `basis` (`net`\|`gross`) declares whether it compares excl. or incl. tax — always explicit (worked example below). |
 | `csp_origins` | no | `<origin>` list | Extra CSP origins. |
 | `admin_resource` | yes | string | ACL resource gating the admin section. |
 | `module_label_chain` | no | `<module label="…">` list | Admin Version-panel rows; rows for missing modules silently skip. |
@@ -217,7 +217,7 @@ touch points, in dependency order:
 The overlay then declares the value in its `brand.xml`:
 
 ```xml
-<minimum_order amount="250" currency="EUR"/>
+<minimum_order amount="250" currency="EUR" basis="net"/>
 ```
 
 **Release ordering:** the parent release containing steps 1–6 must be

--- a/docs/brand-overlay-guide.md
+++ b/docs/brand-overlay-guide.md
@@ -126,7 +126,7 @@ across modules). Elements may appear in any order (`xs:all`).
 | `api_base_url` | yes | string | Two API base for this brand. |
 | `available_payment_terms` | yes | `<term>` list | Day counts offered (positive integers). |
 | `surcharge_fixed_max` | no | `amount` + `currency` attrs | Cap on the fixed surcharge component. |
-| `minimum_order` | no | `amount` + `currency` attrs | Minimum basket value for the method to be offered (worked example below). |
+| `minimum_order` | no | `amount` + `currency` attrs | Minimum NET basket value (excl. tax, matching the funding partner's server-side rule) for the method to be offered (worked example below). |
 | `csp_origins` | no | `<origin>` list | Extra CSP origins. |
 | `admin_resource` | yes | string | ACL resource gating the admin section. |
 | `module_label_chain` | no | `<module label="…">` list | Admin Version-panel rows; rows for missing modules silently skip. |

--- a/docs/brand-overlay-guide.md
+++ b/docs/brand-overlay-guide.md
@@ -1,0 +1,236 @@
+# Brand overlay guide
+
+How to build a brand overlay module on top of `Two_Gateway` — a partner
+edition (like the ABN AMRO plugin) that rebrands the payment method
+without forking any code. Reference implementation:
+[two-inc/magento-abn-plugin](https://github.com/two-inc/magento-abn-plugin).
+
+## Architecture in one paragraph
+
+Every module may ship an `etc/brand.xml`. At runtime
+`Two\Gateway\Model\Brand\Loader` enumerates installed modules via
+`ComponentRegistrar`, parses each `brand.xml` into an immutable
+`Two\Gateway\Model\Brand\Descriptor`, and
+`Two\Gateway\Model\Brand\ActiveBrandResolver` picks the single active
+brand for the install. Brand-aware code reads identity values through
+`Two\Gateway\Api\BrandRegistryInterface`, whose default DI binding
+(`Two\Gateway\Brand\DescriptorBackedBrandRegistry`) delegates to the
+resolved descriptor. An overlay therefore changes behaviour by
+*declaring data*, not by overriding classes.
+
+## The single-overlay invariant
+
+`ActiveBrandResolver` enforces **max one overlay brand atop Two**:
+
+- Two alone → Two is active.
+- Two + one overlay → the overlay is active.
+- Three or more brands → `DomainException` at first `resolve()`.
+
+The resolver caches the active descriptor in-process. There is no
+per-store-view brand switching; one install, one brand.
+
+## Files an overlay module needs
+
+```
+your-overlay/
+  registration.php        ComponentRegistrar::register + (optionally) a
+                          class_alias for a legacy gateway FQCN — never a
+                          subclass file, so autoload doesn't force-resolve
+                          the parent at di:compile mid-upgrade
+  etc/
+    module.xml            <sequence> MUST list Magento_Backend,
+                          Magento_Config, Magento_Payment AND Two_Gateway
+                          explicitly: module sequence is not transitively
+                          walked at config-merge time, and a missing entry
+                          makes the admin section override silently no-op
+                          on alphabetical-sort installs
+    brand.xml             the brand declaration (schema below)
+    di.xml                virtualType for the payment method +
+                          BrandOverlayRegistry entry (below)
+    config.xml            payment-method defaults (install-time only;
+                          existing core_config_data rows are never
+                          rewritten)
+    payment.xml           gateway entry — carries NO <model> element
+                          (that lives in config.xml)
+    acl.xml               your `<Vendor>_<Module>::config` resource
+    csp_whitelist.xml     if your brand adds origins
+  view/                   logo + palette only — no PHP/view-model overrides
+  i18n/                   brand-specific strings
+```
+
+Conventions enforced across the overlay ecosystem (see AGENTS.md, the
+parity block): `composer.json` carries no `version:` field;
+`etc/module.xml` omits `setup_version`; `payment.xml` carries no
+`<model>`.
+
+## di.xml wiring
+
+Two things, both small:
+
+```xml
+<!-- Payment-method registration: a virtualType over the generic
+     method. The brand's `code` is the only override; every other
+     constructor argument resolves by type through the ObjectManager,
+     so new required parent constructor params auto-inject. -->
+<virtualType name="ABN\Gateway\Model\AbnPayment"
+             type="Two\Gateway\Model\GenericPaymentMethod">
+    <arguments>
+        <argument name="code" xsi:type="string">abn_payment</argument>
+    </arguments>
+</virtualType>
+
+<!-- Declare the overlay so brand-aware machinery can enumerate it -->
+<type name="Two\Gateway\Model\BrandOverlayRegistry">
+    <arguments>
+        <argument name="overlays" xsi:type="array">
+            <item name="abn_payment" xsi:type="string">abn_payment</item>
+        </argument>
+    </arguments>
+</type>
+```
+
+Do **not** rebind `BrandRegistryInterface`, ship per-brand virtualTypes
+for blocks/view-models, or override admin sections in your own
+system.xml — brand identity resolves at request time via the active
+descriptor, and admin sections are synthesised from the canonical
+template (see `suppressed_fields` below for per-brand control hiding).
+
+## brand.xml schema reference
+
+Root: `<config>` with one or more `<brand>` elements (`brand.xsd`
+enforces unique `code` per file; `Loader` throws on duplicate codes
+across modules). Elements may appear in any order (`xs:all`).
+
+**`<brand>` attributes**
+
+| Attribute | Required | Controls |
+|---|---|---|
+| `code` | yes | Brand + payment-method code (`[a-z][a-z0-9_]*`). Keyed into `sales_order.payment.method` and `core_config_data` paths — frozen for live installs. |
+| `tab_sort_order` | yes | Admin Configuration tab ordering. |
+| `section_prefix` | no | Prefix for synthesised admin section ids (`{prefix}_general`, `{prefix}_payment`, …) and the tab id `{prefix}_gateway`. Defaults to `code` minus a trailing `_payment`. |
+
+**Elements**
+
+| Element | Required | Type | Controls |
+|---|---|---|---|
+| `provider` | yes | string | Short provider name (admin/UI copy). |
+| `provider_full_name` | no | string | Legal entity name. |
+| `product_name` | yes | string | Customer-facing product name (checkout, emails, admin). |
+| `tab_label` | yes | string | Admin Configuration tab label. |
+| `tab_css_class` | no | string | CSS class on the admin tab. |
+| `checkout_subtitle` | no | string | Subtitle under the method title at checkout. |
+| `checkout_url_template` | yes | string | Hosted-checkout URL template (`https://%s.…`). |
+| `brand_tag` | no | string | Checkout-page URL query param (`?brand=<tag>`). **Never sent in order bodies.** |
+| `sign_up_url` | no | string | Merchant signup link in admin. |
+| `documentation_url` | no | string | Docs link in admin. |
+| `api_base_url` | yes | string | Two API base for this brand. |
+| `available_payment_terms` | yes | `<term>` list | Day counts offered (positive integers). |
+| `surcharge_fixed_max` | no | `amount` + `currency` attrs | Cap on the fixed surcharge component. |
+| `minimum_order` | no | `amount` + `currency` attrs | Minimum basket value for the method to be offered (worked example below). |
+| `csp_origins` | no | `<origin>` list | Extra CSP origins. |
+| `admin_resource` | yes | string | ACL resource gating the admin section. |
+| `module_label_chain` | no | `<module label="…">` list | Admin Version-panel rows; rows for missing modules silently skip. |
+| `allowed_currencies` | no | `<currency>` list | Currency allow-list. |
+| `allowed_countries` | no | `<country>` list | Country allow-list. |
+| `extra_http_headers` | no | `<header name="…">` list | Extra headers on API calls. |
+| `suppressed_fields` | no | `<field path="…">` list | Hides admin controls for this brand (below). |
+| `inline_term_fees` | no | boolean | Show per-term merchant fee beside Payment Terms checkboxes in admin (default true). |
+
+### A warning about validation
+
+`brand.xsd` is enforced by CI/IDE tooling only — **nothing validates
+brand.xml against the schema at runtime** (`Loader` uses plain
+`simplexml_load_file`; the `xsi:noNamespaceSchemaLocation` hint is
+passive). Two consequences:
+
+1. A typo'd element is **silently ignored**, not rejected. Deploying an
+   overlay that uses a new element against an older parent that doesn't
+   parse it produces a silently-absent feature, not a deploy failure.
+   Always verify the feature's observable behaviour after deploy.
+2. Where silent mis-parsing would be dangerous, `Loader` carries its own
+   guards (duplicate/empty `code`, malformed `minimum_order`) that throw
+   `DomainException` at load. Follow that pattern when you add fields
+   whose zero-value would silently disable a constraint.
+
+## suppressed_fields: hiding admin controls per brand
+
+```xml
+<suppressed_fields>
+    <field path="payment/payment_terms/payment_terms_duration_days"/>
+</suppressed_fields>
+```
+
+`path` is `section_suffix/group/field` against the synthesised section
+(`{section_prefix}_payment` → `payment_terms` group here).
+`SynthesiseBrandAdminForm` sets `showInDefault/Website/Store="0"` on
+the matching field during section injection: the control stays declared
+in the canonical template but doesn't render for this brand. Use this
+instead of shipping a `<section>` stub in the overlay's system.xml —
+a static stub inserts itself into the merged Structure first and
+short-circuits the synthesised section ordering.
+
+## Worked example: adding a brand-driven field (`minimum_order`)
+
+The €250 ABN minimum-order gate (TWO-24743) is the canonical recipe for
+extending `BrandRegistryInterface` with a new brand-driven value. Six
+touch points, in dependency order:
+
+1. **Schema** — `etc/brand.xsd`: add the element to `brandType`
+   (optional, `minOccurs="0"`, so existing brand.xml files stay valid)
+   plus its complexType. The attribute-pair idiom
+   (`<minimum_order amount="250" currency="EUR"/>`) matches
+   `surcharge_fixed_max`.
+
+2. **Loader** — `Model/Brand/Loader.php` `buildDescriptor()`: parse the
+   element, **normalise and validate** (currency is upper-cased and
+   trimmed; `amount <= 0` or empty currency throws `DomainException` —
+   because nothing validates the xsd at runtime, a typo would otherwise
+   coerce to `0.0` and silently disable the gate). Pass the value as a
+   constructor argument to `Descriptor`.
+
+3. **Value object** — `Model/Brand/Descriptor.php`: append a readonly
+   constructor property + getter. Mirror the same getter on the legacy
+   `Model/Brand.php` value object — both implement
+   `BrandRegistryInterface` and must stay in lockstep until the legacy
+   interface is deleted (see the deprecation note in
+   `Brand/DescriptorBackedBrandRegistry.php`).
+
+4. **Interface + adapter** — `Api/BrandRegistryInterface.php`: declare
+   the getter with the full return-shape docblock
+   (`@return array{amount: float, currency: string}|null` here; null =
+   feature absent). `Brand/DescriptorBackedBrandRegistry.php`: delegate
+   to the resolved descriptor.
+
+5. **Consumer** — the code that reads the value lands in the same PR
+   (no speculative brand fields). For the minimum:
+   `Service/Order/MinimumOrderGate` enforces it at the end of
+   `Two::isAvailable()`. Note its defensive patterns — fail-closed on
+   unresolvable currency/missing FX rate, ERROR-level logging deduped
+   per currency pair, comparison at currency precision — they exist
+   because hiding a payment method is a silent revenue stop when
+   misconfigured.
+
+6. **Tests** — unit tests for the Loader parse/validation and the
+   consumer's boundaries (the `MinimumOrderGateTest` boundary set is the
+   template: exact-minimum, cross-currency, fail-closed paths).
+
+The overlay then declares the value in its `brand.xml`:
+
+```xml
+<minimum_order amount="250" currency="EUR"/>
+```
+
+**Release ordering:** the parent release containing steps 1–6 must be
+deployed before an overlay brand.xml that uses the new element —
+on an older parent the element is silently ignored (see the validation
+warning above), so verify the feature's behaviour (here: the
+€249.99/€250.00 availability boundary) after deploy.
+
+## Local development
+
+`make up` in this repo runs a vanilla Magento dev stack on port 1234;
+the ABN overlay repo's `make up` runs an ABN-flavoured stack on 1235 —
+both can co-run. The overlay repo's `dev/install.sh` supports
+`BASE=released|develop|tag:|sha:|ref:|path:` to test an overlay against
+any parent version, which is exactly what the release-ordering caveat
+above requires before shipping a new brand field.

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -80,6 +80,15 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <config_path>payment/two_payment/active</config_path>
                 </field>
+                <field id="merchant_minimum_order" translate="label" type="text" sortOrder="25" showInDefault="1"
+                       showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Minimum Order Value</label>
+                    <backend_model>Two\Gateway\Model\Config\Backend\MerchantMinimumOrder</backend_model>
+                    <comment model="Two\Gateway\Model\Config\Comment\MerchantMinimumOrder"/>
+                    <depends>
+                        <field id="active">1</field>
+                    </depends>
+                </field>
                 <field id="title" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="1"
                        showInStore="1" canRestore="1">
                     <label>Title</label>

--- a/etc/brand.xsd
+++ b/etc/brand.xsd
@@ -37,6 +37,14 @@
             <xs:element name="api_base_url" type="xs:string"/>
             <xs:element name="available_payment_terms" type="paymentTermsType"/>
             <xs:element name="surcharge_fixed_max" type="surchargeFixedMaxType" minOccurs="0"/>
+            <!--
+                Minimum order value for the payment method to be offered,
+                expressed in a specific currency (e.g. the ABN AMRO product
+                requires a EUR 250 minimum). Absent = no minimum. Baskets in
+                other currencies are converted to this currency via the
+                store's exchange rates before comparing.
+            -->
+            <xs:element name="minimum_order" type="minimumOrderType" minOccurs="0"/>
             <xs:element name="csp_origins" type="cspOriginsType" minOccurs="0"/>
             <xs:element name="admin_resource" type="xs:string"/>
             <xs:element name="module_label_chain" type="moduleLabelChainType" minOccurs="0"/>
@@ -80,6 +88,11 @@
     </xs:complexType>
 
     <xs:complexType name="surchargeFixedMaxType">
+        <xs:attribute name="amount" type="xs:decimal" use="required"/>
+        <xs:attribute name="currency" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="minimumOrderType">
         <xs:attribute name="amount" type="xs:decimal" use="required"/>
         <xs:attribute name="currency" type="xs:string" use="required"/>
     </xs:complexType>

--- a/etc/brand.xsd
+++ b/etc/brand.xsd
@@ -38,11 +38,13 @@
             <xs:element name="available_payment_terms" type="paymentTermsType"/>
             <xs:element name="surcharge_fixed_max" type="surchargeFixedMaxType" minOccurs="0"/>
             <!--
-                Minimum order value for the payment method to be offered,
-                expressed in a specific currency (e.g. the ABN AMRO product
-                requires a EUR 250 minimum). Absent = no minimum. Baskets in
-                other currencies are converted to this currency via the
-                store's exchange rates before comparing.
+                Minimum NET order value (basket total excluding tax) for
+                the payment method to be offered, expressed in a specific
+                currency (e.g. the ABN AMRO product requires a EUR 250 net
+                minimum, matching the funding partner's server-side risk
+                rule). Absent = no minimum. Baskets in other currencies are
+                converted to this currency via the store's exchange rates
+                before comparing.
             -->
             <xs:element name="minimum_order" type="minimumOrderType" minOccurs="0"/>
             <xs:element name="csp_origins" type="cspOriginsType" minOccurs="0"/>

--- a/etc/brand.xsd
+++ b/etc/brand.xsd
@@ -38,13 +38,13 @@
             <xs:element name="available_payment_terms" type="paymentTermsType"/>
             <xs:element name="surcharge_fixed_max" type="surchargeFixedMaxType" minOccurs="0"/>
             <!--
-                Minimum NET order value (basket total excluding tax) for
-                the payment method to be offered, expressed in a specific
-                currency (e.g. the ABN AMRO product requires a EUR 250 net
-                minimum, matching the funding partner's server-side risk
-                rule). Absent = no minimum. Baskets in other currencies are
-                converted to this currency via the store's exchange rates
-                before comparing.
+                Minimum order value for the payment method to be offered:
+                amount + currency + basis (net = basket excluding tax,
+                gross = including; e.g. the ABN AMRO product requires a
+                EUR 250 NET minimum, matching the funding partner's
+                server-side risk rule). Absent = no minimum. Baskets in
+                other currencies are converted to this currency via the
+                store's exchange rates before comparing.
             -->
             <xs:element name="minimum_order" type="minimumOrderType" minOccurs="0"/>
             <xs:element name="csp_origins" type="cspOriginsType" minOccurs="0"/>
@@ -97,6 +97,18 @@
     <xs:complexType name="minimumOrderType">
         <xs:attribute name="amount" type="xs:decimal" use="required"/>
         <xs:attribute name="currency" type="xs:string" use="required"/>
+        <!-- Whether the minimum compares the basket's net (excl. tax) or
+             gross (incl. tax) value. ABN AMRO defines its minimum net;
+             the platform's country defaults are gross — always explicit,
+             never inferred. -->
+        <xs:attribute name="basis" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="net"/>
+                    <xs:enumeration value="gross"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="cspOriginsType">

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -62,8 +62,8 @@
             Per-layer synthesis flags for the brand-overlay v6 mechanism.
             Default 0 (OFF): the synthesis plugin ships dormant so this
             change is purely additive on production. A follow-up PR
-            flips the default to 1 in lockstep with magento-abn-plugin's
-            data-only release (which deletes ABN's renderer-bootstrap
+            flips the default to 1 in lockstep with a brand overlay's
+            data-only release (which deletes the overlay's renderer-bootstrap
             JS). Design v6 §16.3 specifies these as per-layer debugging
             knobs, not a rollback mechanism. Layers shipped in
             subsequent PRs (payment_xml, csp, admin_form) will add
@@ -88,7 +88,7 @@
                 already exists statically (so a brand whose overlay
                 module still ships its own etc/adminhtml/system.xml
                 stays on the static surface — first-writer-wins).
-                Default 1 since the magento-abn-plugin strip-down: the
+                Default 1 since the brand overlay strip-down: the
                 overlay no longer ships its own system.xml, so synthesis
                 is the sole source of the per-brand admin tab. Flip to
                 0 only to debug — vanilla Two installs have no overlay

--- a/view/adminhtml/web/js/payment-terms-config.js
+++ b/view/adminhtml/web/js/payment-terms-config.js
@@ -7,7 +7,7 @@ define(['jquery', 'mage/translate', 'domReady!'], function ($, $t) {
         // `{section}_payment_terms_payment_terms_checkboxes` — strip
         // the suffix to get the section id, then build every other
         // selector against it. This keeps the JS brand-agnostic:
-        // `two_payment` on vanilla, `abn_payment` on ABN, ...
+        // `two_payment` on vanilla, `acme_payment` on a brand overlay, ...
         var $termsContainer = $('.two-term-checkboxes').first();
         if (!$termsContainer.length) {
             return;

--- a/view/adminhtml/web/js/surcharge-grid.js
+++ b/view/adminhtml/web/js/surcharge-grid.js
@@ -9,7 +9,7 @@ define(['jquery', 'mage/translate', 'domReady!'], function ($, $t) {
         // checkboxes container with id `{section}_payment_terms_payment_terms_checkboxes`
         // — strip the suffix to recover the section id and build every
         // other selector against it. Keeps the file brand-agnostic:
-        // `two_payment` on vanilla, `abn_payment` on a brand overlay
+        // `two_payment` on vanilla, `acme_payment` on a brand overlay
         // install, etc. The previous hardcoded `two_payment_*` selectors
         // matched nothing on overlay installs, so $surchargeType.val()
         // returned undefined → getSurchargeType() defaulted to 'none' →

--- a/view/adminhtml/web/js/surcharge-grid.js
+++ b/view/adminhtml/web/js/surcharge-grid.js
@@ -9,7 +9,7 @@ define(['jquery', 'mage/translate', 'domReady!'], function ($, $t) {
         // checkboxes container with id `{section}_payment_terms_payment_terms_checkboxes`
         // — strip the suffix to recover the section id and build every
         // other selector against it. Keeps the file brand-agnostic:
-        // `two_payment` on vanilla, `abn_payment` on an ABN overlay
+        // `two_payment` on vanilla, `abn_payment` on a brand overlay
         // install, etc. The previous hardcoded `two_payment_*` selectors
         // matched nothing on overlay installs, so $surchargeType.val()
         // returned undefined → getSurchargeType() defaulted to 'none' →

--- a/view/frontend/web/css/style.css
+++ b/view/frontend/web/css/style.css
@@ -52,7 +52,7 @@
     color: var(--color-brownie-vanilla);
 }
 
-/* All links inside the Two/ABN payment-method block render blue +
+/* All links inside the Two payment-method block render blue +
    underlined (brand subtitle "lees meer", terms "betaalvoorwaarden", …).
    Scoped to the block rather than a bare `a` so it stays out of the rest
    of checkout and so the class+element specificity wins over resets. */
@@ -263,7 +263,7 @@
  * checkout page (Registered Organisation / Sole Trader): solid Two-brand
  * blue (`--color-blue2`) for the selected state, white fill with blue
  * text for unselected. Brand overlays that ship a different palette
- * (e.g. ABN's teal/white pairing) override these rules from their own
+ * (e.g. a brand overlay's palette) override these rules from their own
  * style.css which loads after this one.
  */
 .two-term-chip {

--- a/view/frontend/web/js/model/brand-config.js
+++ b/view/frontend/web/js/model/brand-config.js
@@ -6,7 +6,7 @@
 /**
  * Brand-overlay-aware config lookup. Reads from
  * `window.checkoutConfig.payment[<methodCode>]` so each brand-overlay
- * payment method (two_payment, abn_payment, …) gets its own config
+ * payment method (two_payment, acme_payment, …) gets its own config
  * subtree without forking the gateway_method renderer per brand.
  *
  * Returns an empty object when the requested subtree is absent so
@@ -50,7 +50,7 @@
 
     /**
      * Returns the payment-method code for the currently-active Two-family
-     * brand (two_payment, abn_payment, …) by scanning checkoutConfig.payment
+     * brand (two_payment, acme_payment, …) by scanning checkoutConfig.payment
      * for a subtree with a truthy `redirectUrlCookieCode`. That field is
      * emitted only by Two_Gateway's Model/Ui/ConfigProvider, so its presence
      * is a reliable Two-family sentinel that does not collide with other

--- a/view/frontend/web/js/model/surcharge.js
+++ b/view/frontend/web/js/model/surcharge.js
@@ -25,7 +25,7 @@ define([
 
     // Resolve the active Two-family brand subtree from checkoutConfig
     // rather than hardcoding `.two_payment`. The brand-overlay 2.0
-    // architecture lets each overlay (abn_payment, …) ship its own
+    // architecture lets each overlay (acme_payment, …) ship its own
     // ConfigProvider subtree under the brand's payment-method code,
     // so this module needs to discover which is active rather than
     // assuming vanilla.

--- a/view/frontend/web/js/view/address-autocomplete.js
+++ b/view/frontend/web/js/view/address-autocomplete.js
@@ -15,7 +15,7 @@ define([
     'use strict';
 
     // Resolve the active Two-family brand subtree so overlays
-    // (abn_payment, …) get their own checkoutApiUrl /
+    // (acme_payment, …) get their own checkoutApiUrl /
     // isCompanySearchEnabled / companySearchLimit instead of falling
     // through to an empty object when the vanilla `two_payment` key
     // isn't present.

--- a/view/frontend/web/js/view/checkout/summary/surcharge.js
+++ b/view/frontend/web/js/view/checkout/summary/surcharge.js
@@ -22,7 +22,7 @@ define([
             var method = quote.paymentMethod();
             // Match against the active Two-family brand code rather
             // than the hardcoded vanilla `two_payment`, so brand
-            // overlays (abn_payment, …) display the surcharge line
+            // overlays (acme_payment, …) display the surcharge line
             // when their own payment method is selected.
             var activeCode = brandConfig.getActiveTwoBrandCode();
             return segment && parseFloat(segment.value) > 0

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -303,7 +303,7 @@ define([
             if (url) {
                 // Magento's place-order action stops the full-screen loader the
                 // moment the AJAX resolves — which leaves the checkout bare for
-                // the few seconds the redirect to the Two/ABN checkout takes,
+                // the few seconds the redirect to the hosted checkout takes,
                 // making buyers think nothing happened. Re-show the loader so
                 // the overlay stays up until the browser actually navigates
                 // away (the new page discards it).

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -83,7 +83,7 @@ define([
             this._super();
 
             // Brand-overlay config: read once at initialize time, keyed on
-            // this.getCode() so abn_payment, two_payment, etc each pull
+            // this.getCode() so acme_payment, two_payment, etc each pull
             // their own subtree from window.checkoutConfig.payment.
             this._brandConfig = getBrandConfig(this.getCode());
             var config = this._brandConfig;


### PR DESCRIPTION
## What

**B1 of the Magento ABN minimum-order work** (stacked on #214; merge that first — base will retarget to `staging` when it lands).

- `etc/brand.xsd`: new optional `<minimum_order amount="" currency=""/>` element, same attribute-pair shape as `surcharge_fixed_max`. Absent ⇒ no minimum.
- Threaded through `Loader` → `Descriptor` → `BrandRegistryInterface` (+ both implementations: `DescriptorBackedBrandRegistry`, legacy `Model\Brand` value object).
- New `Service/Order/MinimumOrderGate`: enforced in `Two::isAvailable()`. Same-currency baskets compare directly; cross-currency baskets convert via the existing `CurrencyRatesProviderInterface` (store FX rates, cross-rate capable). **Missing rate fails closed** — we can't prove the order meets the brand's product minimum, so the method hides rather than offering an order Two would have to decline later.
- Gate takes the method instance's own brand binding (`$this->brandRegistry`), so side-by-side method instances (vanilla `two_payment` + overlay) each gate on their own brand.
- `GenericPaymentMethod` constructor updated in lockstep (ABN overlay aliases to it via `class_alias`, no positional-constructor subclasses outside this repo).

## Why

ABN AMRO's product requires a €250 minimum order; confirmed absent from the Magento ABN plugin (TWO-24743 / plugin parity Phase 0.4). The follow-up PR in magento-abn-plugin populates `<minimum_order amount="250" currency="EUR"/>` — vanilla Two behaviour is unchanged by this PR.

Note: the plan sketched this as two scalar fields (`minimum_order_amount`/`minimum_order_currency`); implemented as one attribute-pair element to match the existing `surcharge_fixed_max` schema idiom.

## Tests

`MinimumOrderGateTest` (8 cases): no-minimum short-circuit, null quote, EUR 249.99 ✗ / 250.00 ✓ boundary, same-currency skips FX lookup, GBP→EUR conversion both sides of the threshold, fail-closed on missing rate. Full suite: 163 tests green on PHPUnit 10.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)