### PR TITLE
TWO-24775/fix: resolve version-panel versions for monorepo and tag-versioned packages

### DIFF
--- a/Block/Adminhtml/System/Config/Field/Version.php
+++ b/Block/Adminhtml/System/Config/Field/Version.php
@@ -201,15 +201,58 @@ class Version extends Field
 
     private function readComposerVersion(string $modulePath): ?string
     {
-        $composer = @file_get_contents($modulePath . '/composer.json');
-        if ($composer === false) {
-            return null;
+        // Monorepo sub-path modules (e.g. ABN_Gateway at <repo>/plugin)
+        // keep their composer.json one level up; check both.
+        foreach ([$modulePath, dirname($modulePath)] as $dir) {
+            $composer = @file_get_contents($dir . '/composer.json');
+            if ($composer === false) {
+                continue;
+            }
+            $data = json_decode($composer, true);
+            if (!is_array($data)) {
+                continue;
+            }
+            if (!empty($data['version'])) {
+                return (string)$data['version'];
+            }
+            if ($version = $this->resolvePackageVersion($data, $dir)) {
+                return $version;
+            }
         }
-        $data = json_decode($composer, true);
-        if (!is_array($data) || empty($data['version'])) {
-            return null;
+        return null;
+    }
+
+    /**
+     * Version for a composer.json that carries no version field (the
+     * convention for tag-versioned packages): ask composer's installed
+     * registry, then fall back to bumpver.toml for git-checkout deploys
+     * (git-sync pods, dev installs) where the package isn't
+     * composer-installed.
+     *
+     * @param array $composerData decoded composer.json
+     */
+    private function resolvePackageVersion(array $composerData, string $dir): ?string
+    {
+        $name = $composerData['name'] ?? null;
+        if (is_string($name)
+            && $name !== ''
+            && class_exists(\Composer\InstalledVersions::class)
+            && \Composer\InstalledVersions::isInstalled($name)
+        ) {
+            $version = \Composer\InstalledVersions::getPrettyVersion($name);
+            if ($version !== null && $version !== '') {
+                return $version;
+            }
         }
-        return (string)$data['version'];
+
+        $bumpver = @file_get_contents($dir . '/bumpver.toml');
+        if ($bumpver !== false
+            && preg_match('/^current_version\s*=\s*"([^"]+)"/m', $bumpver, $m)
+        ) {
+            return $m[1];
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
The ABN admin Version panel showed `—` for the Payment Theme / Hyva Theme rows:

| Module | Version | Why it broke |
|---|---|---|
| ABN_Gateway | — | registers at `<repo>/plugin`; composer.json lives at the repo root |
| ABN_GatewayHyva | — | composer.json exists but carries no `version` field (that repo's convention: tags are the version source) |

Fix in `readComposerVersion`:
1. Also check one directory up from the module path (monorepo sub-path modules).
2. When composer.json has no version field, resolve via `Composer\InstalledVersions` by package name (composer-installed merchant deploys), falling back to `bumpver.toml`'s `current_version` (git-checkout deploys: git-sync pods, dev installs).

Commit and deploy-time columns were already correct; only the version source needed widening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)