### PR TITLE
feat(ABN-460): client-side min-order visibility gate + always-list on Amasty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ plans/
 node_modules/
 
 .worktrees/
+.review/

--- a/Model/GenericPaymentMethod.php
+++ b/Model/GenericPaymentMethod.php
@@ -9,6 +9,7 @@ namespace Two\Gateway\Model;
 
 use Magento\Framework\Api\AttributeValueFactory;
 use Magento\Framework\Api\ExtensionAttributesFactory;
+use Magento\Config\Model\ResourceModel\Config\Data\CollectionFactory as ConfigDataCollectionFactory;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\Data\Collection\AbstractDb;
@@ -85,6 +86,7 @@ class GenericPaymentMethod extends Two
         LogRepository $logRepository,
         MinimumOrderGate $minimumOrderGate,
         MinimumOrderProvider $minimumOrderProvider,
+        ConfigDataCollectionFactory $configDataCollectionFactory,
         ?AbstractResource $resource = null,
         ?AbstractDb $resourceCollection = null,
         array $data = []
@@ -111,6 +113,7 @@ class GenericPaymentMethod extends Two
             $logRepository,
             $minimumOrderGate,
             $minimumOrderProvider,
+            $configDataCollectionFactory,
             $resource,
             $resourceCollection,
             $data

--- a/Model/Two.php
+++ b/Model/Two.php
@@ -811,7 +811,10 @@ class Two extends AbstractMethod
         $baseCurrency = $store !== null ? (string)$store->getBaseCurrencyCode() : '';
         $displayCurrency = (string)($quote->getQuoteCurrencyCode() ?: $baseCurrency);
         if ($displayCurrency === '') {
-            return $empty;
+            // A real quote whose currency cannot be resolved: fail closed
+            // (hide), matching MinimumOrderGate's stance on an empty quote
+            // currency, rather than showing the method for want of a currency.
+            return ['minimums' => [], 'unresolved' => true];
         }
 
         $minimums = [];
@@ -891,19 +894,26 @@ class Two extends AbstractMethod
             if ($minimum === null) {
                 continue;
             }
-            $orderValue = $minimum['basis'] === 'gross'
+            // Project the minimum into the order currency once, then compare —
+            // the same projection the client-display gate uses, so enforce and
+            // display cannot disagree. A null projection means an active minimum
+            // we cannot convert (missing FX rate): fail CLOSED and reject, never
+            // delegate to the fail-soft isBelowMinimum(), which would let a
+            // below-minimum order through on the one path (Amasty + JS bypass)
+            // where this is the sole merchant-minimum enforcer.
+            $display = $this->minimumOrderGate->getMinimumForDisplay($minimum, $orderCurrency, $storeId);
+            if ($display === null) {
+                throw new LocalizedException(
+                    __('Invoice purchase with %1 is not available for this order.', $this->brandRegistry->getProductName())
+                );
+            }
+            $orderValue = $display['basis'] === 'gross'
                 ? (float)$order->getGrandTotal()
                 : (float)$order->getGrandTotal() - (float)$order->getTaxAmount();
-            if (!$this->minimumOrderGate->isBelowMinimum($minimum, $orderValue, $orderCurrency, $storeId)) {
-                continue;
-            }
-            $display = $this->minimumOrderGate->getMinimumForDisplay($minimum, $orderCurrency, $storeId);
-            if ($display !== null) {
+            // +epsilon mirrors the gate/client >= at currency precision.
+            if ($orderValue + 0.0001 < $display['amount']) {
                 throw new LocalizedException($this->minimumOrderMessage($display, $order));
             }
-            throw new LocalizedException(
-                __('Invoice purchase with %1 is not available for this order.', $this->brandRegistry->getProductName())
-            );
         }
     }
 

--- a/Model/Two.php
+++ b/Model/Two.php
@@ -10,6 +10,7 @@ namespace Two\Gateway\Model;
 use Exception;
 use Magento\Framework\Api\AttributeValueFactory;
 use Magento\Framework\Api\ExtensionAttributesFactory;
+use Magento\Config\Model\ResourceModel\Config\Data\CollectionFactory as ConfigDataCollectionFactory;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\Data\Collection\AbstractDb;
@@ -130,6 +131,17 @@ class Two extends AbstractMethod
      * @var MinimumOrderProvider
      */
     private $minimumOrderProvider;
