### PR TITLE
fix: malformed hidden-input name crashes payment-terms deselect-all

### DIFF
--- a/view/adminhtml/templates/system/config/field/payment-terms-checkboxes.phtml
+++ b/view/adminhtml/templates/system/config/field/payment-terms-checkboxes.phtml
@@ -13,8 +13,20 @@ $elementId = $block->getElementId();
 $showFees = $block->showInlineFees();
 ?>
 
-<?php // Hidden fallback — ensures the field posts even when nothing is checked ?>
-<input type="hidden" name="<?= $block->escapeHtmlAttr(rtrim($fieldName, '[]')) ?>" value=""/>
+<?php
+    // Hidden fallback — ensures the field still posts (as an empty scalar) when
+    // no checkbox is ticked, so the backend model runs and rejects the empty
+    // selection instead of the field vanishing from the POST.
+    //
+    // getFieldName() appends '[]' for the checkbox array; the scalar name is
+    // that minus the suffix. Strip exactly the trailing '[]' — NOT rtrim($n,'[]'),
+    // which greedily eats the closing ']' of '[value]' too, producing a malformed
+    // name. On deselect-all that corrupt name was the ONLY thing posted for the
+    // field, so Magento core _processGroup received a string instead of an array
+    // and fatally errored before the backend model ever ran.
+    $scalarFieldName = substr($fieldName, 0, -2);
+?>
+<input type="hidden" name="<?= $block->escapeHtmlAttr($scalarFieldName) ?>" value=""/>
 
 <div id="<?= $block->escapeHtmlAttr($elementId) ?>_checkboxes"
      class="two-term-checkboxes<?= $showFees ? ' two-term-checkboxes--with-fees' : '' ?>"


### PR DESCRIPTION
## What

The deselect-all crash (system error on saving the Two payment config with no payment terms ticked) had a deeper cause than the `beforeSave` guard added in #228 could reach.

The checkbox template's hidden fallback input derived its `name` via `rtrim($fieldName, '[]')`. `rtrim` strips **all** trailing bracket characters, so it also ate the closing `]` of `[value]` → a malformed name (`…[payment_terms][value`). On deselect-all that broken hidden input is the *only* thing posted for the field, so Magento core `Config::_processGroup` got a **string** where it expected the field's data array and fatally errored (`TypeError: Cannot access offset of type string on string`, `Config.php:438`) — **before** the backend model's `beforeSave` ran. That's why the guard never fired.

## Fix

Strip exactly the appended `[]` suffix (`substr($fieldName, 0, -2)`). The field now posts as an empty scalar on deselect-all → core builds it cleanly → the backend model rejects it with the friendly "Select at least one payment term…" message.

## Test

`php -l` clean. Verified against the live exception (`Config.php:438`) read from the staging pod. Combines with #228 (guard) + the prepopulate-shortest render change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)