### PR TITLE
Render payment-terms surcharge as a cart-page totals line

### DIFF
--- a/view/frontend/layout/checkout_cart_index.xml
+++ b/view/frontend/layout/checkout_cart_index.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <!--
+            Render the payment-terms surcharge as a line in the cart-page
+            totals. The quote collector already adds it to the totals (so the
+            grand total includes it), but without this registration the cart
+            page never showed it as its own row — unlike shipping. Mirrors the
+            checkout-page registration in checkout_index_index.xml.
+        -->
+        <referenceBlock name="checkout.cart.totals">
+            <arguments>
+                <argument name="jsLayout" xsi:type="array">
+                    <item name="components" xsi:type="array">
+                        <item name="block-totals" xsi:type="array">
+                            <item name="children" xsi:type="array">
+                                <item name="two-surcharge" xsi:type="array">
+                                    <item name="component" xsi:type="string">Two_Gateway/js/view/cart/totals/surcharge</item>
+                                    <item name="sortOrder" xsi:type="string">39</item>
+                                    <item name="config" xsi:type="array">
+                                        <item name="title" xsi:type="string">Payment terms fee</item>
+                                    </item>
+                                </item>
+                            </item>
+                        </item>
+                    </item>
+                </argument>
+            </arguments>
+        </referenceBlock>
+    </body>
+</page>

--- a/view/frontend/web/js/view/cart/totals/surcharge.js
+++ b/view/frontend/web/js/view/cart/totals/surcharge.js
@@ -1,0 +1,24 @@
+/**
+ * Cart-page totals line for the Two payment terms surcharge.
+ *
+ * Reuses the checkout summary component but relaxes the display rule: the
+ * cart page has no payment-method selector, so there is no live method to
+ * gate on. The server-side Total Collector only emits the 'two_surcharge'
+ * segment when the Two payment method and a term are active on the quote, so
+ * a positive segment value is itself the signal that the surcharge applies.
+ * Without this, the cart page summed the surcharge into the totals (because
+ * the collector ran) but never rendered it as its own line.
+ */
+define([
+    'Two_Gateway/js/view/checkout/summary/surcharge',
+    'Magento_Checkout/js/model/totals'
+], function (Component, totals) {
+    'use strict';
+
+    return Component.extend({
+        isDisplayed: function () {
+            var segment = totals.getSegment('two_surcharge');
+            return !!(segment && parseFloat(segment.value) > 0);
+        }
+    });
+});


### PR DESCRIPTION
**Bug:** with the Two payment method + a surcharge-bearing term selected, navigating to the cart page (`checkout/cart`) shows the surcharge folded into the tax + order totals, but **not as its own line** — unlike shipping.

**Cause:** the surcharge summary component is registered for the checkout page (`checkout_index_index.xml`) but there was no `checkout_cart_index.xml`, so the quote collector's `two_surcharge` segment was summed into the totals without a renderer on the cart route.

**Fix:** register the surcharge segment under the cart-page totals (`block-totals` children), mirroring the checkout registration, via a thin cart-specific component that displays whenever the segment value is positive. The cart page has no payment-method selector to gate on, and the server-side collector only emits the segment when the Two method + a term are active — so a positive segment is itself the signal.

Vanilla (Luma) only. The Hyva theme's **cart** page renders totals through the Hyva theme (separate from the `magento2-hyva-checkout` module in `magento-hyva-extension`); its cart total-segments extension point is a focused follow-up.

Staging only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)