+    /**
+     * @var ConfigDataCollectionFactory
+     */
+    private $configDataCollectionFactory;
+    /**
+     * Per-store memo for isAmastyCheckoutStore(); isAvailable() fires many
+     * times per page and the detection reads config + core_config_data.
+     *
+     * @var array<int, bool>
+     */
+    private $amastyCheckoutStore = [];
 
     /**
      * Two constructor.
@@ -153,6 +165,7 @@ class Two extends AbstractMethod
      * @param LogRepository $logRepository
      * @param MinimumOrderGate $minimumOrderGate
      * @param MinimumOrderProvider $minimumOrderProvider
+     * @param ConfigDataCollectionFactory $configDataCollectionFactory
      * @param AbstractResource|null $resource
      * @param AbstractDb|null $resourceCollection
      * @param array $data
@@ -179,6 +192,7 @@ class Two extends AbstractMethod
         LogRepository $logRepository,
         MinimumOrderGate $minimumOrderGate,
         MinimumOrderProvider $minimumOrderProvider,
+        ConfigDataCollectionFactory $configDataCollectionFactory,
         ?AbstractResource $resource = null,
         ?AbstractDb $resourceCollection = null,
         array $data = []
@@ -209,6 +223,7 @@ class Two extends AbstractMethod
         $this->logRepository = $logRepository;
         $this->minimumOrderGate = $minimumOrderGate;
         $this->minimumOrderProvider = $minimumOrderProvider;
+        $this->configDataCollectionFactory = $configDataCollectionFactory;
     }
 
     /**
@@ -224,6 +239,7 @@ class Two extends AbstractMethod
     public function authorize(InfoInterface $payment, $amount)
     {
         $order = $payment->getOrder();
+        $this->assertOrderMeetsMinimum($order);
         $this->urlCookie->delete();
         $orderReference = (string)rand();
 
@@ -270,12 +286,7 @@ class Two extends AbstractMethod
             if ($declinedOnMinimum && $minimumOrder !== null) {
                 $display = $this->minimumOrderGate->getMinimumForDisplay($minimumOrder, $orderCurrency, $storeId);
                 if ($display !== null) {
-                    throw new LocalizedException(__(
-                        'Invoice purchase with %1 is not available for this order. Minimum order value is %2 %3 tax.',
-                        $this->brandRegistry->getProductName(),
-                        $order->getOrderCurrency()->formatTxt($display['amount']),
-                        $display['basis'] === 'gross' ? __('including') : __('excluding')
-                    ));
+                    throw new LocalizedException($this->minimumOrderMessage($display, $order));
                 }
             }
             throw new LocalizedException(
@@ -745,106 +756,233 @@ class Two extends AbstractMethod
         // setting in the STORE BASE currency; validated on save to meet or
         // exceed the platform floor converted to that currency).
         $storeId = null;
-        if ($quote instanceof \Magento\Quote\Model\Quote && $quote->getStoreId() !== null) {
-            $storeId = (int)$quote->getStoreId();
+        $store = null;
+        if ($quote instanceof \Magento\Quote\Model\Quote) {
+            $store = $quote->getStore();
+            if ($quote->getStoreId() !== null) {
+                $storeId = (int)$quote->getStoreId();
+            }
         }
         // Amasty OneStepCheckout persists the buyer's shipping method to the
-        // server quote only at order placement, so the server quote is blind to
-        // the live shipping choice and this gate would judge a stale total (a
-        // dearer shipping that crosses the minimum never registers server-side).
-        // When Amasty OSC is active for this store, offer the method
-        // unconditionally and let the checkout renderer gate visibility
-        // client-side against the live total; place-order + the Two API still
-        // enforce the minimum fail-closed. Read at STORE scope so it tracks the
-        // active store view (e.g. ?___store=amasty). Absent module → false → no
-        // change for every other checkout.
-        if ($this->_scopeConfig->isSetFlag(
-            'amasty_checkout/general/enabled',
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
-            $storeId
-        )) {
+        // server quote only at order placement, so at checkout-render time the
+        // server quote is blind to the live shipping choice and this gate would
+        // judge a stale total (a dearer shipping that crosses the minimum never
+        // registers server-side). On an Amasty store view we therefore OFFER the
+        // method unconditionally here and gate its visibility client-side
+        // against the live total (see Model\Ui\ConfigProvider + the renderer).
+        // Enforcement is not waived, only deferred: authorize() re-checks the
+        // finalised order total (shipping now known) against BOTH the platform
+        // and merchant minimums fail-closed at placement, and checkout-api
+        // independently enforces the platform floor. isAmastyCheckoutStore()
+        // requires an explicit admin override, not Amasty's inherited config.xml
+        // default, so the bypass cannot leak onto other checkouts.
+        if ($this->isAmastyCheckoutStore($store, $storeId)) {
             return true;
         }
         $platformMinimum = $this->minimumOrderProvider->getMinimum($storeId);
-        $merchantMinimum = $quote instanceof \Magento\Quote\Model\Quote
-            ? $this->buildMerchantMinimum($quote, $platformMinimum)
+        $merchantMinimum = $store !== null
+            ? $this->buildMerchantMinimum((string)$store->getBaseCurrencyCode(), $platformMinimum, $storeId)
             : null;
         return $this->minimumOrderGate->isSatisfied($platformMinimum, $quote, $merchantMinimum);
     }
 
     /**
-     * The active minimum-order constraints for a quote, each already converted
-     * to the quote's display currency, for the checkout renderer's client-side
-     * visibility gate. Same platform + merchant minimums isAvailable() enforces
-     * (kept in step deliberately), projected to {amount, basis} in the display
-     * currency so the JS only has to compare — no rule/FX logic client-side.
+     * The client-side visibility inputs for the Two method on a quote: the
+     * active minimum-order constraints (platform + merchant, the same pair
+     * isAvailable() enforces) projected into the quote's DISPLAY currency so
+     * the renderer only has to compare — no rule/FX logic client-side — plus
+     * whether any active minimum could NOT be projected (missing FX rate).
      *
-     * @return array<int, array{amount: float, basis: string}>
+     * On `unresolved`, the renderer must HIDE the method rather than show it
+     * for want of a number: this mirrors MinimumOrderGate's fail-closed stance
+     * (a minimum we cannot prove satisfied hides the method) so the client gate
+     * does not fail OPEN where the server gate would fail closed.
+     *
+     * @return array{minimums: array<int, array{amount: float, basis: string}>, unresolved: bool}
      */
