### PR TITLE
TWO-24775/feat: basis selector and currency-aware label for the merchant minimum

### DIFF
--- a/Block/Adminhtml/System/Config/Field/MinimumOrderValue.php
+++ b/Block/Adminhtml/System/Config/Field/MinimumOrderValue.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Block\Adminhtml\System\Config\Field;
+
+use Magento\Backend\Block\Template\Context;
+use Magento\Config\Block\System\Config\Form\Field;
+use Magento\Framework\Data\Form\Element\AbstractElement;
+use Magento\Store\Model\StoreManagerInterface;
+
+/**
+ * Renders the merchant minimum-order-value field with the store base
+ * currency in the label ("Minimum Order Value, EUR") - the value is
+ * interpreted in that currency, so the label must say which one the
+ * current config scope resolves to.
+ */
+class MinimumOrderValue extends Field
+{
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    public function __construct(
+        Context $context,
+        StoreManagerInterface $storeManager,
+        array $data = []
+    ) {
+        $this->storeManager = $storeManager;
+        parent::__construct($context, $data);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function render(AbstractElement $element)
+    {
+        $currency = $this->resolveScopeBaseCurrency();
+        if ($currency !== '') {
+            $element->setLabel(__('Minimum Order Value, %1', $currency));
+        }
+        return parent::render($element);
+    }
+
+    /**
+     * Base currency of the store the admin config-scope selector points
+     * at (store param, website default store, or the global default
+     * store).
+     *
+     * Counterparts: Comment\MerchantMinimumOrder::resolveScopeStore() and
+     * Backend\MerchantMinimumOrder::resolveScopeStore() resolve the same
+     * scope for the comment text and the save-time validation. Keep the
+     * three in lockstep or the label, the displayed floor, and the
+     * validated floor can disagree on the currency.
+     */
+    private function resolveScopeBaseCurrency(): string
+    {
+        try {
+            if ($storeCode = $this->getRequest()->getParam('store')) {
+                return (string)$this->storeManager->getStore($storeCode)->getBaseCurrencyCode();
+            }
+            if ($websiteCode = $this->getRequest()->getParam('website')) {
+                $website = $this->storeManager->getWebsite($websiteCode);
+                $store = $this->storeManager->getStore($website->getDefaultGroup()->getDefaultStoreId());
+                return (string)$store->getBaseCurrencyCode();
+            }
+            return (string)$this->storeManager->getStore()->getBaseCurrencyCode();
+        } catch (\Exception $e) {
+            return '';
+        }
+    }
+}

--- a/Model/Config/Comment/MerchantMinimumOrder.php
+++ b/Model/Config/Comment/MerchantMinimumOrder.php
@@ -72,7 +72,7 @@ class MerchantMinimumOrder implements CommentInterface
         );
         if ($platformMinimum === null) {
             return (string)__(
-                'Hide the payment method below this order value (store base currency, including tax). Leave empty for no minimum.'
+                'Hide the payment method below this order value (store base currency, on the tax basis selected below). Leave empty for no minimum.'
             );
         }
 
@@ -105,7 +105,7 @@ class MerchantMinimumOrder implements CommentInterface
         }
 
         return (string)__(
-            'Platform minimum %1, %2 tax. A value here is interpreted in the store base currency on the same tax basis and must exceed it.',
+            'Platform minimum %1, %2 tax. A value here is interpreted in the store base currency on the tax basis selected below and must exceed it.',
             $minimumDisplay,
             $platformMinimum['basis'] === 'gross' ? __('including') : __('excluding')
         );

--- a/Model/Config/Source/MinimumOrderBasis.php
+++ b/Model/Config/Source/MinimumOrderBasis.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Model\Config\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+
+/**
+ * Tax basis for the merchant's minimum order value: whether the basket
+ * is compared including (gross) or excluding (net) tax. Matches the
+ * basis vocabulary of the API's min_order_basis field.
+ */
+class MinimumOrderBasis implements OptionSourceInterface
+{
+    public const GROSS = 'gross';
+    public const NET = 'net';
+
+    /**
+     * @inheritDoc
+     */
+    public function toOptionArray(): array
+    {
+        return [
+            ['value' => self::GROSS, 'label' => __('Including tax (gross)')],
+            ['value' => self::NET, 'label' => __('Excluding tax (net)')],
+        ];
+    }
+}

