### PR TITLE
TWO-24764/docs: Brand overlay guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@ Two's Magento 2 BNPL payment plugin. Brand-aware single-module
 extension; brand-specific identity values resolve through
 `Two\Gateway\Api\BrandRegistryInterface`. The default DI
 binding in `etc/di.xml` resolves to `Two\Gateway\Brand\TwoBrand`.
+Building a partner overlay or adding a brand-driven field:
+see docs/brand-overlay-guide.md.
 
 Standard Magento dev workflow: composer install, bin/magento
 setup:di:compile, setup:upgrade, cache:flush. PHPUnit under Test/.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,8 @@
 Two's Magento 2 BNPL payment plugin. Brand-aware single-module
 extension; brand-specific identity values resolve through
 `Two\Gateway\Api\BrandRegistryInterface`. The default DI
-binding in `etc/di.xml` resolves to `Two\Gateway\Brand\TwoBrand`.
+binding in `etc/di.xml` resolves to
+`Two\Gateway\Brand\DescriptorBackedBrandRegistry`.
 Building a partner overlay or adding a brand-driven field:
 see docs/brand-overlay-guide.md.
 

--- a/Api/BrandOverlayRegistryInterface.php
+++ b/Api/BrandOverlayRegistryInterface.php
@@ -47,7 +47,7 @@ interface BrandOverlayRegistryInterface
      * method" (observers, controllers, the order-reference lookup in
      * Service\Payment\OrderService) use this instead of the previous
      * pattern of `=== Two::CODE` which excluded overlay methods like
-     * `abn_payment` and produced "Unable to find the requested order"
+     * `acme_payment` and produced "Unable to find the requested order"
      * errors on overlay checkouts.
      */
     public function isTwoStackMethod(string $method): bool;

--- a/Api/BrandRegistryInterface.php
+++ b/Api/BrandRegistryInterface.php
@@ -104,7 +104,7 @@ interface BrandRegistryInterface
 
     /**
      * Magento payment-method code for the active brand (e.g.
-     * "two_payment", "abn_payment"). Used to build brand-aware
+     * "two_payment", "acme_payment"). Used to build brand-aware
      * `payment/<code>/*` CCD paths from a single shared codebase
      * — callers do not hold this value in their own constructor
      * args.

--- a/Api/BrandRegistryInterface.php
+++ b/Api/BrandRegistryInterface.php
@@ -63,9 +63,9 @@ interface BrandRegistryInterface
     /**
      * Minimum order value required for this brand's payment method to
      * be offered at checkout: amount + currency + basis ('net' = basket
-     * excluding tax, 'gross' = including; ABN AMRO defines its minimum
-     * net, matching the funding partner's server-side risk rule, while
-     * the platform's country defaults are gross — hence explicit).
+     * excluding tax, 'gross' = including). Basis is always explicit in
+     * brand.xml — funding-partner rules and platform country defaults
+     * may differ, so the brand declares its requirement unambiguously.
      * Returning null means there is no minimum. Baskets in other
      * currencies are converted to this currency via the store's
      * exchange rates before comparing.
@@ -122,7 +122,7 @@ interface BrandRegistryInterface
 
     /**
      * Ordered label => module-name map for the admin Version panel
-     * (Stores → Configuration → ABN/Two AMRO → Version). Brand
+     * (Stores → Configuration → [Brand] → Version). Brand
      * overlays append their theme modules to the parent runtime
      * rows; the Version block renders one row per ComponentRegistrar-
      * resolvable module and silently skips unregistered entries.

--- a/Block/Adminhtml/Creditmemo/SurchargeOverride.php
+++ b/Block/Adminhtml/Creditmemo/SurchargeOverride.php
@@ -143,7 +143,7 @@ class SurchargeOverride extends Template
     /**
      * Label for the row — mirrors the order's surcharge description so the
      * editable line on the creditmemo create form reads the same as the
-     * static line shown elsewhere (e.g. "Zakelijk op Rekening - 30 dagen"
+     * static line shown elsewhere (e.g. "Partner Product - 30 dagen"
      * prefixed with "Refund").
      */
     public function getLabel(): string

