### PR TITLE
ABN-457/feat: configurable buyer fee share rounding (Magento)

### DIFF
--- a/Api/Config/RepositoryInterface.php
+++ b/Api/Config/RepositoryInterface.php
@@ -364,4 +364,26 @@ interface RepositoryInterface
      * @return string
      */
     public function getSurchargeFixedCurrency(?int $storeId = null): string;
+
+    /**
+     * Get the buyer surcharge rounding basis (none/up/down/standard).
+     *
+     * "none" means no rounding is applied to the buyer fee share line item.
+     *
+     * @param int|null $storeId
+     *
+     * @return string
+     */
+    public function getSurchargeRoundingBasis(?int $storeId = null): string;
+
+    /**
+     * Get the increment the buyer surcharge line item is rounded to.
+     *
+     * Zero (or unset) means no step is configured.
+     *
+     * @param int|null $storeId
+     *
+     * @return float
+     */
+    public function getSurchargeRoundingStep(?int $storeId = null): float;
 }

--- a/Model/Config/Repository.php
+++ b/Model/Config/Repository.php
@@ -582,4 +582,20 @@ class Repository implements RepositoryInterface
     {
         return (string)$this->getConfig($this->path('surcharge_fixed_currency'), $storeId);
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSurchargeRoundingBasis(?int $storeId = null): string
+    {
+        return (string)$this->getConfig($this->path('surcharge_rounding_basis'), $storeId) ?: 'none';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSurchargeRoundingStep(?int $storeId = null): float
+    {
+        return (float)$this->getConfig($this->path('surcharge_rounding_step'), $storeId);
+    }
 }

--- a/Model/Config/Source/RoundingBasis.php
+++ b/Model/Config/Source/RoundingBasis.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Model\Config\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+
+/**
+ * Direction the buyer surcharge line item is snapped to the rounding step.
+ *
+ * NONE leaves the amount at the standard two-decimal precision (no rounding
+ * block is sent to the pricing API). The other values map to the API's
+ * UP / DOWN / STANDARD bases.
+ */
+class RoundingBasis implements OptionSourceInterface
+{
+    public const NONE = 'none';
+    public const UP = 'up';
+    public const DOWN = 'down';
+    public const STANDARD = 'standard';
+
+    /**
+     * @inheritDoc
+     */
+    public function toOptionArray(): array
+    {
+        return [
+            ['value' => self::NONE, 'label' => __('None')],
+            ['value' => self::UP, 'label' => __('Up')],
+            ['value' => self::DOWN, 'label' => __('Down')],
+            ['value' => self::STANDARD, 'label' => __('Standard')],
+        ];
+    }
+}

--- a/Service/Order/SurchargeCalculator.php
+++ b/Service/Order/SurchargeCalculator.php
@@ -11,6 +11,7 @@ use Magento\Framework\Exception\LocalizedException;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
 use Two\Gateway\Api\CurrencyRatesProviderInterface;
 use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
+use Two\Gateway\Model\Config\Source\RoundingBasis;
 use Two\Gateway\Model\Config\Source\SurchargeType;
 use Two\Gateway\Service\Api\Adapter;
 
@@ -25,6 +26,17 @@ use Two\Gateway\Service\Api\Adapter;
  */
 class SurchargeCalculator
 {
+    /**
+     * Maps the merchant's rounding-basis config value to the pricing API's
+     * rounding basis enum. A value absent from this map (i.e. "none") means
+     * no rounding block is sent.
+     */
+    private const ROUNDING_BASIS_TO_API = [
+        RoundingBasis::UP => 'UP',
+        RoundingBasis::DOWN => 'DOWN',
+        RoundingBasis::STANDARD => 'STANDARD',
+    ];
+
     /**
      * @var ConfigRepository
      */
@@ -175,6 +187,7 @@ class SurchargeCalculator
      *  - percentage types supply `percentage`
      *  - fixed types supply `surcharge` (FX-converted to order currency)
      *  - limit > 0 supplies `cap` (FX-converted to order currency)
+     *  - a rounding basis + step supplies `rounding` (percentage modes only)
      *  - differential mode supplies `reference_terms` so the API computes
      *    the threshold itself — no delta math in the plugin
      *  - `surcharge_basis` is sent explicitly for clarity
@@ -214,12 +227,50 @@ class SurchargeCalculator
             $payload['cap'] = $this->convertAmount((float)$config['limit'], $fixedCurrency, $orderCurrency);
         }
 
+        // `rounding` snaps the final buyer line item to a clean increment, computed
+        // server-side. Like `cap`, the admin only exposes the controls for the
+        // percentage and fixed_and_percentage types (a fixed-only fee is constant —
+        // there is nothing to snap), so the $hasPercentage gate stops a stored basis/
+        // step left over from a previous surcharge type leaking into a fixed-only
+        // request.
+        if ($hasPercentage) {
+            $rounding = $this->buildRounding($storeId);
+            if ($rounding !== null) {
+                $payload['rounding'] = $rounding;
+            }
+        }
+
         if ($this->configRepository->isSurchargeDifferential($storeId)) {
             $defaultDays = $this->configRepository->getDefaultPaymentTerm($storeId);
             $payload['reference_terms'] = $this->buildOrderTerms($defaultDays, $storeId);
         }
 
         return $payload;
+    }
+
+    /**
+     * Build the `rounding` block from merchant config, or null when rounding
+     * is off (basis "none") or the step is not a positive number.
+     *
+     * The pricing API requires both step and basis when the block is present
+     * and rejects a step <= 0, so an unconfigured/zero step omits the block
+     * entirely rather than sending an invalid request.
+     *
+     * @return array{step: float, basis: string}|null
+     */
+    private function buildRounding(?int $storeId): ?array
+    {
+        $basis = $this->configRepository->getSurchargeRoundingBasis($storeId);
+        if (!isset(self::ROUNDING_BASIS_TO_API[$basis])) {
+            return null;
+        }
+
+        $step = $this->configRepository->getSurchargeRoundingStep($storeId);
+        if ($step <= 0.0) {
+            return null;
+        }
+
+        return ['step' => $step, 'basis' => self::ROUNDING_BASIS_TO_API[$basis]];
     }
 
     /**

--- a/Test/Unit/Service/Order/SurchargeCalculatorTest.php
+++ b/Test/Unit/Service/Order/SurchargeCalculatorTest.php
@@ -10,6 +10,7 @@ use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
 use Two\Gateway\Api\CurrencyRatesProviderInterface;
 use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
 use Two\Gateway\Model\ApiTranslator\NullApiTranslator;
+use Two\Gateway\Model\Config\Source\RoundingBasis;
 use Two\Gateway\Model\Config\Source\SurchargeType;
 use Two\Gateway\Service\Api\Adapter;
 use Two\Gateway\Service\Order\SurchargeCalculator;
@@ -69,6 +70,12 @@ class SurchargeCalculatorTest extends TestCase
     private function stubFixedCurrency(string $currency = 'NOK'): void
     {
         $this->config->method('getSurchargeFixedCurrency')->willReturn($currency);
+    }
+
+    private function stubRounding(string $basis, float $step): void
+    {
+        $this->config->method('getSurchargeRoundingBasis')->willReturn($basis);
+        $this->config->method('getSurchargeRoundingStep')->willReturn($step);
     }
 
     private function stubFxRate(string $from, float $multiplier): void
@@ -357,6 +364,130 @@ class SurchargeCalculatorTest extends TestCase
             ->willReturn(['buyer_fee_share' => 0]);
 
         $this->calculator->calculate(1000.0, 60, 'NO', 'NOK');
+    }
+
+    // ── Rounding ─────────────────────────────────────────────────────
+
+    public function testPayloadIncludesRoundingForPercentage(): void
+    {
+        $this->stubCommonConfig(SurchargeType::PERCENTAGE);
+        $this->stubSurchargeConfig(50);
+        $this->stubRounding(RoundingBasis::UP, 1.0);
+
+        $this->adapter->expects($this->once())
+            ->method('execute')
+            ->with(
+                '/v1/pricing/order/fee',
+                $this->callback(function ($payload) {
+                    return $payload['buyer_fee_share']['rounding'] === ['step' => 1.0, 'basis' => 'UP'];
+                })
+            )
+            ->willReturn(['buyer_fee_share' => 0]);
+
+        $this->calculator->calculate(1000.0, 60, 'NO', 'NOK');
+    }
+
+    public function testPayloadIncludesRoundingForFixedAndPercentage(): void
+    {
+        $this->stubCommonConfig(SurchargeType::FIXED_AND_PERCENTAGE);
+        $this->stubSurchargeConfig(50, 5);
+        $this->stubFixedCurrency('NOK');
+        $this->stubRounding(RoundingBasis::STANDARD, 0.5);
+
+        $this->adapter->expects($this->once())
+            ->method('execute')
+            ->with(
+                '/v1/pricing/order/fee',
+                $this->callback(function ($payload) {
+                    return $payload['buyer_fee_share']['rounding'] === ['step' => 0.5, 'basis' => 'STANDARD'];
+                })
+            )
+            ->willReturn(['buyer_fee_share' => 0]);
+
+        $this->calculator->calculate(1000.0, 60, 'NO', 'NOK');
+    }
+
+    public function testRoundingBasisDownMapsToApiEnum(): void
+    {
+        $this->stubCommonConfig(SurchargeType::PERCENTAGE);
+        $this->stubSurchargeConfig(50);
+        $this->stubRounding(RoundingBasis::DOWN, 10.0);
+
+        $this->adapter->expects($this->once())
+            ->method('execute')
+            ->with(
+                '/v1/pricing/order/fee',
+                $this->callback(function ($payload) {
+                    return $payload['buyer_fee_share']['rounding']['basis'] === 'DOWN';
+                })
+            )
+            ->willReturn(['buyer_fee_share' => 0]);
+
+        $this->calculator->calculate(1000.0, 60, 'NO', 'NOK');
+    }
+
+    public function testPayloadOmitsRoundingWhenBasisNone(): void
+    {
+        $this->stubCommonConfig(SurchargeType::PERCENTAGE);
+        $this->stubSurchargeConfig(50);
+        // A configured step is irrelevant when the basis is "none".
+        $this->stubRounding(RoundingBasis::NONE, 1.0);
+
+        $this->adapter->expects($this->once())
+            ->method('execute')
+            ->with(
+                '/v1/pricing/order/fee',
+                $this->callback(function ($payload) {
+                    return !array_key_exists('rounding', $payload['buyer_fee_share']);
+                })
+            )
+            ->willReturn(['buyer_fee_share' => 0]);
+
+        $this->calculator->calculate(1000.0, 60, 'NO', 'NOK');
+    }
+
+    public function testPayloadOmitsRoundingWhenStepNotPositive(): void
+    {
+        // A basis with no (zero) step is incomplete and the API rejects step <= 0,
+        // so the block is omitted rather than sent invalid.
+        $this->stubCommonConfig(SurchargeType::PERCENTAGE);
+        $this->stubSurchargeConfig(50);
+        $this->stubRounding(RoundingBasis::STANDARD, 0.0);
+
+        $this->adapter->expects($this->once())
+            ->method('execute')
+            ->with(
+                '/v1/pricing/order/fee',
+                $this->callback(function ($payload) {
+                    return !array_key_exists('rounding', $payload['buyer_fee_share']);
+                })
+            )
+            ->willReturn(['buyer_fee_share' => 0]);
+
+        $this->calculator->calculate(1000.0, 60, 'NO', 'NOK');
+    }
+
+    public function testPayloadOmitsRoundingInFixedOnlyModeEvenWhenConfigured(): void
+    {
+        // The admin never exposes rounding for a fixed-only fee (there is nothing
+        // to snap). A stored basis/step left over from a previous percentage
+        // configuration must not leak into a fixed-only request.
+        $this->stubCommonConfig(SurchargeType::FIXED);
+        $this->stubSurchargeConfig(0, 10);
+        $this->stubFixedCurrency('NOK');
+        $this->stubRounding(RoundingBasis::UP, 1.0);
+
+        $this->adapter->expects($this->once())
+            ->method('execute')
+            ->with(
+                '/v1/pricing/order/fee',
+                $this->callback(function ($payload) {
+                    return !array_key_exists('rounding', $payload['buyer_fee_share']);
+                })
+            )
+            ->willReturn(['buyer_fee_share' => 0]);
+
+        $this->calculator->calculate(1000.0, 30, 'NO', 'NOK');
     }
 
     // ── Differential mode (reference_terms) ──────────────────────────

--- a/Test/Unit/Service/Order/SurchargeCalculatorTest.php
+++ b/Test/Unit/Service/Order/SurchargeCalculatorTest.php
@@ -379,7 +379,9 @@ class SurchargeCalculatorTest extends TestCase
             ->with(
                 '/v1/pricing/order/fee',
                 $this->callback(function ($payload) {
-                    return $payload['buyer_fee_share']['rounding'] === ['step' => 1.0, 'basis' => 'UP'];
+                    $share = $payload['buyer_fee_share'];
+                    return $share['rounding'] === ['step' => 1.0, 'basis' => 'UP']
+                        && $share['percentage'] === 50.0;
                 })
             )
             ->willReturn(['buyer_fee_share' => 0]);
@@ -399,7 +401,11 @@ class SurchargeCalculatorTest extends TestCase
             ->with(
                 '/v1/pricing/order/fee',
                 $this->callback(function ($payload) {
-                    return $payload['buyer_fee_share']['rounding'] === ['step' => 0.5, 'basis' => 'STANDARD'];
+                    $share = $payload['buyer_fee_share'];
+                    // Rounding is added alongside the other keys, not in place of them.
+                    return $share['rounding'] === ['step' => 0.5, 'basis' => 'STANDARD']
+                        && $share['surcharge'] === 5.0
+                        && $share['percentage'] === 50.0;
                 })
             )
             ->willReturn(['buyer_fee_share' => 0]);
@@ -418,7 +424,8 @@ class SurchargeCalculatorTest extends TestCase
             ->with(
                 '/v1/pricing/order/fee',
                 $this->callback(function ($payload) {
-                    return $payload['buyer_fee_share']['rounding']['basis'] === 'DOWN';
+                    // Full structure: basis maps to DOWN and the step passes through intact.
+                    return $payload['buyer_fee_share']['rounding'] === ['step' => 10.0, 'basis' => 'DOWN'];
                 })
             )
             ->willReturn(['buyer_fee_share' => 0]);
@@ -446,13 +453,16 @@ class SurchargeCalculatorTest extends TestCase
         $this->calculator->calculate(1000.0, 60, 'NO', 'NOK');
     }
 
-    public function testPayloadOmitsRoundingWhenStepNotPositive(): void
+    /**
+     * @dataProvider nonPositiveStepProvider
+     */
+    public function testPayloadOmitsRoundingWhenStepNotPositive(float $step): void
     {
-        // A basis with no (zero) step is incomplete and the API rejects step <= 0,
-        // so the block is omitted rather than sent invalid.
+        // A basis with a non-positive step is incomplete and the API rejects
+        // step <= 0, so the block is omitted rather than sent invalid.
         $this->stubCommonConfig(SurchargeType::PERCENTAGE);
         $this->stubSurchargeConfig(50);
-        $this->stubRounding(RoundingBasis::STANDARD, 0.0);
+        $this->stubRounding(RoundingBasis::STANDARD, $step);
 
         $this->adapter->expects($this->once())
             ->method('execute')
@@ -465,6 +475,15 @@ class SurchargeCalculatorTest extends TestCase
             ->willReturn(['buyer_fee_share' => 0]);
 
         $this->calculator->calculate(1000.0, 60, 'NO', 'NOK');
+    }
+
+    /** @return array<string, array{float}> */
+    public function nonPositiveStepProvider(): array
+    {
+        return [
+            'zero step' => [0.0],
+            'negative step' => [-5.0],
+        ];
     }
 
     public function testPayloadOmitsRoundingInFixedOnlyModeEvenWhenConfigured(): void

