### PR TITLE
fix(ABN-460): re-evaluate payment visibility when checkout totals change

### DIFF
--- a/Test/Js/payment-availability.test.js
+++ b/Test/Js/payment-availability.test.js
@@ -181,7 +181,7 @@ describe('Two_Gateway/js/view/payment-availability', () => {
         expect(getPaymentInformation).toHaveBeenCalledTimes(1);
     });
 
-    it('ignores a totals change while a refresh is still in flight', () => {
+    it('defers a mid-flight totals change and runs it when the refresh resolves', () => {
         const { totals, getPaymentInformation } = setup(
             { grand_total: '224.00' },
             { defer: true }
@@ -189,13 +189,40 @@ describe('Two_Gateway/js/view/payment-availability', () => {
         totals({ grand_total: '264.00' });
         expect(getPaymentInformation).toHaveBeenCalledTimes(1);
 
-        // Re-entrant change before the in-flight call resolves: swallowed.
+        // Change before the in-flight call resolves: parked, not fired yet.
         totals({ grand_total: '300.00' });
         expect(getPaymentInformation).toHaveBeenCalledTimes(1);
 
-        // Once the in-flight call resolves, later changes refresh again.
+        // In-flight call resolves → the parked change drives a second refresh.
         getPaymentInformation.lastDeferred.resolve();
+        expect(getPaymentInformation).toHaveBeenCalledTimes(2);
+
+        // Second resolves with nothing parked → no third refresh.
+        getPaymentInformation.lastDeferred.resolve();
+        expect(getPaymentInformation).toHaveBeenCalledTimes(2);
+
+        // A later change still refreshes normally.
         totals({ grand_total: '320.00' });
+        expect(getPaymentInformation).toHaveBeenCalledTimes(3);
+    });
+
+    it('coalesces multiple mid-flight changes to the latest parked value', () => {
+        const { totals, getPaymentInformation } = setup(
+            { grand_total: '224.00' },
+            { defer: true }
+        );
+        totals({ grand_total: '264.00' });
+        totals({ grand_total: '300.00' });
+        totals({ grand_total: '310.00' });
+        // Only the first fired; 300 and 310 collapse into one parked value.
+        expect(getPaymentInformation).toHaveBeenCalledTimes(1);
+
+        getPaymentInformation.lastDeferred.resolve();
+        expect(getPaymentInformation).toHaveBeenCalledTimes(2);
+
+        // The parked refresh advanced the baseline to 310, so resolving with
+        // nothing new parked ends the chain.
+        getPaymentInformation.lastDeferred.resolve();
         expect(getPaymentInformation).toHaveBeenCalledTimes(2);
     });
 

--- a/Test/Js/payment-availability.test.js
+++ b/Test/Js/payment-availability.test.js
@@ -1,0 +1,208 @@
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ *
+ * Behavioural tests for the checkout payment-availability refresher
+ * (view/frontend/web/js/view/payment-availability.js).
+ *
+ * The component subscribes to quote.getTotals() and re-asks the server
+ * for payment availability (get-payment-information) whenever the grand
+ * total actually moves. The delicate parts are the dedup and loop guards:
+ *  - it must NOT refresh on the bootstrap total core already fetched for,
+ *  - it must NOT refresh on a no-op re-emit (same grand total),
+ *  - and crucially it must NOT loop, because get-payment-information itself
+ *    re-emits the totals observable via quote.setTotals().
+ * These are exactly what this test pins down.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const SRC = fs.readFileSync(
+    path.resolve(__dirname, '../../view/frontend/web/js/view/payment-availability.js'),
+    'utf8'
+);
+
+/**
+ * Load the AMD module by shimming `define`, capturing the factory, and
+ * invoking it with the supplied dependency mocks. Returns the module's
+ * export (the extended uiComponent constructor).
+ */
+function loadComponent(deps) {
+    let factory;
+    const sandbox = {
+        define: function (depList, fn) {
+            factory = fn;
+        }
+    };
+    vm.runInNewContext(SRC, sandbox);
+
+    return factory(
+        deps.Component,
+        deps.$,
+        deps.quote,
+        deps.getPaymentInformation,
+        deps.globalMessageList || { addErrorMessage: function () {} }
+    );
+}
+
+/** Minimal KO-style observable: callable getter/setter with subscribe. */
+function makeObservable(initial) {
+    let value = initial;
+    const subscribers = [];
+    const obs = function () {
+        if (arguments.length) {
+            value = arguments[0];
+            subscribers.slice().forEach(function (fn) {
+                fn(value);
+            });
+        }
+
+        return value;
+    };
+    obs.subscribe = function (fn) {
+        subscribers.push(fn);
+    };
+
+    return obs;
+}
+
+/** Minimal uiComponent stand-in: extend() returns a constructor. */
+const ComponentMock = {
+    extend: function (proto) {
+        function Ctor() {}
+        Ctor.prototype = Object.assign({ _super: function () {} }, proto);
+
+        return Ctor;
+    }
+};
+
+/** jQuery Deferred/when stubs that fire always() regardless of order. */
+const $mock = {
+    Deferred: function () {
+        let resolved = false;
+        const callbacks = [];
+        const d = {
+            resolve: function () {
+                resolved = true;
+                callbacks.splice(0).forEach(function (fn) {
+                    fn();
+                });
+
+                return d;
+            },
+            always: function (fn) {
+                if (resolved) {
+                    fn();
+                } else {
+                    callbacks.push(fn);
+                }
+
+                return d;
+            }
+        };
+
+        return d;
+    },
+    when: function (d) {
+        return d;
+    }
+};
+
+function setup(initialTotals, opts) {
+    opts = opts || {};
+    const totals = makeObservable(initialTotals);
+    const quote = { getTotals: function () { return totals; } };
+    // The action resolves synchronously unless the test asks it to defer,
+    // and (like the real one) re-emits the totals observable with the same
+    // grand total to model quote.setTotals().
+    const getPaymentInformation = jest.fn(function (deferred) {
+        if (opts.reEmitSameTotal) {
+            totals(Object.assign({}, totals()));
+        }
+        if (!opts.defer) {
+            deferred.resolve();
+        } else {
+            getPaymentInformation.lastDeferred = deferred;
+        }
+    });
+
+    const Widget = loadComponent({
+        Component: ComponentMock,
+        $: $mock,
+        quote: quote,
+        getPaymentInformation: getPaymentInformation
+    });
+    const instance = new Widget();
+    instance.initialize();
+
+    return { instance, totals, getPaymentInformation };
+}
+
+describe('Two_Gateway/js/view/payment-availability', () => {
+    it('does not refresh on the bootstrap total the component mounts with', () => {
+        const { getPaymentInformation } = setup({ grand_total: '224.00' });
+        expect(getPaymentInformation).not.toHaveBeenCalled();
+    });
+
+    it('refreshes when the grand total changes (crossing the threshold)', () => {
+        const { totals, getPaymentInformation } = setup({ grand_total: '224.00' });
+        totals({ grand_total: '264.00' });
+        expect(getPaymentInformation).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not refresh on a no-op re-emit with an unchanged grand total', () => {
+        const { totals, getPaymentInformation } = setup({ grand_total: '224.00' });
+        totals({ grand_total: '224.00' });
+        expect(getPaymentInformation).not.toHaveBeenCalled();
+    });
+
+    it('does not loop when get-payment-information re-emits the same total', () => {
+        // The action calls quote.setTotals() on success, re-firing the
+        // subscriber. With an unchanged grand total the guard must swallow it.
+        const { totals, getPaymentInformation } = setup(
+            { grand_total: '224.00' },
+            { reEmitSameTotal: true }
+        );
+        totals({ grand_total: '264.00' });
+        expect(getPaymentInformation).toHaveBeenCalledTimes(1);
+    });
+
+    it('seeds the baseline from the first emit when totals are absent at mount', () => {
+        const { totals, getPaymentInformation } = setup(null);
+        // First emit is the bootstrap load core already fetched for: baseline only.
+        totals({ grand_total: '224.00' });
+        expect(getPaymentInformation).not.toHaveBeenCalled();
+        // A genuine subsequent change refreshes.
+        totals({ grand_total: '264.00' });
+        expect(getPaymentInformation).toHaveBeenCalledTimes(1);
+    });
+
+    it('ignores a totals change while a refresh is still in flight', () => {
+        const { totals, getPaymentInformation } = setup(
+            { grand_total: '224.00' },
+            { defer: true }
+        );
+        totals({ grand_total: '264.00' });
+        expect(getPaymentInformation).toHaveBeenCalledTimes(1);
+
+        // Re-entrant change before the in-flight call resolves: swallowed.
+        totals({ grand_total: '300.00' });
+        expect(getPaymentInformation).toHaveBeenCalledTimes(1);
+
+        // Once the in-flight call resolves, later changes refresh again.
+        getPaymentInformation.lastDeferred.resolve();
+        totals({ grand_total: '320.00' });
+        expect(getPaymentInformation).toHaveBeenCalledTimes(2);
+    });
+
+    it('ignores emits with an absent or unparseable grand total', () => {
+        const { totals, getPaymentInformation } = setup({ grand_total: '224.00' });
+        totals(null);
+        totals({ grand_total: 'not-a-number' });
+        expect(getPaymentInformation).not.toHaveBeenCalled();
+    });
+});

--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -63,6 +63,17 @@
                                 </item>
                                 <item name="sidebar" xsi:type="array">
                                     <item name="children" xsi:type="array">
+                                        <!--
+                                            Headless: re-runs server-side payment
+                                            availability when the totals change so the
+                                            method shows/hides as the basket crosses the
+                                            minimum-order threshold. Mounted here (always
+                                            present) rather than under the payment renderer,
+                                            which is absent while the method is hidden.
+                                        -->
+                                        <item name="two-payment-availability" xsi:type="array">
+                                            <item name="component" xsi:type="string">Two_Gateway/js/view/payment-availability</item>
+                                        </item>
                                         <item name="summary" xsi:type="array">
                                             <item name="children" xsi:type="array">
                                                 <item name="totals" xsi:type="array">

--- a/view/frontend/web/js/view/payment-availability.js
+++ b/view/frontend/web/js/view/payment-availability.js
@@ -57,6 +57,13 @@ define([
             // observable while a refresh is still in flight.
             this._refreshing = false;
 
+            // Trailing edge: a total that changes again mid-refresh is
+            // parked here and re-run when the in-flight refresh resolves,
+            // so rapid interactions (switch shipping, then apply a coupon)
+            // still converge on the final total rather than leaving the
+            // availability decided against a superseded value.
+            this._pendingGrandTotal = null;
+
             // Baseline the grand total from the totals already loaded at
             // mount (core has just fetched the payment list for this value
             // on step entry, so there is nothing to re-ask yet). A KO
@@ -87,9 +94,6 @@ define([
          * @param {Object|null} totals
          */
         _onTotalsChanged: function (totals) {
-            if (this._refreshing) {
-                return;
-            }
             var grandTotal = this._readGrandTotal(totals);
 
             if (grandTotal === null) {
@@ -106,8 +110,17 @@ define([
             if (grandTotal === this._lastGrandTotal) {
                 // A no-op re-emit (Magento republishes the observable in
                 // several flows without a value change) — including the one
-                // get-payment-information itself triggers. Skipping it is
-                // what keeps this off an infinite refresh loop.
+                // get-payment-information itself triggers. Testing this
+                // BEFORE the in-flight guard is what keeps the self-triggered
+                // re-emit off both the refresh loop and the pending queue.
+                return;
+            }
+            if (this._refreshing) {
+                // A genuine change arrived while a refresh is in flight. Park
+                // it; _refreshAvailability re-runs against the latest parked
+                // value once the current call resolves.
+                this._pendingGrandTotal = grandTotal;
+
                 return;
             }
             this._lastGrandTotal = grandTotal;
@@ -123,12 +136,26 @@ define([
             var deferred = $.Deferred();
 
             this._refreshing = true;
-            // Pass the shared checkout message list so a failed refresh
-            // reports through the standard error path rather than
-            // dereferencing a null container inside the core action.
-            getPaymentInformation(deferred, globalMessageList);
+            this._pendingGrandTotal = null;
+
+            try {
+                // Pass the shared checkout message list so a failed refresh
+                // reports through the standard error path rather than
+                // dereferencing a null container inside the core action.
+                getPaymentInformation(deferred, globalMessageList);
+            } catch (e) {
+                // A synchronous throw would otherwise strand _refreshing at
+                // true and wedge the component. Reject so the always() below
+                // clears the flag and drains any parked change.
+                deferred.reject(e);
+            }
             $.when(deferred).always(function () {
                 self._refreshing = false;
+                if (self._pendingGrandTotal !== null &&
+                    self._pendingGrandTotal !== self._lastGrandTotal) {
+                    self._lastGrandTotal = self._pendingGrandTotal;
+                    self._refreshAvailability();
+                }
             });
         }
     });

--- a/view/frontend/web/js/view/payment-availability.js
+++ b/view/frontend/web/js/view/payment-availability.js
@@ -1,0 +1,135 @@
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+/**
+ * Re-evaluates payment-method availability when the quote totals change.
+ *
+ * The payment method's availability (Model\Two::isAvailable) depends on
+ * the order value via the minimum-order gate, which compares the quote
+ * grand total (net or gross) against the funding-partner / merchant
+ * minimum. That check is server-side and correct — but Luma's
+ * payment-service caches the method list from the last
+ * set-shipping-information / payment-information fetch and does NOT
+ * re-filter it when the totals move afterward (a later shipping-method
+ * switch, a coupon applied on the payment step). So a basket that crosses
+ * the minimum after the payment step is reached keeps its stale
+ * visibility until a full checkout reload. Hyvä and FireCheckout re-fetch
+ * on every totals change and are unaffected; this component gives Luma
+ * (and Luma-derived one-step checkouts) the same behaviour.
+ *
+ * The fix re-ASKS the server rather than re-deciding in JS: on a genuine
+ * totals change it calls get-payment-information, which re-runs
+ * isAvailable server-side and repopulates the payment-method list. The
+ * minimum-order logic (currency conversion, net/gross basis,
+ * platform-vs-merchant floor) stays in one place — the server gate — and
+ * is never duplicated here, so the client cannot drift from what the
+ * Two API enforces at order creation.
+ *
+ * Mounted from checkout_index_index.xml under the always-present sidebar,
+ * NOT under the Two payment renderer: when the method is hidden
+ * (below-minimum) its renderer is not instantiated, so a refresher living
+ * there could never bring the method back once it becomes eligible.
+ */
+define([
+    'uiComponent',
+    'jquery',
+    'Magento_Checkout/js/model/quote',
+    'Magento_Checkout/js/action/get-payment-information',
+    'Magento_Ui/js/model/messageList'
+], function (Component, $, quote, getPaymentInformation, globalMessageList) {
+    'use strict';
+
+    return Component.extend({
+        defaults: {
+            template: null
+        },
+
+        /**
+         * @returns {Object} chainable
+         */
+        initialize: function () {
+            this._super();
+
+            // Guard against re-entrancy: get-payment-information calls
+            // quote.setTotals() on success, which re-emits the totals
+            // observable while a refresh is still in flight.
+            this._refreshing = false;
+
+            // Baseline the grand total from the totals already loaded at
+            // mount (core has just fetched the payment list for this value
+            // on step entry, so there is nothing to re-ask yet). A KO
+            // subscribable does not replay, so seeding here is what lets us
+            // detect the FIRST post-mount change on a fast/returning-customer
+            // stack where the bootstrap emit fired before we subscribed.
+            this._lastGrandTotal = this._readGrandTotal(quote.getTotals()());
+
+            quote.getTotals().subscribe(this._onTotalsChanged.bind(this));
+
+            return this;
+        },
+
+        /**
+         * @param {Object|null} totals
+         * @returns {Number|null} parsed grand total, or null when absent/NaN
+         */
+        _readGrandTotal: function (totals) {
+            if (!totals) {
+                return null;
+            }
+            var value = parseFloat(totals.grand_total);
+
+            return isNaN(value) ? null : value;
+        },
+
+        /**
+         * @param {Object|null} totals
+         */
+        _onTotalsChanged: function (totals) {
+            if (this._refreshing) {
+                return;
+            }
+            var grandTotal = this._readGrandTotal(totals);
+
+            if (grandTotal === null) {
+                return;
+            }
+            if (this._lastGrandTotal === null) {
+                // First value we have seen — core already fetched the
+                // payment list for it. Record as the baseline and wait for
+                // a real change.
+                this._lastGrandTotal = grandTotal;
+
+                return;
+            }
+            if (grandTotal === this._lastGrandTotal) {
+                // A no-op re-emit (Magento republishes the observable in
+                // several flows without a value change) — including the one
+                // get-payment-information itself triggers. Skipping it is
+                // what keeps this off an infinite refresh loop.
+                return;
+            }
+            this._lastGrandTotal = grandTotal;
+            this._refreshAvailability();
+        },
+
+        /**
+         * Re-run server-side availability and repopulate the payment-method
+         * list for the current quote state.
+         */
+        _refreshAvailability: function () {
+            var self = this;
+            var deferred = $.Deferred();
+
+            this._refreshing = true;
+            // Pass the shared checkout message list so a failed refresh
+            // reports through the standard error path rather than
+            // dereferencing a null container inside the core action.
+            getPaymentInformation(deferred, globalMessageList);
+            $.when(deferred).always(function () {
+                self._refreshing = false;
+            });
+        }
+    });
+});


### PR DESCRIPTION
## Problem

In **Luma** and **Amasty OneStepCheckout**, the payment method's visibility does not update when the shipping method or a discount changes on the checkout page — it only re-evaluates after a full checkout reload. **Hyvä and FireCheckout are unaffected** (they re-fetch the payment list on every totals change).

### Repro (Luma)
Merchant minimum 250 net, basket 224 net:
1. Free shipping (224 < 250) → method hidden ✅
2. Select flat rate (+40 → 264 ≥ 250) → method **does not appear** ❌
3. Round-trip /checkout/cart → back → method appears ✅ (reload re-runs the server check)
4. Select free shipping again (224 < 250) → method **remains visible** ❌
5. Round-trip cart → checkout → method hidden ✅

Steps 3 and 5 prove the value basis is already correct both ways. This is **not a value bug and not a regression** — the gate has always compared the quote grand total (net/gross), which includes shipping and discounts. It is a **stale-state** bug: Luma's `payment-service` caches the method list from the last shipping/payment-information fetch and never re-filters it when totals move afterward.

## Fix

A headless checkout component subscribes to `quote.getTotals()` and, on a genuine grand-total change, calls `get-payment-information` to re-run server-side `isAvailable` and repopulate the method list.

- **Re-asks the server; never re-decides in JS.** The minimum logic (currency conversion, net/gross basis, platform-vs-merchant floor) stays only in the server gate — no duplication, no drift from what the API enforces at order creation.
- **Mounted under the always-present sidebar**, not the payment renderer — the renderer is unmounted while the method is hidden, so a refresher living there could never bring it back.
- Guards **dedup** no-op re-emits and prevent the **refresh loop** the action's own `setTotals()` would otherwise cause; a change while a refresh is in flight is swallowed.

## Severity

UX only — no money leak. Place-order re-runs `isAvailable` server-side and the API enforces the minimum at order creation (fail-closed), so a below-minimum order cannot be placed regardless.

## Tests

Jest coverage for baseline-seeding, threshold-cross refresh, no-op dedup, loop guard, re-entrancy, and NaN handling. Full suite green (37).

## Manual QA on staging (please verify)

- [ ] Luma: method shows/hides live when switching shipping method across the threshold (repro steps 2 + 4)
- [ ] Luma: coupon applied on the payment step that drops below the minimum hides the method
- [ ] Amasty OSC: same behaviour
- [ ] No flicker, no reset of an already-selected payment method, no refresh loop
- [ ] Hyvä + FireCheckout unchanged (regression check)

_ABN-460. Scope open question for Priyanka: is Amasty OSC an in-scope supported target or a happy side-effect?_

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)