### PR TITLE
INF-1598/ci: repoint actions to consolidated monorepos

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -37,7 +37,7 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
     steps:
-      - uses: two-inc/claude-code-reviewer@main
+      - uses: two-inc/actions-public/claude-reviewer@main
         env:
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
         with:


### PR DESCRIPTION
Repoints the shared CI actions consumed here from the legacy `*-action` repos to their consolidated homes. Part of INF-1598.