--- a/Block/Adminhtml/System/Config/Field/SurchargeGrid.php
+++ b/Block/Adminhtml/System/Config/Field/SurchargeGrid.php
@@ -490,7 +490,7 @@ class SurchargeGrid extends Field
 
     /**
      * Build a fully-qualified config path under the active brand's
-     * payment-method subtree (e.g. `payment/abn_payment/...` on an
+     * payment-method subtree (e.g. `payment/acme_payment/...` on an
      * ABN install). The brand code is resolved at call time from
      * BrandRegistryInterface, which routes through ActiveBrandResolver
      * to the active brand's brand.xml — no per-brand DI rebinding.

--- a/Model/Brand/Descriptor.php
+++ b/Model/Brand/Descriptor.php
@@ -116,7 +116,7 @@ final class Descriptor
         if ($this->sectionPrefix !== '') {
             return $this->sectionPrefix;
         }
-        // Derive: `two_payment` → `two`, `abn_payment` → `abn`.
+        // Derive: `two_payment` → `two`, `acme_payment` → `acme`.
         // Strictly strip a TRAILING `_payment` suffix only; using
         // strstr() would incorrectly shorten a hypothetical
         // `foo_payment_method` to `foo`.

--- a/Model/GenericPaymentMethod.php
+++ b/Model/GenericPaymentMethod.php
@@ -50,7 +50,7 @@ use Two\Gateway\Service\UrlCookie;
  *   <virtualType name="ABN\Gateway\Model\AbnPayment"
  *                type="Two\Gateway\Model\GenericPaymentMethod">
  *       <arguments>
- *           <argument name="code" xsi:type="string">abn_payment</argument>
+ *           <argument name="code" xsi:type="string">acme_payment</argument>
  *           <argument name="brand" xsi:type="object">ABN\Gateway\Model\AbnBrand</argument>
  *       </arguments>
  *   </virtualType>
@@ -112,7 +112,7 @@ class GenericPaymentMethod extends Two
             $resourceCollection,
             $data
         );
-        // Brand-overlay payment-method code, e.g. 'abn_payment'. Replaces
+        // Brand-overlay payment-method code, e.g. 'acme_payment'. Replaces
         // the hardcoded `self::CODE` baked into the parent Two class so a
         // single class can back multiple brand-overlay virtualTypes.
         $this->_code = $code;

--- a/Model/Two.php
+++ b/Model/Two.php
@@ -715,7 +715,7 @@ class Two extends AbstractMethod
      *
      * The active + api-key check must be method-code-bound (`_code`), not
      * brand-aware. Both `two_payment` and an overlay's method (e.g.
-     * `abn_payment`) can be registered side-by-side; routing this method's
+     * `acme_payment`) can be registered side-by-side; routing this method's
      * self-check through the brand-aware ConfigRepository would make Two's
      * instance answer with the overlay's config (because the brand-aware
      * fallback resolves to the install's active brand, not this instance's

--- a/Model/Two.php
+++ b/Model/Two.php
@@ -320,7 +320,7 @@ class Two extends AbstractMethod
      *   2. BrandRegistry::getProductName() (brand overlay fallback).
      *
      * Optionally suffixed with the buyer's selected term in days
-     * (e.g. "Zakelijk op Rekening - 60 days"). DataAssignObserver
+     * (e.g. "Partner Product - 60 days"). DataAssignObserver
      * stores the chosen term under the `selectedTerm` key as a
      * scalar; the duration is wrapped in a separate __() call so the
      * existing "%1 days" CSV entry handles localisation.

--- a/Model/Ui/ConfigProvider.php
+++ b/Model/Ui/ConfigProvider.php
@@ -23,7 +23,7 @@ use Two\Gateway\Model\Two;
  * Populates `window.checkoutConfig.payment[<code>]` with the runtime
  * config the gateway_method renderer needs. The `$code` constructor
  * argument decides which subtree of `payment` gets populated, so
- * brand-overlay packages (magento-abn-plugin) can declare a
+ * brand-overlay packages can declare a
  * virtualType of this class with `code='abn_payment'` and a
  * brand-bound BrandRegistryInterface to expose their own subtree
  * without re-implementing the body of getConfig().

--- a/Model/Ui/ConfigProvider.php
+++ b/Model/Ui/ConfigProvider.php
@@ -24,7 +24,7 @@ use Two\Gateway\Model\Two;
  * config the gateway_method renderer needs. The `$code` constructor
  * argument decides which subtree of `payment` gets populated, so
  * brand-overlay packages can declare a
- * virtualType of this class with `code='abn_payment'` and a
+ * virtualType of this class with `code='acme_payment'` and a
  * brand-bound BrandRegistryInterface to expose their own subtree
  * without re-implementing the body of getConfig().
  *

--- a/Plugin/Magento/Checkout/Block/LayoutProcessor/SynthesiseBrandRenderers.php
+++ b/Plugin/Magento/Checkout/Block/LayoutProcessor/SynthesiseBrandRenderers.php
@@ -21,9 +21,8 @@ use Two\Gateway\Model\Brand\Descriptor;
  * view/frontend/web/js/view/payment/two_payment.js file shipped
  * with magento-plugin. This plugin therefore only emits a synthesis
  * entry when the resolved active brand is something other than the
- * default Two brand (i.e. when an overlay package such as the
- * future data-only magento-abn-plugin is installed and contributes
- * its own etc/brand.xml).
+ * default Two brand (i.e. when a data-only brand overlay package
+ * is installed and contributes its own etc/brand.xml).
  *
  * Gated by the system/two_brand_synthesis/checkout_renderers/enabled
  * flag, default 0. While dormant, afterProcess is a pass-through.

--- a/Plugin/Magento/Config/Model/Config/Structure/Reader/SynthesiseBrandAdminForm.php
+++ b/Plugin/Magento/Config/Model/Config/Structure/Reader/SynthesiseBrandAdminForm.php
@@ -268,7 +268,7 @@ class SynthesiseBrandAdminForm
      * are declared) but renders as hidden in the admin form.
      *
      * @param array<string,mixed> $section
-     * @param string $sectionId Full section id, e.g. `abn_payment`.
+     * @param string $sectionId Full section id, e.g. `acme_payment`.
      * @param string $sectionPrefix Brand's section prefix, e.g. `abn`.
      * @param string[] $suppressedPaths `section_suffix/group/field` paths.
      * @return array<string,mixed>
@@ -281,7 +281,7 @@ class SynthesiseBrandAdminForm
     ): array {
         $expectedPrefix = $sectionPrefix . '_';
         // section_suffix is everything after the brand prefix in the
-        // section id, e.g. `payment` for `abn_payment`.
+        // section id, e.g. `payment` for `acme_payment`.
         if (strncmp($sectionId, $expectedPrefix, strlen($expectedPrefix)) !== 0) {
             return $section;
         }

--- a/Plugin/Model/Sales/AfterPlaceOrder.php
+++ b/Plugin/Model/Sales/AfterPlaceOrder.php
@@ -14,7 +14,7 @@ use Two\Gateway\Model\Two;
 /**
  * AfterPlaceOrder Plugin
  * Set Two-stack orders (parent-brand `two_payment` + any registered
- * brand overlays such as `abn_payment`) to status pending after place.
+ * brand overlays such as `acme_payment`) to status pending after place.
  */
 class AfterPlaceOrder
 {

--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ Install also runs:
 
 ### Brand overlays
 
-Brand-specific overlay packages (e.g. ABN AMRO's Zakelijk op Rekening) live in
-their own Composer packages and are installed separately from this plugin, not
-through `make install`. See `two-inc/magento-abn-plugin` for the ABN overlay.
+Brand-specific overlay packages live in their own Composer packages and are
+installed separately from this plugin, not through `make install`. See
+`docs/brand-overlay-guide.md` for how overlay modules are structured.
 
 ### Debugging
 

--- a/Service/Order/MinimumOrderGate.php
+++ b/Service/Order/MinimumOrderGate.php
@@ -14,15 +14,14 @@ use Two\Gateway\Api\CurrencyRatesProviderInterface;
 use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
 
 /**
- * Enforces a brand's minimum order value (e.g. the ABN AMRO product
- * requires a €250 minimum) when deciding whether the payment method
- * is offered at checkout.
+ * Enforces a brand's minimum order value when deciding whether the
+ * payment method is offered at checkout.
  *
  * The minimum is declared per brand in brand.xml as
  * `<minimum_order amount="250" currency="EUR" basis="net"/>` and
  * compares the basket's net (grand total minus tax) or gross value per
- * the declared basis — ABN AMRO's funding-partner rule is net; the
- * platform's country defaults are gross. Baskets in a different
+ * the declared basis — always explicit, since funding-partner rules and
+ * platform country defaults may differ. Baskets in a different
  * currency are converted to the brand currency via the store's
  * exchange rates before comparing. When no rate is
  * configured the gate fails closed: the method is hidden rather

--- a/docs/brand-overlay-guide.md
+++ b/docs/brand-overlay-guide.md
@@ -1,9 +1,7 @@
 # Brand overlay guide
 
-How to build a brand overlay module on top of `Two_Gateway` — a partner
-edition (like the ABN AMRO plugin) that rebrands the payment method
-without forking any code. Reference implementation:
-[two-inc/magento-abn-plugin](https://github.com/two-inc/magento-abn-plugin).
+How to build a brand overlay module on top of `Two_Gateway` — a brand
+overlay edition that rebrands the payment method without forking any code.
 
 ## Architecture in one paragraph
 
@@ -72,10 +70,10 @@ Two things, both small:
      method. The brand's `code` is the only override; every other
      constructor argument resolves by type through the ObjectManager,
      so new required parent constructor params auto-inject. -->
-<virtualType name="ABN\Gateway\Model\AbnPayment"
+<virtualType name="Acme\Gateway\Model\AcmePayment"
              type="Two\Gateway\Model\GenericPaymentMethod">
     <arguments>
-        <argument name="code" xsi:type="string">abn_payment</argument>
+        <argument name="code" xsi:type="string">acme_payment</argument>
     </arguments>
 </virtualType>
 
@@ -83,7 +81,7 @@ Two things, both small:
 <type name="Two\Gateway\Model\BrandOverlayRegistry">
     <arguments>
         <argument name="overlays" xsi:type="array">
-            <item name="abn_payment" xsi:type="string">abn_payment</item>
+            <item name="acme_payment" xsi:type="string">acme_payment</item>
         </argument>
     </arguments>
 </type>
@@ -171,7 +169,7 @@ short-circuits the synthesised section ordering.
 
 ## Worked example: adding a brand-driven field (`minimum_order`)
 
-The €250 ABN minimum-order gate (TWO-24743) is the canonical recipe for
+The minimum-order gate (TWO-24743) — a €250 EUR floor — is the canonical recipe for
 extending `BrandRegistryInterface` with a new brand-driven value. Six
 touch points, in dependency order:
 
@@ -229,8 +227,8 @@ warning above), so verify the feature's behaviour (here: the
 ## Local development
 
 `make up` in this repo runs a vanilla Magento dev stack on port 1234;
-the ABN overlay repo's `make up` runs an ABN-flavoured stack on 1235 —
-both can co-run. The overlay repo's `dev/install.sh` supports
+a brand overlay repo's `make up` typically runs a brand-flavoured stack
+on a different port — both can co-run. The overlay repo's `dev/install.sh` supports
 `BASE=released|develop|tag:|sha:|ref:|path:` to test an overlay against
 any parent version, which is exactly what the release-ordering caveat
 above requires before shipping a new brand field.

--- a/docs/brand-overlay-guide.md
+++ b/docs/brand-overlay-guide.md
@@ -126,7 +126,7 @@ across modules). Elements may appear in any order (`xs:all`).
 | `api_base_url` | yes | string | Two API base for this brand. |
 | `available_payment_terms` | yes | `<term>` list | Day counts offered (positive integers). |
 | `surcharge_fixed_max` | no | `amount` + `currency` attrs | Cap on the fixed surcharge component. |
-| `minimum_order` | no | `amount` + `currency` attrs | Minimum NET basket value (excl. tax, matching the funding partner's server-side rule) for the method to be offered (worked example below). |
+| `minimum_order` | no | `amount` + `currency` + `basis` attrs | Minimum basket value for the method to be offered; `basis` (`net`\|`gross`) declares whether it compares excl. or incl. tax — always explicit (worked example below). |
 | `csp_origins` | no | `<origin>` list | Extra CSP origins. |
 | `admin_resource` | yes | string | ACL resource gating the admin section. |
 | `module_label_chain` | no | `<module label="…">` list | Admin Version-panel rows; rows for missing modules silently skip. |
@@ -217,7 +217,7 @@ touch points, in dependency order:
 The overlay then declares the value in its `brand.xml`:
 
 ```xml
-<minimum_order amount="250" currency="EUR"/>
+<minimum_order amount="250" currency="EUR" basis="net"/>
 ```
 
 **Release ordering:** the parent release containing steps 1–6 must be

--- a/docs/brand-overlay-guide.md
+++ b/docs/brand-overlay-guide.md
@@ -126,7 +126,7 @@ across modules). Elements may appear in any order (`xs:all`).
 | `api_base_url` | yes | string | Two API base for this brand. |
 | `available_payment_terms` | yes | `<term>` list | Day counts offered (positive integers). |
 | `surcharge_fixed_max` | no | `amount` + `currency` attrs | Cap on the fixed surcharge component. |
-| `minimum_order` | no | `amount` + `currency` attrs | Minimum basket value for the method to be offered (worked example below). |
+| `minimum_order` | no | `amount` + `currency` attrs | Minimum NET basket value (excl. tax, matching the funding partner's server-side rule) for the method to be offered (worked example below). |
 | `csp_origins` | no | `<origin>` list | Extra CSP origins. |
 | `admin_resource` | yes | string | ACL resource gating the admin section. |
 | `module_label_chain` | no | `<module label="…">` list | Admin Version-panel rows; rows for missing modules silently skip. |

--- a/docs/brand-overlay-guide.md
+++ b/docs/brand-overlay-guide.md
@@ -1,0 +1,236 @@
+# Brand overlay guide
+
+How to build a brand overlay module on top of `Two_Gateway` — a partner
+edition (like the ABN AMRO plugin) that rebrands the payment method
+without forking any code. Reference implementation:
+[two-inc/magento-abn-plugin](https://github.com/two-inc/magento-abn-plugin).
+
+## Architecture in one paragraph
+
+Every module may ship an `etc/brand.xml`. At runtime
+`Two\Gateway\Model\Brand\Loader` enumerates installed modules via
+`ComponentRegistrar`, parses each `brand.xml` into an immutable
+`Two\Gateway\Model\Brand\Descriptor`, and
+`Two\Gateway\Model\Brand\ActiveBrandResolver` picks the single active
+brand for the install. Brand-aware code reads identity values through
+`Two\Gateway\Api\BrandRegistryInterface`, whose default DI binding
+(`Two\Gateway\Brand\DescriptorBackedBrandRegistry`) delegates to the
+resolved descriptor. An overlay therefore changes behaviour by
+*declaring data*, not by overriding classes.
+
+## The single-overlay invariant
+
+`ActiveBrandResolver` enforces **max one overlay brand atop Two**:
+
+- Two alone → Two is active.
+- Two + one overlay → the overlay is active.
+- Three or more brands → `DomainException` at first `resolve()`.
+
+The resolver caches the active descriptor in-process. There is no
+per-store-view brand switching; one install, one brand.
+
+## Files an overlay module needs
+
+```
+your-overlay/
+  registration.php        ComponentRegistrar::register + (optionally) a
+                          class_alias for a legacy gateway FQCN — never a
+                          subclass file, so autoload doesn't force-resolve
+                          the parent at di:compile mid-upgrade
+  etc/
+    module.xml            <sequence> MUST list Magento_Backend,
+                          Magento_Config, Magento_Payment AND Two_Gateway
+                          explicitly: module sequence is not transitively
+                          walked at config-merge time, and a missing entry
+                          makes the admin section override silently no-op
+                          on alphabetical-sort installs
+    brand.xml             the brand declaration (schema below)
+    di.xml                virtualType for the payment method +
+                          BrandOverlayRegistry entry (below)
+    config.xml            payment-method defaults (install-time only;
+                          existing core_config_data rows are never
+                          rewritten)
+    payment.xml           gateway entry — carries NO <model> element
+                          (that lives in config.xml)
+    acl.xml               your `<Vendor>_<Module>::config` resource
+    csp_whitelist.xml     if your brand adds origins
+  view/                   logo + palette only — no PHP/view-model overrides
+  i18n/                   brand-specific strings
+```
+
+Conventions enforced across the overlay ecosystem (see AGENTS.md, the
+parity block): `composer.json` carries no `version:` field;
+`etc/module.xml` omits `setup_version`; `payment.xml` carries no
+`<model>`.
+
+## di.xml wiring
+
+Two things, both small:
+
+```xml
+<!-- Payment-method registration: a virtualType over the generic
+     method. The brand's `code` is the only override; every other
+     constructor argument resolves by type through the ObjectManager,
+     so new required parent constructor params auto-inject. -->
+<virtualType name="ABN\Gateway\Model\AbnPayment"
+             type="Two\Gateway\Model\GenericPaymentMethod">
+    <arguments>
+        <argument name="code" xsi:type="string">abn_payment</argument>
+    </arguments>
+</virtualType>
+
+<!-- Declare the overlay so brand-aware machinery can enumerate it -->
+<type name="Two\Gateway\Model\BrandOverlayRegistry">
+    <arguments>
+        <argument name="overlays" xsi:type="array">
+            <item name="abn_payment" xsi:type="string">abn_payment</item>
+        </argument>
+    </arguments>
+</type>
+```
+
+Do **not** rebind `BrandRegistryInterface`, ship per-brand virtualTypes
+for blocks/view-models, or override admin sections in your own
+system.xml — brand identity resolves at request time via the active
+descriptor, and admin sections are synthesised from the canonical
+template (see `suppressed_fields` below for per-brand control hiding).
+
+## brand.xml schema reference
+
+Root: `<config>` with one or more `<brand>` elements (`brand.xsd`
+enforces unique `code` per file; `Loader` throws on duplicate codes
+across modules). Elements may appear in any order (`xs:all`).
+
+**`<brand>` attributes**
+
+| Attribute | Required | Controls |
+|---|---|---|
+| `code` | yes | Brand + payment-method code (`[a-z][a-z0-9_]*`). Keyed into `sales_order.payment.method` and `core_config_data` paths — frozen for live installs. |
+| `tab_sort_order` | yes | Admin Configuration tab ordering. |
+| `section_prefix` | no | Prefix for synthesised admin section ids (`{prefix}_general`, `{prefix}_payment`, …) and the tab id `{prefix}_gateway`. Defaults to `code` minus a trailing `_payment`. |
+
+**Elements**
+
+| Element | Required | Type | Controls |
+|---|---|---|---|
+| `provider` | yes | string | Short provider name (admin/UI copy). |
+| `provider_full_name` | no | string | Legal entity name. |
+| `product_name` | yes | string | Customer-facing product name (checkout, emails, admin). |
+| `tab_label` | yes | string | Admin Configuration tab label. |
+| `tab_css_class` | no | string | CSS class on the admin tab. |
+| `checkout_subtitle` | no | string | Subtitle under the method title at checkout. |
+| `checkout_url_template` | yes | string | Hosted-checkout URL template (`https://%s.…`). |
+| `brand_tag` | no | string | Checkout-page URL query param (`?brand=<tag>`). **Never sent in order bodies.** |
+| `sign_up_url` | no | string | Merchant signup link in admin. |
+| `documentation_url` | no | string | Docs link in admin. |
+| `api_base_url` | yes | string | Two API base for this brand. |
+| `available_payment_terms` | yes | `<term>` list | Day counts offered (positive integers). |
+| `surcharge_fixed_max` | no | `amount` + `currency` attrs | Cap on the fixed surcharge component. |
+| `minimum_order` | no | `amount` + `currency` attrs | Minimum basket value for the method to be offered (worked example below). |
+| `csp_origins` | no | `<origin>` list | Extra CSP origins. |
+| `admin_resource` | yes | string | ACL resource gating the admin section. |
+| `module_label_chain` | no | `<module label="…">` list | Admin Version-panel rows; rows for missing modules silently skip. |
+| `allowed_currencies` | no | `<currency>` list | Currency allow-list. |
+| `allowed_countries` | no | `<country>` list | Country allow-list. |
+| `extra_http_headers` | no | `<header name="…">` list | Extra headers on API calls. |
+| `suppressed_fields` | no | `<field path="…">` list | Hides admin controls for this brand (below). |
+| `inline_term_fees` | no | boolean | Show per-term merchant fee beside Payment Terms checkboxes in admin (default true). |
+
+### A warning about validation
+
+`brand.xsd` is enforced by CI/IDE tooling only — **nothing validates
+brand.xml against the schema at runtime** (`Loader` uses plain
+`simplexml_load_file`; the `xsi:noNamespaceSchemaLocation` hint is
+passive). Two consequences:
+
+1. A typo'd element is **silently ignored**, not rejected. Deploying an
+   overlay that uses a new element against an older parent that doesn't
+   parse it produces a silently-absent feature, not a deploy failure.
+   Always verify the feature's observable behaviour after deploy.
+2. Where silent mis-parsing would be dangerous, `Loader` carries its own
+   guards (duplicate/empty `code`, malformed `minimum_order`) that throw
+   `DomainException` at load. Follow that pattern when you add fields
+   whose zero-value would silently disable a constraint.
+
+## suppressed_fields: hiding admin controls per brand
+
+```xml
+<suppressed_fields>
+    <field path="payment/payment_terms/payment_terms_duration_days"/>
+</suppressed_fields>
+```
+
+`path` is `section_suffix/group/field` against the synthesised section
+(`{section_prefix}_payment` → `payment_terms` group here).
+`SynthesiseBrandAdminForm` sets `showInDefault/Website/Store="0"` on
+the matching field during section injection: the control stays declared
+in the canonical template but doesn't render for this brand. Use this
+instead of shipping a `<section>` stub in the overlay's system.xml —
+a static stub inserts itself into the merged Structure first and
+short-circuits the synthesised section ordering.
+
+## Worked example: adding a brand-driven field (`minimum_order`)
+
+The €250 ABN minimum-order gate (TWO-24743) is the canonical recipe for
+extending `BrandRegistryInterface` with a new brand-driven value. Six
+touch points, in dependency order:
+
+1. **Schema** — `etc/brand.xsd`: add the element to `brandType`
+   (optional, `minOccurs="0"`, so existing brand.xml files stay valid)
+   plus its complexType. The attribute-pair idiom
+   (`<minimum_order amount="250" currency="EUR"/>`) matches
+   `surcharge_fixed_max`.
+
+2. **Loader** — `Model/Brand/Loader.php` `buildDescriptor()`: parse the
+   element, **normalise and validate** (currency is upper-cased and
+   trimmed; `amount <= 0` or empty currency throws `DomainException` —
+   because nothing validates the xsd at runtime, a typo would otherwise
+   coerce to `0.0` and silently disable the gate). Pass the value as a
+   constructor argument to `Descriptor`.
+
+3. **Value object** — `Model/Brand/Descriptor.php`: append a readonly
+   constructor property + getter. Mirror the same getter on the legacy
+   `Model/Brand.php` value object — both implement
+   `BrandRegistryInterface` and must stay in lockstep until the legacy
+   interface is deleted (see the deprecation note in
+   `Brand/DescriptorBackedBrandRegistry.php`).
+
+4. **Interface + adapter** — `Api/BrandRegistryInterface.php`: declare
+   the getter with the full return-shape docblock
+   (`@return array{amount: float, currency: string}|null` here; null =
+   feature absent). `Brand/DescriptorBackedBrandRegistry.php`: delegate
+   to the resolved descriptor.
+
+5. **Consumer** — the code that reads the value lands in the same PR
+   (no speculative brand fields). For the minimum:
+   `Service/Order/MinimumOrderGate` enforces it at the end of
+   `Two::isAvailable()`. Note its defensive patterns — fail-closed on
+   unresolvable currency/missing FX rate, ERROR-level logging deduped
+   per currency pair, comparison at currency precision — they exist
+   because hiding a payment method is a silent revenue stop when
+   misconfigured.
+
+6. **Tests** — unit tests for the Loader parse/validation and the
+   consumer's boundaries (the `MinimumOrderGateTest` boundary set is the
+   template: exact-minimum, cross-currency, fail-closed paths).
+
+The overlay then declares the value in its `brand.xml`:
+
+```xml
+<minimum_order amount="250" currency="EUR"/>
+```
+
+**Release ordering:** the parent release containing steps 1–6 must be
+deployed before an overlay brand.xml that uses the new element —
+on an older parent the element is silently ignored (see the validation
+warning above), so verify the feature's behaviour (here: the
+€249.99/€250.00 availability boundary) after deploy.
+
+## Local development
+
+`make up` in this repo runs a vanilla Magento dev stack on port 1234;
+the ABN overlay repo's `make up` runs an ABN-flavoured stack on 1235 —
+both can co-run. The overlay repo's `dev/install.sh` supports
+`BASE=released|develop|tag:|sha:|ref:|path:` to test an overlay against
+any parent version, which is exactly what the release-ordering caveat
+above requires before shipping a new brand field.

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -62,8 +62,8 @@
             Per-layer synthesis flags for the brand-overlay v6 mechanism.
             Default 0 (OFF): the synthesis plugin ships dormant so this
             change is purely additive on production. A follow-up PR
-            flips the default to 1 in lockstep with magento-abn-plugin's
-            data-only release (which deletes ABN's renderer-bootstrap
+            flips the default to 1 in lockstep with a brand overlay's
+            data-only release (which deletes the overlay's renderer-bootstrap
             JS). Design v6 §16.3 specifies these as per-layer debugging
             knobs, not a rollback mechanism. Layers shipped in
             subsequent PRs (payment_xml, csp, admin_form) will add
@@ -88,7 +88,7 @@
                 already exists statically (so a brand whose overlay
                 module still ships its own etc/adminhtml/system.xml
                 stays on the static surface — first-writer-wins).
-                Default 1 since the magento-abn-plugin strip-down: the
+                Default 1 since the brand overlay strip-down: the
                 overlay no longer ships its own system.xml, so synthesis
                 is the sole source of the per-brand admin tab. Flip to
                 0 only to debug — vanilla Two installs have no overlay

--- a/view/adminhtml/web/js/payment-terms-config.js
+++ b/view/adminhtml/web/js/payment-terms-config.js
@@ -7,7 +7,7 @@ define(['jquery', 'mage/translate', 'domReady!'], function ($, $t) {
         // `{section}_payment_terms_payment_terms_checkboxes` — strip
         // the suffix to get the section id, then build every other
         // selector against it. This keeps the JS brand-agnostic:
-        // `two_payment` on vanilla, `abn_payment` on ABN, ...
+        // `two_payment` on vanilla, `acme_payment` on a brand overlay, ...
         var $termsContainer = $('.two-term-checkboxes').first();
         if (!$termsContainer.length) {
             return;

--- a/view/adminhtml/web/js/surcharge-grid.js
+++ b/view/adminhtml/web/js/surcharge-grid.js
@@ -9,7 +9,7 @@ define(['jquery', 'mage/translate', 'domReady!'], function ($, $t) {
         // checkboxes container with id `{section}_payment_terms_payment_terms_checkboxes`
         // — strip the suffix to recover the section id and build every
         // other selector against it. Keeps the file brand-agnostic:
-        // `two_payment` on vanilla, `abn_payment` on a brand overlay
+        // `two_payment` on vanilla, `acme_payment` on a brand overlay
         // install, etc. The previous hardcoded `two_payment_*` selectors
         // matched nothing on overlay installs, so $surchargeType.val()
         // returned undefined → getSurchargeType() defaulted to 'none' →

--- a/view/adminhtml/web/js/surcharge-grid.js
+++ b/view/adminhtml/web/js/surcharge-grid.js
@@ -9,7 +9,7 @@ define(['jquery', 'mage/translate', 'domReady!'], function ($, $t) {
         // checkboxes container with id `{section}_payment_terms_payment_terms_checkboxes`
         // — strip the suffix to recover the section id and build every
         // other selector against it. Keeps the file brand-agnostic:
-        // `two_payment` on vanilla, `abn_payment` on an ABN overlay
+        // `two_payment` on vanilla, `abn_payment` on a brand overlay
         // install, etc. The previous hardcoded `two_payment_*` selectors
         // matched nothing on overlay installs, so $surchargeType.val()
         // returned undefined → getSurchargeType() defaulted to 'none' →

--- a/view/frontend/web/css/style.css
+++ b/view/frontend/web/css/style.css
@@ -52,7 +52,7 @@
     color: var(--color-brownie-vanilla);
 }
 
-/* All links inside the Two/ABN payment-method block render blue +
+/* All links inside the Two payment-method block render blue +
    underlined (brand subtitle "lees meer", terms "betaalvoorwaarden", …).
    Scoped to the block rather than a bare `a` so it stays out of the rest
    of checkout and so the class+element specificity wins over resets. */
@@ -263,7 +263,7 @@
  * checkout page (Registered Organisation / Sole Trader): solid Two-brand
  * blue (`--color-blue2`) for the selected state, white fill with blue
  * text for unselected. Brand overlays that ship a different palette
- * (e.g. ABN's teal/white pairing) override these rules from their own
+ * (e.g. a brand overlay's palette) override these rules from their own
  * style.css which loads after this one.
  */
 .two-term-chip {

--- a/view/frontend/web/js/model/brand-config.js
+++ b/view/frontend/web/js/model/brand-config.js
@@ -6,7 +6,7 @@
 /**
  * Brand-overlay-aware config lookup. Reads from
  * `window.checkoutConfig.payment[<methodCode>]` so each brand-overlay
- * payment method (two_payment, abn_payment, …) gets its own config
+ * payment method (two_payment, acme_payment, …) gets its own config
  * subtree without forking the gateway_method renderer per brand.
  *
  * Returns an empty object when the requested subtree is absent so
@@ -50,7 +50,7 @@
 
     /**
      * Returns the payment-method code for the currently-active Two-family
-     * brand (two_payment, abn_payment, …) by scanning checkoutConfig.payment
+     * brand (two_payment, acme_payment, …) by scanning checkoutConfig.payment
      * for a subtree with a truthy `redirectUrlCookieCode`. That field is
      * emitted only by Two_Gateway's Model/Ui/ConfigProvider, so its presence
      * is a reliable Two-family sentinel that does not collide with other

--- a/view/frontend/web/js/model/surcharge.js
+++ b/view/frontend/web/js/model/surcharge.js
@@ -25,7 +25,7 @@ define([
 
     // Resolve the active Two-family brand subtree from checkoutConfig
     // rather than hardcoding `.two_payment`. The brand-overlay 2.0
-    // architecture lets each overlay (abn_payment, …) ship its own
+    // architecture lets each overlay (acme_payment, …) ship its own
     // ConfigProvider subtree under the brand's payment-method code,
     // so this module needs to discover which is active rather than
     // assuming vanilla.

--- a/view/frontend/web/js/view/address-autocomplete.js
+++ b/view/frontend/web/js/view/address-autocomplete.js
@@ -15,7 +15,7 @@ define([
     'use strict';
 
     // Resolve the active Two-family brand subtree so overlays
-    // (abn_payment, …) get their own checkoutApiUrl /
+    // (acme_payment, …) get their own checkoutApiUrl /
     // isCompanySearchEnabled / companySearchLimit instead of falling
     // through to an empty object when the vanilla `two_payment` key
     // isn't present.

--- a/view/frontend/web/js/view/checkout/summary/surcharge.js
+++ b/view/frontend/web/js/view/checkout/summary/surcharge.js
@@ -22,7 +22,7 @@ define([
             var method = quote.paymentMethod();
             // Match against the active Two-family brand code rather
             // than the hardcoded vanilla `two_payment`, so brand
-            // overlays (abn_payment, …) display the surcharge line
+            // overlays (acme_payment, …) display the surcharge line
             // when their own payment method is selected.
             var activeCode = brandConfig.getActiveTwoBrandCode();
             return segment && parseFloat(segment.value) > 0

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -303,7 +303,7 @@ define([
             if (url) {
                 // Magento's place-order action stops the full-screen loader the
                 // moment the AJAX resolves — which leaves the checkout bare for
-                // the few seconds the redirect to the Two/ABN checkout takes,
+                // the few seconds the redirect to the hosted checkout takes,
                 // making buyers think nothing happened. Re-show the loader so
                 // the overlay stays up until the browser actually navigates
                 // away (the new page discards it).

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -83,7 +83,7 @@ define([
             this._super();
 
             // Brand-overlay config: read once at initialize time, keyed on
-            // this.getCode() so abn_payment, two_payment, etc each pull
+            // this.getCode() so acme_payment, two_payment, etc each pull
             // their own subtree from window.checkoutConfig.payment.
             this._brandConfig = getBrandConfig(this.getCode());
             var config = this._brandConfig;


### PR DESCRIPTION
## What

C4 of the plugin parity plan (TWO-24739 → TWO-24764): docs-only. A brand overlay can currently only be built by reverse-engineering an existing overlay; this guide writes the architecture down.

**Stacked on #215** (TWO-24743) — the guide uses the minimum-order gate as its worked example for adding brand-driven fields, so it must not ship before B1. Merge #214 → #215 → this.

## Contents

- Architecture: Loader → Descriptor → ActiveBrandResolver → DescriptorBackedBrandRegistry, and why overlays declare data instead of overriding classes
- Required overlay files (with the hard-won notes: module.xml sequence completeness, class_alias-not-subclass, payment.xml carries no model)
- di.xml wiring: GenericPaymentMethod virtualType + BrandOverlayRegistry; what NOT to wire
- Full `brand.xml` schema reference (every element/attribute and what it controls, incl. `inline_term_fees`, `suppressed_fields` mechanics)
- The single-overlay invariant
- **The runtime-validation warning**: brand.xsd is CI/IDE-only, older parents silently ignore unknown elements — release-ordering rule + Loader guard pattern
- Worked example: the six touch points of `minimum_order` (xsd → Loader validation → Descriptor + legacy mirror → interface/adapter → consumer-in-same-PR → tests)

## Test plan

- [x] Facts cross-checked against the code on the #215 branch and an existing brand overlay (di.xml, registration.php, AGENTS conventions)
- [ ] Reviewer sanity-read by someone who hasn't lived in this code

🤖 Generated with [Claude Code](https://claude.com/claude-code)