-    public function getDisplayMinimums(?CartInterface $quote): array
+    public function getMinimumOrderVisibility(?CartInterface $quote): array
     {
+        $empty = ['minimums' => [], 'unresolved' => false];
         if (!$quote instanceof \Magento\Quote\Model\Quote) {
-            return [];
+            return $empty;
         }
         $storeId = $quote->getStoreId() !== null ? (int)$quote->getStoreId() : null;
         $store = $quote->getStore();
-        $displayCurrency = (string)($quote->getQuoteCurrencyCode()
-            ?: ($store !== null ? $store->getBaseCurrencyCode() : ''));
+        $baseCurrency = $store !== null ? (string)$store->getBaseCurrencyCode() : '';
+        $displayCurrency = (string)($quote->getQuoteCurrencyCode() ?: $baseCurrency);
         if ($displayCurrency === '') {
-            return [];
+            return $empty;
         }
 
-        $out = [];
+        $minimums = [];
+        $unresolved = false;
         $platform = $this->minimumOrderProvider->getMinimum($storeId);
-        if ($platform !== null) {
-            $shown = $this->minimumOrderGate->getMinimumForDisplay($platform, $displayCurrency, $storeId);
-            if ($shown !== null) {
-                $out[] = $shown;
+        $active = [$platform, $this->buildMerchantMinimum($baseCurrency, $platform, $storeId)];
+        foreach ($active as $minimum) {
+            if ($minimum === null) {
+                continue;
             }
+            $shown = $this->minimumOrderGate->getMinimumForDisplay($minimum, $displayCurrency, $storeId);
+            if ($shown === null) {
+                $unresolved = true;
+                continue;
+            }
+            $minimums[] = $shown;
         }
 
-        $merchant = $this->buildMerchantMinimum($quote, $platform);
-        if ($merchant !== null) {
-            $shown = $this->minimumOrderGate->getMinimumForDisplay($merchant, $displayCurrency, $storeId);
-            if ($shown !== null) {
-                $out[] = $shown;
-            }
-        }
-
-        return $out;
+        return ['minimums' => $minimums, 'unresolved' => $unresolved];
     }
 
     /**
-     * The merchant's own optional minimum-order tuple for a quote, or null when
-     * unset (<= 0) or the store base currency is unresolvable. Single source of
-     * truth shared by isAvailable()'s server gate and getDisplayMinimums()'s
-     * client-display projection: the two MUST agree on the constraint, so the
-     * construction lives in exactly one place. Amount is in the store BASE
-     * currency (validated on save to meet/exceed the platform floor); basis
-     * falls back to the platform minimum's basis, then 'gross', when the admin
-     * value is neither 'net' nor 'gross'.
+     * The merchant's own optional minimum-order tuple, in the store BASE
+     * currency, or null when unset (<= 0) or the base currency is unknown.
+     * Single source of truth shared by isAvailable()'s server gate,
+     * getMinimumOrderVisibility()'s client-display projection, and the
+     * authorize() placement backstop: they MUST agree on the constraint, so
+     * the construction lives in exactly one place. Amount is validated on save
+     * to meet/exceed the platform floor; basis falls back to the platform
+     * minimum's basis, then 'gross', when the admin value is neither 'net' nor
+     * 'gross'.
      *
+     * @param string $baseCurrency Store base currency the merchant amount is denominated in.
      * @param array<string, mixed>|null $platform Platform minimum, for basis fallback only.
+     * @param int|null $storeId Scope for the admin config reads.
      * @return array{amount: float, currency: string, basis: string}|null
      */
-    private function buildMerchantMinimum(\Magento\Quote\Model\Quote $quote, ?array $platform): ?array
+    private function buildMerchantMinimum(string $baseCurrency, ?array $platform, ?int $storeId = null): ?array
     {
-        $merchantValue = (float)$this->getConfigData('merchant_minimum_order');
-        if ($merchantValue <= 0) {
+        $merchantValue = (float)$this->getConfigData('merchant_minimum_order', $storeId);
+        if ($merchantValue <= 0 || $baseCurrency === '') {
             return null;
         }
-        $store = $quote->getStore();
-        $currency = $store !== null ? (string)$store->getBaseCurrencyCode() : '';
-        if ($currency === '') {
-            return null;
-        }
-        $merchantBasis = (string)$this->getConfigData('merchant_minimum_order_basis');
+        $merchantBasis = (string)$this->getConfigData('merchant_minimum_order_basis', $storeId);
         return [
             'amount' => $merchantValue,
-            'currency' => $currency,
+            'currency' => $baseCurrency,
             'basis' => in_array($merchantBasis, ['net', 'gross'], true)
                 ? $merchantBasis
                 : ($platform['basis'] ?? 'gross'),
         ];
+    }
+
+    /**
+     * Fail-closed server backstop: reject a finalised order below the platform
+     * or merchant minimum at placement. A normal buyer never reaches this — the
+     * checkout renderer's client-side gate (and isAvailable() on non-Amasty
+     * checkouts) already hides the method below the minimum. It catches the
+     * paths that evade the client gate: JS disabled, direct API calls, or a
+     * total that dropped after the method was selected. It is also the SOLE
+     * server enforcer of the MERCHANT minimum on Amasty, where isAvailable() is
+     * bypassed and the order total (with shipping) is only complete here at
+     * placement; checkout-api independently enforces the platform floor but
+     * never receives the merchant's own admin minimum.
+     *
+     * @throws LocalizedException when the finalised order is below a minimum.
+     */
+    private function assertOrderMeetsMinimum(Order $order): void
+    {
+        $storeId = $order->getStoreId() !== null ? (int)$order->getStoreId() : null;
+        $orderCurrency = (string)$order->getOrderCurrencyCode();
+        $store = $order->getStore();
+        $baseCurrency = $store !== null ? (string)$store->getBaseCurrencyCode() : '';
+        $platform = $this->minimumOrderProvider->getMinimum($storeId);
+        $active = [$platform, $this->buildMerchantMinimum($baseCurrency, $platform, $storeId)];
+        foreach ($active as $minimum) {
+            if ($minimum === null) {
+                continue;
+            }
+            $orderValue = $minimum['basis'] === 'gross'
+                ? (float)$order->getGrandTotal()
+                : (float)$order->getGrandTotal() - (float)$order->getTaxAmount();
+            if (!$this->minimumOrderGate->isBelowMinimum($minimum, $orderValue, $orderCurrency, $storeId)) {
+                continue;
+            }
+            $display = $this->minimumOrderGate->getMinimumForDisplay($minimum, $orderCurrency, $storeId);
+            if ($display !== null) {
+                throw new LocalizedException($this->minimumOrderMessage($display, $order));
+            }
+            throw new LocalizedException(
+                __('Invoice purchase with %1 is not available for this order.', $this->brandRegistry->getProductName())
+            );
+        }
+    }
+
+    /**
+     * Buyer-facing "below minimum order value" message for a display-currency
+     * minimum tuple. Shared by the authorize() backstop and the API-decline
+     * interpretation so both surface the same wording.
+     *
+     * @param array{amount: float, basis: string} $displayMinimum
+     */
+    private function minimumOrderMessage(array $displayMinimum, Order $order): Phrase
+    {
+        return __(
+            'Invoice purchase with %1 is not available for this order. Minimum order value is %2 %3 tax.',
+            $this->brandRegistry->getProductName(),
+            $order->getOrderCurrency()->formatTxt($displayMinimum['amount']),
+            $displayMinimum['basis'] === 'gross' ? __('including') : __('excluding')
+        );
+    }
+
+    /**
+     * Whether this store view runs Amasty OneStepCheckout as a DELIBERATE,
+     * admin-set choice — the signal that isAvailable()'s server min gate must
+     * be deferred to the client gate + authorize() backstop (see isAvailable()).
+     *
+     * We cannot simply read amasty_checkout/general/enabled via ScopeConfig:
+     * Amasty ships that flag as enabled=1 in config.xml, so on every store view
+     * where an admin never touched the setting it reads true by inheritance and
+     * the bypass would leak onto Luma / Hyva / Fire checkouts, silently
+     * disabling their (working, shipping-aware) server gate. We therefore
+     * require BOTH the effective flag to be on AND an explicit core_config_data
+     * override enabling it in this store's scope chain — proof an admin
+     * configured Amasty, not merely inherited the packaged default. Memoised
+     * per store; isAvailable() fires repeatedly per page.
+     */
+    private function isAmastyCheckoutStore(?\Magento\Store\Api\Data\StoreInterface $store, ?int $storeId): bool
+    {
+        if ($store === null || $storeId === null) {
+            return false;
+        }
+        if (isset($this->amastyCheckoutStore[$storeId])) {
+            return $this->amastyCheckoutStore[$storeId];
+        }
+        $enabled = $this->_scopeConfig->isSetFlag(
+            'amasty_checkout/general/enabled',
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $storeId
+        ) && $this->hasAmastyConfigOverride($store);
+        $this->amastyCheckoutStore[$storeId] = $enabled;
+        return $enabled;
+    }
+
+    /**
+     * Whether an explicit core_config_data row enables Amasty OSC anywhere in
+     * this store's scope chain (default, its website, or the store view) — i.e.
+     * an admin set the value, as opposed to inheriting Amasty's config.xml
+     * packaged default. A store-scoped disable is already reflected by the
+     * effective isSetFlag() check in the caller, so any truthy override in the
+     * chain proves deliberate intent.
+     */
+    private function hasAmastyConfigOverride(\Magento\Store\Api\Data\StoreInterface $store): bool
+    {
+        $collection = $this->configDataCollectionFactory->create();
+        $collection->addFieldToFilter('path', 'amasty_checkout/general/enabled');
+        foreach ($collection as $row) {
+            if (!(bool)$row->getValue()) {
+                continue;
+            }
+            $scope = (string)$row->getScope();
+            $scopeId = (int)$row->getScopeId();
+            if ($scope === ScopeConfigInterface::SCOPE_TYPE_DEFAULT
+                || ($scope === \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITES
+                    && $scopeId === (int)$store->getWebsiteId())
+                || ($scope === \Magento\Store\Model\ScopeInterface::SCOPE_STORES
+                    && $scopeId === (int)$store->getId())
+            ) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/Model/Two.php
+++ b/Model/Two.php
@@ -766,24 +766,9 @@ class Two extends AbstractMethod
             return true;
         }
         $platformMinimum = $this->minimumOrderProvider->getMinimum($storeId);
-        $merchantMinimum = null;
-        if ($quote instanceof \Magento\Quote\Model\Quote) {
-            $merchantValue = (float)$this->getConfigData('merchant_minimum_order');
-            if ($merchantValue > 0) {
-                $store = $quote->getStore();
-                $currency = $store !== null ? (string)$store->getBaseCurrencyCode() : '';
-                if ($currency !== '') {
-                    $merchantBasis = (string)$this->getConfigData('merchant_minimum_order_basis');
-                    $merchantMinimum = [
-                        'amount' => $merchantValue,
-                        'currency' => $currency,
-                        'basis' => in_array($merchantBasis, ['net', 'gross'], true)
-                            ? $merchantBasis
-                            : ($platformMinimum['basis'] ?? 'gross'),
-                    ];
-                }
-            }
-        }
+        $merchantMinimum = $quote instanceof \Magento\Quote\Model\Quote
+            ? $this->buildMerchantMinimum($quote, $platformMinimum)
+            : null;
         return $this->minimumOrderGate->isSatisfied($platformMinimum, $quote, $merchantMinimum);
     }
 
@@ -818,25 +803,48 @@ class Two extends AbstractMethod
             }
         }
 
-        $merchantValue = (float)$this->getConfigData('merchant_minimum_order');
-        if ($merchantValue > 0 && $store !== null && (string)$store->getBaseCurrencyCode() !== '') {
-            $merchantBasis = (string)$this->getConfigData('merchant_minimum_order_basis');
-            $shown = $this->minimumOrderGate->getMinimumForDisplay(
-                [
-                    'amount' => $merchantValue,
-                    'currency' => (string)$store->getBaseCurrencyCode(),
-                    'basis' => in_array($merchantBasis, ['net', 'gross'], true)
-                        ? $merchantBasis
-                        : ($platform['basis'] ?? 'gross'),
-                ],
-                $displayCurrency,
-                $storeId
-            );
+        $merchant = $this->buildMerchantMinimum($quote, $platform);
+        if ($merchant !== null) {
+            $shown = $this->minimumOrderGate->getMinimumForDisplay($merchant, $displayCurrency, $storeId);
             if ($shown !== null) {
                 $out[] = $shown;
             }
         }
 
         return $out;
+    }
+
+    /**
+     * The merchant's own optional minimum-order tuple for a quote, or null when
+     * unset (<= 0) or the store base currency is unresolvable. Single source of
+     * truth shared by isAvailable()'s server gate and getDisplayMinimums()'s
+     * client-display projection: the two MUST agree on the constraint, so the
+     * construction lives in exactly one place. Amount is in the store BASE
+     * currency (validated on save to meet/exceed the platform floor); basis
+     * falls back to the platform minimum's basis, then 'gross', when the admin
+     * value is neither 'net' nor 'gross'.
+     *
+     * @param array<string, mixed>|null $platform Platform minimum, for basis fallback only.
+     * @return array{amount: float, currency: string, basis: string}|null
+     */
+    private function buildMerchantMinimum(\Magento\Quote\Model\Quote $quote, ?array $platform): ?array
+    {
+        $merchantValue = (float)$this->getConfigData('merchant_minimum_order');
+        if ($merchantValue <= 0) {
+            return null;
+        }
+        $store = $quote->getStore();
+        $currency = $store !== null ? (string)$store->getBaseCurrencyCode() : '';
+        if ($currency === '') {
+            return null;
+        }
+        $merchantBasis = (string)$this->getConfigData('merchant_minimum_order_basis');
+        return [
+            'amount' => $merchantValue,
+            'currency' => $currency,
+            'basis' => in_array($merchantBasis, ['net', 'gross'], true)
+                ? $merchantBasis
+                : ($platform['basis'] ?? 'gross'),
+        ];
     }
 }

