### PR TITLE
ABN-449/fix: stack single-term chip surcharge below the term days

### DIFF
--- a/view/frontend/web/css/style.css
+++ b/view/frontend/web/css/style.css
@@ -344,9 +344,6 @@
 }
 
 .two-term-chip--single {
-    flex-direction: row;
-    align-items: center;
-    gap: 8px;
     border-color: var(--color-blue2);
     background: var(--color-blue2);
     color: var(--color-white);


### PR DESCRIPTION
Fixes [ABN-449](https://linear.app/tillit/issue/ABN-449).

The sole-available-term chip overrode the base chip's `flex-direction: column` with `row`, rendering "60 days +€X" on one line. Per the Figma design the surcharge stacks below the days, exactly like the multi-term chips. Removes the row override; the chip now inherits the column layout.

Companion PR in magento-hyva-extension carries the same fix for Hyva (where QA reported it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)