--- a/etc/adminhtml/brand_form_template.xml
+++ b/etc/adminhtml/brand_form_template.xml
@@ -294,6 +294,30 @@
                     <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\SurchargeGrid</frontend_model>
                     <backend_model>Two\Gateway\Model\Config\Backend\SurchargeGrid</backend_model>
                 </field>
+                <field id="surcharge_rounding_basis" translate="label comment" type="select" sortOrder="110"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Buyer Fee Rounding</label>
+                    <comment>Snap the buyer surcharge line item to a clean increment. Select None for standard two-decimal amounts.</comment>
+                    <source_model>Two\Gateway\Model\Config\Source\RoundingBasis</source_model>
+                    <config_path>payment/{{code}}/surcharge_rounding_basis</config_path>
+                    <depends>
+                        <field id="surcharge_type" separator=",">percentage,fixed_and_percentage</field>
+                    </depends>
+                </field>
+                <field id="surcharge_rounding_step" translate="label comment" type="text" sortOrder="120"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Rounding Step</label>
+                    <comment><![CDATA[Increment the surcharge is rounded to (e.g. 1 = whole units, 0.50 = nearest half). Must be greater than zero.]]></comment>
+                    <backend_model>Two\Gateway\Model\Config\Backend\LocaleDecimal</backend_model>
+                    <validate>validate-number validate-greater-than-zero</validate>
+                    <config_path>payment/{{code}}/surcharge_rounding_step</config_path>
+                    <depends>
+                        <field id="surcharge_type" separator=",">percentage,fixed_and_percentage</field>
+                        <field id="surcharge_rounding_basis" separator=",">up,down,standard</field>
+                    </depends>
+                </field>
             </group>
             <group id="advanced" translate="label" type="text" sortOrder="30"
                    showInDefault="1" showInWebsite="1" showInStore="1"

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -218,6 +218,28 @@
                     <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\SurchargeGrid</frontend_model>
                     <backend_model>Two\Gateway\Model\Config\Backend\SurchargeGrid</backend_model>
                 </field>