--- a/Model/Two.php
+++ b/Model/Two.php
@@ -748,6 +748,23 @@ class Two extends AbstractMethod
         if ($quote instanceof \Magento\Quote\Model\Quote && $quote->getStoreId() !== null) {
             $storeId = (int)$quote->getStoreId();
         }
+        // Amasty OneStepCheckout persists the buyer's shipping method to the
+        // server quote only at order placement, so the server quote is blind to
+        // the live shipping choice and this gate would judge a stale total (a
+        // dearer shipping that crosses the minimum never registers server-side).
+        // When Amasty OSC is active for this store, offer the method
+        // unconditionally and let the checkout renderer gate visibility
+        // client-side against the live total; place-order + the Two API still
+        // enforce the minimum fail-closed. Read at STORE scope so it tracks the
+        // active store view (e.g. ?___store=amasty). Absent module → false → no
+        // change for every other checkout.
+        if ($this->_scopeConfig->isSetFlag(
+            'amasty_checkout/general/enabled',
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $storeId
+        )) {
+            return true;
+        }
         $platformMinimum = $this->minimumOrderProvider->getMinimum($storeId);
         $merchantMinimum = null;
         if ($quote instanceof \Magento\Quote\Model\Quote) {
@@ -768,5 +785,58 @@ class Two extends AbstractMethod
             }
         }
         return $this->minimumOrderGate->isSatisfied($platformMinimum, $quote, $merchantMinimum);
