### PR TITLE
Show Merchant ID + short name on the API-key settings field

### DIFF
--- a/Block/Adminhtml/System/Config/Field/ApiKeyCheck.php
+++ b/Block/Adminhtml/System/Config/Field/ApiKeyCheck.php
@@ -84,9 +84,14 @@ class ApiKeyCheck extends Field
                 'error' => $error
             ];
         } else {
+            // verify_api_key returns {id, short_name}; surface both so the
+            // merchant can confirm at a glance which account the key resolves to.
             return [
                 'message' => __('API key is valid'),
-                'status' => 'success'
+                'status' => 'success',
+                'merchant_id' => is_array($result) && isset($result['id']) ? (string)$result['id'] : '',
+                'merchant_short_name' => is_array($result) && isset($result['short_name'])
+                    ? (string)$result['short_name'] : ''
             ];
         }
     }

--- a/view/adminhtml/templates/system/config/field/apikey.phtml
+++ b/view/adminhtml/templates/system/config/field/apikey.phtml
@@ -18,4 +18,10 @@ $status = $block->getApiKeyStatus();
     <?php if (isset($status['error'])): ?>
         <span class="api-key-error-message"><?= $block->escapeHtml($status['error']); ?></span>
     <?php endif; ?>
+    <?php if (!empty($status['merchant_id'])): ?>
+        <div style="margin-top: 8px; color: #666; font-size: 13px;">
+            <strong><?= $block->escapeHtml(__('Merchant ID:')); ?></strong>
+            <?= $block->escapeHtml($status['merchant_id']); ?><?php if (!empty($status['merchant_short_name'])): ?> &middot; <?= $block->escapeHtml($status['merchant_short_name']); ?><?php endif; ?>
+        </div>
+    <?php endif; ?>
 </div>


### PR DESCRIPTION
The API-key config field reported only valid/invalid. `verify_api_key` also returns the merchant id and short name — surface both beneath the status line so the merchant can confirm which account the key resolves to.

Refreshes on save (Magento re-renders the verify result on config save). Magento config has no inline JS key-verify, so there's no live-on-keystroke refresh as in the WooCommerce equivalent — adding one would be disproportionate; save-time refresh matches Magento's existing pattern.

Staging only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)