### PR TITLE
fix: require at least one payment term (deselect-all system error)

### DIFF
--- a/Block/Adminhtml/System/Config/Field/PaymentTermsCheckboxes.php
+++ b/Block/Adminhtml/System/Config/Field/PaymentTermsCheckboxes.php
@@ -81,7 +81,17 @@ class PaymentTermsCheckboxes extends Field
     {
         $element = $this->getData('element');
         $value = $element ? (string)$element->getValue() : '';
-        return array_filter(array_map('intval', explode(',', $value)));
+        $selected = array_values(array_filter(array_map('intval', explode(',', $value))));
+        if (count($selected) === 0) {
+            // Nothing stored: prepopulate the shortest available term so the form
+            // never loads with no selection (a selection is mandatory on save).
+            $available = array_map('intval', $this->getAvailableTerms());
+            sort($available);
+            if (count($available) > 0) {
+                $selected = [$available[0]];
+            }
+        }
+        return $selected;
     }
 
     /**

--- a/Model/Config/Backend/PaymentTermsCheckboxes.php
+++ b/Model/Config/Backend/PaymentTermsCheckboxes.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Two\Gateway\Model\Config\Backend;
 
 use Magento\Framework\App\Config\Value;
+use Magento\Framework\Exception\LocalizedException;
 
 /**
  * Backend model for payment terms checkboxes.
@@ -19,15 +20,38 @@ class PaymentTermsCheckboxes extends Value
 {
     /**
      * @inheritDoc
+     *
+     * @throws LocalizedException when the merchant clears every term after
+     *         terms were previously configured.
      */
     public function beforeSave()
     {
-        $value = $this->getValue();
-        if (is_array($value)) {
-            $value = array_filter(array_map('intval', $value));
-            sort($value);
-            $this->setValue(implode(',', $value));
+        $raw = $this->getValue();
+        if (is_array($raw)) {
+            $value = array_filter(array_map('intval', $raw));
+        } else {
+            // CSV string (e.g. a CLI config:set) — normalise identically.
+            $value = array_filter(array_map('intval', explode(',', (string)$raw)));
         }
+        sort($value);
+
+        // The optional custom term (sibling field) also satisfies the
+        // "offer at least one term" rule.
+        $custom = (int)$this->getFieldsetDataValue('payment_terms_duration_days');
+        $newHasTerms = count($value) > 0 || $custom > 0;
+
+        // An empty selection is a valid "use the account default term" state,
+        // but the merchant may not transition a configured gateway into it —
+        // clearing all terms is what previously surfaced a system error.
+        $oldHasTerms = (string)$this->getOldValue() !== '';
+
+        if (!$newHasTerms && $oldHasTerms) {
+            throw new LocalizedException(
+                __('Select at least one payment term, or enter a custom term. Clearing every term is not allowed once terms have been configured.')
+            );
+        }
+
+        $this->setValue(implode(',', $value));
         return parent::beforeSave();
     }
 }

--- a/Model/Config/Backend/PaymentTermsCheckboxes.php
+++ b/Model/Config/Backend/PaymentTermsCheckboxes.php
@@ -21,8 +21,8 @@ class PaymentTermsCheckboxes extends Value
     /**
      * @inheritDoc
      *
-     * @throws LocalizedException when the merchant clears every term after
-     *         terms were previously configured.
+     * @throws LocalizedException when no payment term is selected and no custom
+     *         term is entered — a selection is mandatory.
      */
     public function beforeSave()
     {
@@ -35,19 +35,12 @@ class PaymentTermsCheckboxes extends Value
         }
         sort($value);
 
-        // The optional custom term (sibling field) also satisfies the
-        // "offer at least one term" rule.
+        // A selection is mandatory. The optional custom term (sibling field)
+        // also satisfies it, so a single off-preset term may be offered alone.
         $custom = (int)$this->getFieldsetDataValue('payment_terms_duration_days');
-        $newHasTerms = count($value) > 0 || $custom > 0;
-
-        // An empty selection is a valid "use the account default term" state,
-        // but the merchant may not transition a configured gateway into it —
-        // clearing all terms is what previously surfaced a system error.
-        $oldHasTerms = (string)$this->getOldValue() !== '';
-
-        if (!$newHasTerms && $oldHasTerms) {
+        if (count($value) === 0 && $custom <= 0) {
             throw new LocalizedException(
-                __('Select at least one payment term, or enter a custom term. Clearing every term is not allowed once terms have been configured.')
+                __('Select at least one payment term or enter a custom term.')
             );
         }
 


### PR DESCRIPTION
## What

`PaymentTermsCheckboxes::beforeSave` silently stored an empty set when the merchant deselected every payment term, which then surfaced a system error downstream.

- `beforeSave` now **rejects an empty selection** with a clear `LocalizedException` ("Select at least one payment term or enter a custom term.") instead of a later crash. A custom-days entry in the sibling field also satisfies it. A term selection is mandatory.
- The checkbox block **prepopulates the shortest available term** when nothing is stored, so the form never loads with no selection.

## Why

Deselecting all terms is a reachable admin action that currently breaks. Caught while aligning the WooCommerce plugin's payment-terms admin to this one.

## Test

`php -l` clean (8.1/8.2). Render/validation logic is small and self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)