+                <field id="surcharge_rounding_basis" translate="label comment" type="select" sortOrder="110"
+                       showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Buyer Fee Rounding</label>
+                    <comment>Snap the buyer surcharge line item to a clean increment. Select None for standard two-decimal amounts.</comment>
+                    <source_model>Two\Gateway\Model\Config\Source\RoundingBasis</source_model>
+                    <config_path>payment/two_payment/surcharge_rounding_basis</config_path>
+                    <depends>
+                        <field id="surcharge_type" separator=",">percentage,fixed_and_percentage</field>
+                    </depends>
+                </field>
+                <field id="surcharge_rounding_step" translate="label comment" type="text" sortOrder="120"
+                       showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Rounding Step</label>
+                    <comment><![CDATA[Increment the surcharge is rounded to (e.g. 1 = whole units, 0.50 = nearest half). Must be greater than zero.]]></comment>
+                    <backend_model>Two\Gateway\Model\Config\Backend\LocaleDecimal</backend_model>
+                    <validate>validate-number validate-greater-than-zero</validate>
+                    <config_path>payment/two_payment/surcharge_rounding_step</config_path>
+                    <depends>
+                        <field id="surcharge_type" separator=",">percentage,fixed_and_percentage</field>
+                        <field id="surcharge_rounding_basis" separator=",">up,down,standard</field>
+                    </depends>
+                </field>
             </group>
             <group id="advanced" translate="label comment" type="text" sortOrder="30" showInDefault="1" showInWebsite="1"
                    showInStore="1">

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -53,6 +53,8 @@
                 <surcharge_differential>0</surcharge_differential>
                 <surcharge_line_description>Payment terms fee - %1 days</surcharge_line_description>
                 <surcharge_tax_rate/>
