### PR TITLE
TWO-24998: make Magento version-combination CI coverage honest (classifier + skip surfacing)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          matrix=$(./dev/magento-support-matrix.sh --emit-matrix)
-          skips=$(./dev/magento-support-matrix.sh --emit-skips)
-          php_lint_matrix=$(./dev/magento-support-matrix.sh --emit-php-lint-matrix)
+          # One classification, sliced three ways — so the run/skip/lint lists
+          # are always mutually consistent (a transient image-probe blip can't
+          # land a combo in one list but not its mirror) and we hit upstream +
+          # Docker Hub once, not 3x (review: brtkwr on #237).
+          all=$(./dev/magento-support-matrix.sh --emit-all)
+          matrix=$(echo "$all" | jq -c '.matrix')
+          skips=$(echo "$all" | jq -c '.skips')
+          php_lint_matrix=$(echo "$all" | jq -c '.php_lint')
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
           echo "php_lint_matrix=$php_lint_matrix" >> "$GITHUB_OUTPUT"
           echo "Runnable PHPStan / DI-compile matrix:"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,35 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           matrix=$(./dev/magento-support-matrix.sh --emit-matrix)
+          skips=$(./dev/magento-support-matrix.sh --emit-skips)
           php_lint_matrix=$(./dev/magento-support-matrix.sh --emit-php-lint-matrix)
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
           echo "php_lint_matrix=$php_lint_matrix" >> "$GITHUB_OUTPUT"
-          echo "Generated PHPStan / DI-compile matrix:"
+          echo "Runnable PHPStan / DI-compile matrix:"
           echo "$matrix" | jq .
+          echo "Skipped (NOT tested) combinations:"
+          echo "$skips" | jq .
           echo "Generated PHP lint matrix:"
           echo "$php_lint_matrix" | jq .
+
+          # The run/skip decision is made HERE, at matrix-assembly time — the
+          # test jobs only ever receive runnable combos, so a green test leg
+          # always means "tested" (TWO-24998). Untestable combos never become
+          # green legs; instead they are surfaced two ways that read clearly as
+          # "not run" at a glance:
+          #   1. a coverage table in this job's step summary, and
+          #   2. one ::warning:: annotation per skipped combo (yellow, shown on
+          #      the run summary — distinct from a green pass).
+          {
+            echo "## Magento × PHP version coverage"
+            echo ""
+            echo "| Magento | PHP | Status | Reason |"
+            echo "|---|---|---|---|"
+            echo "$matrix" | jq -r '.[] | "| \(.magento) | \(.php) | ✅ tested | |"'
+            echo "$skips"  | jq -r '.[] | "| \(.magento) | \(.php) | 🚫 NOT run | \(.skip_reason) |"'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "$skips" | jq -r '.[]
+            | "::warning title=Combination NOT tested::\(.magento) / PHP \(.php) — \(.skip_reason)"'
 
   lint:
     name: Lint (PHP ${{ matrix.php }})
@@ -121,37 +143,16 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.discover-magento-matrix.outputs.matrix) }}
     steps:
-      # Honour the classifier's run/skip tag (TWO-24998). A `skip` combo
-      # records its reason to the step summary + a ::warning:: and every
-      # later step gates off — the leg shows green (GHA can't paint a
-      # matrix leg grey; job-level `if:` is evaluated before matrix
-      # expansion) but carries its reason in plain, greppable text.
-      - name: Classify combo
-        id: classify
-        run: |
-          if [ "${{ matrix.status }}" = "skip" ]; then
-            {
-              echo "### ⏭️ PHPStan — ${{ matrix.magento }} / PHP ${{ matrix.php }} — SKIPPED"
-              echo ""
-              echo "Reason: ${{ matrix.skip_reason }}"
-            } >> "$GITHUB_STEP_SUMMARY"
-            echo "::warning title=Skipped combo (PHPStan)::${{ matrix.magento }}/PHP ${{ matrix.php }} — ${{ matrix.skip_reason }}"
-            echo "proceed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "proceed=true" >> "$GITHUB_OUTPUT"
-          fi
-
+      # The matrix carries only runnable combos (see discover-magento-matrix),
+      # so every leg here is a real test — a green leg means "tested".
       - uses: actions/checkout@v7
-        if: steps.classify.outputs.proceed == 'true'
 
       - name: Start Magento docker container
-        if: steps.classify.outputs.proceed == 'true'
         run: |
           docker run --detach --name magento-project-community-edition \
             michielgerritsen/magento-project-community-edition:${{ matrix.php_image }}-magento${{ matrix.magento }}
 
       - name: Upload tracked source into container
-        if: steps.classify.outputs.proceed == 'true'
         # Ship only tracked files — avoids leaking .git/, dotfiles,
         # or any untracked working-tree state into the CI container.
         # `git ls-files | tar` is preferred over `git archive` here
@@ -163,7 +164,6 @@ jobs:
           git ls-files -z | tar --null -cf - -T - | docker exec -i magento-project-community-edition tar -x -C /data/extensions/magento-plugin
 
       - name: Install extension from uploaded source
-        if: steps.classify.outputs.proceed == 'true'
         run: |
           docker exec magento-project-community-edition \
             composer config repositories.local path '/data/extensions/*'
@@ -171,13 +171,11 @@ jobs:
             composer require 'two-inc/magento2:*@dev' --no-plugins
 
       - name: Activate extension
-        if: steps.classify.outputs.proceed == 'true'
         run: |
           docker exec magento-project-community-edition ./retry \
             "php bin/magento module:enable Two_Gateway && php bin/magento setup:upgrade && php bin/magento setup:di:compile"
 
       - name: Run PHPStan
-        if: steps.classify.outputs.proceed == 'true'
         run: |
           docker exec magento-project-community-edition /bin/bash -c \
             "./vendor/bin/phpstan analyse --no-progress -c /data/extensions/*/phpstan.neon /data/extensions"
@@ -191,34 +189,16 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.discover-magento-matrix.outputs.matrix) }}
     steps:
-      # Honour the classifier's run/skip tag (TWO-24998) — see the PHPStan
-      # job's Classify step for the full rationale.
-      - name: Classify combo
-        id: classify
-        run: |
-          if [ "${{ matrix.status }}" = "skip" ]; then
-            {
-              echo "### ⏭️ DI compile — ${{ matrix.magento }} / PHP ${{ matrix.php }} — SKIPPED"
-              echo ""
-              echo "Reason: ${{ matrix.skip_reason }}"
-            } >> "$GITHUB_STEP_SUMMARY"
-            echo "::warning title=Skipped combo (DI compile)::${{ matrix.magento }}/PHP ${{ matrix.php }} — ${{ matrix.skip_reason }}"
-            echo "proceed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "proceed=true" >> "$GITHUB_OUTPUT"
-          fi
-
+      # The matrix carries only runnable combos (see discover-magento-matrix),
+      # so every leg here is a real test — a green leg means "tested".
       - uses: actions/checkout@v7
-        if: steps.classify.outputs.proceed == 'true'
 
       - name: Start Magento docker container
-        if: steps.classify.outputs.proceed == 'true'
         run: |
           docker run --detach --name magento-project-community-edition \
             michielgerritsen/magento-project-community-edition:${{ matrix.php_image }}-magento${{ matrix.magento }}
 
       - name: Upload tracked source into container
-        if: steps.classify.outputs.proceed == 'true'
         # Ship only tracked files — avoids leaking .git/, dotfiles,
         # or any untracked working-tree state into the CI container.
         # `git ls-files | tar` is preferred over `git archive` here
@@ -230,7 +210,6 @@ jobs:
           git ls-files -z | tar --null -cf - -T - | docker exec -i magento-project-community-edition tar -x -C /data/extensions/magento-plugin
 
       - name: Install extension from uploaded source
-        if: steps.classify.outputs.proceed == 'true'
         run: |
           docker exec magento-project-community-edition \
             composer config repositories.local path '/data/extensions/*'
@@ -238,7 +217,6 @@ jobs:
             composer require 'two-inc/magento2:*@dev' --no-plugins
 
       - name: Run setup:di:compile
-        if: steps.classify.outputs.proceed == 'true'
         run: |
           docker exec magento-project-community-edition ./retry \
             "php bin/magento setup:di:compile"
@@ -253,7 +231,6 @@ jobs:
       # in any of these surfaces as an empty or error-containing
       # config:show output.
       - name: Install-time smoke test (ABN-423 M3)
-        if: steps.classify.outputs.proceed == 'true'
         run: |
           docker exec magento-project-community-edition ./retry \
             "php bin/magento module:enable Two_Gateway && php bin/magento setup:upgrade && php bin/magento cache:flush"
@@ -292,31 +269,3 @@ jobs:
           cache: 'npm'
       - run: npm ci --no-audit --no-fund
       - run: npm run test:js
-
-  # Durable, greppable record of exactly which Magento × PHP combinations
-  # this run exercised and — for the rest — why it couldn't (TWO-24998).
-  # `if: always()` so the table renders even when a matrix leg fails; it
-  # reads the classifier's output directly, so it reflects run/skip intent
-  # independent of leg pass/fail. Serves the merchant-troubleshooting flow:
-  # open the run for a merchant's version → read the table.
-  coverage-report:
-    name: Version coverage report
-    needs: [discover-magento-matrix, phpstan, di-compile]
-    if: always()
-    runs-on: ${{ vars.RUNNER_STANDARD }}
-    steps:
-      - name: Render coverage table
-        env:
-          MATRIX: ${{ needs.discover-magento-matrix.outputs.matrix }}
-        run: |
-          {
-            echo "## Magento × PHP version coverage"
-            echo ""
-            echo "| Magento | PHP | Status | Reason |"
-            echo "|---|---|---|---|"
-            echo "$MATRIX" | jq -r '.[]
-              | if .status == "skip"
-                then "| \(.magento) | \(.php) | ⏭️ skipped | \(.skip_reason) |"
-                else "| \(.magento) | \(.php) | ✅ tested | |"
-                end'
-          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,14 +121,37 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.discover-magento-matrix.outputs.matrix) }}
     steps:
+      # Honour the classifier's run/skip tag (TWO-24998). A `skip` combo
+      # records its reason to the step summary + a ::warning:: and every
+      # later step gates off — the leg shows green (GHA can't paint a
+      # matrix leg grey; job-level `if:` is evaluated before matrix
+      # expansion) but carries its reason in plain, greppable text.
+      - name: Classify combo
+        id: classify
+        run: |
+          if [ "${{ matrix.status }}" = "skip" ]; then
+            {
+              echo "### ⏭️ PHPStan — ${{ matrix.magento }} / PHP ${{ matrix.php }} — SKIPPED"
+              echo ""
+              echo "Reason: ${{ matrix.skip_reason }}"
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning title=Skipped combo (PHPStan)::${{ matrix.magento }}/PHP ${{ matrix.php }} — ${{ matrix.skip_reason }}"
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@v7
+        if: steps.classify.outputs.proceed == 'true'
 
       - name: Start Magento docker container
+        if: steps.classify.outputs.proceed == 'true'
         run: |
           docker run --detach --name magento-project-community-edition \
             michielgerritsen/magento-project-community-edition:${{ matrix.php_image }}-magento${{ matrix.magento }}
 
       - name: Upload tracked source into container
+        if: steps.classify.outputs.proceed == 'true'
         # Ship only tracked files — avoids leaking .git/, dotfiles,
         # or any untracked working-tree state into the CI container.
         # `git ls-files | tar` is preferred over `git archive` here
@@ -140,6 +163,7 @@ jobs:
           git ls-files -z | tar --null -cf - -T - | docker exec -i magento-project-community-edition tar -x -C /data/extensions/magento-plugin
 
       - name: Install extension from uploaded source
+        if: steps.classify.outputs.proceed == 'true'
         run: |
           docker exec magento-project-community-edition \
             composer config repositories.local path '/data/extensions/*'
@@ -147,11 +171,13 @@ jobs:
             composer require 'two-inc/magento2:*@dev' --no-plugins
 
       - name: Activate extension
+        if: steps.classify.outputs.proceed == 'true'
         run: |
           docker exec magento-project-community-edition ./retry \
             "php bin/magento module:enable Two_Gateway && php bin/magento setup:upgrade && php bin/magento setup:di:compile"
 
       - name: Run PHPStan
+        if: steps.classify.outputs.proceed == 'true'
         run: |
           docker exec magento-project-community-edition /bin/bash -c \
             "./vendor/bin/phpstan analyse --no-progress -c /data/extensions/*/phpstan.neon /data/extensions"
@@ -165,14 +191,34 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.discover-magento-matrix.outputs.matrix) }}
     steps:
+      # Honour the classifier's run/skip tag (TWO-24998) — see the PHPStan
+      # job's Classify step for the full rationale.
+      - name: Classify combo
+        id: classify
+        run: |
+          if [ "${{ matrix.status }}" = "skip" ]; then
+            {
+              echo "### ⏭️ DI compile — ${{ matrix.magento }} / PHP ${{ matrix.php }} — SKIPPED"
+              echo ""
+              echo "Reason: ${{ matrix.skip_reason }}"
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning title=Skipped combo (DI compile)::${{ matrix.magento }}/PHP ${{ matrix.php }} — ${{ matrix.skip_reason }}"
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@v7
+        if: steps.classify.outputs.proceed == 'true'
 
       - name: Start Magento docker container
+        if: steps.classify.outputs.proceed == 'true'
         run: |
           docker run --detach --name magento-project-community-edition \
             michielgerritsen/magento-project-community-edition:${{ matrix.php_image }}-magento${{ matrix.magento }}
 
       - name: Upload tracked source into container
+        if: steps.classify.outputs.proceed == 'true'
         # Ship only tracked files — avoids leaking .git/, dotfiles,
         # or any untracked working-tree state into the CI container.
         # `git ls-files | tar` is preferred over `git archive` here
@@ -184,6 +230,7 @@ jobs:
           git ls-files -z | tar --null -cf - -T - | docker exec -i magento-project-community-edition tar -x -C /data/extensions/magento-plugin
 
       - name: Install extension from uploaded source
+        if: steps.classify.outputs.proceed == 'true'
         run: |
           docker exec magento-project-community-edition \
             composer config repositories.local path '/data/extensions/*'
@@ -191,6 +238,7 @@ jobs:
             composer require 'two-inc/magento2:*@dev' --no-plugins
 
       - name: Run setup:di:compile
+        if: steps.classify.outputs.proceed == 'true'
         run: |
           docker exec magento-project-community-edition ./retry \
             "php bin/magento setup:di:compile"
@@ -205,6 +253,7 @@ jobs:
       # in any of these surfaces as an empty or error-containing
       # config:show output.
       - name: Install-time smoke test (ABN-423 M3)
+        if: steps.classify.outputs.proceed == 'true'
         run: |
           docker exec magento-project-community-edition ./retry \
             "php bin/magento module:enable Two_Gateway && php bin/magento setup:upgrade && php bin/magento cache:flush"
@@ -243,3 +292,31 @@ jobs:
           cache: 'npm'
       - run: npm ci --no-audit --no-fund
       - run: npm run test:js
+
+  # Durable, greppable record of exactly which Magento × PHP combinations
+  # this run exercised and — for the rest — why it couldn't (TWO-24998).
+  # `if: always()` so the table renders even when a matrix leg fails; it
+  # reads the classifier's output directly, so it reflects run/skip intent
+  # independent of leg pass/fail. Serves the merchant-troubleshooting flow:
+  # open the run for a merchant's version → read the table.
+  coverage-report:
+    name: Version coverage report
+    needs: [discover-magento-matrix, phpstan, di-compile]
+    if: always()
+    runs-on: ${{ vars.RUNNER_STANDARD }}
+    steps:
+      - name: Render coverage table
+        env:
+          MATRIX: ${{ needs.discover-magento-matrix.outputs.matrix }}
+        run: |
+          {
+            echo "## Magento × PHP version coverage"
+            echo ""
+            echo "| Magento | PHP | Status | Reason |"
+            echo "|---|---|---|---|"
+            echo "$MATRIX" | jq -r '.[]
+              | if .status == "skip"
+                then "| \(.magento) | \(.php) | ⏭️ skipped | \(.skip_reason) |"
+                else "| \(.magento) | \(.php) | ✅ tested | |"
+                end'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/dev/magento-support-matrix.sh
+++ b/dev/magento-support-matrix.sh
@@ -1,54 +1,63 @@
 #!/usr/bin/env bash
-# dev/magento-support-matrix.sh — discover the install-smoke / PHPStan
-# matrix dynamically from upstream.
+# dev/magento-support-matrix.sh — discover AND CLASSIFY the CI version matrix
+# dynamically from upstream.
 #
 # Usage:
-#   ./dev/magento-support-matrix.sh                       # human-readable report
-#   ./dev/magento-support-matrix.sh --emit-matrix         # GHA matrix JSON: Magento × PHP cross-product
-#   ./dev/magento-support-matrix.sh --emit-php-lint-matrix # GHA matrix JSON: PHP-only (for the PHP lint job)
+#   ./dev/magento-support-matrix.sh                        # human-readable report
+#   ./dev/magento-support-matrix.sh --emit-matrix          # GHA matrix JSON: classified Magento × PHP combos
+#   ./dev/magento-support-matrix.sh --emit-php-lint-matrix # GHA matrix JSON: PHP-only (lint / phpunit jobs)
+#
+# This script is a CLASSIFIER, not a filter. Every combination inside the
+# current support window is EMITTED, tagged with a status:
+#     {"...","status":"run"}                          — CI exercises this combo
+#     {"...","status":"skip","skip_reason":"..."}     — CI records why it can't
+# Nothing testable is silently green; nothing untestable silently vanishes.
+# The consuming jobs' first step reads matrix.status and either does the work
+# (run) or writes the reason to $GITHUB_STEP_SUMMARY + a ::warning:: and exits
+# 0 (skip). See TWO-24998.
 #
 # Strategy:
 #   1. Query github.com/magento/magento2 tags for bare-semver 2.4.x.
-#   2. Apply Adobe's lifecycle policy: current minor + N previous minors
-#      (default 2, ie. a 3-minor support window).
-#   3. Drop any version on `intentionally_excluded` (e.g. docker image
-#      not yet published by the CI-image maintainer).
-#   4. For each remaining Magento minor: fetch its raw composer.json
-#      and parse `require.php` to get the PHP constraint (e.g.
-#      "~8.2.0||~8.3.0||~8.4.0" → minors [8.2, 8.3, 8.4]).
-#   5. Query php.net/releases for currently-supported PHP minors
-#      (active + security). Intersect with the per-Magento constraint
-#      to drop combinations PHP itself no longer supports.
-#   6. Emit the cross-product as a GHA matrix.
+#   2. Support window = current minor + (SUPPORT_WINDOW-1) previous minors,
+#      taken over ALL minors. Image availability does NOT slide the window:
+#      an in-policy minor with no CI image is surfaced as a skip, it is NOT
+#      silently replaced by an older out-of-policy minor (TWO-24998 Defect 2 —
+#      "the window silently trails a minor behind").
+#   3. For each window minor: fetch composer.json, parse require.php → the
+#      PHP minors it accepts (e.g. "~8.2.0||~8.3.0||~8.4.0" → 8.2 8.3 8.4).
+#   4. php.net/releases → currently-supported PHP minors.
+#   5. Classify each (window-minor × accepted-PHP) combo, first matching wins:
+#        past upstream PHP support   — accepted by Magento but EOL per php.net
+#        intentionally excluded: ... — on the manual list (usually empty now)
+#        no CI image published       — deterministic image tag has no manifest
+#        run                         — otherwise
+#   6. Emit every combo with its status. The php-lint matrix is the union of
+#      php.net-supported accepted PHP minors — image-independent, since the
+#      lint / phpunit jobs use setup-php, not the Magento docker images.
 #
-# This replaces the hand-maintained EOL list AND the hand-maintained
-# min-PHP map with discovery from upstream (Doug 2026-05-22 follow-up
-# to r5 #10). The script is the single source of truth for which
-# Magento × PHP combinations CI exercises.
+# Replaces the hand-maintained EOL list AND the hand-maintained min-PHP map
+# with upstream discovery (Doug 2026-05-22, r5 #10). TWO-24998 additionally
+# retired the hand-maintained image-exclusion entries in favour of a docker
+# manifest probe (see intentionally_excluded + probe_image below).
 
 set -euo pipefail
 
-# How many minor lines (current + previous) we claim to support. Adobe's
-# policy is "current + previous 2" → 3 total.
+# How many minor lines (current + previous) we support. Adobe's policy is
+# "current + previous 2" → 3 total. This bounds the window over ALL published
+# minors; it does NOT skip over image-less minors (see header note 2).
 SUPPORT_WINDOW=${SUPPORT_WINDOW:-3}
 
-# Versions / combinations Magento has published upstream but we cannot
-# test yet (e.g. michielgerritsen/magento-project-community-edition image
-# not built for that combination). Two entry forms:
+CI_IMAGE_REPO="michielgerritsen/magento-project-community-edition"
+
+# Combos we DELIBERATELY choose not to test even though a CI image exists.
+# This is NOT the place for "no image published yet" — that case is detected
+# automatically by the docker manifest probe (probe_image) and surfaced as a
+# `no CI image published` skip. Expect this list to stay empty; add an entry
+# only for a genuine "we will not test X" policy decision, documenting why.
 #
-#   "<magento>:<reason>"               whole-minor exclusion. Slot is NOT
-#                                      replaced — the support window shrinks
-#                                      by one.
-#
-#   "<magento>:php=<X.Y>:<reason>"     combo exclusion. The Magento minor
-#                                      itself stays in the window; only the
-#                                      named PHP pairing is dropped.
-#
-# Each entry documents WHY the exclusion exists so future maintainers
-# know when it can drop.
+#   "<magento>:<reason>"               whole-minor: every PHP pairing skips
+#   "<magento>:php=<X.Y>:<reason>"     single combo: only that PHP pairing skips
 intentionally_excluded=(
-    "2.4.9:michielgerritsen/magento-project-community-edition image not yet published for php83-fpm-magento2.4.9"
-    "2.4.8:php=8.2:michielgerritsen/magento-project-community-edition publishes php83/php84 tags only for magento2.4.8 (Adobe's composer.json accepts 8.2 but no image exists)"
 )
 
 mode=report
@@ -65,45 +74,50 @@ log() {
 }
 
 # Authorise GitHub API when a token is available to dodge anon rate-limit.
+# NB: only ever sent to github.com hosts (see fetch_json's use_auth arg) — we
+# do NOT leak the token to php.net.
 gh_headers=()
 [ -n "${GH_TOKEN:-${GITHUB_TOKEN:-}}" ] \
     && gh_headers=(-H "Authorization: Bearer ${GH_TOKEN:-$GITHUB_TOKEN}")
 
 # ---------------------------------------------------------------------------
-# Step 1: discover Magento support window from upstream tags.
+# fetch_json <description> <url> <use_gh_auth:0|1> [validator-jq-expr]
 #
-# Fetches with one retry on transient failure. Validates HTTP status and
-# JSON shape before piping to jq — previously a rate-limited / 502 / HTML
-# response would surface as a cryptic jq error like "Cannot index string
-# with string \"name\"" instead of the actual upstream problem.
+# Fetches with one retry on transient failure. Validates HTTP 200 and
+# (optionally) the JSON shape before returning the body — a rate-limited /
+# 502 / HTML response would otherwise surface as a cryptic downstream jq
+# error like `Cannot index string with string "name"` instead of the real
+# upstream problem. `use_gh_auth=1` attaches the GitHub bearer token; pass 0
+# for third-party hosts (php.net) so credentials never leave github.com.
 # ---------------------------------------------------------------------------
-fetch_magento_tags() {
-    local url='https://api.github.com/repos/magento/magento2/tags?per_page=100'
-    local attempt response http_code body
+fetch_json() {
+    local desc="$1" url="$2" use_auth="$3" validator="${4:-}"
+    local headers=() attempt response http_code body
+    [ "$use_auth" = "1" ] && headers=("${gh_headers[@]}")
     for attempt in 1 2; do
         if ! response=$(curl -sS --max-time 30 -w '\n%{http_code}' \
-                -H 'Cache-Control: no-cache' "${gh_headers[@]}" "$url" 2>&1); then
-            echo "::warning::GitHub tags API attempt ${attempt}: curl failed: ${response}" >&2
+                -H 'Cache-Control: no-cache' "${headers[@]}" "$url" 2>&1); then
+            echo "::warning::${desc} attempt ${attempt}: curl failed: ${response}" >&2
             [ "$attempt" -lt 2 ] && { sleep 5; continue; }
-            echo "::error::GitHub tags API unreachable after retry" >&2
+            echo "::error::${desc} unreachable after retry" >&2
             return 2
         fi
         http_code="${response##*$'\n'}"
         body="${response%$'\n'*}"
         if [ "$http_code" != "200" ]; then
-            echo "::warning::GitHub tags API attempt ${attempt}: HTTP ${http_code}" >&2
-            echo "Response body (first 500 chars):" >&2
+            echo "::warning::${desc} attempt ${attempt}: HTTP ${http_code}" >&2
+            printf 'Response body (first 500 chars): ' >&2
             printf '%s' "$body" | head -c 500 >&2; echo >&2
             [ "$attempt" -lt 2 ] && { sleep 5; continue; }
-            echo "::error::GitHub tags API persistently returning HTTP ${http_code}" >&2
+            echo "::error::${desc} persistently returning HTTP ${http_code}" >&2
             return 2
         fi
-        if ! printf '%s' "$body" | jq -e 'type == "array"' >/dev/null 2>&1; then
-            echo "::warning::GitHub tags API attempt ${attempt}: response is not a JSON array" >&2
-            echo "Response body (first 500 chars):" >&2
+        if [ -n "$validator" ] && ! printf '%s' "$body" | jq -e "$validator" >/dev/null 2>&1; then
+            echo "::warning::${desc} attempt ${attempt}: response failed shape check ($validator)" >&2
+            printf 'Response body (first 500 chars): ' >&2
             printf '%s' "$body" | head -c 500 >&2; echo >&2
             [ "$attempt" -lt 2 ] && { sleep 5; continue; }
-            echo "::error::GitHub tags API persistently returning non-array response" >&2
+            echo "::error::${desc} persistently malformed" >&2
             return 2
         fi
         printf '%s' "$body"
@@ -112,7 +126,44 @@ fetch_magento_tags() {
     return 2
 }
 
-tags_json=$(fetch_magento_tags) || exit 2
+# ---------------------------------------------------------------------------
+# probe_image <image-tag> → prints one of: exists | missing | error
+#
+# Distinguishes a genuinely-unpublished image (skip) from a transient
+# registry failure (fail TOWARD running the test, per TWO-24998 Phase 2 —
+# a Docker Hub blip must not silently zero the matrix). `docker manifest
+# inspect` returns non-zero for both cases, so we inspect stderr: a clear
+# "not found"-class message → missing; anything else → retry once → error.
+# ---------------------------------------------------------------------------
+probe_image() {
+    local img="$1" attempt out
+    if ! command -v docker >/dev/null 2>&1; then
+        echo "::warning::probe_image: docker CLI unavailable; treating '$img' as runnable" >&2
+        echo error
+        return 0
+    fi
+    for attempt in 1 2; do
+        if out=$(DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect "$img" 2>&1); then
+            echo exists
+            return 0
+        fi
+        if printf '%s' "$out" | grep -qiE 'no such manifest|manifest unknown|not found|does not exist'; then
+            echo missing
+            return 0
+        fi
+        [ "$attempt" -lt 2 ] && { sleep 3; continue; }
+        echo "::warning::probe_image: '$img' inspect errored (not a clean 'missing'), defaulting to run: ${out}" >&2
+        echo error
+        return 0
+    done
+}
+
+# ---------------------------------------------------------------------------
+# Step 1: discover Magento minors from upstream tags; take the top-N window.
+# ---------------------------------------------------------------------------
+tags_json=$(fetch_json "GitHub tags API" \
+    'https://api.github.com/repos/magento/magento2/tags?per_page=100' \
+    1 'type == "array"') || exit 2
 
 all_minors=$(printf '%s' "$tags_json" \
     | jq -r 'map(.name)
@@ -126,9 +177,17 @@ if [ -z "$all_minors" ]; then
     exit 2
 fi
 
-# Build excluded maps. Two scopes:
-#   excluded_minor_map[<magento>]      = reason     (whole-minor exclusion)
-#   excluded_combo_map[<magento>|<php>] = reason    (combo-level exclusion)
+# Window = the SUPPORT_WINDOW most-recent minors, over ALL of them. We do NOT
+# pre-filter image-less/excluded minors out before taking the top-N — doing so
+# would let an older out-of-policy minor backfill the window and hide the fact
+# that an in-policy minor is currently untestable (TWO-24998 Defect 2).
+supported=$(echo "$all_minors" | head -n "$SUPPORT_WINDOW")
+log "Magento support window ($SUPPORT_WINDOW most-recent minors):"
+log "$supported" | sed 's/^/  /'
+
+# Build intentional-exclusion maps. Two scopes:
+#   excluded_minor_map[<magento>]       = reason    (whole-minor)
+#   excluded_combo_map[<magento>|<php>] = reason    (single combo)
 declare -A excluded_minor_map=()
 declare -A excluded_combo_map=()
 for entry in "${intentionally_excluded[@]:-}"; do
@@ -145,32 +204,12 @@ for entry in "${intentionally_excluded[@]:-}"; do
     fi
 done
 
-# Drop whole-minor exclusions BEFORE taking the top-N so an excluded
-# minor doesn't burn a window slot (otherwise the next minor down falls
-# off the bottom of the window). Combo exclusions don't affect slot count.
-filtered_minors=()
-for m in $all_minors; do
-    [ -n "${excluded_minor_map[$m]:-}" ] && continue
-    filtered_minors+=("$m")
-done
-supported=$(printf '%s\n' "${filtered_minors[@]}" | head -n "$SUPPORT_WINDOW")
-log "Magento support window ($SUPPORT_WINDOW most-recent eligible minors):"
-log "$supported" | sed 's/^/  /'
-
-# Surface whole-minor exclusions so the report is self-documenting.
-if [ ${#excluded_minor_map[@]} -gt 0 ]; then
-    log "Whole-minor exclusions in force:"
-    for v in "${!excluded_minor_map[@]}"; do
-        log "  $v — ${excluded_minor_map[$v]}"
-    done
-fi
-
 # ---------------------------------------------------------------------------
 # Step 2: discover currently-supported PHP minors from php.net.
 # ---------------------------------------------------------------------------
-php_releases_json=$(curl -sH 'Cache-Control: no-cache' \
+php_releases_json=$(fetch_json "php.net releases feed" \
     'https://www.php.net/releases/?json' \
-    || { echo "::error::Could not reach php.net/releases JSON feed" >&2; exit 2; })
+    0 'type == "object"') || exit 2
 
 # Union of `supported_versions` across all majors, e.g. ["8.2","8.3","8.4","8.5"].
 supported_php_minors=$(echo "$php_releases_json" \
@@ -186,22 +225,22 @@ log "Currently-supported PHP minors (php.net):"
 log "$supported_php_minors" | sed 's/^/  /'
 
 # ---------------------------------------------------------------------------
-# Step 3: for each Magento minor, fetch composer.json and parse php constraint.
+# Step 3: for each window minor, fetch composer.json and parse php constraint.
 #
-# Magento's constraint format is "~8.2.0||~8.3.0||~8.4.0" — one tilde
-# range per supported minor, OR-joined. `~8.X.0` means ">=8.X.0,<8.(X+1).0",
-# so each clause uniquely identifies one PHP minor.
+# Magento's constraint format is "~8.2.0||~8.3.0||~8.4.0" — one tilde range
+# per supported minor, OR-joined. `~8.X.0` means ">=8.X.0,<8.(X+1).0", so each
+# clause uniquely identifies one PHP minor.
 # ---------------------------------------------------------------------------
 declare -A magento_php_minors=()  # magento_minor → space-separated PHP minors
 for minor in $supported; do
-    composer_json=$(curl -sH 'Cache-Control: no-cache' "${gh_headers[@]}" \
-        "https://raw.githubusercontent.com/magento/magento2/$minor/composer.json")
+    composer_json=$(fetch_json "magento/magento2@$minor composer.json" \
+        "https://raw.githubusercontent.com/magento/magento2/$minor/composer.json" \
+        1 'type == "object"') || exit 2
     php_constraint=$(echo "$composer_json" | jq -r '.require.php // empty')
     if [ -z "$php_constraint" ]; then
         echo "::error::magento/magento2@$minor composer.json missing require.php" >&2
         exit 2
     fi
-    # Extract every "~X.Y.0" clause → "X.Y".
     php_minors_for_magento=$(echo "$php_constraint" \
         | grep -oE '~[0-9]+\.[0-9]+\.0' \
         | sed -E 's/~([0-9]+\.[0-9]+)\.0/\1/' \
@@ -215,61 +254,84 @@ for minor in $supported; do
 done
 
 # ---------------------------------------------------------------------------
-# Step 4: build the cross-product matrix, intersected with PHP support.
+# Step 4: classify every (window-minor × accepted-PHP) combo.
 # ---------------------------------------------------------------------------
 matrix_entries=()
-excluded_warnings=()
-declare -A php_lint_minors=()  # union of PHP minors actually emitted
+declare -A php_lint_minors=()   # union of php.net-supported accepted PHP minors
+run_count=0
+skip_count=0
+
+emit() {  # emit <magento> <php> <php_image> <status> <skip_reason>
+    matrix_entries+=("$(jq -nc \
+        --arg magento "$1" \
+        --arg php "$2" \
+        --arg php_image "$3" \
+        --arg status "$4" \
+        --arg skip_reason "$5" \
+        '{magento:$magento, php:$php, php_image:$php_image, status:$status, skip_reason:$skip_reason}')")
+    if [ "$4" = "run" ]; then run_count=$((run_count+1)); else skip_count=$((skip_count+1)); fi
+}
 
 for minor in $supported; do
     accepted="${magento_php_minors[$minor]:-}"
     [ -z "$accepted" ] && continue
+    minor_excl="${excluded_minor_map[$minor]:-}"
 
-    # Intersect Magento's accepted PHP with php.net-supported PHP, then
-    # drop any combo flagged on `excluded_combo_map`.
-    matched=()
     for php in $accepted; do
-        if ! echo "$supported_php_minors" | grep -qxF "$php"; then
-            continue
-        fi
-        if [ -n "${excluded_combo_map[$minor|$php]:-}" ]; then
-            excluded_warnings+=("$minor × PHP $php — ${excluded_combo_map[$minor|$php]}")
-            continue
-        fi
-        matched+=("$php")
-    done
-    if [ ${#matched[@]} -eq 0 ]; then
-        excluded_warnings+=("$minor — every accepted PHP in '$accepted' is past upstream PHP support or combo-excluded")
-        continue
-    fi
-
-    for php in "${matched[@]}"; do
         php_image="php$(echo "$php" | tr -d '.')-fpm"
-        matrix_entries+=("$(jq -nc \
-            --arg magento "$minor" \
-            --arg php "$php" \
-            --arg php_image "$php_image" \
-            '{magento: $magento, php: $php, php_image: $php_image}')")
+        img_tag="${CI_IMAGE_REPO}:${php_image}-magento${minor}"
+
+        # 1. Past upstream PHP support (php.net no longer lists this minor).
+        if ! echo "$supported_php_minors" | grep -qxF "$php"; then
+            emit "$minor" "$php" "$php_image" skip "past upstream PHP support"
+            continue
+        fi
+        # php.net-supported → contributes to the (image-independent) lint set,
+        # regardless of whether the Magento×PHP combo runs or skips below.
         php_lint_minors["$php"]=1
+
+        # 2. Intentional exclusion (whole-minor, then single-combo).
+        if [ -n "$minor_excl" ]; then
+            emit "$minor" "$php" "$php_image" skip "intentionally excluded: $minor_excl"
+            continue
+        fi
+        combo_excl="${excluded_combo_map[$minor|$php]:-}"
+        if [ -n "$combo_excl" ]; then
+            emit "$minor" "$php" "$php_image" skip "intentionally excluded: $combo_excl"
+            continue
+        fi
+
+        # 3. CI image availability (auto-probed — no hand-maintained list).
+        case "$(probe_image "$img_tag")" in
+            missing)
+                emit "$minor" "$php" "$php_image" skip "no CI image published ($img_tag)"
+                continue
+                ;;
+        esac
+
+        # 4. Runnable.
+        emit "$minor" "$php" "$php_image" run ""
     done
 done
 
-if [ ${#excluded_warnings[@]} -gt 0 ]; then
-    log "Excluded from this run:"
-    for w in "${excluded_warnings[@]}"; do
-        log "  $w"
-    done
-fi
-
 if [ ${#matrix_entries[@]} -eq 0 ]; then
-    echo "::error::Support matrix is empty — every supported minor is excluded" >&2
+    echo "::error::No combos classified — window / constraint parsing failed" >&2
     exit 1
+fi
+if [ "$run_count" -eq 0 ]; then
+    # Not fatal — an all-skip run is a legitimate (loud) signal that zero
+    # combos are currently testable. The coverage-report job surfaces it.
+    echo "::warning::Every in-window combo classified as SKIP — zero real version coverage this run" >&2
 fi
 
 matrix_json=$(printf '%s\n' "${matrix_entries[@]}" | jq -sc '.')
-php_lint_json=$(printf '%s\n' "${!php_lint_minors[@]}" \
-    | sort -V \
-    | jq -R . | jq -sc 'map({php: .})')
+if [ ${#php_lint_minors[@]} -eq 0 ]; then
+    php_lint_json='[]'
+else
+    php_lint_json=$(printf '%s\n' "${!php_lint_minors[@]}" \
+        | sort -V \
+        | jq -R . | jq -sc 'map({php: .})')
+fi
 
 case "$mode" in
     matrix)
@@ -279,11 +341,16 @@ case "$mode" in
         echo "$php_lint_json"
         ;;
     report)
-        echo "Install-smoke / PHPStan matrix:"
-        echo "$matrix_json" | jq .
+        echo ""
+        echo "Classified Magento × PHP matrix ($run_count run, $skip_count skip):"
+        echo "$matrix_json" | jq -r '.[]
+            | if .status == "skip"
+              then "  SKIP  \(.magento) PHP \(.php) — \(.skip_reason)"
+              else "  RUN   \(.magento) PHP \(.php)"
+              end'
         echo ""
         echo "PHP lint matrix:"
-        echo "$php_lint_json" | jq .
+        echo "$php_lint_json" | jq -r '.[].php | "  \(.)"'
         echo ""
         echo "magento-support-matrix OK."
         ;;

--- a/dev/magento-support-matrix.sh
+++ b/dev/magento-support-matrix.sh
@@ -70,6 +70,13 @@ case "${1:-}" in
     --emit-matrix) mode=matrix ;;
     --emit-skips) mode=skips ;;
     --emit-php-lint-matrix) mode=php_lint ;;
+    # One classification, all three slices in a single object. The CI discover
+    # step uses this so the run-list, skip-list and lint-list come from ONE run
+    # of the classifier — not three independent runs that each re-fetch upstream
+    # and re-probe every image. Prevents a transient `docker manifest inspect`
+    # blip from putting a combo in one slice but not its mirror, and cuts the
+    # anonymous Docker Hub rate-limit exposure 3x (review: brtkwr on #237).
+    --emit-all) mode=all ;;
     "") mode=report ;;
     *) echo "Unknown flag: $1" >&2; exit 2 ;;
 esac
@@ -140,6 +147,13 @@ fetch_json() {
 # a Docker Hub blip must not silently zero the matrix). `docker manifest
 # inspect` returns non-zero for both cases, so we inspect stderr: a clear
 # "not found"-class message → missing; anything else → retry once → error.
+#
+# Trade-off (by design, review: brtkwr on #237): because "error" maps to RUN,
+# under degraded / rate-limited registry conditions a genuinely-missing image
+# is classified `run` and surfaces as a RED matrix leg rather than the intended
+# yellow (::warning::) skip. We prefer a loud red on a Docker Hub blip over a
+# silent green that hides zero coverage. Every such case emits the ::warning::
+# above, so the run/skip mismatch is greppable in the job log.
 # ---------------------------------------------------------------------------
 probe_image() {
     local img="$1" attempt out
@@ -358,6 +372,14 @@ case "$mode" in
         ;;
     php_lint)
         echo "$php_lint_json"
+        ;;
+    all)
+        # Single-classification bundle for the CI discover step (see --emit-all).
+        jq -nc \
+            --argjson matrix "$run_json" \
+            --argjson skips "$skip_json" \
+            --argjson php_lint "$php_lint_json" \
+            '{matrix: $matrix, skips: $skips, php_lint: $php_lint}'
         ;;
     report)
         echo ""

--- a/dev/magento-support-matrix.sh
+++ b/dev/magento-support-matrix.sh
@@ -4,17 +4,22 @@
 #
 # Usage:
 #   ./dev/magento-support-matrix.sh                        # human-readable report
-#   ./dev/magento-support-matrix.sh --emit-matrix          # GHA matrix JSON: classified Magento × PHP combos
+#   ./dev/magento-support-matrix.sh --emit-matrix          # GHA matrix JSON: RUNNABLE Magento × PHP combos
+#   ./dev/magento-support-matrix.sh --emit-skips           # JSON: combos we CANNOT run, with reasons
 #   ./dev/magento-support-matrix.sh --emit-php-lint-matrix # GHA matrix JSON: PHP-only (lint / phpunit jobs)
 #
-# This script is a CLASSIFIER, not a filter. Every combination inside the
-# current support window is EMITTED, tagged with a status:
-#     {"...","status":"run"}                          — CI exercises this combo
-#     {"...","status":"skip","skip_reason":"..."}     — CI records why it can't
+# This script CLASSIFIES every combination inside the current support window
+# as run | skip, then splits the two:
+#   --emit-matrix  → only runnable combos. These become real matrix legs, so a
+#                    green leg genuinely means "tested" — a skipped combo is
+#                    NEVER emitted here and so can never masquerade as a passed
+#                    test (TWO-24998: the run/skip decision happens at
+#                    matrix-assembly time, not inside a green job).
+#   --emit-skips   → the combos we could not run, each with a skip_reason. The
+#                    discover job renders these to $GITHUB_STEP_SUMMARY and
+#                    emits a ::warning:: per combo so an untested combination is
+#                    visible at a glance and cannot be mistaken for a pass.
 # Nothing testable is silently green; nothing untestable silently vanishes.
-# The consuming jobs' first step reads matrix.status and either does the work
-# (run) or writes the reason to $GITHUB_STEP_SUMMARY + a ::warning:: and exits
-# 0 (skip). See TWO-24998.
 #
 # Strategy:
 #   1. Query github.com/magento/magento2 tags for bare-semver 2.4.x.
@@ -63,6 +68,7 @@ intentionally_excluded=(
 mode=report
 case "${1:-}" in
     --emit-matrix) mode=matrix ;;
+    --emit-skips) mode=skips ;;
     --emit-php-lint-matrix) mode=php_lint ;;
     "") mode=report ;;
     *) echo "Unknown flag: $1" >&2; exit 2 ;;
@@ -324,7 +330,13 @@ if [ "$run_count" -eq 0 ]; then
     echo "::warning::Every in-window combo classified as SKIP — zero real version coverage this run" >&2
 fi
 
-matrix_json=$(printf '%s\n' "${matrix_entries[@]}" | jq -sc '.')
+# Full classified set, then split into the runnable matrix and the skip list.
+# Runnable combos carry only the keys the test jobs consume ({magento, php,
+# php_image}); skip combos carry their reason instead of an image.
+classified_json=$(printf '%s\n' "${matrix_entries[@]}" | jq -sc '.')
+run_json=$(echo "$classified_json" | jq -c '[.[] | select(.status == "run") | {magento, php, php_image}]')
+skip_json=$(echo "$classified_json" | jq -c '[.[] | select(.status == "skip") | {magento, php, skip_reason}]')
+
 if [ ${#php_lint_minors[@]} -eq 0 ]; then
     php_lint_json='[]'
 else
@@ -335,7 +347,10 @@ fi
 
 case "$mode" in
     matrix)
-        echo "$matrix_json"
+        echo "$run_json"
+        ;;
+    skips)
+        echo "$skip_json"
         ;;
     php_lint)
         echo "$php_lint_json"
@@ -343,7 +358,7 @@ case "$mode" in
     report)
         echo ""
         echo "Classified Magento × PHP matrix ($run_count run, $skip_count skip):"