+    }
+
+    /**
+     * The active minimum-order constraints for a quote, each already converted
+     * to the quote's display currency, for the checkout renderer's client-side
+     * visibility gate. Same platform + merchant minimums isAvailable() enforces
+     * (kept in step deliberately), projected to {amount, basis} in the display
+     * currency so the JS only has to compare — no rule/FX logic client-side.
+     *
+     * @return array<int, array{amount: float, basis: string}>
+     */
+    public function getDisplayMinimums(?CartInterface $quote): array
+    {
+        if (!$quote instanceof \Magento\Quote\Model\Quote) {
+            return [];
+        }
+        $storeId = $quote->getStoreId() !== null ? (int)$quote->getStoreId() : null;
+        $store = $quote->getStore();
+        $displayCurrency = (string)($quote->getQuoteCurrencyCode()
+            ?: ($store !== null ? $store->getBaseCurrencyCode() : ''));
+        if ($displayCurrency === '') {
+            return [];
+        }
+
+        $out = [];
+        $platform = $this->minimumOrderProvider->getMinimum($storeId);
+        if ($platform !== null) {
+            $shown = $this->minimumOrderGate->getMinimumForDisplay($platform, $displayCurrency, $storeId);
+            if ($shown !== null) {
+                $out[] = $shown;
+            }
+        }
+
+        $merchantValue = (float)$this->getConfigData('merchant_minimum_order');
+        if ($merchantValue > 0 && $store !== null && (string)$store->getBaseCurrencyCode() !== '') {
+            $merchantBasis = (string)$this->getConfigData('merchant_minimum_order_basis');
+            $shown = $this->minimumOrderGate->getMinimumForDisplay(
+                [
+                    'amount' => $merchantValue,
+                    'currency' => (string)$store->getBaseCurrencyCode(),
+                    'basis' => in_array($merchantBasis, ['net', 'gross'], true)
+                        ? $merchantBasis
+                        : ($platform['basis'] ?? 'gross'),
+                ],
+                $displayCurrency,
+                $storeId
+            );
+            if ($shown !== null) {
+                $out[] = $shown;
+            }
+        }
+
+        return $out;
     }
 }

--- a/Model/Ui/ConfigProvider.php
+++ b/Model/Ui/ConfigProvider.php
@@ -143,6 +143,11 @@ class ConfigProvider implements ConfigProviderInterface
                     'selectedPaymentTerm' => (int)$this->checkoutSession->getTwoSelectedTerm()
                         ?: $this->configRepository->getDefaultPaymentTerm(),
                     'currencySymbol' => $this->getCurrencySymbol(),
+                    // Server-resolved minimum-order constraints in the display
+                    // currency, for the renderer's client-side visibility gate
+                    // (hide below min; on Amasty, where isAvailable offers the
+                    // method unconditionally, this also drives showing above it).
+                    'minimumOrder' => $this->two->getDisplayMinimums($this->checkoutSession->getQuote()),
                     'subtitleHtml' => $this->getSubtitleHtml(),
                     'surchargeDescription' => $this->configRepository->getSurchargeLineDescription(),
                     'isPaymentTermsEnabled' => true,

