### PR TITLE
INF-1601/fix: resync version strings so Release workflow can cut 2.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "two-inc/magento2",
     "description": "Two B2B BNPL payments extension for Magento",
     "type": "magento2-module",
-    "version": "2.0.0-dev",
+    "version": "1.16.2",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -26,7 +26,7 @@
                     Has no effect when no overlay is registered.
                 -->
                 <hide_when_overlay_installed>1</hide_when_overlay_installed>
-                <version>2.0.0-dev</version>
+                <version>1.16.2</version>
                 <title>Two - Buy Now Pay Later on Invoice Terms</title>
                 <sort_order>-10</sort_order>
                 <mode>sandbox</mode>


### PR DESCRIPTION
## Context

Every `Release` workflow run on `main` has **failed at the bumpver step** since `composer.json` + `etc/config.xml` were hand-set to `2.0.0-dev`. The most recent failure was the run triggered by #233's merge (2026-07-01 07:28), which errored with:

```
New Version: 2.0.0
ERROR - No match for pattern '"version": "MAJOR.MINOR.PATCH[-TAGNUM]",'
```

Root cause: `bumpver.toml` carries `current_version = "1.16.2"`, but the two version files were set to `2.0.0-dev`. bumpver replaces occurrences of the *current* version (`1.16.2`), so it can't find the string to replace. The `-dev` suffix also doesn't satisfy the `[-TAGNUM]` pattern (TAGNUM needs a trailing number, e.g. `-dev1`). Net effect: no tag has been cut and magento-plugin's staging→main work is unreleased.

## Changes

- `composer.json`: `"version": "2.0.0-dev"` → `"1.16.2"`
- `etc/config.xml`: `<version>2.0.0-dev</version>` → `1.16.2`

## Scope / Non-goals

- Does **not** drop the version field (unlike magento-abn-plugin) — both fields are functional, rendered in admin by `Block/Adminhtml/System/Config/Field/Version.php`, so they stay and keep being bumped.
- Does not touch `bumpver.toml`, `release.yml`, or `ci.yml`.

## Effect on merge

On merge to `main`, CI runs, the `Release` workflow fires, and bumpver now finds `1.16.2` to replace. With three `feat!:`/`fix!:` breaking commits since the `1.16.2` tag, it computes a **major** bump → tags and releases **2.0.0**, updating both files to `2.0.0` in the bump commit. Part of getting the ABN plugin release out (magento-plugin is the unbranded base under magento-abn-plugin).

## Validation

- Confirmed the failing run (`gh run view 28501050979 --log-failed`) errors precisely at the bumpver replace step, not earlier.
- Confirmed `bumpver.toml` `current_version = "1.16.2"` and both files were the only carriers of `2.0.0-dev` (`git grep 2.0.0-dev`).

## Ticket

- INF-1601