-        echo "$matrix_json" | jq -r '.[]
+        echo "$classified_json" | jq -r '.[]
             | if .status == "skip"
               then "  SKIP  \(.magento) PHP \(.php) — \(.skip_reason)"
               else "  RUN   \(.magento) PHP \(.php)"

--- a/dev/magento-support-matrix.sh
+++ b/dev/magento-support-matrix.sh
@@ -247,10 +247,14 @@ for minor in $supported; do
         echo "::error::magento/magento2@$minor composer.json missing require.php" >&2
         exit 2
     fi
+    # `|| true`: under `set -o pipefail`, grep exits 1 when a constraint has no
+    # `~X.Y.0` clause (e.g. an unexpected format), which would terminate the
+    # script here and bypass the diagnostic below. Swallow it so the empty-check
+    # fires with a useful error instead.
     php_minors_for_magento=$(echo "$php_constraint" \
         | grep -oE '~[0-9]+\.[0-9]+\.0' \
         | sed -E 's/~([0-9]+\.[0-9]+)\.0/\1/' \
-        | sort -V)
+        | sort -V) || true
     if [ -z "$php_minors_for_magento" ]; then
         echo "::error::Could not parse php constraint '$php_constraint' for Magento $minor" >&2
         exit 2
@@ -284,7 +288,7 @@ for minor in $supported; do
     minor_excl="${excluded_minor_map[$minor]:-}"
 
     for php in $accepted; do
