### PR TITLE
ABN-455/fix: don't send surcharge cap in fixed-only mode

### DIFF
--- a/Service/Order/SurchargeCalculator.php
+++ b/Service/Order/SurchargeCalculator.php
@@ -205,7 +205,12 @@ class SurchargeCalculator
             $payload['surcharge'] = $this->convertAmount((float)$config['fixed'], $fixedCurrency, $orderCurrency);
         }
 
-        if ($config['limit'] !== null) {
+        // `cap` only applies where the fee has a percentage component. The admin
+        // grid exposes the Limit field for the percentage and fixed_and_percentage
+        // types only (a fixed-only fee is constant — there is nothing to clamp), so
+        // a stored limit left over from a previous surcharge type must not leak into
+        // a fixed-only request and clamp the fee.
+        if ($hasPercentage && $config['limit'] !== null) {
             $payload['cap'] = $this->convertAmount((float)$config['limit'], $fixedCurrency, $orderCurrency);
         }
 

--- a/Test/Unit/Service/Order/SurchargeCalculatorTest.php
+++ b/Test/Unit/Service/Order/SurchargeCalculatorTest.php
@@ -314,10 +314,14 @@ class SurchargeCalculatorTest extends TestCase
         $this->calculator->calculate(1000.0, 60, 'NO', 'NOK');
     }
 
-    public function testPayloadIncludesExplicitZeroCap(): void
+    public function testPayloadOmitsCapInFixedOnlyModeEvenWhenLimitSet(): void
     {
+        // A fixed-only fee is constant and has nothing to clamp; the admin grid
+        // never exposes the Limit field for this type. A stored limit (e.g. left
+        // over from a previous percentage configuration) must not leak into the
+        // request and clamp the fixed fee.
         $this->stubCommonConfig(SurchargeType::FIXED);
-        $this->stubSurchargeConfig(0, 10, 0.0);
+        $this->stubSurchargeConfig(0, 10, 25.0);
         $this->stubFixedCurrency('NOK');
 
         $this->adapter->expects($this->once())
@@ -325,13 +329,34 @@ class SurchargeCalculatorTest extends TestCase
             ->with(
                 '/v1/pricing/order/fee',
                 $this->callback(function ($payload) {
-                    return array_key_exists('cap', $payload['buyer_fee_share'])
-                        && $payload['buyer_fee_share']['cap'] === 0.0;
+                    return !array_key_exists('cap', $payload['buyer_fee_share']);
                 })
             )
             ->willReturn(['buyer_fee_share' => 0]);
 
         $this->calculator->calculate(1000.0, 30, 'NO', 'NOK');
+    }
+
+    public function testPayloadIncludesCapInPercentageOnlyMode(): void
+    {
+        // The Limit field IS exposed for the percentage type, so a configured
+        // limit must still be sent as the cap when no fixed component is present.
+        $this->stubCommonConfig(SurchargeType::PERCENTAGE);
+        $this->stubSurchargeConfig(50, 0, 30);
+        $this->stubFixedCurrency('NOK');
+
+        $this->adapter->expects($this->once())
+            ->method('execute')
+            ->with(
+                '/v1/pricing/order/fee',
+                $this->callback(function ($payload) {
+                    return $payload['buyer_fee_share']['cap'] === 30.0
+                        && !array_key_exists('surcharge', $payload['buyer_fee_share']);
+                })
+            )
+            ->willReturn(['buyer_fee_share' => 0]);
+
+        $this->calculator->calculate(1000.0, 60, 'NO', 'NOK');
     }
 
     // ── Differential mode (reference_terms) ──────────────────────────


### PR DESCRIPTION
## Problem

`SurchargeCalculator::buildBuyerFeeShare()` sent `cap` to `/v1/pricing/order/fee` whenever a per-term `limit` was stored — **regardless of surcharge type**. The admin grid (`surcharge-grid.phtml`) only exposes the Limit field for the `percentage` and `fixed_and_percentage` types; a fixed-only fee is constant and has nothing to clamp.

Consequence: a `limit` left over from a previous percentage configuration (e.g. merchant switches Percentage → Fixed without clearing) leaks into a fixed-only request and clamps the fee — the "clamping to max value" symptom.

## Fix

Gate `cap` on `$hasPercentage`, matching the admin UI contract. One-line guard.

## Tests (`SurchargeCalculatorTest`, 25/25 green)

- Flipped `testPayloadIncludesExplicitZeroCap` → `testPayloadOmitsCapInFixedOnlyModeEvenWhenLimitSet` — the old test was asserting the bug (FIXED mode sending `cap: 0.0`, which clamps the fee to zero).
- Added `testPayloadIncludesCapInPercentageOnlyMode` to lock the boundary so the gate doesn't over-correct.

## Scope

- Fixes the **fixed-only cap leak** only. Percentage / fixed+percentage capping is unchanged (correct per UI).
- Does **not** address the headline ABN-455 symptom (percentage values applying in fixed mode) — that path is already type-gated in current code and could not be reproduced; suspected default-vs-Hyva config divergence, pending QA retest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)