### PR TITLE
fix(TWO-25020): resolve version-panel commit SHA from the Composer registry

### DIFF
--- a/Block/Adminhtml/System/Config/Field/Version.php
+++ b/Block/Adminhtml/System/Config/Field/Version.php
@@ -267,8 +267,18 @@ class Version extends Field
      * Magento init job behaviour, which makes the realpath of
      * registration.php contain no worktree segment).
      */
-    private function extractCommit(string $modulePath): string
+    protected function extractCommit(string $modulePath): string
     {
+        // Composer-installed deploys (Packagist/dist — the current 2.0
+        // distribution model) put the module under vendor/ with NO .git
+        // worktree, so the path-based resolution below finds nothing. The
+        // installed registry records the exact source/dist commit, which is
+        // authoritative and layout-independent — prefer it.
+        $fromComposer = $this->commitFromComposer($modulePath);
+        if ($fromComposer !== null) {
+            return $fromComposer;
+        }
+
         $gitFile = $modulePath . '/.git';
         if (is_file($gitFile)) {
             // .git is always `gitdir: <relpath>\n`; cap the read defensively
@@ -288,6 +298,51 @@ class Version extends Field
             return substr($m[1], 0, 7);
         }
         return '';
+    }
+
+    /**
+     * 7-char commit SHA from Composer's installed registry, or null when the
+     * module isn't composer-installed or carries no hex source reference.
+     *
+     * Reads the package name from composer.json (checking the module dir and
+     * one level up — monorepo sub-path modules keep composer.json a level up,
+     * mirroring readComposerVersion()), then asks the installed registry for
+     * that package's source/dist reference. A path-repo or branch install may
+     * carry a non-SHA reference; the hex guard rejects those so the caller
+     * falls back to the .git/worktree resolution.
+     */
+    protected function commitFromComposer(string $modulePath): ?string
+    {
+        foreach ([$modulePath, dirname($modulePath)] as $dir) {
+            $composer = @file_get_contents($dir . '/composer.json');
+            if ($composer === false) {
+                continue;
+            }
+            $data = json_decode($composer, true);
+            $name = is_array($data) ? ($data['name'] ?? null) : null;
+            if (!is_string($name) || $name === '') {
+                continue;
+            }
+            $ref = $this->composerReference($name);
+            if (is_string($ref) && preg_match('/^[a-f0-9]{7,40}$/', $ref)) {
+                return substr($ref, 0, 7);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * The installed package's source/dist reference (commit SHA), or null.
+     * Wraps the static Composer registry as an override seam for testing.
+     */
+    protected function composerReference(string $packageName): ?string
+    {
+        if (!class_exists(\Composer\InstalledVersions::class)
+            || !\Composer\InstalledVersions::isInstalled($packageName)
+        ) {
+            return null;
+        }
+        return \Composer\InstalledVersions::getReference($packageName);
     }
 
     private function getCodeTs(string $modulePath): int

--- a/Test/Unit/Block/Adminhtml/System/Config/Field/VersionTest.php
+++ b/Test/Unit/Block/Adminhtml/System/Config/Field/VersionTest.php
@@ -1,0 +1,139 @@
+<?php
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Block\Adminhtml\System\Config\Field;
+
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Block\Adminhtml\System\Config\Field\Version;
+
+/**
+ * Tests for commit-SHA resolution in the admin Version panel.
+ *
+ * The regression (TWO-25020): composer-installed deploys put the module under
+ * vendor/ with no .git worktree, so the path-based resolution returned '' and
+ * the panel showed '—'. extractCommit() now prefers Composer's installed
+ * registry (source/dist reference), falling back to the .git/worktree parse.
+ */
+class VersionTest extends TestCase
+{
+    /** @var string */
+    private $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/two-version-test-' . uniqid();
+        mkdir($this->tmpDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (['/.git', '/composer.json', '/registration.php'] as $f) {
+            @unlink($this->tmpDir . $f);
+        }
+        @rmdir($this->tmpDir);
+    }
+
+    private function writeComposerJson(string $name): void
+    {
+        file_put_contents(
+            $this->tmpDir . '/composer.json',
+            json_encode(['name' => $name])
+        );
+    }
+
+    public function testCommitResolvedFromComposerReference(): void
+    {
+        $this->writeComposerJson('two-inc/magento2');
+        $block = new VersionTestable();
+        $block->stubRef = '0aa21947d6ed57bcf6b35f73a5ed192fc6a9a0dd';
+
+        $this->assertSame('0aa2194', $block->commitFromComposerPublic($this->tmpDir));
+    }
+
+    public function testComposerReferenceIsPreferredOverGitWorktree(): void
+    {
+        // Both signals present: composer wins (it's the authoritative,
+        // layout-independent source for a composer-installed module).
+        $this->writeComposerJson('two-inc/magento2');
+        file_put_contents($this->tmpDir . '/.git', "gitdir: /repo/.git/worktrees/deadbeef1234\n");
+        $block = new VersionTestable();
+        $block->stubRef = '0aa21947d6ed57bcf6b35f73a5ed192fc6a9a0dd';
+
+        $this->assertSame('0aa2194', $block->extractCommitPublic($this->tmpDir));
+    }
+
+    public function testFallsBackToGitWorktreeWhenNotComposerInstalled(): void
+    {
+        // composer.json present but the package resolves no reference (null) —
+        // e.g. a git-sync/dev checkout — so the .git worktree parse takes over.
+        $this->writeComposerJson('two-inc/magento2');
+        file_put_contents($this->tmpDir . '/.git', "gitdir: /repo/.git/worktrees/abcdef1234567\n");
+        $block = new VersionTestable();
+        $block->stubRef = null;
+
+        $this->assertSame('abcdef1', $block->extractCommitPublic($this->tmpDir));
+    }
+
+    public function testNonHexReferenceIsRejected(): void
+    {
+        // A path-repo / branch install can carry a non-SHA reference; it must
+        // not be shown as a commit — return null so the caller falls back.
+        $this->writeComposerJson('two-inc/magento2');
+        $block = new VersionTestable();
+        $block->stubRef = 'dev-main';
+
+        $this->assertNull($block->commitFromComposerPublic($this->tmpDir));
+    }
+
+    public function testEmptyWhenNoComposerAndNoGit(): void
+    {
+        $block = new VersionTestable();
+        $block->stubRef = null;
+
+        $this->assertSame('', $block->extractCommitPublic($this->tmpDir));
+    }
+
+    public function testPackageNameReadFromParentDirForMonorepoSubpath(): void
+    {
+        // Monorepo sub-path modules keep composer.json one level up.
+        $sub = $this->tmpDir . '/plugin';
+        mkdir($sub);
+        $this->writeComposerJson('two-inc/magento2');
+        $block = new VersionTestable();
+        $block->stubRef = '0aa21947d6ed57bcf6b35f73a5ed192fc6a9a0dd';
+
+        $this->assertSame('0aa2194', $block->commitFromComposerPublic($sub));
+        @rmdir($sub);
+    }
+}
+
+/**
+ * Constructor-free subclass exposing the protected resolution methods and
+ * stubbing the static Composer registry lookup.
+ */
+class VersionTestable extends Version
+{
+    /** @var string|null */
+    public $stubRef = null;
+
+    // Skip the heavy Field base constructor — these tests exercise pure
+    // resolution logic that needs no injected dependencies.
+    public function __construct()
+    {
+    }
+
+    protected function composerReference(string $packageName): ?string
+    {
+        return $this->stubRef;
+    }
+
+    public function commitFromComposerPublic(string $modulePath): ?string
+    {
+        return $this->commitFromComposer($modulePath);
+    }
+
+    public function extractCommitPublic(string $modulePath): string
+    {
+        return $this->extractCommit($modulePath);
+    }
+}


### PR DESCRIPTION
## Problem

The admin Version / deployment-status panel renders the commit column as `—` on both staging shops (Two + ABN). Per-module version + "Deployed at" still show — only the commit SHA is missing.

## Root cause (confirmed live on the pod)

The module is **composer-installed** under `vendor/two-inc/magento2` (Packagist/dist distribution) — there is **no `.git` worktree**, so `extractCommit()`'s two path regexes (`.git` `gitdir:` → `worktrees/<sha>$`, and `realpath` → `.worktrees/<sha>/`) both find nothing and return `''`. This changed when the deploy model moved from git-sync worktree symlinks to composer packages.

The commit is fully recoverable — `composer.lock` records it and, verified on the pod:

```
InstalledVersions::getReference('two-inc/magento2') === '0aa21947…' (the deployed commit)
```

## Fix

Prefer Composer's installed registry in `extractCommit()`:
- read the package name from `composer.json` (module dir or one level up, mirroring `readComposerVersion()`),
- look up its source/dist reference,
- use it when it's a hex SHA; otherwise fall back to the existing `.git`/worktree parse (git-sync / dev checkouts).

A non-hex reference (path/branch install) is rejected so it can't render as a commit. The static registry call is isolated behind a `composerReference()` seam for testing.

## Tests

New `VersionTest`: composer ref preferred over `.git`, hex validation, git-worktree fallback when not composer-installed, monorepo parent-dir `composer.json`, empty when neither signal present. (No local PHP — validated by CI PHPUnit; the composer-resolution path itself was verified live on the pod.)

## Note

Base Two plugin — the panel is shared, so this fixes the commit column on **both** the Two and ABN shops. ABN overlay packages that are path-installed (no hex reference) will still fall through to `—`; enriching those is out of scope here.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)