### PR TITLE
feat(ABN-460): reactive payment availability via methods-only refresh

### DIFF
--- a/Test/Js/payment-availability.test.js
+++ b/Test/Js/payment-availability.test.js
@@ -1,0 +1,181 @@
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ *
+ * Behavioural tests for the checkout payment-availability refresher
+ * (view/frontend/web/js/view/payment-availability.js).
+ *
+ * It subscribes to quote.getTotals() and, on a genuine grand-total change,
+ * re-fetches payment-information and applies ONLY the method list. The
+ * load-bearing guarantees:
+ *  - it NEVER calls quote.setTotals() (the clobber that got the first attempt
+ *    reverted),
+ *  - it does not fetch on the bootstrap total nor on no-op re-emits,
+ *  - a mid-flight change is parked and run on completion (trailing edge).
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const SRC = fs.readFileSync(
+    path.resolve(__dirname, '../../view/frontend/web/js/view/payment-availability.js'),
+    'utf8'
+);
+
+function loadComponent(deps) {
+    let factory;
+    const sandbox = { define: (depList, fn) => { factory = fn; } };
+    vm.runInNewContext(SRC, sandbox);
+
+    return factory(
+        deps.Component,
+        deps.$,
+        deps.quote,
+        deps.urlBuilder,
+        deps.storage,
+        deps.customer,
+        deps.methodConverter,
+        deps.paymentService,
+        deps.errorProcessor,
+        deps.globalMessageList
+    );
+}
+
+/** Minimal KO-style observable. */
+function makeObservable(initial) {
+    let value = initial;
+    const subs = [];
+    const obs = function () {
+        if (arguments.length) {
+            value = arguments[0];
+            subs.slice().forEach((fn) => fn(value));
+        }
+
+        return value;
+    };
+    obs.subscribe = (fn) => subs.push(fn);
+
+    return obs;
+}
+
+const ComponentMock = {
+    extend: function (proto) {
+        function Ctor() {}
+        Ctor.prototype = Object.assign({ _super: function () {} }, proto);
+
+        return Ctor;
+    }
+};
+
+/** mage/storage.get() stub returning a jQuery-style promise. */
+function makeStorage(opts) {
+    opts = opts || {};
+    const response = opts.response || { totals: { grand_total: '999' }, payment_methods: [{ method: 'two_payment' }] };
+    const get = jest.fn(function () {
+        let settled = null;
+        const done = [];
+        const fail = [];
+        const always = [];
+        const p = {
+            done(cb) { settled === 'done' ? cb(response) : done.push(cb); return p; },
+            fail(cb) { settled === 'fail' ? cb({}) : fail.push(cb); return p; },
+            always(cb) { settled ? cb() : always.push(cb); return p; }
+        };
+        p._resolve = () => { settled = 'done'; done.forEach((c) => c(response)); always.forEach((c) => c()); };
+        p._reject = () => { settled = 'fail'; fail.forEach((c) => c({})); always.forEach((c) => c()); };
+        get._last = p;
+        if (!opts.defer) { p._resolve(); }
+
+        return p;
+    });
+
+    return { get };
+}
+
+function setup(initialTotals, storageOpts) {
+    const totals = makeObservable(initialTotals);
+    const setTotals = jest.fn();
+    const quote = {
+        getTotals: () => totals,
+        getQuoteId: () => 'cart1',
+        setTotals
+    };
+    const storage = makeStorage(storageOpts);
+    const setPaymentMethods = jest.fn();
+    const process = jest.fn();
+    const Widget = loadComponent({
+        Component: ComponentMock,
+        $: {},
+        quote,
+        urlBuilder: { createUrl: (t) => t },
+        storage,
+        customer: { isLoggedIn: () => false },
+        methodConverter: (m) => m,
+        paymentService: { setPaymentMethods },
+        errorProcessor: { process },
+        globalMessageList: {}
+    });
+    const instance = new Widget();
+    instance.initialize();
+
+    return { instance, totals, storage, setPaymentMethods, setTotals, process };
+}
+
+describe('Two_Gateway/js/view/payment-availability', () => {
+    it('does not fetch on the bootstrap total at mount', () => {
+        const { storage } = setup({ grand_total: '224.00' });
+        expect(storage.get).not.toHaveBeenCalled();
+    });
+
+    it('re-fetches and applies ONLY the method list on a grand-total change', () => {
+        const { totals, storage, setPaymentMethods, setTotals } = setup({ grand_total: '224.00' });
+        totals({ grand_total: '264.00' });
+
+        expect(storage.get).toHaveBeenCalledTimes(1);
+        expect(setPaymentMethods).toHaveBeenCalledTimes(1);
+        // The whole point of the rewrite: totals are never clobbered.
+        expect(setTotals).not.toHaveBeenCalled();
+    });
+
+    it('does not fetch on a no-op re-emit with an unchanged grand total', () => {
+        const { totals, storage } = setup({ grand_total: '224.00' });
+        totals({ grand_total: '224.00' });
+        expect(storage.get).not.toHaveBeenCalled();
+    });
+
+    it('seeds the baseline from the first emit when totals are absent at mount', () => {
+        const { totals, storage } = setup(null);
+        totals({ grand_total: '224.00' });
+        expect(storage.get).not.toHaveBeenCalled();
+        totals({ grand_total: '264.00' });
+        expect(storage.get).toHaveBeenCalledTimes(1);
+    });
+
+    it('parks a mid-flight change and runs it once the refresh resolves', () => {
+        const { totals, storage } = setup({ grand_total: '224.00' }, { defer: true });
+        totals({ grand_total: '264.00' });
+        expect(storage.get).toHaveBeenCalledTimes(1);
+
+        // Change before the in-flight fetch resolves: parked, not fired.
+        totals({ grand_total: '300.00' });
+        expect(storage.get).toHaveBeenCalledTimes(1);
+
+        // Resolve → the parked change drives a second fetch.
+        storage.get._last._resolve();
+        expect(storage.get).toHaveBeenCalledTimes(2);
+    });
+
+    it('routes a failed fetch through the error processor and clears the in-flight flag', () => {
+        const { totals, storage, process } = setup({ grand_total: '224.00' }, { defer: true });
+        totals({ grand_total: '264.00' });
+        storage.get._last._reject();
+        expect(process).toHaveBeenCalledTimes(1);
+
+        // Flag cleared → a later change fetches again.
+        totals({ grand_total: '300.00' });
+        expect(storage.get).toHaveBeenCalledTimes(2);
+    });
+});