--- a/Model/Ui/ConfigProvider.php
+++ b/Model/Ui/ConfigProvider.php
@@ -118,6 +118,7 @@ class ConfigProvider implements ConfigProviderInterface
         $paymentTerms = __("payment terms");
         $brandParams = $this->buildBrandQueryString();
         $paymentTermsLink = $this->configRepository->getCheckoutPageUrl() . '/terms' . $brandParams;
+        $minimumOrder = $this->two->getMinimumOrderVisibility($this->checkoutSession->getQuote());
 
         return [
             'payment' => [
@@ -147,7 +148,12 @@ class ConfigProvider implements ConfigProviderInterface
                     // currency, for the renderer's client-side visibility gate
                     // (hide below min; on Amasty, where isAvailable offers the
                     // method unconditionally, this also drives showing above it).
-                    'minimumOrder' => $this->two->getDisplayMinimums($this->checkoutSession->getQuote()),
+                    // minimumOrderUnresolved is true when an active minimum could
+                    // not be projected into the display currency (missing FX
+                    // rate) → the renderer hides, matching the server gate's
+                    // fail-closed stance rather than failing open.
+                    'minimumOrder' => $minimumOrder['minimums'],
+                    'minimumOrderUnresolved' => $minimumOrder['unresolved'],
                     'subtitleHtml' => $this->getSubtitleHtml(),
                     'surchargeDescription' => $this->configRepository->getSurchargeLineDescription(),
                     'isPaymentTermsEnabled' => true,

--- a/Test/Js/amd-harness.js
+++ b/Test/Js/amd-harness.js
@@ -55,7 +55,8 @@ function defaultMocks() {
             shippingAddress: makeObservable({}),
             billingAddress: makeObservable({}),
             getTotals: function () { return makeObservable({}); },
-            getQuoteId: function () { return null; }
+            getQuoteId: function () { return null; },
+            paymentMethod: makeObservable(null)
         },
         'Magento_Customer/js/customer-data': {
             get: function () { return makeObservable({}); },

--- a/Test/Js/amd-harness.js
+++ b/Test/Js/amd-harness.js
@@ -104,6 +104,7 @@ function defaultMocks() {
         },
         'Magento_Catalog/js/price-utils': { formatPrice: function (n) { return String(n); } },
         'Two_Gateway/js/model/surcharge': makeSurchargeMock(),
+        'Two_Gateway/js/model/minimum-order-visibility': function () { return true; },
         'Two_Gateway/js/model/brand-config': (function () {
             function getBrandConfig(code) {
                 return ((typeof window !== 'undefined' && window.checkoutConfig && window.checkoutConfig.payment) || {})[code] || {};

--- a/Test/Js/minimum-order-visibility.test.js
+++ b/Test/Js/minimum-order-visibility.test.js
@@ -36,6 +36,16 @@ describe('Two_Gateway/js/model/minimum-order-visibility', () => {
         expect(isAboveMinimums(null, [{ amount: 250, basis: 'gross' }])).toBe(true);
     });
 
+    it('is visible when totals are collected but grand_total not yet populated', () => {
+        // Magento's quote.getTotals() observable initialises to {} before
+        // totals arrive — data-not-ready, must stay visible, not hide as €0.
+        expect(isAboveMinimums({}, [{ amount: 250, basis: 'gross' }])).toBe(true);
+    });
+
+    it('hides a real zero-total order below the minimum (0 IS data)', () => {
+        expect(isAboveMinimums({ grand_total: '0' }, [{ amount: 250, basis: 'gross' }])).toBe(false);
+    });
+
     it('gross basis compares the grand total', () => {
         const min = [{ amount: 250, basis: 'gross' }];
         expect(isAboveMinimums({ grand_total: '273.00', tax_amount: '45' }, min)).toBe(true);

--- a/Test/Js/minimum-order-visibility.test.js
+++ b/Test/Js/minimum-order-visibility.test.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ *
+ * Tests for the client-side minimum-order visibility test used by the Two
+ * payment renderer (view/frontend/web/js/model/minimum-order-visibility.js).
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const SRC = fs.readFileSync(
+    path.resolve(__dirname, '../../view/frontend/web/js/model/minimum-order-visibility.js'),
+    'utf8'
+);
+
+function load() {
+    let factory;
+    vm.runInNewContext(SRC, { define: (deps, fn) => { factory = fn; } });
+
+    return factory();
+}
+
+const isAboveMinimums = load();
+
+describe('Two_Gateway/js/model/minimum-order-visibility', () => {
+    it('is visible when there are no minimums', () => {
+        expect(isAboveMinimums({ grand_total: '10' }, [])).toBe(true);
+        expect(isAboveMinimums({ grand_total: '10' }, null)).toBe(true);
+    });
+
+    it('is visible when totals are absent (never hide on missing data)', () => {
+        expect(isAboveMinimums(null, [{ amount: 250, basis: 'gross' }])).toBe(true);
+    });
+
+    it('gross basis compares the grand total', () => {
+        const min = [{ amount: 250, basis: 'gross' }];
+        expect(isAboveMinimums({ grand_total: '273.00', tax_amount: '45' }, min)).toBe(true);
+        expect(isAboveMinimums({ grand_total: '238.00', tax_amount: '39' }, min)).toBe(false);
+    });
+
+    it('net basis compares grand total minus tax', () => {
+        const min = [{ amount: 250, basis: 'net' }];
+        // 302.50 gross − 52.50 tax = 250.00 net → satisfied
+        expect(isAboveMinimums({ grand_total: '302.50', tax_amount: '52.50' }, min)).toBe(true);
+        // 273 gross − 45 tax = 228 net → below
+        expect(isAboveMinimums({ grand_total: '273.00', tax_amount: '45.00' }, min)).toBe(false);
+    });
+
+    it('requires EVERY minimum to be satisfied', () => {
+        const mins = [{ amount: 250, basis: 'gross' }, { amount: 300, basis: 'gross' }];
+        expect(isAboveMinimums({ grand_total: '320' }, mins)).toBe(true);
+        expect(isAboveMinimums({ grand_total: '273' }, mins)).toBe(false); // clears 250, fails 300
+    });
+
+    it('treats the boundary as satisfied (>=, currency-precision epsilon)', () => {
+        const min = [{ amount: 250, basis: 'gross' }];
+        expect(isAboveMinimums({ grand_total: '250.00' }, min)).toBe(true);
+        expect(isAboveMinimums({ grand_total: '249.99' }, min)).toBe(false);
+    });
+
+    it('handles missing tax on a net basis as zero tax', () => {
+        const min = [{ amount: 250, basis: 'net' }];
+        expect(isAboveMinimums({ grand_total: '250.00' }, min)).toBe(true);
+    });
+});

--- a/view/frontend/web/js/model/minimum-order-visibility.js
+++ b/view/frontend/web/js/model/minimum-order-visibility.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+/**
+ * Client-side minimum-order visibility test for the Two payment method.
+ *
+ * `minimums` are the server-resolved constraints (`{amount, basis}`) already
+ * projected into the quote's display currency by Model\Two::getDisplayMinimums
+ * — so this only compares, it does not re-derive the rule or do any FX. The
+ * method is visible only when the live quote total satisfies EVERY minimum on
+ * its declared basis (net = grand total − tax, gross = grand total).
+ *
+ * Display-only: server isAvailable + place-order + the Two API are the
+ * enforcers. Absent/empty minimums or absent totals → visible (never hide on
+ * missing data; the server list already gates presence).
+ *
+ * @param {Object|null} totals - Magento quote totals segment (grand_total, tax_amount)
+ * @param {Array|null} minimums - [{amount:Number, basis:'net'|'gross'}]
+ * @returns {Boolean}
+ */
+define([], function () {
+    'use strict';
+
+    return function isAboveMinimums(totals, minimums) {
+        if (!minimums || !minimums.length) {
+            return true;
+        }
+        if (!totals) {
+            return true;
+        }
+        var grand = parseFloat(totals.grand_total) || 0;
+        var tax = parseFloat(totals.tax_amount) || 0;
+
+        return minimums.every(function (m) {
+            var basketValue = m.basis === 'gross' ? grand : grand - tax;
+
+            // +epsilon mirrors the server gate's >= at currency precision.
+            return basketValue + 0.0001 >= m.amount;
+        });
+    };
+});

--- a/view/frontend/web/js/model/minimum-order-visibility.js
+++ b/view/frontend/web/js/model/minimum-order-visibility.js
@@ -27,7 +27,11 @@ define([], function () {
         if (!minimums || !minimums.length) {
             return true;
         }
-        if (!totals) {
+        // Missing totals, or a totals object collected before grand_total is
+        // populated (Magento's observable initialises to {} before totals
+        // arrive): treat as data-not-ready and stay visible — never hide on
+        // missing data. A real grand_total of 0 IS data and is compared.
+        if (!totals || totals.grand_total === undefined || totals.grand_total === null) {
             return true;
         }
         var grand = parseFloat(totals.grand_total) || 0;

--- a/view/frontend/web/js/model/minimum-order-visibility.js
+++ b/view/frontend/web/js/model/minimum-order-visibility.js
@@ -7,7 +7,7 @@
  * Client-side minimum-order visibility test for the Two payment method.
  *
  * `minimums` are the server-resolved constraints (`{amount, basis}`) already
- * projected into the quote's display currency by Model\Two::getDisplayMinimums
+ * projected into the quote's display currency by Model\Two::getMinimumOrderVisibility
  * — so this only compares, it does not re-derive the rule or do any FX. The
  * method is visible only when the live quote total satisfies EVERY minimum on
  * its declared basis (net = grand total − tax, gross = grand total).

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -127,8 +127,10 @@ define([
             // fail-closed stance rather than failing open. Enforcement itself is
             // server-side (isAvailable on non-Amasty; authorize() + the Two API
             // at placement on Amasty) — this is display only. No minimums and
-            // nothing unresolved → always visible. pureComputed so it sleeps
-            // when the renderer is unbound (Amasty re-renders the method list).
+            // nothing unresolved → always visible. pureComputed + the explicit
+            // dispose() teardown below are what release the totals dependency
+            // when the renderer is destroyed (the deselect subscription keeps
+            // the computed awake, so we rely on dispose(), not auto-sleep).
             var self = this;
             var minimums = config.minimumOrder || [];
             var minimumsUnresolved = !!config.minimumOrderUnresolved;

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -119,13 +119,34 @@ define([
             // display currency; we only compare against the live quote total.
             // Hides the method below the minimum (the case the server can miss
             // on Amasty, where shipping isn't persisted until place-order); on
-            // Amasty isAvailable offers the method unconditionally, so this also
-            // drives showing it once the total clears the minimum. Server
-            // isAvailable + place-order + the Two API remain the enforcers —
-            // this is display only. No minimums → always visible.
+            // an Amasty store view isAvailable offers the method
+            // unconditionally, so this also drives showing it once the total
+            // clears the minimum. config.minimumOrderUnresolved is set when the
+            // server has an active minimum it could NOT convert to the display
+            // currency (missing FX rate) → hide, mirroring the server gate's
+            // fail-closed stance rather than failing open. Enforcement itself is
+            // server-side (isAvailable on non-Amasty; authorize() + the Two API
+            // at placement on Amasty) — this is display only. No minimums and
+            // nothing unresolved → always visible. pureComputed so it sleeps
+            // when the renderer is unbound (Amasty re-renders the method list).
+            var self = this;
             var minimums = config.minimumOrder || [];
-            this.isTwoVisible = ko.computed(function () {
-                return isAboveMinimums(quote.getTotals()(), minimums);
+            var minimumsUnresolved = !!config.minimumOrderUnresolved;
+            this.isTwoVisible = ko.pureComputed(function () {
+                return !minimumsUnresolved && isAboveMinimums(quote.getTotals()(), minimums);
+            });
+            // Hiding the radio is not enough on Amasty, whose global place-order
+            // button lives outside this renderer: if the total drops below the
+            // minimum while Two is the selected method (e.g. a cheaper shipping
+            // rate picked after selection), deselect it so a hidden method can
+            // never be the one submitted. authorize() is the server backstop;
+            // this is the earlier, cleaner client stop. Subscription disposed
+            // in dispose() so re-renders don't leak it.
+            this._twoVisibilitySub = this.isTwoVisible.subscribe(function (visible) {
+                var selected = quote.paymentMethod();
+                if (!visible && selected && selected.method === self.getCode()) {
+                    quote.paymentMethod(null);
+                }
             });
 
             var terms = config.availableBuyerTerms || [];
@@ -180,6 +201,21 @@ define([
             this.configureFormValidation();
             this.popupMessageListener();
             return this;
+        },
+        /**
+         * Tear down the minimum-order visibility subscription and computed so a
+         * re-rendered method list (Amasty rebuilds it on shipping/total change)
+         * doesn't accumulate live subscriptions to the singleton quote totals.
+         */
+        dispose: function () {
+            if (this._twoVisibilitySub) {
+                this._twoVisibilitySub.dispose();
+                this._twoVisibilitySub = null;
+            }
+            if (this.isTwoVisible && this.isTwoVisible.dispose) {
+                this.isTwoVisible.dispose();
+            }
+            this._super();
         },
         selectTerm: function (days) {
             surchargeModel.selectTerm(days);

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -18,6 +18,7 @@ define([
     'Magento_Catalog/js/price-utils',
     'Two_Gateway/js/model/surcharge',
     'Two_Gateway/js/model/brand-config',
+    'Two_Gateway/js/model/minimum-order-visibility',
     'Magento_Ui/js/lib/view/utils/async',
     'mage/validation',
     'jquery/jquery-storageapi'
@@ -35,7 +36,8 @@ define([
     url,
     priceUtils,
     surchargeModel,
-    getBrandConfig
+    getBrandConfig,
+    isAboveMinimums
 ) {
     'use strict';
 
@@ -111,6 +113,20 @@ define([
             this.isProjectFieldEnabled = config.isProjectFieldEnabled;
             this.isOrderNoteFieldEnabled = config.isOrderNoteFieldEnabled;
             this.isPONumberFieldEnabled = config.isPONumberFieldEnabled;
+
+            // Client-side minimum-order visibility gate. config.minimumOrder is
+            // the server-resolved constraint(s) {amount, basis} already in the
+            // display currency; we only compare against the live quote total.
+            // Hides the method below the minimum (the case the server can miss
+            // on Amasty, where shipping isn't persisted until place-order); on
+            // Amasty isAvailable offers the method unconditionally, so this also
+            // drives showing it once the total clears the minimum. Server
+            // isAvailable + place-order + the Two API remain the enforcers —
+            // this is display only. No minimums → always visible.
+            var minimums = config.minimumOrder || [];
+            this.isTwoVisible = ko.computed(function () {
+                return isAboveMinimums(quote.getTotals()(), minimums);
+            });
 
             var terms = config.availableBuyerTerms || [];
             this.availableBuyerTerms = terms;

--- a/view/frontend/web/template/payment/gateway_method.html
+++ b/view/frontend/web/template/payment/gateway_method.html
@@ -1,6 +1,6 @@
 <div
     class="payment-method two-payment-method"
-    data-bind="css: {'_active': (getCode() == isChecked())}"
+    data-bind="css: {'_active': (getCode() == isChecked())}, visible: isTwoVisible"
 >
     <div class="payment-method-title field choice">
         <div class="payment-option-title-container">


### PR DESCRIPTION
## Problem

Min-order show/hide is broken on **Amasty OneStepCheckout** (Luma/Hyvä/Fire are correct). Amasty persists the shipping method to the server quote only at **place-order**, so `isAvailable` judges a shipping-blind total:
- **Case 1 (should show):** basket €238 + flat shipping = €273 ≥ min, but the server sees €238 → excludes Two → not in the list → can't be revealed.
- **Case 2 (should hide):** a stale-high shipping persists server-side (cart re-entry, or a discount recollect), buyer switches to free → server still lists Two while the live total is under min.

Confirmed live via the Chrome bridge: after selecting flat-rate, client total moved €190.40→€225.40 but `payment-information` stayed at €190.40 — the server never saw the shipping.

## Fix (agreed approach: always-list on Amasty + client-side gate)

1. **`Model\Two::isAvailable`** — when Amasty OSC is enabled for the quote's store (`amasty_checkout/general/enabled`, **STORE scope** so it tracks `?___store=amasty`), offer the method unconditionally. Every other checkout keeps the authoritative server gate. Absent module → false → no change.
2. **Client-side visibility gate** — `ConfigProvider` exposes the server-resolved minimum(s) `{amount, basis}` in the **display currency** (`getDisplayMinimums` — server does rule-resolution + FX; JS only compares). The renderer's `isTwoVisible` computed (pure `minimum-order-visibility` helper) drives a `visible` binding: hides below the live total (universal **case-2** safety net; on Amasty **also shows** above min → fixes **case 1**).

Net: Amasty now reacts to shipping both ways via the client; Luma/Hyvä/Fire unchanged (server gate + `#245`) plus a client hide safety-net. **Display-only** — server `isAvailable` + place-order + the Two API still enforce fail-closed, so a below-min order can't complete.

## Tests
Jest: `minimum-order-visibility` helper — net/gross basis, multi-minimum, boundary (`>=`), missing-data (`49 green`). amd-harness registers the new dep. PHP structural changes covered by CI; **behaviour to be browser-verified across all four checkouts on the dev shop before this is relied on.**

## Verification plan
Post-merge → dev shop git-syncs → verify on `magento-dev.staging.achterafbetalen.co`:
- `?___store=amasty`: €238 free → hidden; select flat (€273) → **shows**; back to free → **hides**; discount routes → toggles.
- `?___store=default` (Luma) / `fire` / `hyva`: unchanged, still correct (regression check).

If any issue, clean revert.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)