+                <surcharge_rounding_basis>none</surcharge_rounding_basis>
+                <surcharge_rounding_step/>
                 <can_use_internal>0</can_use_internal>
                 <can_use_checkout>1</can_use_checkout>
                 <payment_action>authorize</payment_action>

--- a/i18n/nb_NO.csv
+++ b/i18n/nb_NO.csv
@@ -197,7 +197,7 @@
 "Country is not valid.","Land er ikke gyldig."
 "Developed by Magmodules.","Utviklet av Magmodules."
 "Email Address is not valid.","E-postadresse er ikke gyldig."
-"Enter a limit amount (in %1) if you do not want to charge your customer more than a specific amount.","Skriv inn et maksbeløp (i %1) hvis du ikke vil belaste kunden mer enn et bestemt beløp."
+"Enter a limit amount (in %1) if you do not want to charge your customer more than a specific amount. Leave the limit field empty if you don't want to impose a limit amount.","Skriv inn et maksbeløp (i %1) hvis du ikke vil belaste kunden mer enn et bestemt beløp. La feltet stå tomt hvis du ikke vil angi et maksbeløp."
 "Enter the amount and percentage of the fee you want to charge your customer. Max %1 / %2.","Skriv inn beløpet og prosentandelen av gebyret du vil belaste kunden. Maks %1 / %2."
 "Enter the amount you want to charge your customer. Max %1.","Skriv inn beløpet du vil belaste kunden. Maks %1."
 "Enter the percentage of the fee you want to charge your customer. Max: %1.","Skriv inn prosentandelen av gebyret du vil belaste kunden. Maks: %1."