--- a/Model/Two.php
+++ b/Model/Two.php
@@ -756,10 +756,13 @@ class Two extends AbstractMethod
                 $store = $quote->getStore();
                 $currency = $store !== null ? (string)$store->getBaseCurrencyCode() : '';
                 if ($currency !== '') {
+                    $merchantBasis = (string)$this->getConfigData('merchant_minimum_order_basis');
                     $merchantMinimum = [
                         'amount' => $merchantValue,
                         'currency' => $currency,
-                        'basis' => $platformMinimum['basis'] ?? 'gross',
+                        'basis' => in_array($merchantBasis, ['net', 'gross'], true)
+                            ? $merchantBasis
+                            : ($platformMinimum['basis'] ?? 'gross'),
                     ];
                 }
             }

--- a/etc/adminhtml/brand_form_template.xml
+++ b/etc/adminhtml/brand_form_template.xml
@@ -154,12 +154,24 @@
                        showInDefault="1" showInWebsite="1" showInStore="1"
                        canRestore="1" brand_code="{{code}}">
                     <label>Minimum Order Value</label>
+                    <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\MinimumOrderValue</frontend_model>
                     <backend_model>Two\Gateway\Model\Config\Backend\MerchantMinimumOrder</backend_model>
                     <comment model="Two\Gateway\Model\Config\Comment\MerchantMinimumOrder"/>
                     <depends>
                         <field id="active">1</field>
                     </depends>
                     <config_path>payment/{{code}}/merchant_minimum_order</config_path>
+                </field>
+                <field id="merchant_minimum_order_basis" translate="label comment" type="select" sortOrder="26"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Minimum Order Value Tax Basis</label>
+                    <comment>Whether the basket is compared against the minimum including or excluding tax</comment>
+                    <source_model>Two\Gateway\Model\Config\Source\MinimumOrderBasis</source_model>
+                    <depends>
+                        <field id="active">1</field>
+                    </depends>
+                    <config_path>payment/{{code}}/merchant_minimum_order_basis</config_path>
                 </field>
             </group>
             <group id="checkout_fields" translate="label" type="text" sortOrder="20"

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -83,12 +83,23 @@
                 <field id="merchant_minimum_order" translate="label" type="text" sortOrder="25" showInDefault="1"
                        showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Minimum Order Value</label>
+                    <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\MinimumOrderValue</frontend_model>
                     <backend_model>Two\Gateway\Model\Config\Backend\MerchantMinimumOrder</backend_model>
                     <comment model="Two\Gateway\Model\Config\Comment\MerchantMinimumOrder"/>
                     <depends>
                         <field id="active">1</field>
                     </depends>
                     <config_path>payment/two_payment/merchant_minimum_order</config_path>
+                </field>
+                <field id="merchant_minimum_order_basis" translate="label comment" type="select" sortOrder="26"
+                       showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Minimum Order Value Tax Basis</label>
+                    <comment>Whether the basket is compared against the minimum including or excluding tax</comment>
+                    <source_model>Two\Gateway\Model\Config\Source\MinimumOrderBasis</source_model>
+                    <depends>
+                        <field id="active">1</field>
+                    </depends>
+                    <config_path>payment/two_payment/merchant_minimum_order_basis</config_path>
                 </field>
                 <field id="title" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="1"
                        showInStore="1" canRestore="1">

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -31,6 +31,7 @@
                 <sort_order>-10</sort_order>
                 <mode>sandbox</mode>
                 <invoice_type>FUNDED_INVOICE</invoice_type>
+                <merchant_minimum_order_basis>gross</merchant_minimum_order_basis>
                 <days_on_invoice>14</days_on_invoice>
                 <finalize_purchase>1</finalize_purchase>
                 <enable_order_intent>1</enable_order_intent>


### PR DESCRIPTION
Follow-up to #219/#220, two admin-UX gaps in the merchant minimum:

- **Net/gross selector** — new "Minimum Order Value Tax Basis" select (`merchant_minimum_order_basis`, default `gross` via config.xml) in both the static `two_payment` section and the brand form template. `isAvailable()` uses it for the merchant minimum's comparison basis, falling back to the platform minimum's basis when unset (previous behaviour).
- **Currency in the label** — the value field renders as "Minimum Order Value, EUR" via a frontend model that resolves the store base currency for the current admin config scope (store param → website default store → global default), the same scope resolution as the comment and the save-time floor validation. The value is interpreted in that currency, so the label says which one applies.

Comment text updated to reference the selected basis. Full suite green locally (185 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)