### PR TITLE
TWO-24814/TWO-24952: source payment terms + surcharge cap (+ default term) from the merchant API

### DIFF
--- a/Api/BrandRegistryInterface.php
+++ b/Api/BrandRegistryInterface.php
@@ -42,25 +42,6 @@ interface BrandRegistryInterface
     public function getCheckoutUrlTemplate(): string;
 
     /**
-     * Buyer-selectable payment terms (in days) supported by this
-     * brand's commercial agreement.
-     *
-     * @return int[]
-     */
-    public function getAvailablePaymentTerms(): array;
-
-    /**
-     * Maximum allowed value of a fixed-amount surcharge configured
-     * by the merchant, expressed in a specific currency. Returning
-     * null means there is no upper bound — any positive value is
-     * acceptable. Calling code must interpret null as "no max" and
-     * skip the upper-bound check.
-     *
-     * @return array{amount: float, currency: string}|null
-     */
-    public function getSurchargeFixedMax(): ?array;
-
-    /**
      * Buyer-surcharge rounding steps (in major currency units) offered
      * in the admin "Rounding Step" dropdown, ascending. Brand overlays
      * narrow the set via brand.xml <surcharge_rounding_steps>; the

--- a/Block/Adminhtml/System/Config/Field/DefaultPaymentTerm.php
+++ b/Block/Adminhtml/System/Config/Field/DefaultPaymentTerm.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Block\Adminhtml\System\Config\Field;
+
+use Magento\Config\Block\System\Config\Form\Field;
+use Magento\Backend\Block\Template\Context;
+use Magento\Framework\Data\Form\Element\AbstractElement;
+use Two\Gateway\Service\Merchant\SettingsProvider;
+
+/**
+ * Renders the "Default Payment Term" select.
+ *
+ * When the admin has not saved an explicit value, the field is
+ * pre-selected to the merchant's API default term (due_in_days), so a
+ * fresh install shows — and the checkout uses — the same term. Because
+ * the value is only injected for display (never persisted), a later
+ * admin edit is stored normally and wins: the API provides the default,
+ * it does not override an explicit choice (TWO-24859).
+ *
+ * etc/config.xml deliberately carries no static default for this field
+ * so an empty stored value genuinely means "admin never chose".
+ */
+class DefaultPaymentTerm extends Field
+{
+    /** @var SettingsProvider */
+    private $settingsProvider;
+
+    public function __construct(
+        Context $context,
+        SettingsProvider $settingsProvider,
+        array $data = []
+    ) {
+        parent::__construct($context, $data);
+        $this->settingsProvider = $settingsProvider;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function _getElementHtml(AbstractElement $element): string
+    {
+        if ((string)$element->getValue() === '') {
+            $storeId = $this->resolveStoreId($element);
+            $terms = array_map('intval', $this->settingsProvider->getAvailableTerms($storeId));
+            $apiDefault = $this->settingsProvider->getDefaultTerm($storeId);
+            if ($apiDefault !== null && in_array($apiDefault, $terms, true)) {
+                $element->setValue((string)$apiDefault);
+            } elseif (count($terms) > 0) {
+                // No usable API default: fall back to the lowest offered term
+                // so the select never renders with an out-of-set selection.
+                sort($terms);
+                $element->setValue((string)$terms[0]);
+            }
+        }
+        return parent::_getElementHtml($element);
+    }
+
+    /**
+     * Store id for the active config scope, or null for website/default
+     * scope — used to resolve the per-store API key when reading merchant
+     * settings.
+     */
+    private function resolveStoreId(AbstractElement $element): ?int
+    {
+        $form = $element->getForm();
+        if (!$form) {
+            return null;
+        }
+        return (string)$form->getScope() === 'stores' && (int)$form->getScopeId() > 0
+            ? (int)$form->getScopeId()
+            : null;
+    }
+}

--- a/Block/Adminhtml/System/Config/Field/PaymentTermsCheckboxes.php
+++ b/Block/Adminhtml/System/Config/Field/PaymentTermsCheckboxes.php
@@ -15,6 +15,7 @@ use Magento\Store\Model\StoreManagerInterface;
 use Two\Gateway\Api\BrandRegistryInterface;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
 use Two\Gateway\Service\Locale\AdminDecimalFormatter;
+use Two\Gateway\Service\Merchant\SettingsProvider;
 
 /**
  * Renders payment terms as individual checkboxes instead of a multiselect.
@@ -33,6 +34,9 @@ class PaymentTermsCheckboxes extends Field
     /** @var BrandRegistryInterface */
     private $brandRegistry;
 
+    /** @var SettingsProvider */
+    private $settingsProvider;
+
     /** @var StoreManagerInterface */
     private $storeManager;
 
@@ -45,6 +49,7 @@ class PaymentTermsCheckboxes extends Field
     public function __construct(
         Context $context,
         BrandRegistryInterface $brandRegistry,
+        SettingsProvider $settingsProvider,
         StoreManagerInterface $storeManager,
         ScopeConfigInterface $scopeConfig,
         AdminDecimalFormatter $decimalFormatter,
@@ -52,6 +57,7 @@ class PaymentTermsCheckboxes extends Field
     ) {
         parent::__construct($context, $data);
         $this->brandRegistry = $brandRegistry;
+        $this->settingsProvider = $settingsProvider;
         $this->storeManager = $storeManager;
         $this->scopeConfig = $scopeConfig;
         $this->decimalFormatter = $decimalFormatter;
@@ -67,11 +73,23 @@ class PaymentTermsCheckboxes extends Field
     }
 
     /**
-     * Get available payment terms from the constant.
+     * Get the merchant's offerable payment terms from the merchant API.
      */
     public function getAvailableTerms(): array
     {
-        return $this->brandRegistry->getAvailablePaymentTerms();
+        return $this->settingsProvider->getAvailableTerms($this->resolveStoreId());
+    }
+
+    /**
+     * Store id for the active config scope, or null for website/default
+     * scope — used to resolve the per-store API key when reading
+     * merchant settings.
+     */
+    private function resolveStoreId(): ?int
+    {
+        return $this->getScope() === 'stores' && $this->getScopeId() > 0
+            ? $this->getScopeId()
+            : null;
     }
 
     /**

--- a/Block/Adminhtml/System/Config/Field/SurchargeGrid.php
+++ b/Block/Adminhtml/System/Config/Field/SurchargeGrid.php
@@ -17,6 +17,7 @@ use Two\Gateway\Api\BrandRegistryInterface;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
 use Two\Gateway\Api\CurrencyRatesProviderInterface;
 use Two\Gateway\Service\Locale\AdminDecimalFormatter;
+use Two\Gateway\Service\Merchant\SettingsProvider;
 
 /**
  * Renders a grid of surcharge inputs (fixed, percentage, limit) per payment term.
@@ -42,6 +43,9 @@ class SurchargeGrid extends Field
     /** @var BrandRegistryInterface */
     private $brandRegistry;
 
+    /** @var SettingsProvider */
+    private $settingsProvider;
+
     /** @var AdminDecimalFormatter */
     private $decimalFormatter;
 
@@ -60,6 +64,7 @@ class SurchargeGrid extends Field
         StoreManagerInterface $storeManager,
         CurrencyRatesProviderInterface $ratesProvider,
         BrandRegistryInterface $brandRegistry,
+        SettingsProvider $settingsProvider,
         AdminDecimalFormatter $decimalFormatter,
         ResourceConnection $resource,
         array $data = []
@@ -69,6 +74,7 @@ class SurchargeGrid extends Field
         $this->storeManager = $storeManager;
         $this->ratesProvider = $ratesProvider;
         $this->brandRegistry = $brandRegistry;
+        $this->settingsProvider = $settingsProvider;
         $this->decimalFormatter = $decimalFormatter;
         $this->resource = $resource;
     }