--- a/i18n/nl_NL.csv
+++ b/i18n/nl_NL.csv
@@ -199,7 +199,7 @@
 "Enter the amount you want to charge your customer. Max %1.","Vul het bedrag in dat je bij je klant in rekening wilt brengen. Max %1."
 "Enter the amount and percentage of the fee you want to charge your customer. Max %1 / %2.","Vul het bedrag en het percentage van de fee in dat je bij je klant in rekening wilt brengen. Max %1 / %2."
 "Enter the percentage of the fee you want to charge your customer. Max: %1.","Vul het percentage van de fee in dat je bij je klant in rekening wilt brengen. Max: %1."
-"Enter a limit amount (in %1) if you do not want to charge your customer more than a specific amount.","Vul een limietbedrag (in %1) in als je je klant niet meer dan een specifiek bedrag in rekening wilt brengen."
+"Enter a limit amount (in %1) if you do not want to charge your customer more than a specific amount. Leave the limit field empty if you don't want to impose a limit amount.","Vul een limietbedrag (in %1) in als je je klant niet meer dan een specifiek bedrag in rekening wilt brengen. Laat het limietveld leeg als je geen limietbedrag wilt instellen."
 "First Name is not valid.","Voornaam is niet geldig."
 "Fulfilment can be triggered by either initializing shipping or creating an invoice in the Magento admin","Vervulling kan getriggerd worden door verzending of door een factuur aan te maken in het Magento portaal"
 "I accept the %1 and authorize %2 to process my data automatically.","Ik accepteer de %1 en geef toestemming aan %2 voor automatische verwerking van mijn gegevens."