-        php_image="php$(echo "$php" | tr -d '.')-fpm"
+        php_image="php${php//./}-fpm"
         img_tag="${CI_IMAGE_REPO}:${php_image}-magento${minor}"
 
         # 1. Past upstream PHP support (php.net no longer lists this minor).


### PR DESCRIPTION
Child of TWO-24739. Reference implementation (magento-plugin); magento-abn-plugin adopts the reconciled script in a follow-up PR.

## What changed

`dev/magento-support-matrix.sh` classifies every in-window Magento×PHP combo as **run** or **skip**, and the split happens at **matrix-assembly time** (the `discover-magento-matrix` job) — not inside a green job.

- **`--emit-matrix` returns runnable combos only.** phpstan/di-compile legs are therefore all real tests: a green leg unambiguously means "tested." A skipped combo is never a test leg, so it can never masquerade as a pass.
- **`--emit-skips` returns untestable combos with reasons.** The discover job renders them to `$GITHUB_STEP_SUMMARY` as a coverage table **and** emits one `::warning::` annotation per skipped combo — a not-run combination shows up yellow on the run summary, clearly distinct from a green pass, at a glance.
- **Support window is honest.** Current + previous 2 over *all* published minors — image availability no longer slides the window down. An in-policy minor with no CI image is a surfaced skip, not silently backfilled by an older out-of-policy minor.
- **Missing CI image auto-detected** via `docker manifest inspect` (retry + fail-toward-run so a Docker Hub blip can't zero the matrix). Retired the hand-maintained image-exclusion list — which the probe immediately showed was **stale**: 2.4.9 images exist for php84/php85, only php83 is missing.
- **Network hardening:** retry + JSON-shape validation on the php.net and per-minor composer.json fetches (were single un-retried SPOFs). GitHub token no longer sent to php.net.

## Coverage (this run)

Runnable (real green legs): 2.4.9×{8.4,8.5}, 2.4.8×{8.3,8.4}, 2.4.7×{8.2,8.3}. NOT run (warning + table): 2.4.9×8.3 and 2.4.8×8.2 (no CI image), 2.4.7×8.1 (past upstream PHP support). Window moved {2.4.8,2.4.7,2.4.6} → the true current+prev2 {2.4.9,2.4.8,2.4.7}; `SUPPORT_WINDOW` is the lever for a wider net.

_Raised by Claude (pairing with Doug)._