@@ -166,7 +172,7 @@ class SurchargeGrid extends Field
      */
     public function getMaxFixed(): ?int
     {
-        $limit = $this->brandRegistry->getSurchargeFixedMax();
+        $limit = $this->settingsProvider->getSurchargeLimit($this->resolveStoreId());
         if ($limit === null) {
             return null;
         }
@@ -232,7 +238,7 @@ class SurchargeGrid extends Field
      */
     public function getFixedLimitLabel(): string
     {
-        $limit = $this->brandRegistry->getSurchargeFixedMax();
+        $limit = $this->settingsProvider->getSurchargeLimit($this->resolveStoreId());
         if ($limit === null) {
             return '';
         }
@@ -271,7 +277,7 @@ class SurchargeGrid extends Field
      */
     public function getCurrencyWarning(): string
     {
-        $limit = $this->brandRegistry->getSurchargeFixedMax();
+        $limit = $this->settingsProvider->getSurchargeLimit($this->resolveStoreId());
         if ($limit === null) {
             return '';
         }
@@ -398,11 +404,22 @@ class SurchargeGrid extends Field
     }
 
     /**
-     * Available term constants (for JS to know which terms are standard).
+     * The merchant's offerable payment terms (for JS to know which
+     * terms are standard), sourced from the merchant API.
      */
     public function getAvailablePaymentTerms(): array
     {
-        return $this->brandRegistry->getAvailablePaymentTerms();
+        return $this->settingsProvider->getAvailableTerms($this->resolveStoreId());
+    }
+
+    /**
+     * Store id for the active config scope, or null for website/default
+     * scope — used to resolve the per-store API key when reading
+     * merchant settings.
+     */
+    private function resolveStoreId(): ?int
+    {
+        return $this->scope === 'stores' && $this->scopeId > 0 ? $this->scopeId : null;
     }
 
     /**

--- a/Brand/DescriptorBackedBrandRegistry.php
+++ b/Brand/DescriptorBackedBrandRegistry.php
@@ -46,16 +46,6 @@ class DescriptorBackedBrandRegistry implements BrandRegistryInterface
         return $this->activeBrandResolver->resolve()->getCheckoutUrlTemplate();
     }
 
-    public function getAvailablePaymentTerms(): array
-    {
-        return $this->activeBrandResolver->resolve()->getAvailablePaymentTerms();
-    }
-
-    public function getSurchargeFixedMax(): ?array
-    {
-        return $this->activeBrandResolver->resolve()->getSurchargeFixedMax();
-    }
-
     public function getSurchargeRoundingSteps(): array
     {
         return $this->activeBrandResolver->resolve()->getSurchargeRoundingSteps();

--- a/Model/Brand.php
+++ b/Model/Brand.php
@@ -34,10 +34,6 @@ class Brand implements BrandRegistryInterface
     private $productName;
     /** @var string */
     private $checkoutUrlTemplate;
-    /** @var int[] */
-    private $availablePaymentTerms;
-    /** @var array{amount: float, currency: string}|null */
-    private $surchargeFixedMax;
     /** @var string */
     private $signUpUrl;
     /** @var string */
@@ -47,17 +43,11 @@ class Brand implements BrandRegistryInterface
     /** @var string */
     private $checkoutSubtitle;
 
-    /**
-     * @param int[] $availablePaymentTerms
-     * @param array{amount: float, currency: string}|null $surchargeFixedMax
-     */
     public function __construct(
         string $provider,
         string $providerFullName,
         string $productName,
         string $checkoutUrlTemplate,
-        array $availablePaymentTerms,
-        ?array $surchargeFixedMax = null,
         string $signUpUrl = '',
         string $documentationUrl = '',
         string $brandTag = '',
@@ -67,8 +57,6 @@ class Brand implements BrandRegistryInterface
         $this->providerFullName = $providerFullName;
         $this->productName = $productName;
         $this->checkoutUrlTemplate = $checkoutUrlTemplate;
-        $this->availablePaymentTerms = $availablePaymentTerms;
-        $this->surchargeFixedMax = $surchargeFixedMax;
         $this->signUpUrl = $signUpUrl;
         $this->documentationUrl = $documentationUrl;
         $this->brandTag = $brandTag;
@@ -93,16 +81,6 @@ class Brand implements BrandRegistryInterface
     public function getCheckoutUrlTemplate(): string
     {
         return $this->checkoutUrlTemplate;
-    }
-
-    public function getAvailablePaymentTerms(): array
-    {
-        return $this->availablePaymentTerms;
-    }
-
-    public function getSurchargeFixedMax(): ?array
-    {
-        return $this->surchargeFixedMax;
     }
 
     /**

--- a/Model/Brand/Descriptor.php
+++ b/Model/Brand/Descriptor.php
@@ -35,8 +35,6 @@ final class Descriptor
      * @param string $signUpUrl Merchant sign-up link shown in admin header.
      * @param string $documentationUrl Plugin docs URL shown in admin header.
      * @param string $apiBaseUrl Outbound API base URL.
-     * @param int[] $availablePaymentTerms Buyer-selectable terms in days.
-     * @param array{amount:float,currency:string}|null $surchargeFixedMax
      * @param string[] $cspOrigins Additional CSP fetch-policy origins.
      * @param string $adminResource ACL resource for the brand's admin form.
      * @param array<array{label:string,module:string}> $moduleLabelChain Version-panel rows.
@@ -61,8 +59,6 @@ final class Descriptor
         private readonly string $signUpUrl,
         private readonly string $documentationUrl,
         private readonly string $apiBaseUrl,
-        private readonly array $availablePaymentTerms,
-        private readonly ?array $surchargeFixedMax,
         private readonly array $cspOrigins,
         private readonly string $adminResource,
         private readonly array $moduleLabelChain,
@@ -191,18 +187,6 @@ final class Descriptor
     public function getApiBaseUrl(): string
     {
         return $this->apiBaseUrl;
-    }
-
-    /** @return int[] */
-    public function getAvailablePaymentTerms(): array
-    {
-        return $this->availablePaymentTerms;
-    }
-
-    /** @return array{amount:float,currency:string}|null */
-    public function getSurchargeFixedMax(): ?array
-    {
-        return $this->surchargeFixedMax;
     }
 
     /**

--- a/Model/Brand/Loader.php
+++ b/Model/Brand/Loader.php
@@ -105,21 +105,6 @@ class Loader
             ));
         }
 
-        $terms = [];
-        if (isset($brand->available_payment_terms->term)) {
-            foreach ($brand->available_payment_terms->term as $term) {
-                $terms[] = (int)$term;
-            }
-        }
-
-        $surchargeFixedMax = null;
-        if (isset($brand->surcharge_fixed_max)) {
-            $surchargeFixedMax = [
-                'amount' => (float)$brand->surcharge_fixed_max['amount'],
-                'currency' => (string)$brand->surcharge_fixed_max['currency'],
-            ];
-        }
-
         // Brand-driven Rounding Step dropdown options. Validate at load
         // time — nothing validates brand.xsd at runtime, so a malformed
         // <step> would otherwise coerce to 0.0 and silently offer a
@@ -214,8 +199,6 @@ class Loader
             (string)($brand->sign_up_url ?? ''),
             (string)($brand->documentation_url ?? ''),
             (string)$brand->api_base_url,
-            $terms,
-            $surchargeFixedMax,
             $cspOrigins,
             (string)$brand->admin_resource,
             $moduleLabelChain,

--- a/Model/Config/Backend/SurchargeGrid.php
+++ b/Model/Config/Backend/SurchargeGrid.php
@@ -21,6 +21,7 @@ use Magento\Store\Model\StoreManagerInterface;
 use Two\Gateway\Api\BrandRegistryInterface;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
 use Two\Gateway\Api\CurrencyRatesProviderInterface;
+use Two\Gateway\Service\Merchant\SettingsProvider;
 
 /**
  * Backend model for the surcharge grid.
@@ -45,6 +46,9 @@ class SurchargeGrid extends Value
     /** @var BrandRegistryInterface */
     private $brandRegistry;
 
+    /** @var SettingsProvider */
+    private $settingsProvider;
+
     /** @var ResourceConnection */
     private $resourceConnection;
 
@@ -57,6 +61,7 @@ class SurchargeGrid extends Value
         StoreManagerInterface $storeManager,
         CurrencyRatesProviderInterface $ratesProvider,
         BrandRegistryInterface $brandRegistry,
+        SettingsProvider $settingsProvider,
         ResourceConnection $resourceConnection,
         ?AbstractResource $resource = null,
         ?AbstractDb $resourceCollection = null,
@@ -67,6 +72,7 @@ class SurchargeGrid extends Value
         $this->storeManager = $storeManager;
         $this->ratesProvider = $ratesProvider;
         $this->brandRegistry = $brandRegistry;
+        $this->settingsProvider = $settingsProvider;
         $this->resourceConnection = $resourceConnection;
     }
 
@@ -213,16 +219,15 @@ class SurchargeGrid extends Value
     }
 
     /**
-     * Get the fixed max converted to the store's base currency.
-     */
-    /**
-     * Brand-defined fixed-fee max, converted into the merchant's base
-     * currency. Returns null when the brand imposes no upper bound;
-     * validateValue() must skip the upper-bound check in that case.
+     * Merchant's fixed-fee surcharge cap (from GET /v1/merchant),
+     * converted into the merchant's base currency. Returns null when
+     * there is no upper bound; validateValue() must skip the
+     * upper-bound check in that case.
      */
     private function getConvertedFixedMax(string $scope, int $scopeId): ?int
     {
-        $limit = $this->brandRegistry->getSurchargeFixedMax();
+        $storeId = ($scope === 'stores' && $scopeId > 0) ? $scopeId : null;
+        $limit = $this->settingsProvider->getSurchargeLimit($storeId);
         if ($limit === null) {
             return null;
         }
@@ -234,7 +239,6 @@ class SurchargeGrid extends Value
             return $limitAmount;
         }
 
-        $storeId = ($scope === 'stores' && $scopeId > 0) ? $scopeId : null;
         $rate = $this->ratesProvider->getRate($limitCurrency, $baseCurrency, $storeId);
         if ($rate !== null && $rate > 0) {
             return (int)ceil($limitAmount * $rate);

--- a/Model/Config/Repository.php
+++ b/Model/Config/Repository.php
@@ -15,6 +15,7 @@ use Magento\Store\Model\ScopeInterface;
 use Magento\Tax\Model\Calculation as TaxCalculation;
 use Two\Gateway\Api\BrandRegistryInterface;
 use Two\Gateway\Api\Config\RepositoryInterface;
+use Two\Gateway\Service\Merchant\SettingsProvider;
 
 /**
  * Config Repository
@@ -47,6 +48,16 @@ class Repository implements RepositoryInterface
     private $brandRegistry;
 
     /**
+     * @var SettingsProvider Injected via \Proxy in di.xml — this
+     *                       Repository owns the API key that the
+     *                       provider resolves the merchant record with,
+     *                       so a direct binding would be a construction
+     *                       cycle. The proxy defers instantiation until
+     *                       getDefaultPaymentTerm() first calls it.
+     */
+    private $settingsProvider;
+
+    /**
      * @var string|null Optional explicit override. Null = resolve
      *                  lazily from BrandRegistryInterface::getCode().
      *                  Kept as a ctor arg for unit-test injection and
@@ -71,6 +82,7 @@ class Repository implements RepositoryInterface
         ProductMetadataInterface $productMetadata,
         TaxCalculation $taxCalculation,
         BrandRegistryInterface $brandRegistry,
+        SettingsProvider $settingsProvider,
         ?string $code = null
     ) {
         $this->scopeConfig = $scopeConfig;
@@ -79,6 +91,7 @@ class Repository implements RepositoryInterface
         $this->productMetadata = $productMetadata;
         $this->taxCalculation = $taxCalculation;
         $this->brandRegistry = $brandRegistry;
+        $this->settingsProvider = $settingsProvider;
         $this->code = $code;
     }
 
@@ -495,12 +508,20 @@ class Repository implements RepositoryInterface
     public function getDefaultPaymentTerm(?int $storeId = null): int
     {
         $terms = $this->getAllBuyerTerms($storeId);
+        // The merchant's default term is authoritative from the merchant
+        // API (due_in_days). Honour it only when it is one of the offered
+        // buyer terms — it is not guaranteed to be a member (TWO-24859).
+        $apiDefault = $this->settingsProvider->getDefaultTerm($storeId);
+        if ($apiDefault !== null && in_array($apiDefault, $terms, true)) {
+            return $apiDefault;
+        }
+        // Otherwise honour the admin-configured default if it is an
+        // available buyer term, else fall back to the lowest available
+        // term so the buyer always lands on a real, selectable term — in
+        // particular a single available term is always the default (and
+        // thus preselected), even if a stale default_payment_term points
+        // elsewhere (ABN-439).
         $default = (int)$this->getConfig($this->path('default_payment_term'), $storeId);
-        // Only honour the configured default if it's actually an available
-        // buyer term. Otherwise fall back to the lowest available term so the
-        // buyer always lands on a real, selectable term — in particular a
-        // single available term is always the default (and thus preselected),
-        // even if a stale default_payment_term points elsewhere (ABN-439).
         if ($default > 0 && in_array($default, $terms, true)) {
             return $default;
         }

--- a/Model/Config/Repository.php
+++ b/Model/Config/Repository.php
@@ -502,29 +502,30 @@ class Repository implements RepositoryInterface
         return $terms;
     }
 
-    /**
-     * @inheritDoc
-     */
     public function getDefaultPaymentTerm(?int $storeId = null): int
     {
         $terms = $this->getAllBuyerTerms($storeId);
-        // The merchant's default term is authoritative from the merchant
-        // API (due_in_days). Honour it only when it is one of the offered
-        // buyer terms — it is not guaranteed to be a member (TWO-24859).
-        $apiDefault = $this->settingsProvider->getDefaultTerm($storeId);
-        if ($apiDefault !== null && in_array($apiDefault, $terms, true)) {
-            return $apiDefault;
-        }
-        // Otherwise honour the admin-configured default if it is an
-        // available buyer term, else fall back to the lowest available
-        // term so the buyer always lands on a real, selectable term — in
-        // particular a single available term is always the default (and
-        // thus preselected), even if a stale default_payment_term points
-        // elsewhere (ABN-439).
+        // An admin who has explicitly configured a default term owns that
+        // choice — the merchant API must not silently override it. Honour
+        // the configured value whenever it is one of the offered buyer
+        // terms. (There is no config.xml fallback for this path, so a value
+        // here means the admin actually saved one — see etc/config.xml.)
         $default = (int)$this->getConfig($this->path('default_payment_term'), $storeId);
         if ($default > 0 && in_array($default, $terms, true)) {
             return $default;
         }
+        // No explicit admin choice: fall back to the merchant's API default
+        // (due_in_days) when it is an offered term. This is the same value
+        // the admin field pre-selects when unset, so a never-touched install
+        // and the checkout agree on the default term (TWO-24859).
+        $apiDefault = $this->settingsProvider->getDefaultTerm($storeId);
+        if ($apiDefault !== null && in_array($apiDefault, $terms, true)) {
+            return $apiDefault;
+        }
+        // Else the lowest available term, so the buyer always lands on a
+        // real, selectable term — in particular a single available term is
+        // always the default (and thus preselected), even if a stale
+        // default_payment_term points elsewhere (ABN-439).
         return $terms ? min($terms) : 30;
     }
 

--- a/Model/Config/Source/AvailablePaymentTerms.php
+++ b/Model/Config/Source/AvailablePaymentTerms.php
@@ -8,20 +8,22 @@ declare(strict_types=1);
 namespace Two\Gateway\Model\Config\Source;
 
 use Magento\Framework\Data\OptionSourceInterface;
-use Two\Gateway\Api\BrandRegistryInterface;
-use Two\Gateway\Api\Config\RepositoryInterface;
+use Two\Gateway\Service\Merchant\SettingsProvider;
 
 /**
  * Available Payment Terms Source Model (multiselect)
+ *
+ * Options come from the merchant's offerable terms on GET /v1/merchant;
+ * the admin narrows the buyer-facing set from them.
  */
 class AvailablePaymentTerms implements OptionSourceInterface
 {
-    /** @var BrandRegistryInterface */
-    private $brandRegistry;
+    /** @var SettingsProvider */
+    private $settingsProvider;
 
-    public function __construct(BrandRegistryInterface $brandRegistry)
+    public function __construct(SettingsProvider $settingsProvider)
     {
-        $this->brandRegistry = $brandRegistry;
+        $this->settingsProvider = $settingsProvider;
     }
 
     /**
@@ -30,7 +32,7 @@ class AvailablePaymentTerms implements OptionSourceInterface
     public function toOptionArray(): array
     {
         $options = [];
-        foreach ($this->brandRegistry->getAvailablePaymentTerms() as $days) {
+        foreach ($this->settingsProvider->getAvailableTerms() as $days) {
             $options[] = ['value' => $days, 'label' => __('%1 days', $days)];
         }
         return $options;

--- a/Service/Merchant/RecordProvider.php
+++ b/Service/Merchant/RecordProvider.php
@@ -29,9 +29,16 @@ use Two\Gateway\Service\Api\Adapter;
  * resolved record is memoized per request and cached for
  * CACHE_LIFETIME seconds, keyed on the API key so a key swap
  * (different merchant, or sandbox <-> production) never serves the old
- * merchant's record. A fetch failure resolves to null and is cached as
- * such: callers degrade to their own "no value configured" behaviour
- * rather than paying two API calls per page view on a blip.
+ * merchant's record.
+ *
+ * Only a *successful* fetch is cached. A failure (no API key,
+ * unresolvable merchant id, error response) resolves to null and is
+ * memoized per request but deliberately NOT written to the cross-request
+ * cache, so the next page view retries rather than serving a 900s-stale
+ * "no record". The first read during an outage can't be protected —
+ * there is nothing to serve — but once one read succeeds it is cached and
+ * served for CACHE_LIFETIME. Callers degrade to their own "no value
+ * configured" behaviour while the record is null.
  */
 class RecordProvider
 {
@@ -116,9 +123,16 @@ class RecordProvider
 
         $record = $this->fetchRecord($storeId);
 
+        // Memoize either way so a single request never pays the
+        // verify+fetch round-trip twice.
         $wrapper = ['record' => $record];
         $this->memo[$cacheKey] = $wrapper;
-        $this->cache->save($this->json->serialize($wrapper), $cacheKey, [], self::CACHE_LIFETIME);
+
+        // Persist only a successful record to the cross-request cache; a
+        // failure is left uncached so the next request retries.
+        if ($record !== null) {
+            $this->cache->save($this->json->serialize($wrapper), $cacheKey, [], self::CACHE_LIFETIME);
+        }
 
         return $record;
     }
@@ -142,6 +156,18 @@ class RecordProvider
 
         $merchant = $this->apiAdapter->execute('/v1/merchant/' . $merchantId, [], 'GET', $storeId);
 
-        return is_array($merchant) ? $merchant : null;
+        // Adapter::execute always returns an array; a failure is signalled by
+        // an error_code / http_status marker (never present on a real merchant
+        // record). Treat those as "no record" so a blip resolves to null
+        // rather than caching an error payload as the merchant record.
+        if (!is_array($merchant) || isset($merchant['error_code']) || isset($merchant['http_status'])) {
+            $this->logRepository->addDebugLog(
+                'RecordProvider: merchant fetch failed, treating as no record',
+                is_array($merchant) ? $merchant : ['response' => $merchant]
+            );
+            return null;
+        }
+
+        return $merchant;
     }
 }

--- a/Service/Merchant/RecordProvider.php
+++ b/Service/Merchant/RecordProvider.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Service\Merchant;
+
+use Magento\Framework\App\CacheInterface;
+use Magento\Framework\Serialize\Serializer\Json;
+use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
+use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
+use Two\Gateway\Service\Api\Adapter;
+
+/**
+ * Resolves the merchant record from GET /v1/merchant/{id} and caches it.
+ *
+ * The merchant endpoint is the single source of truth for the
+ * commercial values the plugin used to carry in brand.xml — the
+ * offerable payment terms, the buyer-surcharge cap, the minimum order
+ * value and the merchant's default term. This provider owns the
+ * fetch-and-cache protocol once, so every consumer (min-order gate,
+ * admin surcharge/terms config, checkout default term) reads a single
+ * cached record rather than re-implementing verify → fetch → cache.
+ *
+ * The API key authenticates but does not name the merchant;
+ * verify_api_key resolves the id the merchant endpoint needs. The
+ * resolved record is memoized per request and cached for
+ * CACHE_LIFETIME seconds, keyed on the API key so a key swap
+ * (different merchant, or sandbox <-> production) never serves the old
+ * merchant's record. A fetch failure resolves to null and is cached as
+ * such: callers degrade to their own "no value configured" behaviour
+ * rather than paying two API calls per page view on a blip.
+ */
+class RecordProvider
+{
+    private const CACHE_KEY_PREFIX = 'two_gateway_merchant_record_';
+    private const CACHE_LIFETIME = 900;
+
+    /**
+     * @var Adapter
+     */
+    private $apiAdapter;
+
+    /**
+     * @var ConfigRepository
+     */
+    private $configRepository;
+
+    /**
+     * @var CacheInterface
+     */
+    private $cache;
+
+    /**
+     * @var Json
+     */
+    private $json;
+
+    /**
+     * @var LogRepository
+     */
+    private $logRepository;
+
+    /**
+     * Per-request memo, keyed like the cache. Holds ['record' => ?array]
+     * wrappers so a resolved "no record" is distinguishable from "not
+     * yet resolved".
+     *
+     * @var array<string,array{record: ?array}>
+     */
+    private $memo = [];
+
+    public function __construct(
+        Adapter $apiAdapter,
+        ConfigRepository $configRepository,
+        CacheInterface $cache,
+        Json $json,
+        LogRepository $logRepository
+    ) {
+        $this->apiAdapter = $apiAdapter;
+        $this->configRepository = $configRepository;
+        $this->cache = $cache;
+        $this->json = $json;
+        $this->logRepository = $logRepository;
+    }
+
+    /**
+     * The merchant record from GET /v1/merchant/{id}, or null when it
+     * cannot currently be resolved (no API key, unresolvable merchant
+     * id, or a fetch failure).
+     *
+     * @return array<string,mixed>|null
+     */
+    public function getRecord(?int $storeId = null): ?array
+    {
+        $apiKey = (string)$this->configRepository->getApiKey($storeId);
+        if ($apiKey === '') {
+            return null;
+        }
+        // Key on the API key so a key swap (different merchant, or
+        // sandbox <-> production) never serves the old merchant's record.
+        $cacheKey = self::CACHE_KEY_PREFIX . hash('sha256', $apiKey);
+
+        if (isset($this->memo[$cacheKey])) {
+            return $this->memo[$cacheKey]['record'];
+        }
+
+        $cached = $this->cache->load($cacheKey);
+        if ($cached !== false) {
+            $wrapper = $this->json->unserialize($cached);
+            $this->memo[$cacheKey] = $wrapper;
+            return $wrapper['record'];
+        }
+
+        $record = $this->fetchRecord($storeId);
+
+        $wrapper = ['record' => $record];
+        $this->memo[$cacheKey] = $wrapper;
+        $this->cache->save($this->json->serialize($wrapper), $cacheKey, [], self::CACHE_LIFETIME);
+
+        return $record;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function fetchRecord(?int $storeId): ?array
+    {
+        // The API key authenticates but does not name the merchant;
+        // verify_api_key resolves the id the merchant endpoint needs.
+        $verify = $this->apiAdapter->execute('/v1/merchant/verify_api_key', [], 'GET', $storeId);
+        $merchantId = $verify['id'] ?? null;
+        if (!is_string($merchantId) || $merchantId === '') {
+            $this->logRepository->addDebugLog(
+                'RecordProvider: could not resolve merchant id, treating as no record',
+                $verify
+            );
+            return null;
+        }
+
+        $merchant = $this->apiAdapter->execute('/v1/merchant/' . $merchantId, [], 'GET', $storeId);
+
+        return is_array($merchant) ? $merchant : null;
+    }
+}

--- a/Service/Merchant/SettingsProvider.php
+++ b/Service/Merchant/SettingsProvider.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Service\Merchant;
+
+/**
+ * Merchant commercial settings, sourced from GET /v1/merchant/{id}.
+ *
+ * These values used to live in each brand's etc/brand.xml as
+ * install-time constants. They are per-merchant commercial terms —
+ * they vary between merchants of the same brand — so the merchant API
+ * is their authoritative source, resolved server-side from the
+ * merchant's pricing package / config with any partner or per-merchant
+ * override already applied.
+ *
+ * Each accessor degrades to the same "nothing configured" outcome the
+ * brand default used to express when the record cannot be resolved
+ * (empty term set, no surcharge cap, no default term): an unconfigured
+ * or invalid API key, or an API blip, must not harden into a wrong
+ * commercial constraint.
+ */
+class SettingsProvider
+{
+    /**
+     * @var RecordProvider
+     */
+    private $recordProvider;
+
+    public function __construct(RecordProvider $recordProvider)
+    {
+        $this->recordProvider = $recordProvider;
+    }
+
+    /**
+     * Offerable buyer payment terms (in net days) for the merchant.
+     * The admin narrows the buyer-facing set from this; an empty array
+     * means the set could not be resolved (the admin surfaces cannot
+     * offer terms until a valid API key resolves).
+     *
+     * @return int[]
+     */
+    public function getAvailableTerms(?int $storeId = null): array
+    {
+        $record = $this->recordProvider->getRecord($storeId);
+        if ($record === null) {
+            return [];
+        }
+        $terms = $record['available_terms'] ?? null;
+        if (!is_array($terms)) {
+            return [];
+        }
+        $days = array_filter(
+            array_map('intval', $terms),
+            static fn(int $t): bool => $t > 0
+        );
+        $days = array_values(array_unique($days));
+        sort($days);
+        return $days;
+    }
+
+    /**
+     * Maximum allowed value of a fixed-amount buyer surcharge the
+     * merchant may configure, in a specific currency. Null means no
+     * upper bound (any positive value is acceptable) — calling code
+     * must interpret null as "no max" and skip the upper-bound check.
+     *
+     * The two surcharge_limit_* fields on the merchant record travel
+     * together; a partial or malformed tuple is treated as "no cap".
+     *
+     * @return array{amount: float, currency: string}|null
+     */
+    public function getSurchargeLimit(?int $storeId = null): ?array
+    {
+        $record = $this->recordProvider->getRecord($storeId);
+        if ($record === null) {
+            return null;
+        }
+        $amount = $record['surcharge_limit_amount'] ?? null;
+        $currency = $record['surcharge_limit_currency'] ?? null;
+        if (!is_numeric($amount)
+            || (float)$amount <= 0
+            || !is_string($currency)
+            || $currency === ''
+        ) {
+            return null;
+        }
+        return [
+            'amount' => (float)$amount,
+            'currency' => strtoupper($currency),
+        ];
+    }
+
+    /**
+     * The merchant's default invoice payment term (due_in_days), in net
+     * days, or null when none is set or it cannot be resolved. Not
+     * guaranteed to be a member of getAvailableTerms(); callers honour
+     * it only when it is an offered term (see TWO-24859).
+     */
+    public function getDefaultTerm(?int $storeId = null): ?int
+    {
+        $record = $this->recordProvider->getRecord($storeId);
+        if ($record === null) {
+            return null;
+        }
+        $due = $record['due_in_days'] ?? null;
+        if (!is_numeric($due) || (int)$due <= 0) {
+            return null;
+        }
+        return (int)$due;
+    }
+}

--- a/Service/Order/MinimumOrderProvider.php
+++ b/Service/Order/MinimumOrderProvider.php
@@ -7,80 +7,34 @@ declare(strict_types=1);
 
 namespace Two\Gateway\Service\Order;
 
-use Magento\Framework\App\CacheInterface;
-use Magento\Framework\Serialize\Serializer\Json;
-use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
-use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
-use Two\Gateway\Service\Api\Adapter;
+use Two\Gateway\Service\Merchant\RecordProvider;
 
 /**
  * Resolves the merchant's minimum order value from the Two API.
  *
  * GET /v1/merchant/{id} carries the effective minimum (funding-partner
  * default with any merchant override, resolved server-side) as
- * min_order_amount / min_order_currency / min_order_basis. That response
- * is the single source of truth: the same value checkout-api enforces at
+ * min_order_amount / min_order_currency / min_order_basis. That is the
+ * single source of truth: the same value checkout-api enforces at
  * order create/intent, so the storefront gate and the server can never
  * disagree on the threshold.
  *
- * isAvailable() fires many times per page view, so the resolved tuple is
- * memoized per request and cached for CACHE_LIFETIME seconds. The "no
- * minimum configured" outcome is cached too - that is the common case and
- * must not cost two API calls per page view. A fetch failure resolves to
- * null (no minimum): the server still enforces, and hiding the payment
- * method on an API blip would be the worse failure.
+ * The merchant record is fetched and cached once by RecordProvider;
+ * this class only projects the min_order_* tuple out of it. A record
+ * that cannot be resolved (or one without a minimum) yields null: the
+ * server still enforces, and hiding the payment method on an API blip
+ * would be the worse failure.
  */
 class MinimumOrderProvider
 {
-    private const CACHE_KEY_PREFIX = 'two_gateway_minimum_order_';
-    private const CACHE_LIFETIME = 900;
-
     /**
-     * @var Adapter
+     * @var RecordProvider
      */
-    private $apiAdapter;
+    private $recordProvider;
 
-    /**
-     * @var ConfigRepository
-     */
-    private $configRepository;
-
-    /**
-     * @var CacheInterface
-     */
-    private $cache;
-
-    /**
-     * @var Json
-     */
-    private $json;
-
-    /**
-     * @var LogRepository
-     */
-    private $logRepository;
-
-    /**
-     * Per-request memo, keyed like the cache. Holds ['minimum' => ?array]
-     * wrappers so a resolved "no minimum" is distinguishable from "not
-     * yet resolved".
-     *
-     * @var array<string,array{minimum: ?array}>
-     */
-    private $memo = [];
-
-    public function __construct(
-        Adapter $apiAdapter,
-        ConfigRepository $configRepository,
-        CacheInterface $cache,
-        Json $json,
-        LogRepository $logRepository
-    ) {
-        $this->apiAdapter = $apiAdapter;
-        $this->configRepository = $configRepository;
-        $this->cache = $cache;
-        $this->json = $json;
-        $this->logRepository = $logRepository;
+    public function __construct(RecordProvider $recordProvider)
+    {
+        $this->recordProvider = $recordProvider;
     }
 
     /**
@@ -91,53 +45,19 @@ class MinimumOrderProvider
      */
     public function getMinimum(?int $storeId = null): ?array
     {
-        $apiKey = (string)$this->configRepository->getApiKey($storeId);
-        if ($apiKey === '') {
+        $record = $this->recordProvider->getRecord($storeId);
+        if ($record === null) {
             return null;
         }
-        // Key on the API key so a key swap (different merchant, or
-        // sandbox <-> production) never serves the old merchant's minimum.
-        $cacheKey = self::CACHE_KEY_PREFIX . hash('sha256', $apiKey);
-
-        if (isset($this->memo[$cacheKey])) {
-            return $this->memo[$cacheKey]['minimum'];
-        }
-
-        $cached = $this->cache->load($cacheKey);
-        if ($cached !== false) {
-            $wrapper = $this->json->unserialize($cached);
-            $this->memo[$cacheKey] = $wrapper;
-            return $wrapper['minimum'];
-        }
-
-        $minimum = $this->fetchMinimum($storeId);
-
-        $wrapper = ['minimum' => $minimum];
-        $this->memo[$cacheKey] = $wrapper;
-        $this->cache->save($this->json->serialize($wrapper), $cacheKey, [], self::CACHE_LIFETIME);
-
-        return $minimum;
+        return $this->parseMinimum($record);
     }
 
     /**
+     * @param array<string,mixed> $merchant
      * @return array{amount: float, currency: string, basis: string}|null
      */
-    private function fetchMinimum(?int $storeId): ?array
+    private function parseMinimum(array $merchant): ?array
     {
-        // The API key authenticates but does not name the merchant;
-        // verify_api_key resolves the id the merchant endpoint needs.
-        $verify = $this->apiAdapter->execute('/v1/merchant/verify_api_key', [], 'GET', $storeId);
-        $merchantId = $verify['id'] ?? null;
-        if (!is_string($merchantId) || $merchantId === '') {
-            $this->logRepository->addDebugLog(
-                'MinimumOrderProvider: could not resolve merchant id, treating as no minimum',
-                $verify
-            );
-            return null;
-        }
-
-        $merchant = $this->apiAdapter->execute('/v1/merchant/' . $merchantId, [], 'GET', $storeId);
-
         $amount = $merchant['min_order_amount'] ?? null;
         $currency = $merchant['min_order_currency'] ?? null;
         $basis = $merchant['min_order_basis'] ?? null;

--- a/Test/Unit/Model/Config/Backend/SurchargeGridTest.php
+++ b/Test/Unit/Model/Config/Backend/SurchargeGridTest.php
@@ -246,8 +246,9 @@ class SurchargeGridTestable
         }
         unset($value['__inherit']);
 
-        // Hard-coded to the test brand's surcharge bound — see
-        // BrandRegistryInterface::getSurchargeFixedMax().
+        // Hard-coded to the merchant's surcharge cap for this test — in
+        // production it comes from SettingsProvider::getSurchargeLimit()
+        // (the GET /v1/merchant surcharge_limit).
         $maxFixed = 25;
         $maxPercentage = ConfigRepository::SURCHARGE_PERCENTAGE_MAX;
 

--- a/Test/Unit/Model/Config/RepositoryPaymentTermsTest.php
+++ b/Test/Unit/Model/Config/RepositoryPaymentTermsTest.php
@@ -211,24 +211,40 @@ class RepositoryPaymentTermsTest extends TestCase
         $this->assertEquals(30, $this->repository->getDefaultPaymentTerm());
     }
 
-    public function testGetDefaultPaymentTermPrefersApiTermWhenOffered(): void
+    public function testGetDefaultPaymentTermAdminChoiceWinsOverApi(): void
     {
-        // The merchant's due_in_days (from GET /v1/merchant) is
-        // authoritative and wins over the admin-configured default when
-        // it is one of the offered buyer terms.
+        // An explicit admin-configured default (when offered) is the
+        // admin's own choice and must NOT be silently overridden by the
+        // merchant's due_in_days (TWO-24859). The API default only seeds
+        // the field when the admin hasn't chosen — see the unset test.
         $this->settingsProvider->method('getDefaultTerm')->willReturn(90);
         $this->stubConfig([
             'payment/two_payment/default_payment_term' => '30',
             'payment/two_payment/payment_terms' => '30,60,90',
             'payment/two_payment/payment_terms_duration_days' => '',
         ]);
-        $this->assertEquals(90, $this->repository->getDefaultPaymentTerm());
+        $this->assertEquals(30, $this->repository->getDefaultPaymentTerm());
+    }
+
+    public function testGetDefaultPaymentTermUsesApiDefaultWhenAdminUnset(): void
+    {
+        // No explicit admin choice (config.xml carries no static default):
+        // fall back to the merchant's due_in_days when it is an offered
+        // term, so a never-touched install matches what the admin field
+        // pre-selects.
+        $this->settingsProvider->method('getDefaultTerm')->willReturn(60);
+        $this->stubConfig([
+            'payment/two_payment/default_payment_term' => '',
+            'payment/two_payment/payment_terms' => '30,60,90',
+            'payment/two_payment/payment_terms_duration_days' => '',
+        ]);
+        $this->assertEquals(60, $this->repository->getDefaultPaymentTerm());
     }
 
     public function testGetDefaultPaymentTermIgnoresApiTermOutsideOfferedTerms(): void
     {
         // due_in_days is not guaranteed to be an offered term; when it
-        // isn't, fall through to the admin-configured default.
+        // isn't, fall through (here to the admin-configured default).
         $this->settingsProvider->method('getDefaultTerm')->willReturn(14);
         $this->stubConfig([
             'payment/two_payment/default_payment_term' => '60',

--- a/Test/Unit/Model/Config/RepositoryPaymentTermsTest.php
+++ b/Test/Unit/Model/Config/RepositoryPaymentTermsTest.php
@@ -12,6 +12,7 @@ use Magento\Tax\Model\Calculation as TaxCalculation;
 use PHPUnit\Framework\TestCase;
 use Two\Gateway\Api\BrandRegistryInterface;
 use Two\Gateway\Model\Config\Repository;
+use Two\Gateway\Service\Merchant\SettingsProvider;
 
 class RepositoryPaymentTermsTest extends TestCase
 {
@@ -20,6 +21,9 @@ class RepositoryPaymentTermsTest extends TestCase
 
     /** @var TaxCalculation|\PHPUnit\Framework\MockObject\MockObject */
     private $taxCalculation;
+
+    /** @var SettingsProvider|\PHPUnit\Framework\MockObject\MockObject */
+    private $settingsProvider;
 
     /** @var Repository */
     private $repository;
@@ -35,13 +39,19 @@ class RepositoryPaymentTermsTest extends TestCase
         $brandRegistry = $this->createMock(BrandRegistryInterface::class);
         $brandRegistry->method('getCode')->willReturn('two_payment');
 
+        // Unstubbed getDefaultTerm() returns null, so the default-term
+        // tests below exercise the config-based fallback; the API-default
+        // cases stub it explicitly.
+        $this->settingsProvider = $this->createMock(SettingsProvider::class);
+
         $this->repository = new Repository(
             $this->scopeConfig,
             $this->createMock(EncryptorInterface::class),
             $this->createMock(UrlInterface::class),
             $this->createMock(ProductMetadataInterface::class),
             $this->taxCalculation,
-            $brandRegistry
+            $brandRegistry,
+            $this->settingsProvider
         );
     }
 
@@ -199,6 +209,33 @@ class RepositoryPaymentTermsTest extends TestCase
             'payment/two_payment/payment_terms_duration_days' => '',
         ]);
         $this->assertEquals(30, $this->repository->getDefaultPaymentTerm());
+    }
+
+    public function testGetDefaultPaymentTermPrefersApiTermWhenOffered(): void
+    {
+        // The merchant's due_in_days (from GET /v1/merchant) is
+        // authoritative and wins over the admin-configured default when
+        // it is one of the offered buyer terms.
+        $this->settingsProvider->method('getDefaultTerm')->willReturn(90);
+        $this->stubConfig([
+            'payment/two_payment/default_payment_term' => '30',
+            'payment/two_payment/payment_terms' => '30,60,90',
+            'payment/two_payment/payment_terms_duration_days' => '',
+        ]);
+        $this->assertEquals(90, $this->repository->getDefaultPaymentTerm());
+    }
+
+    public function testGetDefaultPaymentTermIgnoresApiTermOutsideOfferedTerms(): void
+    {
+        // due_in_days is not guaranteed to be an offered term; when it
+        // isn't, fall through to the admin-configured default.
+        $this->settingsProvider->method('getDefaultTerm')->willReturn(14);
+        $this->stubConfig([
+            'payment/two_payment/default_payment_term' => '60',
+            'payment/two_payment/payment_terms' => '30,60,90',
+            'payment/two_payment/payment_terms_duration_days' => '',
+        ]);
+        $this->assertEquals(60, $this->repository->getDefaultPaymentTerm());
     }
 
     // ── getSurchargeType ─────────────────────────────────────────────

--- a/Test/Unit/Model/Config/RepositoryUrlTest.php
+++ b/Test/Unit/Model/Config/RepositoryUrlTest.php
@@ -11,6 +11,7 @@ use Magento\Tax\Model\Calculation as TaxCalculation;
 use PHPUnit\Framework\TestCase;
 use Two\Gateway\Api\BrandRegistryInterface;
 use Two\Gateway\Model\Config\Repository;
+use Two\Gateway\Service\Merchant\SettingsProvider;
 
 /**
  * Tests for URL generation in Config\Repository:
@@ -42,7 +43,8 @@ class RepositoryUrlTest extends TestCase
             $urlBuilder,
             $productMetadata,
             $this->createMock(TaxCalculation::class),
-            $brand
+            $brand,
+            $this->createMock(SettingsProvider::class)
         );
     }
 

--- a/Test/Unit/Service/Merchant/RecordProviderTest.php
+++ b/Test/Unit/Service/Merchant/RecordProviderTest.php
@@ -1,0 +1,140 @@
+<?php
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Service\Merchant;
+
+use Magento\Framework\App\CacheInterface;
+use Magento\Framework\Serialize\Serializer\Json;
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
+use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
+use Two\Gateway\Service\Api\Adapter;
+use Two\Gateway\Service\Merchant\RecordProvider;
+
+class RecordProviderTest extends TestCase
+{
+    /** @var Adapter|\PHPUnit\Framework\MockObject\MockObject */
+    private $apiAdapter;
+
+    /** @var CacheInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $cache;
+
+    /** @var RecordProvider */
+    private $provider;
+
+    protected function setUp(): void
+    {
+        $this->apiAdapter = $this->createMock(Adapter::class);
+        $configRepository = $this->createMock(ConfigRepository::class);
+        $configRepository->method('getApiKey')->willReturn('test-api-key');
+        $this->cache = $this->createMock(CacheInterface::class);
+        $this->cache->method('load')->willReturn(false);
+
+        $this->provider = new RecordProvider(
+            $this->apiAdapter,
+            $configRepository,
+            $this->cache,
+            new Json(),
+            $this->createMock(LogRepository::class)
+        );
+    }
+
+    private function stubApi(array $verifyResponse, array $merchantResponse = []): void
+    {
+        $this->apiAdapter->method('execute')->willReturnCallback(
+            function (string $endpoint) use ($verifyResponse, $merchantResponse) {
+                return $endpoint === '/v1/merchant/verify_api_key' ? $verifyResponse : $merchantResponse;
+            }
+        );
+    }
+
+    public function testResolvesRecordFromMerchantEndpoint(): void
+    {
+        $record = [
+            'id' => 'abc-123',
+            'available_terms' => [30, 60, 90],
+            'surcharge_limit_amount' => '25.00',
+            'surcharge_limit_currency' => 'EUR',
+        ];
+        $this->stubApi(['id' => 'abc-123'], $record);
+
+        $this->assertSame($record, $this->provider->getRecord(1));
+    }
+
+    public function testUnresolvableMerchantIdResolvesToNull(): void
+    {
+        $this->stubApi(['error' => 'unauthorized']);
+
+        $this->assertNull($this->provider->getRecord(1));
+    }
+
+    public function testNoApiKeyShortCircuitsWithoutApiCall(): void
+    {
+        $configRepository = $this->createMock(ConfigRepository::class);
+        $configRepository->method('getApiKey')->willReturn('');
+        $this->apiAdapter->expects($this->never())->method('execute');
+
+        $provider = new RecordProvider(
+            $this->apiAdapter,
+            $configRepository,
+            $this->cache,
+            new Json(),
+            $this->createMock(LogRepository::class)
+        );
+
+        $this->assertNull($provider->getRecord(1));
+    }
+
+    public function testMemoisesWithinTheRequest(): void
+    {
+        // Multiple consumers (min-order gate, admin terms/surcharge, default
+        // term) hit the record per request; it must cost one verify + one
+        // merchant fetch, not one pair per consumer.
+        $this->apiAdapter->expects($this->exactly(2))->method('execute')->willReturnCallback(
+            function (string $endpoint) {
+                return $endpoint === '/v1/merchant/verify_api_key'
+                    ? ['id' => 'abc-123']
+                    : ['id' => 'abc-123', 'available_terms' => [30, 60, 90]];
+            }
+        );
+
+        $first = $this->provider->getRecord(1);
+        $second = $this->provider->getRecord(1);
+
+        $this->assertSame($first, $second);
+    }
+
+    public function testCacheHitSkipsTheApi(): void
+    {
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->method('load')->willReturn('{"record":{"available_terms":[30,60,90]}}');
+        $this->apiAdapter->expects($this->never())->method('execute');
+
+        $configRepository = $this->createMock(ConfigRepository::class);
+        $configRepository->method('getApiKey')->willReturn('test-api-key');
+        $provider = new RecordProvider(
+            $this->apiAdapter,
+            $configRepository,
+            $cache,
+            new Json(),
+            $this->createMock(LogRepository::class)
+        );
+
+        $this->assertSame(['available_terms' => [30, 60, 90]], $provider->getRecord(1));
+    }
+
+    public function testCachesTheNullOutcome(): void
+    {
+        // An unresolvable merchant is the degraded case and must not cost
+        // two API calls per page view: the resolved null is cached too.
+        $this->stubApi(['error' => 'unauthorized']);
+        $this->cache->expects($this->once())->method('save')->with(
+            '{"record":null}',
+            $this->stringContains('two_gateway_merchant_record_'),
+            [],
+            900
+        );
+
+        $this->assertNull($this->provider->getRecord(1));
+    }
+}

--- a/Test/Unit/Service/Merchant/RecordProviderTest.php
+++ b/Test/Unit/Service/Merchant/RecordProviderTest.php
@@ -123,18 +123,41 @@ class RecordProviderTest extends TestCase
         $this->assertSame(['available_terms' => [30, 60, 90]], $provider->getRecord(1));
     }
 
-    public function testCachesTheNullOutcome(): void
+    public function testMerchantErrorPayloadResolvesToNull(): void
     {
-        // An unresolvable merchant is the degraded case and must not cost
-        // two API calls per page view: the resolved null is cached too.
-        $this->stubApi(['error' => 'unauthorized']);
+        // Adapter::execute returns an error dict (with error_code) on a
+        // failed merchant fetch, not a merchant record — it must resolve to
+        // null, not be treated as the record.
+        $this->stubApi(['id' => 'abc-123'], ['error_code' => 400, 'error_message' => 'boom']);
+
+        $this->assertNull($this->provider->getRecord(1));
+    }
+
+    public function testDoesNotCacheFailureSoNextRequestRetries(): void
+    {
+        // A fetch failure is NOT persisted to the cross-request cache, so a
+        // later page view retries rather than serving a 900s-stale "no
+        // record" (TWO-24952). We can't protect the first read during an
+        // outage, but recovery must not wait out the cache lifetime.
+        $this->stubApi(['id' => 'abc-123'], ['http_status' => 503]);
+        $this->cache->expects($this->never())->method('save');
+
+        $this->assertNull($this->provider->getRecord(1));
+    }
+
+    public function testCachesSuccessfulRecord(): void
+    {
+        // A successful record IS written to the cross-request cache for the
+        // full lifetime, so subsequent requests skip the verify+fetch pair.
+        $record = ['id' => 'abc-123', 'available_terms' => [30, 60, 90]];
+        $this->stubApi(['id' => 'abc-123'], $record);
         $this->cache->expects($this->once())->method('save')->with(
-            '{"record":null}',
+            $this->stringContains('"available_terms"'),
             $this->stringContains('two_gateway_merchant_record_'),
             [],
             900
         );
 
-        $this->assertNull($this->provider->getRecord(1));
+        $this->assertSame($record, $this->provider->getRecord(1));
     }
 }

--- a/Test/Unit/Service/Merchant/SettingsProviderTest.php
+++ b/Test/Unit/Service/Merchant/SettingsProviderTest.php
@@ -1,0 +1,129 @@
+<?php
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Service\Merchant;
+
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Service\Merchant\RecordProvider;
+use Two\Gateway\Service\Merchant\SettingsProvider;
+
+class SettingsProviderTest extends TestCase
+{
+    /** @var RecordProvider|\PHPUnit\Framework\MockObject\MockObject */
+    private $recordProvider;
+
+    /** @var SettingsProvider */
+    private $provider;
+
+    protected function setUp(): void
+    {
+        $this->recordProvider = $this->createMock(RecordProvider::class);
+        $this->provider = new SettingsProvider($this->recordProvider);
+    }
+
+    private function stubRecord(?array $record): void
+    {
+        $this->recordProvider->method('getRecord')->willReturn($record);
+    }
+
+    // --- getAvailableTerms ---
+
+    public function testAvailableTermsAreIntsSortedAscending(): void
+    {
+        $this->stubRecord(['available_terms' => [90, 30, 60]]);
+
+        $this->assertSame([30, 60, 90], $this->provider->getAvailableTerms(1));
+    }
+
+    public function testAvailableTermsDropsNonPositiveAndDedupes(): void
+    {
+        $this->stubRecord(['available_terms' => [30, 0, -5, 30, 60]]);
+
+        $this->assertSame([30, 60], $this->provider->getAvailableTerms(1));
+    }
+
+    public function testAvailableTermsEmptyWhenRecordUnresolved(): void
+    {
+        $this->stubRecord(null);
+
+        $this->assertSame([], $this->provider->getAvailableTerms(1));
+    }
+
+    public function testAvailableTermsEmptyWhenFieldMissingOrNotArray(): void
+    {
+        $this->stubRecord(['id' => 'abc-123']);
+
+        $this->assertSame([], $this->provider->getAvailableTerms(1));
+    }
+
+    // --- getSurchargeLimit ---
+
+    public function testSurchargeLimitResolvedFromRecord(): void
+    {
+        $this->stubRecord([
+            'surcharge_limit_amount' => '25.00',
+            'surcharge_limit_currency' => 'EUR',
+        ]);
+
+        $this->assertSame(
+            ['amount' => 25.0, 'currency' => 'EUR'],
+            $this->provider->getSurchargeLimit(1)
+        );
+    }
+
+    public function testSurchargeLimitNullWhenBothFieldsAbsent(): void
+    {
+        // Both fields travel together; absent = no cap (unrestricted).
+        $this->stubRecord(['id' => 'abc-123']);
+
+        $this->assertNull($this->provider->getSurchargeLimit(1));
+    }
+
+    public function testSurchargeLimitNullOnPartialTuple(): void
+    {
+        $this->stubRecord(['surcharge_limit_amount' => '25.00']);
+
+        $this->assertNull($this->provider->getSurchargeLimit(1));
+    }
+
+    public function testSurchargeLimitNormalisesCurrencyCase(): void
+    {
+        $this->stubRecord([
+            'surcharge_limit_amount' => '25.00',
+            'surcharge_limit_currency' => 'eur',
+        ]);
+
+        $limit = $this->provider->getSurchargeLimit(1);
+        $this->assertSame('EUR', $limit['currency']);
+    }
+
+    public function testSurchargeLimitNullWhenRecordUnresolved(): void
+    {
+        $this->stubRecord(null);
+
+        $this->assertNull($this->provider->getSurchargeLimit(1));
+    }
+
+    // --- getDefaultTerm ---
+
+    public function testDefaultTermFromDueInDays(): void
+    {
+        $this->stubRecord(['due_in_days' => 30]);
+
+        $this->assertSame(30, $this->provider->getDefaultTerm(1));
+    }
+
+    public function testDefaultTermNullWhenAbsentOrNonPositive(): void
+    {
+        $this->stubRecord(['due_in_days' => 0]);
+
+        $this->assertNull($this->provider->getDefaultTerm(1));
+    }
+
+    public function testDefaultTermNullWhenRecordUnresolved(): void
+    {
+        $this->stubRecord(null);
+
+        $this->assertNull($this->provider->getDefaultTerm(1));
+    }
+}

--- a/Test/Unit/Service/Order/MinimumOrderProviderTest.php
+++ b/Test/Unit/Service/Order/MinimumOrderProviderTest.php
@@ -3,55 +3,32 @@ declare(strict_types=1);
 
 namespace Two\Gateway\Test\Unit\Service\Order;
 
-use Magento\Framework\App\CacheInterface;
-use Magento\Framework\Serialize\Serializer\Json;
 use PHPUnit\Framework\TestCase;
-use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
-use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
-use Two\Gateway\Service\Api\Adapter;
+use Two\Gateway\Service\Merchant\RecordProvider;
 use Two\Gateway\Service\Order\MinimumOrderProvider;
 
 class MinimumOrderProviderTest extends TestCase
 {
-    /** @var Adapter|\PHPUnit\Framework\MockObject\MockObject */
-    private $apiAdapter;
-
-    /** @var CacheInterface|\PHPUnit\Framework\MockObject\MockObject */
-    private $cache;
+    /** @var RecordProvider|\PHPUnit\Framework\MockObject\MockObject */
+    private $recordProvider;
 
     /** @var MinimumOrderProvider */
     private $provider;
 
     protected function setUp(): void
     {
-        $this->apiAdapter = $this->createMock(Adapter::class);
-        $configRepository = $this->createMock(ConfigRepository::class);
-        $configRepository->method('getApiKey')->willReturn('test-api-key');
-        $this->cache = $this->createMock(CacheInterface::class);
-        $this->cache->method('load')->willReturn(false);
-
-        $this->provider = new MinimumOrderProvider(
-            $this->apiAdapter,
-            $configRepository,
-            $this->cache,
-            new Json(),
-            $this->createMock(LogRepository::class)
-        );
+        $this->recordProvider = $this->createMock(RecordProvider::class);
+        $this->provider = new MinimumOrderProvider($this->recordProvider);
     }
 
-    private function stubApi(array $verifyResponse, array $merchantResponse = []): void
+    private function stubRecord(?array $record): void
     {
-        $this->apiAdapter->method('execute')->willReturnCallback(
-            function (string $endpoint) use ($verifyResponse, $merchantResponse) {
-                return $endpoint === '/v1/merchant/verify_api_key' ? $verifyResponse : $merchantResponse;
-            }
-        );
+        $this->recordProvider->method('getRecord')->willReturn($record);
     }
 
-    public function testResolvesMinimumFromMerchantEndpoint(): void
+    public function testResolvesMinimumFromMerchantRecord(): void
     {
-        $this->stubApi(['id' => 'abc-123'], [
-            'id' => 'abc-123',
+        $this->stubRecord([
             'min_order_amount' => '250.00',
             'min_order_currency' => 'EUR',
             'min_order_basis' => 'net',
@@ -63,18 +40,18 @@ class MinimumOrderProviderTest extends TestCase
         );
     }
 
-    public function testNoMinimumWhenApiOmitsTheTuple(): void
+    public function testNoMinimumWhenRecordOmitsTheTuple(): void
     {
-        // The common case: merchant has no minimum configured, the API
+        // The common case: merchant has no minimum configured, the record
         // omits all three fields.
-        $this->stubApi(['id' => 'abc-123'], ['id' => 'abc-123']);
+        $this->stubRecord(['id' => 'abc-123']);
 
         $this->assertNull($this->provider->getMinimum(1));
     }
 
     public function testPartialTupleResolvesToNoMinimum(): void
     {
-        $this->stubApi(['id' => 'abc-123'], [
+        $this->stubRecord([
             'min_order_amount' => '250.00',
             'min_order_currency' => 'EUR',
             // basis missing - never gate on a guessed tax basis
@@ -83,92 +60,18 @@ class MinimumOrderProviderTest extends TestCase
         $this->assertNull($this->provider->getMinimum(1));
     }
 
-    public function testUnresolvableMerchantIdResolvesToNoMinimum(): void
+    public function testNullRecordResolvesToNoMinimum(): void
     {
-        $this->stubApi(['error' => 'unauthorized']);
-
-        $this->assertNull($this->provider->getMinimum(1));
-    }
-
-    public function testNoApiKeyShortCircuitsWithoutApiCall(): void
-    {
-        $configRepository = $this->createMock(ConfigRepository::class);
-        $configRepository->method('getApiKey')->willReturn('');
-        $this->apiAdapter->expects($this->never())->method('execute');
-
-        $provider = new MinimumOrderProvider(
-            $this->apiAdapter,
-            $configRepository,
-            $this->cache,
-            new Json(),
-            $this->createMock(LogRepository::class)
-        );
-
-        $this->assertNull($provider->getMinimum(1));
-    }
-
-    public function testMemoisesWithinTheRequest(): void
-    {
-        // isAvailable() fires many times per page view; two getMinimum()
-        // calls must cost one verify + one merchant fetch, not two.
-        $this->apiAdapter->expects($this->exactly(2))->method('execute')->willReturnCallback(
-            function (string $endpoint) {
-                return $endpoint === '/v1/merchant/verify_api_key'
-                    ? ['id' => 'abc-123']
-                    : [
-                        'min_order_amount' => '250.00',
-                        'min_order_currency' => 'EUR',
-                        'min_order_basis' => 'net',
-                    ];
-            }
-        );
-
-        $first = $this->provider->getMinimum(1);
-        $second = $this->provider->getMinimum(1);
-
-        $this->assertSame($first, $second);
-    }
-
-    public function testCacheHitSkipsTheApi(): void
-    {
-        $cache = $this->createMock(CacheInterface::class);
-        $cache->method('load')->willReturn('{"minimum":{"amount":250.0,"currency":"EUR","basis":"net"}}');
-        $this->apiAdapter->expects($this->never())->method('execute');
-
-        $configRepository = $this->createMock(ConfigRepository::class);
-        $configRepository->method('getApiKey')->willReturn('test-api-key');
-        $provider = new MinimumOrderProvider(
-            $this->apiAdapter,
-            $configRepository,
-            $cache,
-            new Json(),
-            $this->createMock(LogRepository::class)
-        );
-
-        $this->assertSame(
-            ['amount' => 250.0, 'currency' => 'EUR', 'basis' => 'net'],
-            $provider->getMinimum(1)
-        );
-    }
-
-    public function testCachesTheNoMinimumOutcome(): void
-    {
-        // "No minimum" is the common case and must not cost two API calls
-        // per page view: the resolved null is cached like a real tuple.
-        $this->stubApi(['id' => 'abc-123'], ['id' => 'abc-123']);
-        $this->cache->expects($this->once())->method('save')->with(
-            '{"minimum":null}',
-            $this->stringContains('two_gateway_minimum_order_'),
-            [],
-            900
-        );
+        // Unresolvable merchant / API blip / no key: RecordProvider yields
+        // null and the gate degrades to "no minimum" (the server enforces).
+        $this->stubRecord(null);
 
         $this->assertNull($this->provider->getMinimum(1));
     }
 
     public function testNormalisesCurrencyCase(): void
     {
-        $this->stubApi(['id' => 'abc-123'], [
+        $this->stubRecord([
             'min_order_amount' => '250.00',
             'min_order_currency' => 'eur',
             'min_order_basis' => 'net',

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -181,6 +181,7 @@
                     <label>Default Payment Term</label>
                     <comment>Select the payment term that will be automatically selected for your customer.</comment>
                     <source_model>Two\Gateway\Model\Config\Source\AvailablePaymentTerms</source_model>
+                    <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\DefaultPaymentTerm</frontend_model>
                     <config_path>payment/two_payment/default_payment_term</config_path>
                 </field>
                 <field id="surcharge_type" translate="label comment" type="select" sortOrder="50" showInDefault="1"

--- a/etc/brand.xml
+++ b/etc/brand.xml
@@ -22,12 +22,6 @@
         <sign_up_url>https://portal.two.inc/auth/merchant/signup</sign_up_url>
         <documentation_url>https://docs.two.inc/developer-portal/plugins/magento</documentation_url>
         <api_base_url>https://api.two.inc</api_base_url>
-        <available_payment_terms>
-            <term>14</term>
-            <term>30</term>
-            <term>60</term>
-            <term>90</term>
-        </available_payment_terms>
         <surcharge_rounding_steps>
             <step>0.10</step>
             <step>0.50</step>

--- a/etc/brand.xsd
+++ b/etc/brand.xsd
@@ -35,7 +35,15 @@
             <xs:element name="sign_up_url" type="xs:string" minOccurs="0"/>
             <xs:element name="documentation_url" type="xs:string" minOccurs="0"/>
             <xs:element name="api_base_url" type="xs:string"/>
-            <xs:element name="available_payment_terms" type="paymentTermsType"/>
+            <!--
+                DEPRECATED, ignored by Loader: the offerable payment terms
+                and the buyer-surcharge cap are now sourced per-merchant
+                from GET /v1/merchant (available_terms / surcharge_limit),
+                not from brand.xml. Kept optional in the schema so brand.xml
+                files carrying the legacy elements still validate during the
+                transition; remove once no brand.xml declares them.
+            -->
+            <xs:element name="available_payment_terms" type="paymentTermsType" minOccurs="0"/>
             <xs:element name="surcharge_fixed_max" type="surchargeFixedMaxType" minOccurs="0"/>
             <!--
                 Buyer-surcharge rounding steps offered in the admin

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -48,7 +48,12 @@
                 <payment_terms_type>standard</payment_terms_type>
                 <payment_terms_duration_days/>
                 <payment_terms>14,30,60,90</payment_terms>
-                <default_payment_term>30</default_payment_term>
+                <!-- No static default: the merchant API's due_in_days seeds the
+                     admin field's default (see the DefaultPaymentTerm
+                     frontend_model), and an empty stored value lets the runtime
+                     resolver tell "admin never chose" from "admin chose", so an
+                     explicit admin choice is never silently overridden by the
+                     API (TWO-24859). -->
                 <surcharge_type>none</surcharge_type>
                 <surcharge_differential>0</surcharge_differential>
                 <surcharge_line_description>Payment terms fee - %1 days</surcharge_line_description>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -9,6 +9,18 @@
         xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <preference for="Two\Gateway\Api\Config\RepositoryInterface"
                 type="Two\Gateway\Model\Config\Repository"/>
+    <!--
+        SettingsProvider resolves the merchant record via the API key
+        this Repository owns, so it is injected as a \Proxy to break the
+        construction cycle (Repository → SettingsProvider → RecordProvider
+        → ConfigRepository). The proxy defers instantiation until
+        getDefaultPaymentTerm() first reads the merchant's default term.
+    -->
+    <type name="Two\Gateway\Model\Config\Repository">
+        <arguments>
+            <argument name="settingsProvider" xsi:type="object">Two\Gateway\Service\Merchant\SettingsProvider\Proxy</argument>
+        </arguments>
+    </type>
     <preference for="Two\Gateway\Api\Log\RepositoryInterface"
                 type="Two\Gateway\Model\Log\Repository"/>
     <preference for="Two\Gateway\Api\Webapi\SoleTraderInterface"


### PR DESCRIPTION
## What

The offerable payment terms, the buyer-surcharge cap and the merchant's default term are **per-merchant commercial values** — they vary between merchants of the same brand — so `GET /v1/merchant` is their authoritative source, not `brand.xml`. This mirrors the minimum-order-value pattern already in the plugin.

## End state

- **`Service/Merchant/RecordProvider`** — one `verify_api_key → GET /v1/merchant` fetch, memoised per request and cached per API key. Single source of the merchant record for every consumer. Only a **successful** fetch is cached; a failure resolves to null and is left uncached so the next request retries rather than serving a stale "no record" for the cache lifetime.
- **`Service/Merchant/SettingsProvider`** — `getAvailableTerms` (`available_terms`), `getSurchargeLimit` (`surcharge_limit`), `getDefaultTerm` (`due_in_days`).
- **`MinimumOrderProvider`** now consumes `RecordProvider` (parsing only); its fetch/cache protocol moved into the shared provider — no behaviour change.
- Admin **payment-terms** + **surcharge-grid** blocks and the `AvailablePaymentTerms` source model read the offerable terms and the surcharge cap from the merchant API. The admin still narrows the buyer-facing term set.
- **Default payment term** — the merchant's `due_in_days` **seeds the admin field's default** (via a new `DefaultPaymentTerm` frontend_model) and the runtime resolver's fallback, but does **not** override an explicit admin choice: an admin-saved value always wins. The static `config.xml` default was removed so an empty stored value genuinely means "admin never chose"; `getDefaultPaymentTerm` returns the admin value when set, else `due_in_days` when offered, else the lowest available term (single-available-term preselect preserved). `SettingsProvider` is injected into `ConfigRepository` via a `\Proxy` to break the construction cycle.
- Removes the now-unused `getAvailablePaymentTerms` / `getSurchargeFixedMax` from `BrandRegistryInterface` and its implementors, the `Descriptor` fields/getters, the `Loader` parse, and `<available_payment_terms>` from the vanilla `brand.xml`. `brand.xsd` keeps the elements optional for the transition.

## Scope / companion

Vanilla-engine half. A companion overlay PR removes the now-inert `<available_payment_terms>` + `<surcharge_fixed_max>` from the partner overlay `brand.xml` (they go dormant the moment this merges). Targets `staging`.

## Surcharge cap: fail-open

The buyer-surcharge cap is enforced **plugin-side** (admin-config guardrail), not server-side — server-side enforcement isn't achievable without significant mess, so the behaviour is deliberately **fail-open**: if the merchant API returns no surcharge limit the cap is treated as "no max" rather than blocking. Accepted trade-off, consistent with the min-order fail-open philosophy.

## Fresh-install note

When the API key is unset/invalid the offerable-terms set resolves empty (the admin can't offer terms until the key validates) — accepted, since a valid key always returns a non-empty set.

## Tests

Unit tests cover: the flipped default-term precedence (admin choice wins, API seeds the unset default), and `RecordProvider` caching only successful records + resolving error payloads to null. `phpstan` + `setup:di:compile` run in CI.

---
_PR description authored by Claude (Doug's session)._
