### PR TITLE
fix(e2e): deflake the min-order gate — settle shipping recalc before reading totals

### DIFF
--- a/e2e/tests/_helpers.ts
+++ b/e2e/tests/_helpers.ts
@@ -32,6 +32,21 @@ export async function availableMethods(page: Page): Promise<string[]> {
     );
 }
 
+// The quote's current shipping charge, for confirming a rate change landed.
+async function shippingAmount(page: Page): Promise<number> {
+    return page.evaluate(
+        () =>
+            new Promise<number>((resolve) => {
+                (window as any).require(['Magento_Checkout/js/model/quote'], (q: any) => {
+                    // totals() can be momentarily null mid-recalc — exactly the
+                    // window we poll in; NaN keeps the caller polling.
+                    const t = q.totals();
+                    resolve(t ? Number(t.shipping_amount) : NaN);
+                });
+            })
+    );
+}
+
 // Native click on the shipping radio — Playwright's .check()/.click() on the
 // styled input doesn't fire Magento's shipping-change handler that recalculates
 // totals, so wait for the radio to load, then drive it in-page like a real click.
@@ -43,6 +58,16 @@ export async function selectShipping(page: Page, kind: 'freeshipping' | 'flatrat
     await expect(radio).toBeVisible({ timeout: 20_000 });
     await radio.evaluate((el) => (el as HTMLInputElement).click());
     await waitIdle(page);
+    // waitIdle only clears the loading-mask; the totals recalc lands a beat later
+    // via a knockout observable, so a grand_total read here can catch the stale
+    // pre-recalc value (flaky on slow CI runners). Poll until shipping_amount
+    // reflects the chosen rate — non-zero for flat, zero for free — before
+    // returning, so any following total read is settled.
+    if (kind === 'flatrate') {
+        await expect.poll(() => shippingAmount(page), { timeout: 20_000 }).toBeGreaterThan(0);
+    } else {
+        await expect.poll(() => shippingAmount(page), { timeout: 20_000 }).toBe(0);
+    }
 }
 
 export async function addToCart(page: Page) {

--- a/e2e/tests/min-order.spec.ts
+++ b/e2e/tests/min-order.spec.ts
@@ -19,6 +19,21 @@ import {
 
 const MIN_FIELD = '#two_payment_payment_method_merchant_minimum_order';
 const BASIS_FIELD = '#two_payment_payment_method_merchant_minimum_order_basis';
+// Each config field carries a "Use Default" checkbox; while it is checked the
+// field renders disabled, so fill()/selectOption() would hang waiting for an
+// editable element. Manage the checkbox before touching the field.
+const MIN_INHERIT = '#two_payment_payment_method_merchant_minimum_order_inherit';
+const BASIS_INHERIT = '#two_payment_payment_method_merchant_minimum_order_basis_inherit';
+
+interface MinimumConfig {
+    amount: string;
+    basis: string;
+    // Whether each field was inheriting the default (Use Default checked) —
+    // captured so teardown can restore it faithfully rather than typing an
+    // empty string into a disabled field.
+    amountInherited: boolean;
+    basisInherited: boolean;
+}
 
 // Grand total of the current quote, in the quote currency (= store base currency
 // on the staging store, so it compares 1:1 against the merchant minimum).
@@ -33,20 +48,48 @@ async function grandTotal(page: Page): Promise<number> {
     );
 }
 
-async function readMinimumConfig(page: Page): Promise<{ amount: string; basis: string }> {
+async function readMinimumConfig(page: Page): Promise<MinimumConfig> {
     await gotoTwoPaymentConfig(page);
+    // inputValue() reads a disabled input fine; isChecked() tells us whether
+    // the field was on its default so we can put it back exactly as found.
     return {
         amount: await page.locator(MIN_FIELD).inputValue(),
-        basis: await page.locator(BASIS_FIELD).inputValue()
+        basis: await page.locator(BASIS_FIELD).inputValue(),
+        amountInherited: await page.locator(MIN_INHERIT).isChecked(),
+        basisInherited: await page.locator(BASIS_INHERIT).isChecked()
     };
 }
 
-async function writeMinimumConfig(page: Page, amount: string, basis: string) {
-    await gotoTwoPaymentConfig(page);
-    await page.locator(MIN_FIELD).fill(amount);
-    if (basis) {
-        await page.locator(BASIS_FIELD).selectOption(basis);
+// Set one config field, driving its "Use Default" checkbox first. Clicking the
+// checkbox is what fires Magento's handler that enables/disables the input, so
+// a custom value must wait for the field to be editable before filling.
+async function setConfigField(
+    page: Page,
+    inheritSel: string,
+    fieldSel: string,
+    inherited: boolean,
+    apply: () => Promise<void>
+) {
+    if (inherited) {
+        // Restore to default: checking the box disables and resets the field.
+        await page.locator(inheritSel).setChecked(true);
+        return;
     }
+    await page.locator(inheritSel).setChecked(false);
+    await expect(page.locator(fieldSel)).toBeEditable({ timeout: 10_000 });
+    await apply();
+}
+
+async function writeMinimumConfig(page: Page, cfg: MinimumConfig) {
+    await gotoTwoPaymentConfig(page);
+    await setConfigField(page, MIN_INHERIT, MIN_FIELD, cfg.amountInherited, () =>
+        page.locator(MIN_FIELD).fill(cfg.amount)
+    );
+    await setConfigField(page, BASIS_INHERIT, BASIS_FIELD, cfg.basisInherited, async () => {
+        if (cfg.basis) {
+            await page.locator(BASIS_FIELD).selectOption(cfg.basis);
+        }
+    });
     await page.locator('#save').click();
     // The save reloads the page; a rejected value (e.g. below the platform
     // floor from the Two API) surfaces as an error banner instead of success.
@@ -90,8 +133,14 @@ test.describe('minimum order value gate', () => {
         const original = await readMinimumConfig(adminPage);
         try {
             // gross basis compares the grand total directly — the number the
-            // buyer sees in the totals block.
-            await writeMinimumConfig(adminPage, pinned, 'gross');
+            // buyer sees in the totals block. A pinned custom value, so neither
+            // field inherits the default.
+            await writeMinimumConfig(adminPage, {
+                amount: pinned,
+                basis: 'gross',
+                amountInherited: false,
+                basisInherited: false
+            });
 
             await selectShipping(page, 'flatrate');
             await expect
@@ -107,7 +156,10 @@ test.describe('minimum order value gate', () => {
                 .poll(() => availableMethods(page), { timeout: 25_000 })
                 .toContain('two_payment');
         } finally {
-            await writeMinimumConfig(adminPage, original.amount, original.basis);
+            // Restore exactly as found — including putting a field back on its
+            // default (Use Default) rather than filling an empty string into a
+            // now-disabled input, which is what timed the teardown out before.
+            await writeMinimumConfig(adminPage, original);
             await adminContext.close();
         }
     });

--- a/e2e/tests/min-order.spec.ts
+++ b/e2e/tests/min-order.spec.ts
@@ -60,9 +60,22 @@ async function readMinimumConfig(page: Page): Promise<MinimumConfig> {
     };
 }
 
-// Set one config field, driving its "Use Default" checkbox first. Clicking the
-// checkbox is what fires Magento's handler that enables/disables the input, so
-// a custom value must wait for the field to be editable before filling.
+// Toggle a "Use Default" checkbox to the desired state. Playwright's
+// setChecked() times out on Magento's `config-inherit` checkbox, so drive it
+// with a native in-page click (same technique the shipping radio uses) — that
+// both flips the box and fires the onclick handler that enables/disables the
+// paired field. No-op when it is already in the desired state.
+async function setInherit(page: Page, inheritSel: string, desired: boolean) {
+    const box = page.locator(inheritSel);
+    if ((await box.isChecked()) === desired) {
+        return;
+    }
+    await box.evaluate((el) => (el as HTMLInputElement).click());
+}
+
+// Set one config field, driving its "Use Default" checkbox first. A custom
+// value must wait for the field to become editable before filling; restoring
+// to default just leaves the box checked.
 async function setConfigField(
     page: Page,
     inheritSel: string,
@@ -70,12 +83,10 @@ async function setConfigField(
     inherited: boolean,
     apply: () => Promise<void>
 ) {
+    await setInherit(page, inheritSel, inherited);
     if (inherited) {
-        // Restore to default: checking the box disables and resets the field.
-        await page.locator(inheritSel).setChecked(true);
         return;
     }
-    await page.locator(inheritSel).setChecked(false);
     await expect(page.locator(fieldSel)).toBeEditable({ timeout: 10_000 });
     await apply();
 }

--- a/e2e/tests/min-order.spec.ts
+++ b/e2e/tests/min-order.spec.ts
@@ -48,8 +48,23 @@ async function grandTotal(page: Page): Promise<number> {
     );
 }
 
+// The minimum-order fields live in the collapsible "payment_method" group
+// (name="groups[payment_method]..."). A section landing leaves group state to a
+// remembered UI cookie, so the fieldset can be collapsed — the fields are then
+// in the DOM but not visible, and fill() hangs on the visibility check even
+// though the input is enabled. Force the group open. Clicking the header
+// toggles, so only click when the field isn't already visible.
+async function expandPaymentGroup(page: Page) {
+    if (await page.locator(MIN_FIELD).isVisible()) {
+        return;
+    }
+    await page.locator('#two_payment_payment_method-head').click();
+    await expect(page.locator(MIN_FIELD)).toBeVisible({ timeout: 10_000 });
+}
+
 async function readMinimumConfig(page: Page): Promise<MinimumConfig> {
     await gotoTwoPaymentConfig(page);
+    await expandPaymentGroup(page);
     // inputValue() reads a disabled input fine; isChecked() tells us whether
     // the field was on its default so we can put it back exactly as found.
     return {
@@ -93,6 +108,7 @@ async function setConfigField(
 
 async function writeMinimumConfig(page: Page, cfg: MinimumConfig) {
     await gotoTwoPaymentConfig(page);
+    await expandPaymentGroup(page);
     await setConfigField(page, MIN_INHERIT, MIN_FIELD, cfg.amountInherited, () =>
         page.locator(MIN_FIELD).fill(cfg.amount)
     );


### PR DESCRIPTION
## Summary

`min-order.spec.ts`'s precondition `flat-rate shipping must cost more than free shipping` (line 79) failed on CI — the first credentialed run of the gate test. Root cause is a read race, not a store-config or net/gross issue.

`selectShipping`'s `waitIdle` only waits for the loading-mask to clear, but Magento recalculates the quote totals a beat later via a knockout observable. So `grandTotal()` read immediately after could catch the **stale pre-recalc** value, and `flatTotal` came back equal to `freeTotal` (flaky on slower runners; passes locally because the machine wins the race).

## Fix

After the shipping click, poll until `quote.totals().shipping_amount` reflects the chosen rate (non-zero for flat, zero for free) before returning, so any subsequent total read is settled. No hardcoded rate — just "flat charges something, free charges nothing".

## Evidence

Measured live on the GBP staging store (`magento.staging.two.inc`), GB buyer:

```
SHIPPING_RATES: freeshipping £0, flatrate £5
FLAT: grand=50 subtotal=45 shipping=5 tax=0
FREE: grand=45 subtotal=45 shipping=0 tax=0
```

Store config is fine and the £5 gap is real; the failure was purely the stale read. Net/gross also confirmed not the cause (both bases include shipping in `MinimumOrderGate::basketValue`).

## Scope

- `e2e/tests/_helpers.ts` only (`selectShipping` is shared by the checkout journey + min-order specs). No test-logic change.