--- a/Test/Js/payment-availability.test.js
+++ b/Test/Js/payment-availability.test.js
@@ -5,13 +5,17 @@
  * Behavioural tests for the checkout payment-availability refresher
  * (view/frontend/web/js/view/payment-availability.js).
  *
- * It subscribes to quote.getTotals() and, on a genuine grand-total change,
- * re-fetches payment-information and applies ONLY the method list. The
- * load-bearing guarantees:
- *  - it NEVER calls quote.setTotals() (the clobber that got the first attempt
- *    reverted),
- *  - it does not fetch on the bootstrap total nor on no-op re-emits,
- *  - a mid-flight change is parked and run on completion (trailing edge).
+ * Load-bearing guarantees:
+ *  - NEVER calls quote.setTotals() (the clobber that got the first attempt
+ *    reverted);
+ *  - only calls paymentService.setPaymentMethods() when the available-method
+ *    SET changed (re-applying an unchanged list rebuilds every Luma renderer
+ *    and wipes in-progress payment forms);
+ *  - no fetch on the bootstrap total nor on no-op re-emits; keys on
+ *    grand_total AND tax (net-basis gate);
+ *  - a mid-flight change is parked and run on completion (trailing edge);
+ *  - a failed probe is silent (no error banner) and rolls back so the next
+ *    emit retries.
  */
 
 'use strict';
@@ -32,19 +36,16 @@ function loadComponent(deps) {
 
     return factory(
         deps.Component,
-        deps.$,
         deps.quote,
         deps.urlBuilder,
         deps.storage,
         deps.customer,
         deps.methodConverter,
-        deps.paymentService,
-        deps.errorProcessor,
-        deps.globalMessageList
+        deps.paymentService
     );
 }
 
-/** Minimal KO-style observable. */
+/** Minimal KO-style observable with a disposable subscription. */
 function makeObservable(initial) {
     let value = initial;
     const subs = [];
@@ -56,7 +57,11 @@ function makeObservable(initial) {
 
         return value;
     };
-    obs.subscribe = (fn) => subs.push(fn);
+    obs.subscribe = (fn) => {
+        subs.push(fn);
+
+        return { dispose: () => { const i = subs.indexOf(fn); if (i > -1) { subs.splice(i, 1); } } };
+    };
 
     return obs;
 }