--- a/i18n/sv_SE.csv
+++ b/i18n/sv_SE.csv
@@ -194,7 +194,7 @@
 "Country is not valid.","Land är inte giltigt."
 "Developed by Magmodules.","Utvecklad av Magmodules."
 "Email Address is not valid.","E-postadress är inte giltig."
-"Enter a limit amount (in %1) if you do not want to charge your customer more than a specific amount.","Ange ett maxbelopp (i %1) om du inte vill debitera din kund mer än ett specifikt belopp."
+"Enter a limit amount (in %1) if you do not want to charge your customer more than a specific amount. Leave the limit field empty if you don't want to impose a limit amount.","Ange ett maxbelopp (i %1) om du inte vill debitera din kund mer än ett specifikt belopp. Lämna fältet tomt om du inte vill ange något maxbelopp."
 "Enter the amount and percentage of the fee you want to charge your customer. Max %1 / %2.","Ange beloppet och procentandelen av avgiften du vill debitera din kund. Max %1 / %2."
 "Enter the amount you want to charge your customer. Max %1.","Ange beloppet du vill debitera din kund. Max %1."
 "Enter the percentage of the fee you want to charge your customer. Max: %1.","Ange procentandelen av avgiften du vill debitera din kund. Max: %1."

--- a/view/adminhtml/templates/system/config/field/surcharge-grid.phtml
+++ b/view/adminhtml/templates/system/config/field/surcharge-grid.phtml
@@ -131,7 +131,7 @@ $columnLabels = [
     $fl = $block->getFixedLimitLabel();
     $pl = $block->getPercentageLimitLabel();
     $limitSentence = __(
-        'Enter a limit amount (in %1) if you do not want to charge your customer more than a specific amount.',
+        'Enter a limit amount (in %1) if you do not want to charge your customer more than a specific amount. Leave the limit field empty if you don\'t want to impose a limit amount.',
         $block->getBaseCurrencySymbol()
     );
     ?>


### PR DESCRIPTION
## What

Adds optional **buyer fee share rounding** controls to the Magento admin, consuming the `rounding` block now supported by the pricing fee API. Merchants can snap the buyer surcharge line item to a clean increment (e.g. whole units, nearest half) instead of the default two-decimal amount.

## Admin

Two fields below the surcharge grid:

| Field | Values | Notes |
|---|---|---|
| Buyer Fee Rounding | None / Up / Down / Standard | default None = off |
| Rounding Step | numeric, > 0 | shown only when a basis is selected |

Both shown only when percentage is part of the surcharge method (Percentage or Fixed + Percentage) — a fixed-only fee is constant, nothing to snap. Mirrored into the brand overlay form so brand-specific admin gets them too.

## Checkout

`SurchargeCalculator` sends `buyer_fee_share.rounding = {step, basis}` only when the fee has a percentage component **and** a basis ≠ None **and** step > 0. The percentage gate mirrors the existing `cap` handling, so a stale basis/step left from a previous percentage setup can't leak into a fixed-only request. Rounding is computed entirely server-side.

## Deploy ordering

Rounding lands in the pricing backend on staging first. On a backend that predates it, the unknown `rounding` field is ignored (not rejected), so this is a safe no-op there until the backend promotes. The staging shop exercises it live.

## Tests

192 unit tests green, incl. new cases: rounding present (percentage / fixed+percentage), basis→enum mapping, omitted for None / step ≤ 0 / fixed-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)