@@ -73,7 +78,7 @@ const ComponentMock = {
 /** mage/storage.get() stub returning a jQuery-style promise. */
 function makeStorage(opts) {
     opts = opts || {};
-    const response = opts.response || { totals: { grand_total: '999' }, payment_methods: [{ method: 'two_payment' }] };
+    const response = opts.response || { payment_methods: [{ method: 'two_payment' }] };
     const get = jest.fn(function () {
         let settled = null;
         const done = [];
@@ -95,59 +100,91 @@ function makeStorage(opts) {
     return { get };
 }
 
-function setup(initialTotals, storageOpts) {
-    const totals = makeObservable(initialTotals);
+function setup(cfg) {
+    cfg = cfg || {};
+    const totals = makeObservable(cfg.initialTotals);
     const setTotals = jest.fn();
     const quote = {
         getTotals: () => totals,
         getQuoteId: () => 'cart1',
         setTotals
     };
-    const storage = makeStorage(storageOpts);
+    const storage = makeStorage(cfg.storage);
     const setPaymentMethods = jest.fn();
-    const process = jest.fn();
+    // Current server-available methods the checkout already shows.
+    const available = cfg.available || [];
+    const paymentService = {
+        setPaymentMethods,
+        getAvailablePaymentMethods: () => available
+    };
+    const createUrl = jest.fn((t) => t);
     const Widget = loadComponent({
         Component: ComponentMock,
-        $: {},
         quote,
-        urlBuilder: { createUrl: (t) => t },
+        urlBuilder: { createUrl },
         storage,
-        customer: { isLoggedIn: () => false },
+        customer: { isLoggedIn: () => !!cfg.loggedIn },
         methodConverter: (m) => m,
-        paymentService: { setPaymentMethods },
-        errorProcessor: { process },
-        globalMessageList: {}
+        paymentService
     });
     const instance = new Widget();
     instance.initialize();
 
-    return { instance, totals, storage, setPaymentMethods, setTotals, process };
+    return { instance, totals, storage, setPaymentMethods, setTotals, createUrl };
 }
 
 describe('Two_Gateway/js/view/payment-availability', () => {
     it('does not fetch on the bootstrap total at mount', () => {
-        const { storage } = setup({ grand_total: '224.00' });
+        const { storage } = setup({ initialTotals: { grand_total: '224.00' } });
         expect(storage.get).not.toHaveBeenCalled();
     });
 
-    it('re-fetches and applies ONLY the method list on a grand-total change', () => {
-        const { totals, storage, setPaymentMethods, setTotals } = setup({ grand_total: '224.00' });
+    it('re-fetches on a grand-total change and never touches totals', () => {
+        const { totals, storage, setTotals } = setup({ initialTotals: { grand_total: '224.00' } });
         totals({ grand_total: '264.00' });
 
         expect(storage.get).toHaveBeenCalledTimes(1);
-        expect(setPaymentMethods).toHaveBeenCalledTimes(1);
         // The whole point of the rewrite: totals are never clobbered.
         expect(setTotals).not.toHaveBeenCalled();
     });
 
-    it('does not fetch on a no-op re-emit with an unchanged grand total', () => {
-        const { totals, storage } = setup({ grand_total: '224.00' });
-        totals({ grand_total: '224.00' });
+    it('applies the method list only when the available-method set changed', () => {
+        // Two currently absent; server now returns it → set changed → apply.
+        const { totals, setPaymentMethods } = setup({
+            initialTotals: { grand_total: '224.00' },
+            available: [],
+            storage: { response: { payment_methods: [{ method: 'two_payment' }] } }
+        });
+        totals({ grand_total: '264.00' });
+        expect(setPaymentMethods).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT re-apply when the method set is unchanged (no renderer churn)', () => {
+        // Two already shown and still returned → set unchanged → skip, so the
+        // buyer's in-progress form/selection is never rebuilt.
+        const { totals, setPaymentMethods } = setup({
+            initialTotals: { grand_total: '264.00' },
+            available: [{ method: 'two_payment' }],
+            storage: { response: { payment_methods: [{ method: 'two_payment' }] } }
+        });
+        totals({ grand_total: '300.00' });
+        expect(setPaymentMethods).not.toHaveBeenCalled();
+    });
+
+    it('does not fetch on a no-op re-emit with an unchanged key', () => {
+        const { totals, storage } = setup({ initialTotals: { grand_total: '224.00', tax_amount: '0' } });
+        totals({ grand_total: '224.00', tax_amount: '0' });
         expect(storage.get).not.toHaveBeenCalled();
     });
 
+    it('keys on tax too — a tax-only change (net basis) triggers a re-fetch', () => {
+        const { totals, storage } = setup({ initialTotals: { grand_total: '264.00', tax_amount: '44.00' } });
+        totals({ grand_total: '264.00', tax_amount: '20.00' });
+        expect(storage.get).toHaveBeenCalledTimes(1);
+    });
+
     it('seeds the baseline from the first emit when totals are absent at mount', () => {
-        const { totals, storage } = setup(null);
+        const { totals, storage } = setup({ initialTotals: null });
         totals({ grand_total: '224.00' });
         expect(storage.get).not.toHaveBeenCalled();
         totals({ grand_total: '264.00' });
@@ -155,27 +192,51 @@ describe('Two_Gateway/js/view/payment-availability', () => {
     });
 
     it('parks a mid-flight change and runs it once the refresh resolves', () => {
-        const { totals, storage } = setup({ grand_total: '224.00' }, { defer: true });
+        const { totals, storage } = setup({ initialTotals: { grand_total: '224.00' }, storage: { defer: true } });
         totals({ grand_total: '264.00' });
         expect(storage.get).toHaveBeenCalledTimes(1);
 
-        // Change before the in-flight fetch resolves: parked, not fired.
         totals({ grand_total: '300.00' });
         expect(storage.get).toHaveBeenCalledTimes(1);
 
-        // Resolve → the parked change drives a second fetch.
         storage.get._last._resolve();
         expect(storage.get).toHaveBeenCalledTimes(2);
     });
 
-    it('routes a failed fetch through the error processor and clears the in-flight flag', () => {
-        const { totals, storage, process } = setup({ grand_total: '224.00' }, { defer: true });
+    it('fails silently and rolls back so the next emit retries', () => {
+        const { totals, storage, setPaymentMethods } = setup({
+            initialTotals: { grand_total: '224.00' },
+            storage: { defer: true }
+        });
         totals({ grand_total: '264.00' });
-        storage.get._last._reject();
-        expect(process).toHaveBeenCalledTimes(1);
+        // No error surfaced (no errorProcessor dependency at all) and no list applied.
+        expect(() => storage.get._last._reject()).not.toThrow();
+        expect(setPaymentMethods).not.toHaveBeenCalled();
 
-        // Flag cleared → a later change fetches again.
+        // Key rolled back → a later change still fetches (retry not stranded).
         totals({ grand_total: '300.00' });
         expect(storage.get).toHaveBeenCalledTimes(2);
+    });
+
+    it('uses the registered-customer URL when logged in', () => {
+        const { totals, createUrl } = setup({ initialTotals: { grand_total: '224.00' }, loggedIn: true });
+        totals({ grand_total: '264.00' });
+        expect(createUrl).toHaveBeenCalledWith('/carts/mine/payment-information', {});
+    });
+
+    it('uses the guest URL with the cart id when not logged in', () => {
+        const { totals, createUrl } = setup({ initialTotals: { grand_total: '224.00' }, loggedIn: false });
+        totals({ grand_total: '264.00' });
+        expect(createUrl).toHaveBeenCalledWith(
+            '/guest-carts/:cartId/payment-information',
+            { cartId: 'cart1' }
+        );
+    });
+
+    it('disposes the totals subscription on destroy', () => {
+        const { instance, totals, storage } = setup({ initialTotals: { grand_total: '224.00' } });
+        instance.destroy();
+        totals({ grand_total: '264.00' });
+        expect(storage.get).not.toHaveBeenCalled();
     });
 });

--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -63,6 +63,17 @@
                                 </item>
                                 <item name="sidebar" xsi:type="array">
                                     <item name="children" xsi:type="array">
+                                        <!--
+                                            Headless: re-runs server-side payment
+                                            availability when the totals change so the
+                                            method shows/hides as the basket crosses the
+                                            minimum-order threshold. Mounted here (always
+                                            present) rather than under the payment renderer,
+                                            which is absent while the method is hidden.
+                                        -->
+                                        <item name="two-payment-availability" xsi:type="array">
+                                            <item name="component" xsi:type="string">Two_Gateway/js/view/payment-availability</item>
+                                        </item>
                                         <item name="summary" xsi:type="array">
                                             <item name="children" xsi:type="array">
                                                 <item name="totals" xsi:type="array">

--- a/view/frontend/web/js/view/payment-availability.js
+++ b/view/frontend/web/js/view/payment-availability.js
@@ -16,15 +16,23 @@
  * re-fetch on every totals change and are unaffected; this gives Luma (and
  * Luma-derived one-step checkouts) the same behaviour.
  *
- * On a genuine grand-total change it re-fetches the payment-information
- * endpoint and applies ONLY the returned method list — the server re-runs
- * isAvailable, so the method appears/disappears in both directions. It
- * deliberately does NOT call quote.setTotals(): the shared core action
- * (get-payment-information) does, which stamps the server's (possibly
- * pre-shipping) totals over the correctly-collected client totals — the
- * regression that got the first attempt reverted. Skipping setTotals also
- * means this can't re-emit the totals observable, so there is no refresh
- * loop to guard against beyond the no-op dedup.
+ * On a genuine totals change it re-fetches the payment-information endpoint
+ * (the server re-runs isAvailable) and applies the returned method list ONLY
+ * WHEN the set of available methods actually changed. Two constraints drive
+ * that:
+ *   - It never calls quote.setTotals(). The shared core action
+ *     (get-payment-information) does, which stamps the server's possibly-
+ *     pre-shipping totals over the correctly-collected client totals — the
+ *     regression that got the first attempt reverted.
+ *   - It skips paymentService.setPaymentMethods() when the method set is
+ *     unchanged. That call swaps the availablePaymentMethods observable with
+ *     fresh object references, which makes Luma's payment list rebuild EVERY
+ *     renderer — wiping a half-filled Two form and the selected method. We
+ *     only want to add/remove Two as it crosses the minimum, not churn the
+ *     list on every totals tick.
+ *
+ * Server isAvailable + place-order + API enforcement stay the sole source of
+ * truth; no minimum logic is duplicated here.
  *
  * Mounted from checkout_index_index.xml under the always-present sidebar,
  * NOT under the Two payment renderer: when the method is hidden its renderer
@@ -32,27 +40,13 @@
  */
 define([
     'uiComponent',
-    'jquery',
     'Magento_Checkout/js/model/quote',
     'Magento_Checkout/js/model/url-builder',
     'mage/storage',
     'Magento_Customer/js/model/customer',
     'Magento_Checkout/js/model/payment/method-converter',
-    'Magento_Checkout/js/model/payment-service',
-    'Magento_Checkout/js/model/error-processor',
-    'Magento_Ui/js/model/messageList'
-], function (
-    Component,
-    $,
-    quote,
-    urlBuilder,
-    storage,
-    customer,
-    methodConverter,
-    paymentService,
-    errorProcessor,
-    globalMessageList
-) {
+    'Magento_Checkout/js/model/payment-service'
+], function (Component, quote, urlBuilder, storage, customer, methodConverter, paymentService) {
     'use strict';
 
     return Component.extend({
@@ -67,89 +61,141 @@ define([
             this._super();
 
             this._refreshing = false;
-            // Trailing edge: a total that changes again mid-refresh is parked
-            // here and re-run when the in-flight refresh resolves, so rapid
-            // interactions (switch shipping, then apply a coupon) converge on
-            // the final total.
-            this._pendingGrandTotal = null;
+            // Trailing edge: a change during an in-flight fetch is parked here
+            // and run when that fetch resolves, so rapid interactions converge.
+            this._pendingKey = null;
             // Baseline from the totals already loaded at mount — core has just
-            // fetched the payment list for this value, so there is nothing to
-            // re-ask yet. A KO subscribable does not replay, so seeding here is
-            // what lets us detect the first post-mount change on a
-            // fast/returning-customer stack.
-            this._lastGrandTotal = this._readGrandTotal(quote.getTotals()());
-
-            quote.getTotals().subscribe(this._onTotalsChanged.bind(this));
+            // fetched the payment list for this value. A KO subscribable does
+            // not replay, so seeding here is what lets us detect the first
+            // post-mount change on a fast/returning-customer stack.
+            this._lastKey = this._readKey(quote.getTotals()());
+            this._totalsSubscription = quote.getTotals().subscribe(this._onTotalsChanged.bind(this));
 
             return this;
         },
 
         /**
-         * @param {Object|null} totals
-         * @returns {Number|null} parsed grand total, or null when absent/NaN
+         * Dispose the totals subscription so a torn-down instance (checkout
+         * re-render, one-step-checkout derivative) leaves no zombie handler.
          */
-        _readGrandTotal: function (totals) {
+        destroy: function () {
+            if (this._totalsSubscription) {
+                this._totalsSubscription.dispose();
+                this._totalsSubscription = null;
+            }
+            this._super();
+        },
+
+        /**
+         * Availability key: grand total AND tax. The min-order gate can compare
+         * on a net basis (grand_total − tax), so a tax-only move can flip
+         * availability without changing grand_total; keying on both makes the
+         * dedup match what the server actually gates on.
+         *
+         * @param {Object|null} totals
+         * @returns {String|null} null when totals/grand_total is absent or NaN
+         */
+        _readKey: function (totals) {
             if (!totals) {
                 return null;
             }
-            var value = parseFloat(totals.grand_total);
+            var grand = parseFloat(totals.grand_total);
+            if (isNaN(grand)) {
+                return null;
+            }
+            var tax = parseFloat(totals.tax_amount) || 0;
 
-            return isNaN(value) ? null : value;
+            return grand + '|' + tax;
         },
 
         /**
          * @param {Object|null} totals
          */
         _onTotalsChanged: function (totals) {
-            var grandTotal = this._readGrandTotal(totals);
+            var key = this._readKey(totals);
 
-            if (grandTotal === null) {
+            if (key === null) {
                 return;
             }
-            if (this._lastGrandTotal === null) {
-                this._lastGrandTotal = grandTotal;
+            if (this._lastKey === null) {
+                this._lastKey = key;
 
                 return;
             }
-            if (grandTotal === this._lastGrandTotal) {
+            if (key === this._lastKey) {
                 return;
             }
             if (this._refreshing) {
-                this._pendingGrandTotal = grandTotal;
+                this._pendingKey = key;
 
                 return;
             }
-            this._lastGrandTotal = grandTotal;
-            this._refresh();
+            this._refresh(key);
         },
 
         /**
-         * Re-fetch the payment-information endpoint and apply ONLY the method
-         * list. Never touches totals (see class doc).
+         * Re-fetch payment-information and apply the method list only when the
+         * available-method set changed. Never touches totals.
+         *
+         * @param {String} targetKey
          */
-        _refresh: function () {
+        _refresh: function (targetKey) {
             var self = this;
+            var priorKey = this._lastKey;
 
+            this._lastKey = targetKey;
             this._refreshing = true;
-            this._pendingGrandTotal = null;
+            this._pendingKey = null;
 
             storage.get(this._paymentInformationUrl(), false)
                 .done(function (response) {
-                    paymentService.setPaymentMethods(
-                        methodConverter(response['payment_methods'])
-                    );
+                    self._applyIfChanged(response);
                 })
-                .fail(function (response) {
-                    errorProcessor.process(response, globalMessageList);
+                .fail(function () {
+                    // Silent: a background availability probe must not paint the
+                    // checkout error banner. Roll the key back so the next
+                    // totals emit retries rather than the failure stranding a
+                    // stale list. (Availability is server-enforced at
+                    // place-order regardless.)
+                    self._lastKey = priorKey;
+                    if (typeof console !== 'undefined' && console.warn) {
+                        console.warn('Two_Gateway: payment availability refresh failed');
+                    }
                 })
                 .always(function () {
                     self._refreshing = false;
-                    if (self._pendingGrandTotal !== null &&
-                        self._pendingGrandTotal !== self._lastGrandTotal) {
-                        self._lastGrandTotal = self._pendingGrandTotal;
-                        self._refresh();
+                    if (self._pendingKey !== null && self._pendingKey !== self._lastKey) {
+                        self._refresh(self._pendingKey);
                     }
                 });
+        },
+
+        /**
+         * Swap the method list only when the set of available method codes
+         * differs from what's shown — otherwise Luma rebuilds every renderer
+         * and wipes in-progress payment forms (see class doc).
+         *
+         * @param {Object} response
+         */
+        _applyIfChanged: function (response) {
+            var incoming = methodConverter((response && response['payment_methods']) || []);
+
+            if (this._codes(incoming) !== this._codes(paymentService.getAvailablePaymentMethods())) {
+                paymentService.setPaymentMethods(incoming);
+            }
+        },
+
+        /**
+         * Order-independent signature of a method list's codes.
+         *
+         * @param {Array|null} methods
+         * @returns {String}
+         */
+        _codes: function (methods) {
+            return (methods || [])
+                .map(function (m) { return m.method; })
+                .sort()
+                .join(',');
         },
 
         /**

--- a/view/frontend/web/js/view/payment-availability.js
+++ b/view/frontend/web/js/view/payment-availability.js
@@ -1,0 +1,169 @@
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+/**
+ * Re-evaluates payment-method availability when the quote totals change.
+ *
+ * Whether the Two method is offered depends on the order value via the
+ * server-side minimum-order gate (Model\Two::isAvailable). On Luma the
+ * payment-service caches the method list from the last
+ * set-shipping-information / payment-information fetch and never re-filters
+ * it when totals move afterwards (a later shipping-method switch, a coupon
+ * applied on the payment step), so a basket crossing the threshold keeps its
+ * stale visibility until a full checkout reload. Hyvä and FireCheckout
+ * re-fetch on every totals change and are unaffected; this gives Luma (and
+ * Luma-derived one-step checkouts) the same behaviour.
+ *
+ * On a genuine grand-total change it re-fetches the payment-information
+ * endpoint and applies ONLY the returned method list — the server re-runs
+ * isAvailable, so the method appears/disappears in both directions. It
+ * deliberately does NOT call quote.setTotals(): the shared core action
+ * (get-payment-information) does, which stamps the server's (possibly
+ * pre-shipping) totals over the correctly-collected client totals — the
+ * regression that got the first attempt reverted. Skipping setTotals also
+ * means this can't re-emit the totals observable, so there is no refresh
+ * loop to guard against beyond the no-op dedup.
+ *
+ * Mounted from checkout_index_index.xml under the always-present sidebar,
+ * NOT under the Two payment renderer: when the method is hidden its renderer
+ * is not instantiated, so a refresher living there could never bring it back.
+ */
+define([
+    'uiComponent',
+    'jquery',
+    'Magento_Checkout/js/model/quote',
+    'Magento_Checkout/js/model/url-builder',
+    'mage/storage',
+    'Magento_Customer/js/model/customer',
+    'Magento_Checkout/js/model/payment/method-converter',
+    'Magento_Checkout/js/model/payment-service',
+    'Magento_Checkout/js/model/error-processor',
+    'Magento_Ui/js/model/messageList'
+], function (
+    Component,
+    $,
+    quote,
+    urlBuilder,
+    storage,
+    customer,
+    methodConverter,
+    paymentService,
+    errorProcessor,
+    globalMessageList
+) {
+    'use strict';
+
+    return Component.extend({
+        defaults: {
+            template: null
+        },
+
+        /**
+         * @returns {Object} chainable
+         */
+        initialize: function () {
+            this._super();
+
+            this._refreshing = false;
+            // Trailing edge: a total that changes again mid-refresh is parked
+            // here and re-run when the in-flight refresh resolves, so rapid
+            // interactions (switch shipping, then apply a coupon) converge on
+            // the final total.
+            this._pendingGrandTotal = null;
+            // Baseline from the totals already loaded at mount — core has just
+            // fetched the payment list for this value, so there is nothing to
+            // re-ask yet. A KO subscribable does not replay, so seeding here is
+            // what lets us detect the first post-mount change on a
+            // fast/returning-customer stack.
+            this._lastGrandTotal = this._readGrandTotal(quote.getTotals()());
+
+            quote.getTotals().subscribe(this._onTotalsChanged.bind(this));
+
+            return this;
+        },
+
+        /**
+         * @param {Object|null} totals
+         * @returns {Number|null} parsed grand total, or null when absent/NaN
+         */
+        _readGrandTotal: function (totals) {
+            if (!totals) {
+                return null;
+            }
+            var value = parseFloat(totals.grand_total);
+
+            return isNaN(value) ? null : value;
+        },
+
+        /**
+         * @param {Object|null} totals
+         */
+        _onTotalsChanged: function (totals) {
+            var grandTotal = this._readGrandTotal(totals);
+
+            if (grandTotal === null) {
+                return;
+            }
+            if (this._lastGrandTotal === null) {
+                this._lastGrandTotal = grandTotal;
+
+                return;
+            }
+            if (grandTotal === this._lastGrandTotal) {
+                return;
+            }
+            if (this._refreshing) {
+                this._pendingGrandTotal = grandTotal;
+
+                return;
+            }
+            this._lastGrandTotal = grandTotal;
+            this._refresh();
+        },
+
+        /**
+         * Re-fetch the payment-information endpoint and apply ONLY the method
+         * list. Never touches totals (see class doc).
+         */
+        _refresh: function () {
+            var self = this;
+
+            this._refreshing = true;
+            this._pendingGrandTotal = null;
+
+            storage.get(this._paymentInformationUrl(), false)
+                .done(function (response) {
+                    paymentService.setPaymentMethods(
+                        methodConverter(response['payment_methods'])
+                    );
+                })
+                .fail(function (response) {
+                    errorProcessor.process(response, globalMessageList);
+                })
+                .always(function () {
+                    self._refreshing = false;
+                    if (self._pendingGrandTotal !== null &&
+                        self._pendingGrandTotal !== self._lastGrandTotal) {
+                        self._lastGrandTotal = self._pendingGrandTotal;
+                        self._refresh();
+                    }
+                });
+        },
+
+        /**
+         * Guest vs registered payment-information URL (mirrors the core action).
+         * @returns {String}
+         */
+        _paymentInformationUrl: function () {
+            if (customer.isLoggedIn()) {
+                return urlBuilder.createUrl('/carts/mine/payment-information', {});
+            }
+
+            return urlBuilder.createUrl('/guest-carts/:cartId/payment-information', {
+                cartId: quote.getQuoteId()
+            });
+        }
+    });
+});


### PR DESCRIPTION
## What

Rebuild of the reverted ABN-460 reactive show/hide (option 1, agreed with Doug). Headless sidebar component subscribes to `quote.getTotals()`; on a genuine grand-total change it re-fetches the payment-information endpoint and applies **only** the returned method list. The server re-runs `isAvailable`, so Two appears/disappears in **both** directions as the basket crosses the minimum — no reload.

## How it differs from the reverted #241

#241 called the shared `Magento_Checkout/js/action/get-payment-information`, which unconditionally runs `quote.setTotals(response.totals)` — stamping the server's (pre-shipping) totals over the correctly-collected client totals. That mis-rendered the order total until a payment method was selected, and showed the method below the minimum on entry.

This version inlines the fetch and applies **only** `paymentService.setPaymentMethods(...)` — **never `setTotals`**. Consequences:
- no totals clobber (the reverted regression is structurally impossible here);
- no self-triggered totals re-emit → no refresh loop to guard against (beyond the no-op-total dedup);
- server `isAvailable` + place-order + API enforcement stay the sole source of truth — **no minimum logic duplicated in JS** (the reason we rejected the client-side gate).

## Tests

Jest (6 cases): no fetch on bootstrap / no-op re-emit; fetch on real change; **`setTotals` never called**; baseline seeding; trailing-edge coalescing of mid-flight changes; error path.

## Verification plan — please read

Runtime behaviour can only be exercised on the **dev shop**, which git-syncs from `staging`. So there is no way to browser-verify this branch pre-merge. Proposed sequence:
1. Merge to `staging` (dev shop is non-customer-facing; revert is clean and proven).
2. Verify on `magento-dev.staging` Luma — Doug's exact repro (224 basket, toggle flat-rate/free-shipping across the 250 min; check the method shows/hides live AND the order total stays correct throughout).
3. Once confirmed on the deployed shop, a follow-up un-skips `min-order.spec.ts` (it can't pass in PR CI until the fix is live on the shop it tests).

If step 2 shows any issue, immediate revert (as before).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)