### PR TITLE
TWO-25072: route surcharge tax through the real Magento tax engine

### DIFF
--- a/Api/Config/RepositoryInterface.php
+++ b/Api/Config/RepositoryInterface.php
@@ -45,6 +45,7 @@ interface RepositoryInterface
     public const XML_PATH_SURCHARGE_DIFFERENTIAL = 'payment/two_payment/surcharge_differential';
     public const XML_PATH_SURCHARGE_LINE_DESCRIPTION = 'payment/two_payment/surcharge_line_description';
     public const XML_PATH_SURCHARGE_TAX_RATE = 'payment/two_payment/surcharge_tax_rate';
+    public const XML_PATH_SURCHARGE_TAX_CLASS_ID = 'payment/two_payment/surcharge_tax_class';
     public const XML_PATH_SURCHARGE_FIXED_CURRENCY = 'payment/two_payment/surcharge_fixed_currency';
     public const XML_PATH_DEFAULT_PRODUCT_TAX_CLASS = 'tax/classes/default_product_tax_class';
     public const XML_PATH_VERSION = 'payment/two_payment/version';
@@ -343,6 +344,24 @@ interface RepositoryInterface
      * @return float
      */
     public function getSurchargeTaxRate(?int $storeId = null): float;
+
+    /**
+     * Get the Product Tax Class id used to tax the surcharge via
+     * Magento's tax rules engine (destination-aware, rule-driven,
+     * additive multi-rate).
+     *
+     * Returns null when the merchant has not opted into engine-driven
+     * surcharge tax (config unset, or explicitly set to the legacy
+     * flat-rate option) — callers must then fall back to
+     * getSurchargeTaxRate(). A value of 0 is a valid selection
+     * ("None"): no tax rule can match class id 0, so the surcharge is
+     * untaxed everywhere.
+     *
+     * @param int|null $storeId
+     *
+     * @return int|null
+     */
+    public function getSurchargeTaxClassId(?int $storeId = null): ?int;
 
     /**
      * Get surcharge config for a specific term

--- a/Model/Config/Repository.php
+++ b/Model/Config/Repository.php
@@ -567,6 +567,21 @@ class Repository implements RepositoryInterface
     }
 
     /**
+     * @inheritDoc
+     */
+    public function getSurchargeTaxClassId(?int $storeId = null): ?int
+    {
+        $configured = $this->getConfig($this->path('surcharge_tax_class'), $storeId);
+        // Unset, or the source model's explicit legacy option (''),
+        // means flat-rate fallback — upgrading merchants who never touch
+        // the new field keep their existing behaviour.
+        if ($configured === null || $configured === '') {
+            return null;
+        }
+        return (int)$configured;
+    }
+
+    /**
      * Look up the store's default tax rate from Magento's tax rules.
      *
      * @param int|null $storeId

--- a/Model/Config/Source/SurchargeTaxClass.php
+++ b/Model/Config/Source/SurchargeTaxClass.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Model\Config\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+use Magento\Tax\Model\TaxClass\Source\Product as ProductTaxClassSource;
+
+/**
+ * Product Tax Class options for the surcharge tax class selector.
+ *
+ * Mirrors Magento core's own tax/classes/shipping_tax_class dropdown
+ * (Magento\Tax\Model\TaxClass\Source\Product) but prepends an explicit
+ * "legacy flat rate" option with an EMPTY value. This matters for
+ * upgrade safety: merchants who configured the flat Surcharge Tax Rate
+ * before this field existed must not be silently flipped onto the tax
+ * rules engine (or onto "None" = zero tax) just because they re-saved
+ * the config page — the empty value is both the unset default and the
+ * explicit opt-out, and Repository::getSurchargeTaxClassId() maps it
+ * to null (= use the flat rate).
+ *
+ * The delegate's option list includes "None" (value 0) plus every
+ * Product Tax Class; selecting a class routes surcharge tax through
+ * TaxCalculationInterface with full destination/rule resolution.
+ */
+class SurchargeTaxClass implements OptionSourceInterface
+{
+    /**
+     * @var ProductTaxClassSource
+     */
+    private $productTaxClassSource;
+
+    public function __construct(ProductTaxClassSource $productTaxClassSource)
+    {
+        $this->productTaxClassSource = $productTaxClassSource;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function toOptionArray(): array
+    {
+        $options = [
+            ['value' => '', 'label' => __('Use flat Surcharge Tax Rate below (legacy)')],
+        ];
+        foreach ($this->productTaxClassSource->getAllOptions(true) as $option) {
+            $options[] = $option;
+        }
+        return $options;
+    }
+}

--- a/Model/Total/Surcharge.php
+++ b/Model/Total/Surcharge.php
@@ -16,6 +16,7 @@ use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
 use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
 use Two\Gateway\Model\Config\Source\SurchargeType;
 use Two\Gateway\Service\Order\SurchargeCalculator;
+use Two\Gateway\Service\Order\SurchargeTaxCalculator;
 
 /**
  * Quote total collector for the Two payment terms surcharge.
@@ -45,6 +46,11 @@ class Surcharge extends AbstractTotal
     private $surchargeCalculator;
 
     /**
+     * @var SurchargeTaxCalculator
+     */
+    private $surchargeTaxCalculator;
+
+    /**
      * @var LogRepository
      */
     private $logRepository;
@@ -62,12 +68,14 @@ class Surcharge extends AbstractTotal
         CheckoutSession $checkoutSession,
         ConfigRepository $configRepository,
         SurchargeCalculator $surchargeCalculator,
+        SurchargeTaxCalculator $surchargeTaxCalculator,
         LogRepository $logRepository,
         array $allowedMethods = ['two_payment']
     ) {
         $this->checkoutSession = $checkoutSession;
         $this->configRepository = $configRepository;
         $this->surchargeCalculator = $surchargeCalculator;
+        $this->surchargeTaxCalculator = $surchargeTaxCalculator;
         $this->logRepository = $logRepository;
         $this->allowedMethods = array_fill_keys($allowedMethods, true);
         $this->setCode('two_surcharge');
@@ -192,14 +200,50 @@ class Surcharge extends AbstractTotal
         // contract (Money 2dp / UnitPrice 6dp / Rate 6dp / Quantity 8dp).
         // ComposeOrder / ComposeRefund / ComposeCapture / ComposeShipment
         // do the per-field outbound rounding via roundAmt().
-        $taxRate = $result['tax_rate'] / 100;
-        $taxAmount = round($netAmount * $taxRate, 6);
+        $baseToQuoteRate = (float)$quote->getBaseToQuoteRate() ?: 1.0;
+        $baseNetAmount = round($netAmount / $baseToQuoteRate, 6);
+
+        // Tax: destination-aware via Magento's tax rules engine when a
+        // surcharge Product Tax Class is configured (TWO-25072), else the
+        // legacy flat admin-configured percentage from the pricing result.
+        $surchargeTaxClassId = $this->configRepository->getSurchargeTaxClassId($storeId);
+        if ($surchargeTaxClassId !== null) {
+            try {
+                $taxResult = $this->surchargeTaxCalculator->calculateForQuote(
+                    $quote,
+                    $shippingAssignment,
+                    $netAmount,
+                    $baseNetAmount,
+                    $surchargeTaxClassId,
+                    $storeId
+                );
+            } catch (\Exception $e) {
+                // Same posture as the surcharge calculation above: never
+                // silently zero the tax on unexpected failure — surface a
+                // user-facing error rather than under-charge the buyer.
+                $this->logRepository->addErrorLog('TotalCollector: surcharge tax calculation failed', [
+                    'error' => $e->getMessage(),
+                    'trace' => $e->getTraceAsString(),
+                ]);
+                $this->clearSessionSurcharge();
+                throw new \Magento\Framework\Exception\LocalizedException(
+                    __('Unable to calculate payment terms surcharge. Please try again in a moment.'),
+                    $e
+                );
+            }
+            $taxAmount = round($taxResult['tax_amount'], 6);
+            $baseTaxAmount = round($taxResult['base_tax_amount'], 6);
+            $taxRatePercent = (float)$taxResult['tax_rate'];
+        } else {
+            $taxRatePercent = (float)$result['tax_rate'];
+            $taxAmount = round($netAmount * $taxRatePercent / 100, 6);
+            $baseTaxAmount = round($taxAmount / $baseToQuoteRate, 6);
+        }
+
         $grossAmount = round($netAmount + $taxAmount, 6);
 
         // Convert to base currency for base_* fields (order totals/tax reports)
-        $baseToQuoteRate = (float)$quote->getBaseToQuoteRate() ?: 1.0;
-        $baseGrossAmount = round($grossAmount / $baseToQuoteRate, 6);
-        $baseTaxAmount = round($taxAmount / $baseToQuoteRate, 6);
+        $baseGrossAmount = round($baseNetAmount + $baseTaxAmount, 6);
 
         $total->setGrandTotal($grandTotal + $grossAmount);
         $total->setBaseGrandTotal((float)$total->getBaseGrandTotal() + $baseGrossAmount);
@@ -212,13 +256,12 @@ class Surcharge extends AbstractTotal
         // collector runs on every shipping/address change, and a clobber on
         // a speculative pass (no items, no two_payment, etc.) would zero a
         // valid value set by an earlier pass for the placement address.
-        $baseNetAmount = round($netAmount / $baseToQuoteRate, 6);
         $total->setData('two_surcharge_amount', $netAmount);
         $total->setData('base_two_surcharge_amount', $baseNetAmount);
         $total->setData('two_surcharge_tax_amount', $taxAmount);
         $total->setData('base_two_surcharge_tax_amount', $baseTaxAmount);
         $total->setData('two_surcharge_description', $result['description']);
-        $total->setData('two_surcharge_tax_rate', $result['tax_rate']);
+        $total->setData('two_surcharge_tax_rate', $taxRatePercent);
 
         // Note: setData/setTitle/setValue on $total here doesn't propagate to
         // segment building. Magento's TotalsReader::fetch() builds fresh Total
@@ -231,7 +274,7 @@ class Surcharge extends AbstractTotal
         $this->checkoutSession->setTwoSurchargeTax($taxAmount);
         $this->checkoutSession->setTwoSurchargeGross($grossAmount);
         $this->checkoutSession->setTwoSurchargeDescription($result['description']);
-        $this->checkoutSession->setTwoSurchargeTaxRate($result['tax_rate']);
+        $this->checkoutSession->setTwoSurchargeTaxRate($taxRatePercent);
 
         $this->logRepository->addDebugLog('TotalCollector: applied', [
             'net' => $netAmount,

--- a/Service/Order/SurchargeTaxCalculator.php
+++ b/Service/Order/SurchargeTaxCalculator.php
@@ -243,7 +243,8 @@ class SurchargeTaxCalculator
                     ->setValue($taxClassId)
             );
 
-        $shippingAddress = $shippingAssignment->getShipping()->getAddress();
+        $shipping = $shippingAssignment->getShipping();
+        $shippingAddress = $shipping !== null ? $shipping->getAddress() : null;
 
         $quoteDetails = $this->quoteDetailsFactory->create();
         $quoteDetails->setBillingAddress($this->mapAddress($quote->getBillingAddress()));

--- a/Service/Order/SurchargeTaxCalculator.php
+++ b/Service/Order/SurchargeTaxCalculator.php
@@ -9,6 +9,7 @@ namespace Two\Gateway\Service\Order;
 
 use Magento\Customer\Api\Data\AddressInterfaceFactory as CustomerAddressFactory;
 use Magento\Customer\Api\Data\RegionInterfaceFactory as CustomerAddressRegionFactory;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Quote\Api\Data\ShippingAssignmentInterface;
 use Magento\Quote\Model\Quote;
@@ -120,7 +121,16 @@ class SurchargeTaxCalculator
      * Runs calculateTax() twice — quote currency and base currency —
      * exactly as core's Tax collector computes taxDetails and
      * baseTaxDetails, so base amounts don't inherit quote-currency
-     * rounding artefacts.
+     * rounding artefacts. Both passes use $round=true, matching core's
+     * getQuoteTaxDetails() invocations, so per-rate rounding in
+     * additive multi-rate jurisdictions behaves identically to a
+     * native product/shipping line.
+     *
+     * Never silently zero: if either engine pass fails to return an
+     * item for our code (e.g. a third-party TaxCalculationInterface
+     * override drops unknown item types), this throws rather than
+     * returning a valid-looking zero — the caller surfaces a
+     * user-facing error instead of under-charging.
      *
      * @param Quote $quote
      * @param ShippingAssignmentInterface $shippingAssignment
@@ -130,6 +140,7 @@ class SurchargeTaxCalculator
      * @param int $storeId
      *
      * @return array{tax_amount: float, base_tax_amount: float, tax_rate: float}
+     * @throws LocalizedException when an engine pass omits the surcharge item
      */
     public function calculateForQuote(
         Quote $quote,
@@ -139,41 +150,75 @@ class SurchargeTaxCalculator
         int $taxClassId,
         int $storeId
     ): array {
+        // $round=true on both passes — core's Tax collector
+        // (Magento\Tax\Model\Sales\Total\Quote\Tax::getQuoteTaxDetails)
+        // always calls calculateTax() with the default $round=true for
+        // both the quote-currency and base-currency computations. The
+        // 6dp rounding below is then a no-op safety net that only caps
+        // precision at the API wire contract.
         $taxDetails = $this->taxCalculation->calculateTax(
             $this->buildQuoteDetails($quote, $shippingAssignment, $netAmount, $taxClassId),
             $storeId,
-            false
+            true
         );
         $baseTaxDetails = $this->taxCalculation->calculateTax(
             $this->buildQuoteDetails($quote, $shippingAssignment, $baseNetAmount, $taxClassId),
             $storeId,
-            false
+            true
         );
 
-        $taxAmount = 0.0;
-        $taxRate = 0.0;
-        foreach ((array)$taxDetails->getItems() as $item) {
-            if ($item->getCode() === self::ITEM_CODE) {
-                $taxAmount = (float)$item->getRowTax();
-                $taxRate = (float)$item->getTaxPercent();
-            }
-        }
-        $baseTaxAmount = 0.0;
-        foreach ((array)$baseTaxDetails->getItems() as $item) {
-            if ($item->getCode() === self::ITEM_CODE) {
-                $baseTaxAmount = (float)$item->getRowTax();
-            }
-        }
+        // Each pass is checked independently: a mismatch (one pass
+        // resolves, the other doesn't) must never produce an order with
+        // inconsistent tax_amount / base_tax_amount.
+        [$taxAmount, $taxRate] = $this->extractSurchargeItemTax($taxDetails, 'quote');
+        [$baseTaxAmount] = $this->extractSurchargeItemTax($baseTaxDetails, 'base');
 
-        if ($taxAmount > 0) {
-            $this->warnIfNoTaxClassIsTaxed($taxClassId, $taxAmount, $taxRate);
-        }
+        // Unconditional (not gated on $taxAmount > 0): deleting a
+        // Product Tax Class cascades its Tax Calculation rules away, so
+        // the realistic "configured class no longer exists" case
+        // resolves to zero tax — exactly the case that must not pass
+        // silently.
+        $this->validateConfiguredTaxClass($taxClassId, $taxAmount, $taxRate);
 
         return [
             'tax_amount' => round($taxAmount, 6),
             'base_tax_amount' => round($baseTaxAmount, 6),
             'tax_rate' => $taxRate,
         ];
+    }
+
+    /**
+     * Pull row tax + percent for our item out of a TaxDetails result.
+     *
+     * Throws when the engine returned no item for our code — an
+     * empty/mismatched item set is an unexpected engine response
+     * (e.g. a third-party TaxCalculationInterface override), NOT a
+     * legitimate zero-rate destination match (that still returns the
+     * item, with rowTax 0).
+     *
+     * @param \Magento\Tax\Api\Data\TaxDetailsInterface $taxDetails
+     * @param string $currencyPass 'quote'|'base', for the error message
+     * @return array{0: float, 1: float} [rowTax, taxPercent]
+     * @throws LocalizedException
+     */
+    private function extractSurchargeItemTax($taxDetails, string $currencyPass): array
+    {
+        foreach ((array)$taxDetails->getItems() as $item) {
+            if ($item->getCode() === self::ITEM_CODE) {
+                return [(float)$item->getRowTax(), (float)$item->getTaxPercent()];
+            }
+        }
+
+        $this->logRepository->addErrorLog(
+            'SurchargeTaxCalculator: tax engine returned no result item for the surcharge',
+            ['currency_pass' => $currencyPass, 'item_code' => self::ITEM_CODE]
+        );
+        throw new LocalizedException(
+            __(
+                'Surcharge tax calculation returned no result for the surcharge line (%1 currency pass).',
+                $currencyPass
+            )
+        );
     }
 
     /**
@@ -250,14 +295,25 @@ class SurchargeTaxCalculator
     }
 
     /**
-     * Defensive guard for the always-zero guarantee: if the configured
-     * class is the auto-provisioned no-tax class but the engine
-     * resolved real tax, a merchant has attached a Tax Rule to it.
-     * Warn loudly (error log) but do NOT fail checkout — the engine
-     * result is still internally consistent, just not what the class
-     * name promises.
+     * Defensive guards on the configured class, run UNCONDITIONALLY for
+     * every calculation (not only when tax resolved non-zero):
+     *
+     * 1. Existence: deleting a Product Tax Class in Magento cascades
+     *    its Tax Calculation rules away, so the deleted-class case
+     *    resolves to zero tax — the merchant silently stops collecting
+     *    surcharge tax. Checking existence only when $taxAmount > 0
+     *    would skip exactly that case. Log a clear error whenever the
+     *    configured id no longer resolves, regardless of tax amount.
+     *
+     * 2. Always-zero guarantee: if the configured class is the
+     *    auto-provisioned no-tax class but the engine resolved real
+     *    tax, a merchant has attached a Tax Rule to it.
+     *
+     * Both warn loudly (error log) but do NOT fail checkout — the
+     * engine result is still internally consistent, just not what the
+     * merchant's configuration promises.
      */
-    private function warnIfNoTaxClassIsTaxed(int $taxClassId, float $taxAmount, float $taxRate): void
+    private function validateConfiguredTaxClass(int $taxClassId, float $taxAmount, float $taxRate): void
     {
         if ($taxClassId <= 0) {
             return;
@@ -265,16 +321,19 @@ class SurchargeTaxCalculator
         try {
             $taxClass = $this->taxClassRepository->get($taxClassId);
         } catch (NoSuchEntityException $e) {
-            // Configured class deleted after selection: TYPE_ID key still
-            // resolved tax via a rule referencing the raw id, or another
-            // edge. Surface it — merchant should re-point the config.
+            // Configured class deleted after selection. Cascade deletion
+            // of its rules means this usually resolves to ZERO tax, so
+            // this log line is the only signal — merchant must re-point
+            // the config.
             $this->logRepository->addErrorLog(
-                'SurchargeTaxCalculator: configured surcharge tax class no longer exists',
-                ['tax_class_id' => $taxClassId]
+                'SurchargeTaxCalculator: configured surcharge tax class id no longer exists — '
+                . 'surcharge tax resolves to the engine result without it (typically zero). '
+                . 'Re-select a valid Surcharge Tax Class in configuration.',
+                ['tax_class_id' => $taxClassId, 'tax_amount' => $taxAmount]
             );
             return;
         }
-        if ($taxClass->getClassName() === self::NO_TAX_CLASS_NAME) {
+        if ($taxAmount > 0 && $taxClass->getClassName() === self::NO_TAX_CLASS_NAME) {
             $this->logRepository->addErrorLog(
                 'SurchargeTaxCalculator: the "' . self::NO_TAX_CLASS_NAME . '" tax class has a Tax Rule '
                 . 'attached and resolved non-zero surcharge tax. This class must stay rule-free to '

--- a/Service/Order/SurchargeTaxCalculator.php
+++ b/Service/Order/SurchargeTaxCalculator.php
@@ -1,0 +1,286 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Service\Order;
+
+use Magento\Customer\Api\Data\AddressInterfaceFactory as CustomerAddressFactory;
+use Magento\Customer\Api\Data\RegionInterfaceFactory as CustomerAddressRegionFactory;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Quote\Api\Data\ShippingAssignmentInterface;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\Quote\Address as QuoteAddress;
+use Magento\Tax\Api\Data\QuoteDetailsInterfaceFactory;
+use Magento\Tax\Api\Data\QuoteDetailsItemInterfaceFactory;
+use Magento\Tax\Api\Data\TaxClassKeyInterface;
+use Magento\Tax\Api\Data\TaxClassKeyInterfaceFactory;
+use Magento\Tax\Api\TaxCalculationInterface;
+use Magento\Tax\Api\TaxClassRepositoryInterface;
+use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
+
+/**
+ * Resolves surcharge tax through Magento's real tax rules engine.
+ *
+ * Mirrors how Magento core taxes its own non-catalog line item —
+ * shipping (CommonTaxCollector::getShippingDataObject): build a
+ * QuoteDetailsItem carrying the configured Product Tax Class as a
+ * TYPE_ID TaxClassKey, wrap it in QuoteDetails with the quote's
+ * billing/shipping addresses and customer tax class, and hand it to
+ * TaxCalculationInterface::calculateTax(). That gives the surcharge
+ * destination-aware rate resolution via Tax Rules (Customer Tax Class
+ * x Product Tax Class x Tax Rate), native additive multi-rate
+ * stacking (US state+local, CA GST+PST), and zero when no rule
+ * matches — the same treatment every real product line gets.
+ */
+class SurchargeTaxCalculator
+{
+    /**
+     * Item code/type used in the QuoteDetails we submit. Namespaced so
+     * it can never collide with core item types ('product', 'shipping').
+     */
+    public const ITEM_CODE = 'two_surcharge';
+
+    /**
+     * Class name of the auto-provisioned always-zero Product Tax Class
+     * (created by Setup\Patch\Data\SurchargeNoTaxClass). Ships with no
+     * Tax Rule attached, so selecting it guarantees an untaxed
+     * surcharge for every destination. calculateForQuote() logs a
+     * warning if this class ever resolves non-zero tax — that means a
+     * merchant attached a Tax Rule to it and silently broke the
+     * guarantee.
+     */
+    public const NO_TAX_CLASS_NAME = 'Payment Terms Surcharge - No Tax';
+
+    /**
+     * @var TaxCalculationInterface
+     */
+    private $taxCalculation;
+
+    /**
+     * @var QuoteDetailsInterfaceFactory
+     */
+    private $quoteDetailsFactory;
+
+    /**
+     * @var QuoteDetailsItemInterfaceFactory
+     */
+    private $quoteDetailsItemFactory;
+
+    /**
+     * @var TaxClassKeyInterfaceFactory
+     */
+    private $taxClassKeyFactory;
+
+    /**
+     * @var CustomerAddressFactory
+     */
+    private $customerAddressFactory;
+
+    /**
+     * @var CustomerAddressRegionFactory
+     */
+    private $customerAddressRegionFactory;
+
+    /**
+     * @var TaxClassRepositoryInterface
+     */
+    private $taxClassRepository;
+
+    /**
+     * @var LogRepository
+     */
+    private $logRepository;
+
+    public function __construct(
+        TaxCalculationInterface $taxCalculation,
+        QuoteDetailsInterfaceFactory $quoteDetailsFactory,
+        QuoteDetailsItemInterfaceFactory $quoteDetailsItemFactory,
+        TaxClassKeyInterfaceFactory $taxClassKeyFactory,
+        CustomerAddressFactory $customerAddressFactory,
+        CustomerAddressRegionFactory $customerAddressRegionFactory,
+        TaxClassRepositoryInterface $taxClassRepository,
+        LogRepository $logRepository
+    ) {
+        $this->taxCalculation = $taxCalculation;
+        $this->quoteDetailsFactory = $quoteDetailsFactory;
+        $this->quoteDetailsItemFactory = $quoteDetailsItemFactory;
+        $this->taxClassKeyFactory = $taxClassKeyFactory;
+        $this->customerAddressFactory = $customerAddressFactory;
+        $this->customerAddressRegionFactory = $customerAddressRegionFactory;
+        $this->taxClassRepository = $taxClassRepository;
+        $this->logRepository = $logRepository;
+    }
+
+    /**
+     * Calculate surcharge tax for the given net amounts via Tax Rules.
+     *
+     * Runs calculateTax() twice — quote currency and base currency —
+     * exactly as core's Tax collector computes taxDetails and
+     * baseTaxDetails, so base amounts don't inherit quote-currency
+     * rounding artefacts.
+     *
+     * @param Quote $quote
+     * @param ShippingAssignmentInterface $shippingAssignment
+     * @param float $netAmount surcharge net, quote currency
+     * @param float $baseNetAmount surcharge net, base currency
+     * @param int $taxClassId configured Product Tax Class id (0 = None)
+     * @param int $storeId
+     *
+     * @return array{tax_amount: float, base_tax_amount: float, tax_rate: float}
+     */
+    public function calculateForQuote(
+        Quote $quote,
+        ShippingAssignmentInterface $shippingAssignment,
+        float $netAmount,
+        float $baseNetAmount,
+        int $taxClassId,
+        int $storeId
+    ): array {
+        $taxDetails = $this->taxCalculation->calculateTax(
+            $this->buildQuoteDetails($quote, $shippingAssignment, $netAmount, $taxClassId),
+            $storeId,
+            false
+        );
+        $baseTaxDetails = $this->taxCalculation->calculateTax(
+            $this->buildQuoteDetails($quote, $shippingAssignment, $baseNetAmount, $taxClassId),
+            $storeId,
+            false
+        );
+
+        $taxAmount = 0.0;
+        $taxRate = 0.0;
+        foreach ((array)$taxDetails->getItems() as $item) {
+            if ($item->getCode() === self::ITEM_CODE) {
+                $taxAmount = (float)$item->getRowTax();
+                $taxRate = (float)$item->getTaxPercent();
+            }
+        }
+        $baseTaxAmount = 0.0;
+        foreach ((array)$baseTaxDetails->getItems() as $item) {
+            if ($item->getCode() === self::ITEM_CODE) {
+                $baseTaxAmount = (float)$item->getRowTax();
+            }
+        }
+
+        if ($taxAmount > 0) {
+            $this->warnIfNoTaxClassIsTaxed($taxClassId, $taxAmount, $taxRate);
+        }
+
+        return [
+            'tax_amount' => round($taxAmount, 6),
+            'base_tax_amount' => round($baseTaxAmount, 6),
+            'tax_rate' => $taxRate,
+        ];
+    }
+
+    /**
+     * Build the QuoteDetails submission, mirroring core's
+     * CommonTaxCollector::prepareQuoteDetails() + getShippingDataObject().
+     */
+    private function buildQuoteDetails(
+        Quote $quote,
+        ShippingAssignmentInterface $shippingAssignment,
+        float $amount,
+        int $taxClassId
+    ) {
+        $item = $this->quoteDetailsItemFactory->create()
+            ->setType(self::ITEM_CODE)
+            ->setCode(self::ITEM_CODE)
+            ->setQuantity(1)
+            ->setUnitPrice($amount)
+            ->setIsTaxIncluded(false)
+            ->setTaxClassKey(
+                $this->taxClassKeyFactory->create()
+                    ->setType(TaxClassKeyInterface::TYPE_ID)
+                    ->setValue($taxClassId)
+            );
+
+        $shippingAddress = $shippingAssignment->getShipping()->getAddress();
+
+        $quoteDetails = $this->quoteDetailsFactory->create();
+        $quoteDetails->setBillingAddress($this->mapAddress($quote->getBillingAddress()));
+        $quoteDetails->setShippingAddress($this->mapAddress($shippingAddress));
+        $quoteDetails->setCustomerTaxClassKey(
+            $this->taxClassKeyFactory->create()
+                ->setType(TaxClassKeyInterface::TYPE_ID)
+                ->setValue($quote->getCustomerTaxClassId())
+        );
+        $quoteDetails->setCustomerId($quote->getCustomerId());
+        $quoteDetails->setItems([$item]);
+
+        return $quoteDetails;
+    }
+
+    /**
+     * Map a quote address onto the customer AddressInterface shape the
+     * tax engine consumes — verbatim CommonTaxCollector::mapAddress().
+     *
+     * @param QuoteAddress|null $address
+     * @return \Magento\Customer\Api\Data\AddressInterface|null
+     */
+    private function mapAddress($address)
+    {
+        if ($address === null) {
+            return null;
+        }
+        $region = $this->customerAddressRegionFactory->create(
+            [
+                'data' => [
+                    'region_id' => $address->getRegionId(),
+                    'region_code' => $address->getRegionCode(),
+                    'region' => $address->getRegion(),
+                ],
+            ]
+        );
+
+        return $this->customerAddressFactory->create(
+            [
+                'data' => [
+                    'country_id' => $address->getCountryId(),
+                    'region' => $region,
+                    'postcode' => $address->getPostcode(),
+                    'city' => $address->getCity(),
+                    'street' => $address->getStreet(),
+                ],
+            ]
+        );
+    }
+
+    /**
+     * Defensive guard for the always-zero guarantee: if the configured
+     * class is the auto-provisioned no-tax class but the engine
+     * resolved real tax, a merchant has attached a Tax Rule to it.
+     * Warn loudly (error log) but do NOT fail checkout — the engine
+     * result is still internally consistent, just not what the class
+     * name promises.
+     */
+    private function warnIfNoTaxClassIsTaxed(int $taxClassId, float $taxAmount, float $taxRate): void
+    {
+        if ($taxClassId <= 0) {
+            return;
+        }
+        try {
+            $taxClass = $this->taxClassRepository->get($taxClassId);
+        } catch (NoSuchEntityException $e) {
+            // Configured class deleted after selection: TYPE_ID key still
+            // resolved tax via a rule referencing the raw id, or another
+            // edge. Surface it — merchant should re-point the config.
+            $this->logRepository->addErrorLog(
+                'SurchargeTaxCalculator: configured surcharge tax class no longer exists',
+                ['tax_class_id' => $taxClassId]
+            );
+            return;
+        }
+        if ($taxClass->getClassName() === self::NO_TAX_CLASS_NAME) {
+            $this->logRepository->addErrorLog(
+                'SurchargeTaxCalculator: the "' . self::NO_TAX_CLASS_NAME . '" tax class has a Tax Rule '
+                . 'attached and resolved non-zero surcharge tax. This class must stay rule-free to '
+                . 'guarantee an untaxed surcharge — detach the Tax Rule or select a different class.',
+                ['tax_class_id' => $taxClassId, 'tax_amount' => $taxAmount, 'tax_rate' => $taxRate]
+            );
+        }
+    }
+}

--- a/Setup/Patch/Data/SurchargeNoTaxClass.php
+++ b/Setup/Patch/Data/SurchargeNoTaxClass.php
@@ -10,6 +10,7 @@ namespace Two\Gateway\Setup\Patch\Data;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Tax\Api\TaxClassManagementInterface;
+use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
 use Two\Gateway\Service\Order\SurchargeTaxCalculator;
 
 /**
@@ -23,8 +24,14 @@ use Two\Gateway\Service\Order\SurchargeTaxCalculator;
  * any jurisdiction, so selecting it in the Surcharge Tax Class dropdown
  * yields zero surcharge tax for every destination.
  *
- * SurchargeTaxCalculator logs an error if this class ever resolves
- * non-zero tax (i.e. someone attached a Tax Rule to it later).
+ * Name-collision guard: if a merchant already has a Product Tax Class
+ * with this exact name, the patch does NOT insert a duplicate — but a
+ * pre-existing class may carry Tax Rules, silently breaking the
+ * "guaranteed untaxed" promise. In that case the patch logs a loud
+ * error so the collision is visible; it never silently treats a
+ * rule-bearing class as the safe no-tax class. (Runtime defence in
+ * depth: SurchargeTaxCalculator also logs an error if this class ever
+ * resolves non-zero tax at checkout.)
  *
  * Inserts via the tax_class table directly — the same shape core's own
  * install data uses — keyed idempotently on (class_name, class_type).
@@ -36,9 +43,17 @@ class SurchargeNoTaxClass implements DataPatchInterface
      */
     private $moduleDataSetup;
 
-    public function __construct(ModuleDataSetupInterface $moduleDataSetup)
-    {
+    /**
+     * @var LogRepository
+     */
+    private $logRepository;
+
+    public function __construct(
+        ModuleDataSetupInterface $moduleDataSetup,
+        LogRepository $logRepository
+    ) {
         $this->moduleDataSetup = $moduleDataSetup;
+        $this->logRepository = $logRepository;
     }
 
     /**
@@ -51,14 +66,33 @@ class SurchargeNoTaxClass implements DataPatchInterface
         $connection = $this->moduleDataSetup->getConnection();
         $table = $this->moduleDataSetup->getTable('tax_class');
 
-        $exists = $connection->fetchOne(
+        $existingClassId = $connection->fetchOne(
             $connection->select()
                 ->from($table, 'class_id')
                 ->where('class_name = ?', SurchargeTaxCalculator::NO_TAX_CLASS_NAME)
                 ->where('class_type = ?', TaxClassManagementInterface::TYPE_PRODUCT)
         );
 
-        if (!$exists) {
+        if ($existingClassId) {
+            // Name collision (or idempotent re-run of this patch). Safe
+            // only if the existing class has NO Tax Rules attached —
+            // rules are recorded in tax_calculation.product_tax_class_id.
+            $attachedRuleCount = (int)$connection->fetchOne(
+                $connection->select()
+                    ->from($this->moduleDataSetup->getTable('tax_calculation'), 'COUNT(*)')
+                    ->where('product_tax_class_id = ?', $existingClassId)
+            );
+            if ($attachedRuleCount > 0) {
+                $this->logRepository->addErrorLog(
+                    'SurchargeNoTaxClass: a Product Tax Class named "'
+                    . SurchargeTaxCalculator::NO_TAX_CLASS_NAME . '" already exists and has '
+                    . $attachedRuleCount . ' Tax Rule(s) attached. It CANNOT guarantee an untaxed '
+                    . 'surcharge — do not select it as the Surcharge Tax Class expecting zero tax, '
+                    . 'or detach its Tax Rules first. No replacement class was created.',
+                    ['class_id' => $existingClassId, 'attached_rule_count' => $attachedRuleCount]
+                );
+            }
+        } else {
             $connection->insert($table, [
                 'class_name' => SurchargeTaxCalculator::NO_TAX_CLASS_NAME,
                 'class_type' => TaxClassManagementInterface::TYPE_PRODUCT,

--- a/Setup/Patch/Data/SurchargeNoTaxClass.php
+++ b/Setup/Patch/Data/SurchargeNoTaxClass.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Setup\Patch\Data;
+
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+use Magento\Tax\Api\TaxClassManagementInterface;
+use Two\Gateway\Service\Order\SurchargeTaxCalculator;
+
+/**
+ * Provision an always-zero Product Tax Class for the surcharge.
+ *
+ * Magento ships no out-of-the-box "None"/0% Product Tax Class, so a
+ * merchant who wants a guaranteed-untaxed surcharge would otherwise
+ * have to create one by hand. This patch inserts
+ * "Payment Terms Surcharge - No Tax" (SurchargeTaxCalculator::NO_TAX_CLASS_NAME)
+ * with NO Tax Rule attached: the tax engine resolves no rule for it in
+ * any jurisdiction, so selecting it in the Surcharge Tax Class dropdown
+ * yields zero surcharge tax for every destination.
+ *
+ * SurchargeTaxCalculator logs an error if this class ever resolves
+ * non-zero tax (i.e. someone attached a Tax Rule to it later).
+ *
+ * Inserts via the tax_class table directly — the same shape core's own
+ * install data uses — keyed idempotently on (class_name, class_type).
+ */
+class SurchargeNoTaxClass implements DataPatchInterface
+{
+    /**
+     * @var ModuleDataSetupInterface
+     */
+    private $moduleDataSetup;
+
+    public function __construct(ModuleDataSetupInterface $moduleDataSetup)
+    {
+        $this->moduleDataSetup = $moduleDataSetup;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function apply()
+    {
+        $this->moduleDataSetup->getConnection()->startSetup();
+
+        $connection = $this->moduleDataSetup->getConnection();
+        $table = $this->moduleDataSetup->getTable('tax_class');
+
+        $exists = $connection->fetchOne(
+            $connection->select()
+                ->from($table, 'class_id')
+                ->where('class_name = ?', SurchargeTaxCalculator::NO_TAX_CLASS_NAME)
+                ->where('class_type = ?', TaxClassManagementInterface::TYPE_PRODUCT)
+        );
+
+        if (!$exists) {
+            $connection->insert($table, [
+                'class_name' => SurchargeTaxCalculator::NO_TAX_CLASS_NAME,
+                'class_type' => TaxClassManagementInterface::TYPE_PRODUCT,
+            ]);
+        }
+
+        $this->moduleDataSetup->getConnection()->endSetup();
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getDependencies()
+    {
+        return [];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getAliases()
+    {
+        return [];
+    }
+}

--- a/Test/Stubs/QuoteTotals.php
+++ b/Test/Stubs/QuoteTotals.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Quote total-collection stubs for testing Model\Total\Surcharge.
+ *
+ * AbstractTotal must declare collect()/fetch() with the same parameter
+ * types the plugin's collector uses — PHP forbids a subclass adding
+ * parameter types over an untyped parent, so an empty catch-all stub
+ * would fatal on class load. Total and the checkout Session are
+ * DataObject-style magic bags, matching how Magento's real classes
+ * behave for the fields the collector touches.
+ *
+ * Must be required BEFORE the catch-all autoloader in bootstrap.php.
+ */
+declare(strict_types=1);
+
+namespace Magento\Quote\Model\Quote\Address {
+    if (!class_exists(Total::class, false)) {
+        class Total extends \Two\Gateway\Test\Stubs\UnderscoreDataObject
+        {
+        }
+    }
+}
+
+namespace Magento\Quote\Model\Quote\Address\Total {
+    if (!class_exists(AbstractTotal::class, false)) {
+        abstract class AbstractTotal
+        {
+            /** @var string */
+            protected $_code;
+
+            public function setCode($code)
+            {
+                $this->_code = $code;
+                return $this;
+            }
+
+            public function getCode()
+            {
+                return $this->_code;
+            }
+
+            public function collect(
+                \Magento\Quote\Model\Quote $quote,
+                \Magento\Quote\Api\Data\ShippingAssignmentInterface $shippingAssignment,
+                \Magento\Quote\Model\Quote\Address\Total $total
+            ) {
+                return $this;
+            }
+
+            public function fetch(
+                \Magento\Quote\Model\Quote $quote,
+                \Magento\Quote\Model\Quote\Address\Total $total
+            ) {
+                return [];
+            }
+        }
+    }
+}
+
+namespace Magento\Checkout\Model {
+    if (!class_exists(Session::class, false)) {
+        /**
+         * Checkout session stub: magic get/set like the real session's
+         * storage passthrough (getTwoSurchargeAmount() etc).
+         */
+        class Session extends \Two\Gateway\Test\Stubs\UnderscoreDataObject
+        {
+        }
+    }
+}

--- a/Test/Stubs/TaxEngine.php
+++ b/Test/Stubs/TaxEngine.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Stubs for Magento's tax rules engine API surface, used by the
+ * SurchargeTaxCalculator tests.
+ *
+ * Signatures mirror magento/magento2 2.4-develop:
+ *   Magento\Tax\Api\TaxCalculationInterface::calculateTax(
+ *       QuoteDetailsInterface $quoteDetails, $storeId = null, $round = true)
+ *   Magento\Tax\Api\Data\TaxClassKeyInterface::TYPE_ID / TYPE_NAME
+ *
+ * The data objects (QuoteDetails, QuoteDetailsItem, TaxClassKey,
+ * TaxDetails, TaxDetailsItem) are DataObject-backed so fluent
+ * setters/getters resolve via __call, exactly like Magento's own
+ * AbstractExtensibleObject-generated models behave for these fields.
+ * The *InterfaceFactory classes mirror Magento's generated factories.
+ *
+ * Must be required BEFORE the catch-all autoloader in bootstrap.php.
+ */
+declare(strict_types=1);
+
+namespace Magento\Tax\Api {
+    if (!interface_exists(TaxCalculationInterface::class, false)) {
+        interface TaxCalculationInterface
+        {
+            /**
+             * @param \Magento\Tax\Api\Data\QuoteDetailsInterface $quoteDetails
+             * @param null|int $storeId
+             * @param bool $round
+             * @return \Magento\Tax\Api\Data\TaxDetailsInterface
+             */
+            public function calculateTax($quoteDetails, $storeId = null, $round = true);
+        }
+    }
+    if (!interface_exists(TaxClassRepositoryInterface::class, false)) {
+        interface TaxClassRepositoryInterface
+        {
+            /**
+             * @param int $taxClassId
+             * @return \Magento\Tax\Api\Data\TaxClassInterface
+             */
+            public function get($taxClassId);
+        }
+    }
+    if (!interface_exists(TaxClassManagementInterface::class, false)) {
+        interface TaxClassManagementInterface
+        {
+            public const TYPE_CUSTOMER = 'CUSTOMER';
+            public const TYPE_PRODUCT = 'PRODUCT';
+        }
+    }
+}
+
+namespace Magento\Tax\Api\Data {
+    if (!interface_exists(TaxClassKeyInterface::class, false)) {
+        interface TaxClassKeyInterface
+        {
+            public const TYPE_ID = 'id';
+            public const TYPE_NAME = 'name';
+        }
+    }
+    if (!interface_exists(QuoteDetailsInterface::class, false)) {
+        interface QuoteDetailsInterface
+        {
+        }
+    }
+    if (!interface_exists(QuoteDetailsItemInterface::class, false)) {
+        interface QuoteDetailsItemInterface
+        {
+        }
+    }
+    if (!interface_exists(TaxDetailsInterface::class, false)) {
+        interface TaxDetailsInterface
+        {
+        }
+    }
+    if (!interface_exists(TaxDetailsItemInterface::class, false)) {
+        interface TaxDetailsItemInterface
+        {
+        }
+    }
+    if (!interface_exists(TaxClassInterface::class, false)) {
+        interface TaxClassInterface
+        {
+        }
+    }
+
+    if (!class_exists(QuoteDetails::class, false)) {
+        class QuoteDetails extends \Magento\Framework\DataObject implements QuoteDetailsInterface
+        {
+        }
+        class QuoteDetailsItem extends \Magento\Framework\DataObject implements QuoteDetailsItemInterface
+        {
+        }
+        class TaxClassKey extends \Magento\Framework\DataObject implements TaxClassKeyInterface
+        {
+        }
+        class TaxDetails extends \Magento\Framework\DataObject implements TaxDetailsInterface
+        {
+        }
+        class TaxDetailsItem extends \Magento\Framework\DataObject implements TaxDetailsItemInterface
+        {
+        }
+        class TaxClass extends \Magento\Framework\DataObject implements TaxClassInterface
+        {
+        }
+    }
+
+    if (!class_exists(QuoteDetailsInterfaceFactory::class, false)) {
+        class QuoteDetailsInterfaceFactory
+        {
+            public function create(array $data = [])
+            {
+                return new QuoteDetails($data['data'] ?? []);
+            }
+        }
+        class QuoteDetailsItemInterfaceFactory
+        {
+            public function create(array $data = [])
+            {
+                return new QuoteDetailsItem($data['data'] ?? []);
+            }
+        }
+        class TaxClassKeyInterfaceFactory
+        {
+            public function create(array $data = [])
+            {
+                return new TaxClassKey($data['data'] ?? []);
+            }
+        }
+    }
+}
+
+namespace Magento\Customer\Api\Data {
+    if (!interface_exists(AddressInterface::class, false)) {
+        interface AddressInterface
+        {
+        }
+    }
+    if (!class_exists(AddressInterfaceFactory::class, false)) {
+        // Underscore-mapped: the calculator passes snake_case data keys
+        // ('country_id', 'region_id'), read back via getCountryId() etc.
+        class Address extends \Two\Gateway\Test\Stubs\UnderscoreDataObject implements AddressInterface
+        {
+        }
+        class Region extends \Two\Gateway\Test\Stubs\UnderscoreDataObject
+        {
+        }
+        class AddressInterfaceFactory
+        {
+            public function create(array $arguments = [])
+            {
+                return new Address($arguments['data'] ?? []);
+            }
+        }
+        class RegionInterfaceFactory
+        {
+            public function create(array $arguments = [])
+            {
+                return new Region($arguments['data'] ?? []);
+            }
+        }
+    }
+}
+
+namespace Magento\Framework\Exception {
+    if (!class_exists(NoSuchEntityException::class, false)) {
+        class NoSuchEntityException extends LocalizedException
+        {
+            public function __construct(?\Magento\Framework\Phrase $phrase = null, ?\Exception $cause = null)
+            {
+                parent::__construct($phrase ?? new \Magento\Framework\Phrase('No such entity.'), $cause);
+            }
+        }
+    }
+}

--- a/Test/Stubs/UnderscoreDataObject.php
+++ b/Test/Stubs/UnderscoreDataObject.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * DataObject-style magic bag with Magento's real camelCase→snake_case
+ * key conversion (getGrandTotal() ↔ getData('grand_total')), unlike
+ * Stubs/DataObject.php whose lcfirst mapping predates it and is relied
+ * on by older tests. Autoloaded via the Two\Gateway PSR-4 rule in
+ * Test/bootstrap.php.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Stubs;
+
+class UnderscoreDataObject
+{
+    /** @var array */
+    protected $_data = [];
+
+    public function __construct(array $data = [])
+    {
+        $this->_data = $data;
+    }
+
+    public function getData($key = '')
+    {
+        if ($key === '') {
+            return $this->_data;
+        }
+        return $this->_data[$key] ?? null;
+    }
+
+    public function setData($key, $value = null)
+    {
+        if (is_array($key)) {
+            $this->_data = $key;
+        } else {
+            $this->_data[$key] = $value;
+        }
+        return $this;
+    }
+
+    public function hasData($key = ''): bool
+    {
+        return array_key_exists($key, $this->_data);
+    }
+
+    public function __call($method, $args)
+    {
+        $prefix = substr($method, 0, 3);
+        $key = $this->underscore(substr($method, 3));
+
+        if ($prefix === 'set') {
+            return $this->setData($key, $args[0] ?? null);
+        }
+        if ($prefix === 'get') {
+            return $this->getData($key);
+        }
+        if ($prefix === 'has') {
+            return $this->hasData($key);
+        }
+
+        return null;
+    }
+
+    private function underscore(string $name): string
+    {
+        return strtolower((string)preg_replace('/(.)([A-Z])/', '$1_$2', $name));
+    }
+}

--- a/Test/Unit/Model/Config/RepositoryPaymentTermsTest.php
+++ b/Test/Unit/Model/Config/RepositoryPaymentTermsTest.php
@@ -336,6 +336,33 @@ class RepositoryPaymentTermsTest extends TestCase
         $this->assertEquals(0.0, $this->repository->getSurchargeTaxRate());
     }
 
+    // ── getSurchargeTaxClassId ──────────────────────────────────────
+
+    public function testGetSurchargeTaxClassIdReturnsConfiguredClass(): void
+    {
+        $this->stubConfig(['payment/two_payment/surcharge_tax_class' => '4']);
+        $this->assertSame(4, $this->repository->getSurchargeTaxClassId());
+    }
+
+    public function testGetSurchargeTaxClassIdZeroIsValidNoneSelection(): void
+    {
+        $this->stubConfig(['payment/two_payment/surcharge_tax_class' => '0']);
+        $this->assertSame(0, $this->repository->getSurchargeTaxClassId());
+    }
+
+    public function testGetSurchargeTaxClassIdNullWhenUnset(): void
+    {
+        $this->stubConfig([]);
+        $this->assertNull($this->repository->getSurchargeTaxClassId());
+    }
+
+    public function testGetSurchargeTaxClassIdNullOnExplicitLegacySelection(): void
+    {
+        // The source model's legacy option saves an empty string.
+        $this->stubConfig(['payment/two_payment/surcharge_tax_class' => '']);
+        $this->assertNull($this->repository->getSurchargeTaxClassId());
+    }
+
     // ── getSurchargeConfig ──────────────────────────────────────────
 
     public function testGetSurchargeConfigReturnsPerTermValues(): void

--- a/Test/Unit/Model/Total/SurchargeTest.php
+++ b/Test/Unit/Model/Total/SurchargeTest.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Model\Total;
+
+use Magento\Checkout\Model\Session as CheckoutSession;
+use Magento\Framework\DataObject;
+use Magento\Quote\Api\Data\ShippingAssignmentInterface;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\Quote\Address\Total;
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
+use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
+use Two\Gateway\Model\Total\Surcharge;
+use Two\Gateway\Service\Order\SurchargeCalculator;
+use Two\Gateway\Service\Order\SurchargeTaxCalculator;
+
+/**
+ * TWO-25072 coverage for the quote total collector's tax branching,
+ * asserted on the exact fields downstream consumers read:
+ *
+ *  - Total data two_surcharge_[tax_]amount / two_surcharge_tax_rate —
+ *    copied onto the order via the sales_convert_quote_address
+ *    fieldset, then read by Service\Order\ComposeOrder to build the
+ *    BUYER_FEE line item (net_amount / tax_amount / tax_rate) in
+ *    Two's order-creation API payload.
+ *  - Session TwoSurchargeAmount/Tax/TaxRate — ComposeOrder's fallback
+ *    channel when the order columns are unpopulated.
+ *
+ * With a surcharge tax class configured the tax must come from the
+ * tax rules engine (SurchargeTaxCalculator); without one, from the
+ * legacy flat percentage.
+ */
+class SurchargeTest extends TestCase
+{
+    /** @var CheckoutSession */
+    private $session;
+
+    /** @var ConfigRepository|\PHPUnit\Framework\MockObject\MockObject */
+    private $config;
+
+    /** @var SurchargeCalculator|\PHPUnit\Framework\MockObject\MockObject */
+    private $surchargeCalculator;
+
+    /** @var SurchargeTaxCalculator|\PHPUnit\Framework\MockObject\MockObject */
+    private $taxCalculator;
+
+    /** @var Surcharge */
+    private $collector;
+
+    protected function setUp(): void
+    {
+        $this->session = new CheckoutSession();
+        $this->config = $this->createMock(ConfigRepository::class);
+        $this->surchargeCalculator = $this->createMock(SurchargeCalculator::class);
+        $this->taxCalculator = $this->createMock(SurchargeTaxCalculator::class);
+
+        $this->collector = new Surcharge(
+            $this->session,
+            $this->config,
+            $this->surchargeCalculator,
+            $this->taxCalculator,
+            $this->createMock(LogRepository::class)
+        );
+    }
+
+    private function makeQuote(): Quote
+    {
+        return new class extends Quote {
+            public function getPayment()
+            {
+                return new DataObject(['method' => 'two_payment']);
+            }
+
+            public function getStoreId()
+            {
+                return 1;
+            }
+
+            public function getQuoteCurrencyCode()
+            {
+                return 'USD';
+            }
+
+            public function getBillingAddress()
+            {
+                return new DataObject(['countryId' => 'US']);
+            }
+
+            public function getShippingAddress()
+            {
+                return new DataObject(['countryId' => 'US']);
+            }
+
+            public function getBaseToQuoteRate()
+            {
+                return 1.0;
+            }
+        };
+    }
+
+    private function makeShippingAssignment(): ShippingAssignmentInterface
+    {
+        return new class implements ShippingAssignmentInterface {
+            public function getItems()
+            {
+                return [new DataObject()];
+            }
+
+            public function getShipping()
+            {
+                return new DataObject(['address' => new DataObject(['countryId' => 'US'])]);
+            }
+        };
+    }
+
+    private function stubBaseline(): void
+    {
+        $this->config->method('getSurchargeType')->willReturn('percentage');
+        $this->session->setTwoSelectedTerm(30);
+        $this->surchargeCalculator->method('calculate')->willReturn([
+            'amount' => 100.0,
+            'tax_rate' => 21.0, // legacy flat rate from config, via pricing result
+            'description' => 'Payment terms fee - 30 days',
+        ]);
+    }
+
+    public function testEngineTaxUsedWhenTaxClassConfigured(): void
+    {
+        $this->stubBaseline();
+        $this->config->method('getSurchargeTaxClassId')->willReturn(4);
+        // Engine resolves a combined US state+local 7.25% for this destination.
+        $this->taxCalculator->expects($this->once())
+            ->method('calculateForQuote')
+            ->with(
+                $this->anything(),
+                $this->anything(),
+                100.0,
+                100.0,
+                4,
+                1
+            )
+            ->willReturn(['tax_amount' => 7.25, 'base_tax_amount' => 7.25, 'tax_rate' => 7.25]);
+
+        $total = new Total(['grand_total' => 1000.0, 'base_grand_total' => 1000.0]);
+        $this->collector->collect($this->makeQuote(), $this->makeShippingAssignment(), $total);
+
+        // Fields the conversion fieldset copies to the order and
+        // ComposeOrder forwards to Two's API as the BUYER_FEE line.
+        $this->assertEqualsWithDelta(100.0, $total->getData('two_surcharge_amount'), 1e-9);
+        $this->assertEqualsWithDelta(7.25, $total->getData('two_surcharge_tax_amount'), 1e-9);
+        $this->assertEqualsWithDelta(7.25, $total->getData('two_surcharge_tax_rate'), 1e-9);
+        $this->assertEqualsWithDelta(1107.25, $total->getGrandTotal(), 1e-9);
+        $this->assertEqualsWithDelta(7.25, $total->getTaxAmount(), 1e-9);
+
+        // ComposeOrder's session fallback channel.
+        $this->assertEqualsWithDelta(100.0, $this->session->getTwoSurchargeAmount(), 1e-9);
+        $this->assertEqualsWithDelta(7.25, $this->session->getTwoSurchargeTax(), 1e-9);
+        $this->assertEqualsWithDelta(107.25, $this->session->getTwoSurchargeGross(), 1e-9);
+        $this->assertEqualsWithDelta(7.25, $this->session->getTwoSurchargeTaxRate(), 1e-9);
+    }
+
+    public function testEngineZeroForUnmatchedDestinationStillZeroTax(): void
+    {
+        $this->stubBaseline();
+        $this->config->method('getSurchargeTaxClassId')->willReturn(99);
+        // No Tax Rule matches (e.g. the provisioned no-tax class).
+        $this->taxCalculator->method('calculateForQuote')
+            ->willReturn(['tax_amount' => 0.0, 'base_tax_amount' => 0.0, 'tax_rate' => 0.0]);
+
+        $total = new Total(['grand_total' => 1000.0, 'base_grand_total' => 1000.0]);
+        $this->collector->collect($this->makeQuote(), $this->makeShippingAssignment(), $total);
+
+        $this->assertEqualsWithDelta(100.0, $total->getData('two_surcharge_amount'), 1e-9);
+        $this->assertEqualsWithDelta(0.0, $total->getData('two_surcharge_tax_amount'), 1e-9);
+        $this->assertEqualsWithDelta(1100.0, $total->getGrandTotal(), 1e-9);
+        $this->assertEqualsWithDelta(0.0, $this->session->getTwoSurchargeTax(), 1e-9);
+    }
+
+    public function testLegacyFlatRateWhenNoTaxClassConfigured(): void
+    {
+        $this->stubBaseline();
+        $this->config->method('getSurchargeTaxClassId')->willReturn(null);
+        $this->taxCalculator->expects($this->never())->method('calculateForQuote');
+
+        $total = new Total(['grand_total' => 1000.0, 'base_grand_total' => 1000.0]);
+        $this->collector->collect($this->makeQuote(), $this->makeShippingAssignment(), $total);
+
+        // Pre-existing behaviour: net * flat rate.
+        $this->assertEqualsWithDelta(21.0, $total->getData('two_surcharge_tax_amount'), 1e-9);
+        $this->assertEqualsWithDelta(21.0, $total->getData('two_surcharge_tax_rate'), 1e-9);
+        $this->assertEqualsWithDelta(1121.0, $total->getGrandTotal(), 1e-9);
+        $this->assertEqualsWithDelta(21.0, $this->session->getTwoSurchargeTax(), 1e-9);
+    }
+}

--- a/Test/Unit/Service/Order/SurchargeTaxCalculatorTest.php
+++ b/Test/Unit/Service/Order/SurchargeTaxCalculatorTest.php
@@ -141,6 +141,16 @@ class SurchargeTaxCalculatorTest extends TestCase
         };
     }
 
+    private function makeNullShippingAssignment(): ShippingAssignmentInterface
+    {
+        return new class implements ShippingAssignmentInterface {
+            public function getShipping()
+            {
+                return null;
+            }
+        };
+    }
+
     private function stubRegularTaxClass(): void
     {
         $this->taxClassRepository->method('get')->willReturn(
@@ -223,6 +233,30 @@ class SurchargeTaxCalculatorTest extends TestCase
         $this->assertSame(TaxClassKeyInterface::TYPE_ID, $details->getCustomerTaxClassKey()->getType());
         $this->assertSame(3, $details->getCustomerTaxClassKey()->getValue());
         $this->assertSame(42, $details->getCustomerId());
+    }
+
+    // ── virtual-only quote: no shipping on the assignment ───────────
+
+    public function testNullShippingOnAssignmentDegradesToNullShippingAddress(): void
+    {
+        // A virtual-item-only quote can carry a shipping assignment whose
+        // getShipping() is null; the calculator must not fatal on it and
+        // must submit a null shipping address (mapAddress()'s absent-address
+        // path) so the engine falls back to its default rate resolution.
+        $this->stubEngineRate(0.0);
+        $this->stubRegularTaxClass();
+
+        $result = $this->calculator->calculateForQuote(
+            $this->makeQuote($this->usAddress()),
+            $this->makeNullShippingAssignment(),
+            100.0,
+            100.0,
+            4,
+            1
+        );
+
+        $this->assertNull($this->capturedQuoteDetails[0]->getShippingAddress());
+        $this->assertEqualsWithDelta(0.0, $result['tax_amount'], 1e-9);
     }
 
     // ── no matching tax rule for the destination ────────────────────

--- a/Test/Unit/Service/Order/SurchargeTaxCalculatorTest.php
+++ b/Test/Unit/Service/Order/SurchargeTaxCalculatorTest.php
@@ -1,0 +1,326 @@
+<?php
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Service\Order;
+
+use Magento\Customer\Api\Data\AddressInterfaceFactory;
+use Magento\Customer\Api\Data\RegionInterfaceFactory;
+use Magento\Framework\DataObject;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Quote\Api\Data\ShippingAssignmentInterface;
+use Magento\Quote\Model\Quote;
+use Magento\Tax\Api\Data\QuoteDetailsInterfaceFactory;
+use Magento\Tax\Api\Data\QuoteDetailsItemInterfaceFactory;
+use Magento\Tax\Api\Data\TaxClass;
+use Magento\Tax\Api\Data\TaxClassKeyInterface;
+use Magento\Tax\Api\Data\TaxClassKeyInterfaceFactory;
+use Magento\Tax\Api\Data\TaxDetails;
+use Magento\Tax\Api\Data\TaxDetailsItem;
+use Magento\Tax\Api\TaxCalculationInterface;
+use Magento\Tax\Api\TaxClassRepositoryInterface;
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
+use Two\Gateway\Service\Order\SurchargeTaxCalculator;
+
+/**
+ * Coverage for TWO-25072: surcharge tax through Magento's real tax
+ * rules engine (shipping-tax pattern) instead of a flat admin rate.
+ *
+ * TaxCalculationInterface is mocked (no live Magento install); the
+ * mock simulates rule resolution outcomes — a combined additive
+ * multi-rate jurisdiction (US state + local), a destination with no
+ * matching rule, and the always-zero provisioned class.
+ */
+class SurchargeTaxCalculatorTest extends TestCase
+{
+    /** @var TaxCalculationInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $taxCalculation;
+
+    /** @var TaxClassRepositoryInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $taxClassRepository;
+
+    /** @var LogRepository|\PHPUnit\Framework\MockObject\MockObject */
+    private $log;
+
+    /** @var SurchargeTaxCalculator */
+    private $calculator;
+
+    /** @var \Magento\Tax\Api\Data\QuoteDetailsInterface[] QuoteDetails captured per calculateTax() call */
+    private $capturedQuoteDetails = [];
+
+    protected function setUp(): void
+    {
+        $this->taxCalculation = $this->createMock(TaxCalculationInterface::class);
+        $this->taxClassRepository = $this->createMock(TaxClassRepositoryInterface::class);
+        $this->log = $this->createMock(LogRepository::class);
+        $this->capturedQuoteDetails = [];
+
+        $this->calculator = new SurchargeTaxCalculator(
+            $this->taxCalculation,
+            new QuoteDetailsInterfaceFactory(),
+            new QuoteDetailsItemInterfaceFactory(),
+            new TaxClassKeyInterfaceFactory(),
+            new AddressInterfaceFactory(),
+            new RegionInterfaceFactory(),
+            $this->taxClassRepository,
+            $this->log
+        );
+    }
+
+    /**
+     * Simulate the tax engine resolving rules at a rate: the returned
+     * TaxDetails item taxes the submitted unit price at $ratePercent
+     * (additive sub-rates arrive from Magento as one combined percent —
+     * e.g. CA 6% state + 1.25% local = 7.25).
+     */
+    private function stubEngineRate(float $ratePercent): void
+    {
+        $this->taxCalculation->method('calculateTax')->willReturnCallback(
+            function ($quoteDetails) use ($ratePercent) {
+                $this->capturedQuoteDetails[] = $quoteDetails;
+                $item = $quoteDetails->getItems()[0];
+                $rowTax = (float)$item->getUnitPrice() * (float)$item->getQuantity() * $ratePercent / 100;
+                $detailsItem = new TaxDetailsItem([
+                    'code' => $item->getCode(),
+                    'rowTax' => $rowTax,
+                    'taxPercent' => $ratePercent,
+                ]);
+                return new TaxDetails(['items' => [$item->getCode() => $detailsItem]]);
+            }
+        );
+    }
+
+    private function makeQuote(DataObject $billingAddress): Quote
+    {
+        return new class($billingAddress) extends Quote {
+            /** @var DataObject */
+            private $billing;
+
+            public function __construct(DataObject $billing)
+            {
+                $this->billing = $billing;
+            }
+
+            public function getBillingAddress()
+            {
+                return $this->billing;
+            }
+
+            public function getCustomerTaxClassId()
+            {
+                return 3;
+            }
+
+            public function getCustomerId()
+            {
+                return 42;
+            }
+        };
+    }
+
+    private function makeShippingAssignment(DataObject $address): ShippingAssignmentInterface
+    {
+        return new class($address) implements ShippingAssignmentInterface {
+            /** @var DataObject */
+            private $address;
+
+            public function __construct(DataObject $address)
+            {
+                $this->address = $address;
+            }
+
+            public function getShipping()
+            {
+                return new DataObject(['address' => $this->address]);
+            }
+        };
+    }
+
+    private function stubRegularTaxClass(): void
+    {
+        $this->taxClassRepository->method('get')->willReturn(
+            new TaxClass(['className' => 'Taxable Goods'])
+        );
+    }
+
+    private function usAddress(): DataObject
+    {
+        return new DataObject([
+            'countryId' => 'US',
+            'regionId' => 12,
+            'regionCode' => 'CA',
+            'region' => 'California',
+            'postcode' => '90210',
+            'city' => 'Beverly Hills',
+            'street' => ['1 Rodeo Dr'],
+        ]);
+    }
+
+    // ── destination-aware, multi-rate additive jurisdiction ─────────
+
+    public function testCombinedStateAndLocalRateIsApplied(): void
+    {
+        // CA combined 6% state + 1.25% local = 7.25%
+        $this->stubEngineRate(7.25);
+        $this->stubRegularTaxClass();
+
+        $result = $this->calculator->calculateForQuote(
+            $this->makeQuote($this->usAddress()),
+            $this->makeShippingAssignment($this->usAddress()),
+            100.0,
+            80.0, // base currency net
+            4,
+            1
+        );
+
+        $this->assertEqualsWithDelta(7.25, $result['tax_amount'], 1e-9);
+        $this->assertEqualsWithDelta(5.8, $result['base_tax_amount'], 1e-9);
+        $this->assertEqualsWithDelta(7.25, $result['tax_rate'], 1e-9);
+    }
+
+    public function testQuoteDetailsCarryClassKeyAndDestination(): void
+    {
+        $this->stubEngineRate(7.25);
+        $this->stubRegularTaxClass();
+
+        $this->calculator->calculateForQuote(
+            $this->makeQuote($this->usAddress()),
+            $this->makeShippingAssignment($this->usAddress()),
+            100.0,
+            100.0,
+            4,
+            1
+        );
+
+        // Two calls: quote currency + base currency (core's taxDetails /
+        // baseTaxDetails pairing).
+        $this->assertCount(2, $this->capturedQuoteDetails);
+
+        $details = $this->capturedQuoteDetails[0];
+        $item = $details->getItems()[0];
+
+        // Item mirrors CommonTaxCollector::getShippingDataObject().
+        $this->assertSame(SurchargeTaxCalculator::ITEM_CODE, $item->getCode());
+        $this->assertSame(1, $item->getQuantity());
+        $this->assertEqualsWithDelta(100.0, $item->getUnitPrice(), 1e-9);
+        $this->assertFalse($item->getIsTaxIncluded());
+        $this->assertSame(TaxClassKeyInterface::TYPE_ID, $item->getTaxClassKey()->getType());
+        $this->assertSame(4, $item->getTaxClassKey()->getValue());
+
+        // Destination context: mapped shipping address with full
+        // (country, region, postcode) tuple for rate resolution.
+        $shipping = $details->getShippingAddress();
+        $this->assertSame('US', $shipping->getCountryId());
+        $this->assertSame('90210', $shipping->getPostcode());
+        $this->assertSame(12, $shipping->getRegion()->getRegionId());
+
+        // Customer side of the rule: customer tax class + id from quote.
+        $this->assertSame(TaxClassKeyInterface::TYPE_ID, $details->getCustomerTaxClassKey()->getType());
+        $this->assertSame(3, $details->getCustomerTaxClassKey()->getValue());
+        $this->assertSame(42, $details->getCustomerId());
+    }
+
+    // ── no matching tax rule for the destination ────────────────────
+
+    public function testNoMatchingRuleYieldsZeroTax(): void
+    {
+        $this->stubEngineRate(0.0);
+
+        $result = $this->calculator->calculateForQuote(
+            $this->makeQuote($this->usAddress()),
+            $this->makeShippingAssignment($this->usAddress()),
+            100.0,
+            100.0,
+            4,
+            1
+        );
+
+        $this->assertSame(0.0, $result['tax_amount']);
+        $this->assertSame(0.0, $result['base_tax_amount']);
+        $this->assertSame(0.0, $result['tax_rate']);
+    }
+
+    // ── always-zero provisioned class ───────────────────────────────
+
+    public function testNoTaxClassYieldsZeroEverywhereWithoutWarning(): void
+    {
+        // The provisioned class ships with no Tax Rule attached, so the
+        // engine resolves nothing regardless of destination.
+        $this->stubEngineRate(0.0);
+        $this->log->expects($this->never())->method('addErrorLog');
+
+        $result = $this->calculator->calculateForQuote(
+            $this->makeQuote($this->usAddress()),
+            $this->makeShippingAssignment($this->usAddress()),
+            100.0,
+            100.0,
+            99, // provisioned no-tax class id
+            1
+        );
+
+        $this->assertSame(0.0, $result['tax_amount']);
+    }
+
+    public function testWarnsWhenNoTaxClassResolvesRealTax(): void
+    {
+        // A merchant attached a Tax Rule to the always-zero class:
+        // the guarantee is broken — warn loudly, do not fail checkout.
+        $this->stubEngineRate(25.0);
+        $this->taxClassRepository->method('get')->with(99)->willReturn(
+            new TaxClass(['className' => SurchargeTaxCalculator::NO_TAX_CLASS_NAME])
+        );
+        $this->log->expects($this->once())->method('addErrorLog')
+            ->with($this->stringContains('Tax Rule'), $this->anything());
+
+        $result = $this->calculator->calculateForQuote(
+            $this->makeQuote($this->usAddress()),
+            $this->makeShippingAssignment($this->usAddress()),
+            100.0,
+            100.0,
+            99,
+            1
+        );
+
+        // Engine result is still returned — internally consistent.
+        $this->assertEqualsWithDelta(25.0, $result['tax_amount'], 1e-9);
+    }
+
+    public function testTaxedRegularClassDoesNotWarn(): void
+    {
+        $this->stubEngineRate(21.0);
+        $this->taxClassRepository->method('get')->with(4)->willReturn(
+            new TaxClass(['className' => 'Taxable Goods'])
+        );
+        $this->log->expects($this->never())->method('addErrorLog');
+
+        $result = $this->calculator->calculateForQuote(
+            $this->makeQuote($this->usAddress()),
+            $this->makeShippingAssignment($this->usAddress()),
+            100.0,
+            100.0,
+            4,
+            1
+        );
+
+        $this->assertEqualsWithDelta(21.0, $result['tax_amount'], 1e-9);
+    }
+
+    public function testDeletedConfiguredClassLogsErrorButReturnsEngineResult(): void
+    {
+        $this->stubEngineRate(10.0);
+        $this->taxClassRepository->method('get')->willThrowException(new NoSuchEntityException());
+        $this->log->expects($this->once())->method('addErrorLog')
+            ->with($this->stringContains('no longer exists'), $this->anything());
+
+        $result = $this->calculator->calculateForQuote(
+            $this->makeQuote($this->usAddress()),
+            $this->makeShippingAssignment($this->usAddress()),
+            100.0,
+            100.0,
+            7,
+            1
+        );
+
+        $this->assertEqualsWithDelta(10.0, $result['tax_amount'], 1e-9);
+    }
+}

--- a/Test/Unit/Service/Order/SurchargeTaxCalculatorTest.php
+++ b/Test/Unit/Service/Order/SurchargeTaxCalculatorTest.php
@@ -48,12 +48,16 @@ class SurchargeTaxCalculatorTest extends TestCase
     /** @var \Magento\Tax\Api\Data\QuoteDetailsInterface[] QuoteDetails captured per calculateTax() call */
     private $capturedQuoteDetails = [];
 
+    /** @var bool[] $round argument captured per calculateTax() call */
+    private $capturedRoundArgs = [];
+
     protected function setUp(): void
     {
         $this->taxCalculation = $this->createMock(TaxCalculationInterface::class);
         $this->taxClassRepository = $this->createMock(TaxClassRepositoryInterface::class);
         $this->log = $this->createMock(LogRepository::class);
         $this->capturedQuoteDetails = [];
+        $this->capturedRoundArgs = [];
 
         $this->calculator = new SurchargeTaxCalculator(
             $this->taxCalculation,
@@ -76,8 +80,9 @@ class SurchargeTaxCalculatorTest extends TestCase
     private function stubEngineRate(float $ratePercent): void
     {
         $this->taxCalculation->method('calculateTax')->willReturnCallback(
-            function ($quoteDetails) use ($ratePercent) {
+            function ($quoteDetails, $storeId = null, $round = true) use ($ratePercent) {
                 $this->capturedQuoteDetails[] = $quoteDetails;
+                $this->capturedRoundArgs[] = $round;
                 $item = $quoteDetails->getItems()[0];
                 $rowTax = (float)$item->getUnitPrice() * (float)$item->getQuantity() * $ratePercent / 100;
                 $detailsItem = new TaxDetailsItem([
@@ -225,6 +230,7 @@ class SurchargeTaxCalculatorTest extends TestCase
     public function testNoMatchingRuleYieldsZeroTax(): void
     {
         $this->stubEngineRate(0.0);
+        $this->stubRegularTaxClass();
 
         $result = $this->calculator->calculateForQuote(
             $this->makeQuote($this->usAddress()),
@@ -247,6 +253,9 @@ class SurchargeTaxCalculatorTest extends TestCase
         // The provisioned class ships with no Tax Rule attached, so the
         // engine resolves nothing regardless of destination.
         $this->stubEngineRate(0.0);
+        $this->taxClassRepository->method('get')->with(99)->willReturn(
+            new TaxClass(['className' => SurchargeTaxCalculator::NO_TAX_CLASS_NAME])
+        );
         $this->log->expects($this->never())->method('addErrorLog');
 
         $result = $this->calculator->calculateForQuote(
@@ -322,5 +331,139 @@ class SurchargeTaxCalculatorTest extends TestCase
         );
 
         $this->assertEqualsWithDelta(10.0, $result['tax_amount'], 1e-9);
+    }
+
+    public function testDeletedConfiguredClassLogsErrorEvenWhenTaxIsZero(): void
+    {
+        // The realistic deleted-class case: Magento cascades the class's
+        // Tax Calculation rules away, so the engine resolves ZERO tax.
+        // The existence check must run unconditionally — gating it on
+        // tax_amount > 0 would make the merchant silently stop
+        // collecting surcharge tax with no log signal.
+        $this->stubEngineRate(0.0);
+        $this->taxClassRepository->method('get')->willThrowException(new NoSuchEntityException());
+        $this->log->expects($this->once())->method('addErrorLog')
+            ->with($this->stringContains('no longer exists'), $this->anything());
+
+        $result = $this->calculator->calculateForQuote(
+            $this->makeQuote($this->usAddress()),
+            $this->makeShippingAssignment($this->usAddress()),
+            100.0,
+            100.0,
+            7,
+            1
+        );
+
+        // Zero result is still returned (checkout not blocked) — the
+        // error log is the signal.
+        $this->assertSame(0.0, $result['tax_amount']);
+        $this->assertSame(0.0, $result['base_tax_amount']);
+    }
+
+    // ── engine returns no item for our code (never silently zero) ───
+
+    public function testEngineResponseWithoutSurchargeItemThrows(): void
+    {
+        // Empty item set — e.g. a third-party TaxCalculationInterface
+        // override (Avalara/TaxJar style) dropping unknown item types.
+        // Must throw, NOT return a valid-looking zero: indistinguishable
+        // from a legitimate zero-rate destination match otherwise.
+        $this->taxCalculation->method('calculateTax')->willReturn(
+            new TaxDetails(['items' => []])
+        );
+        $this->stubRegularTaxClass();
+
+        $this->expectException(\Magento\Framework\Exception\LocalizedException::class);
+
+        $this->calculator->calculateForQuote(
+            $this->makeQuote($this->usAddress()),
+            $this->makeShippingAssignment($this->usAddress()),
+            100.0,
+            100.0,
+            4,
+            1
+        );
+    }
+
+    public function testEngineResponseWithMismatchedItemCodeThrows(): void
+    {
+        $this->taxCalculation->method('calculateTax')->willReturn(
+            new TaxDetails(['items' => [
+                'shipping' => new TaxDetailsItem(['code' => 'shipping', 'rowTax' => 5.0, 'taxPercent' => 5.0]),
+            ]])
+        );
+        $this->stubRegularTaxClass();
+
+        $this->expectException(\Magento\Framework\Exception\LocalizedException::class);
+
+        $this->calculator->calculateForQuote(
+            $this->makeQuote($this->usAddress()),
+            $this->makeShippingAssignment($this->usAddress()),
+            100.0,
+            100.0,
+            4,
+            1
+        );
+    }
+
+    public function testBaseCurrencyPassMissingItemThrowsDespiteQuotePassSucceeding(): void
+    {
+        // Currency-pair consistency: each pass is checked independently.
+        // Quote pass resolves, base pass returns an empty set — without
+        // the per-pass check this would produce a mismatched order
+        // (tax_amount nonzero, base_tax_amount zero).
+        $call = 0;
+        $this->taxCalculation->method('calculateTax')->willReturnCallback(
+            function ($quoteDetails) use (&$call) {
+                $call++;
+                if ($call === 1) {
+                    $item = $quoteDetails->getItems()[0];
+                    return new TaxDetails(['items' => [
+                        $item->getCode() => new TaxDetailsItem([
+                            'code' => $item->getCode(),
+                            'rowTax' => 7.25,
+                            'taxPercent' => 7.25,
+                        ]),
+                    ]]);
+                }
+                return new TaxDetails(['items' => []]);
+            }
+        );
+        $this->stubRegularTaxClass();
+
+        $this->expectException(\Magento\Framework\Exception\LocalizedException::class);
+
+        $this->calculator->calculateForQuote(
+            $this->makeQuote($this->usAddress()),
+            $this->makeShippingAssignment($this->usAddress()),
+            100.0,
+            80.0,
+            4,
+            1
+        );
+    }
+
+    // ── rounding flag mirrors core ──────────────────────────────────
+
+    public function testCalculateTaxIsCalledWithRoundTrueForBothPasses(): void
+    {
+        // Core's Tax::getQuoteTaxDetails() always calls calculateTax()
+        // with the default $round=true for both the quote-currency and
+        // base-currency passes — the surcharge must get identical
+        // per-rate rounding treatment in additive multi-rate
+        // jurisdictions (US state+local, CA GST+PST).
+        $this->stubEngineRate(7.25);
+        $this->stubRegularTaxClass();
+
+        $this->calculator->calculateForQuote(
+            $this->makeQuote($this->usAddress()),
+            $this->makeShippingAssignment($this->usAddress()),
+            100.0,
+            80.0,
+            4,
+            1
+        );
+
+        $this->assertSame([true, true], $this->capturedRoundArgs);
     }
 }

--- a/Test/Unit/Setup/Patch/Data/SurchargeNoTaxClassTest.php
+++ b/Test/Unit/Setup/Patch/Data/SurchargeNoTaxClassTest.php
@@ -1,0 +1,209 @@
+<?php
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Setup\Patch\Data;
+
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
+use Two\Gateway\Service\Order\SurchargeTaxCalculator;
+use Two\Gateway\Setup\Patch\Data\SurchargeNoTaxClass;
+
+/**
+ * Coverage for the always-zero tax class provisioning patch,
+ * specifically the name-collision guard: a pre-existing merchant class
+ * with the same name must never be silently treated as the safe
+ * "no tax" class when it has Tax Rules attached.
+ */
+class SurchargeNoTaxClassTest extends TestCase
+{
+    /** @var FakeConnection */
+    private $connection;
+
+    /** @var LogRepository|\PHPUnit\Framework\MockObject\MockObject */
+    private $log;
+
+    /** @var SurchargeNoTaxClass */
+    private $patch;
+
+    protected function setUp(): void
+    {
+        $this->connection = new FakeConnection();
+        $this->log = $this->createMock(LogRepository::class);
+
+        $connection = $this->connection;
+        $moduleDataSetup = new class($connection) implements ModuleDataSetupInterface {
+            /** @var FakeConnection */
+            private $connection;
+
+            public function __construct($connection)
+            {
+                $this->connection = $connection;
+            }
+
+            public function getConnection()
+            {
+                return $this->connection;
+            }
+
+            public function getTable($tableName)
+            {
+                return 'prefix_' . $tableName;
+            }
+        };
+
+        $this->patch = new SurchargeNoTaxClass($moduleDataSetup, $this->log);
+    }
+
+    public function testCreatesClassWhenNameIsFree(): void
+    {
+        $this->connection->existingClassId = false;
+        $this->log->expects($this->never())->method('addErrorLog');
+
+        $this->patch->apply();
+
+        $this->assertCount(1, $this->connection->inserts);
+        [$table, $data] = $this->connection->inserts[0];
+        $this->assertSame('prefix_tax_class', $table);
+        $this->assertSame(SurchargeTaxCalculator::NO_TAX_CLASS_NAME, $data['class_name']);
+        $this->assertSame('PRODUCT', $data['class_type']);
+        // No rule-count probe needed when the class did not pre-exist.
+        $this->assertNull($this->connection->ruleCountQueryClassId);
+    }
+
+    public function testIdempotentRerunWithRuleFreeExistingClassIsSilent(): void
+    {
+        // Normal second run of this patch: our own class exists, no
+        // rules attached — nothing inserted, nothing logged.
+        $this->connection->existingClassId = '17';
+        $this->connection->attachedRuleCount = 0;
+        $this->log->expects($this->never())->method('addErrorLog');
+
+        $this->patch->apply();
+
+        $this->assertCount(0, $this->connection->inserts);
+        $this->assertSame('17', $this->connection->ruleCountQueryClassId);
+    }
+
+    public function testCollisionWithRuleBearingClassLogsLoudlyAndDoesNotInsert(): void
+    {
+        // A merchant already had a Product Tax Class with this exact
+        // name AND Tax Rules attached to it: reusing it would silently
+        // break the "guaranteed untaxed" promise. Expect a loud error
+        // log and no insert.
+        $this->connection->existingClassId = '17';
+        $this->connection->attachedRuleCount = 2;
+        $this->log->expects($this->once())->method('addErrorLog')
+            ->with(
+                $this->logicalAnd(
+                    $this->stringContains('already exists'),
+                    $this->stringContains('Tax Rule'),
+                    $this->stringContains('CANNOT guarantee an untaxed')
+                ),
+                $this->callback(function ($context) {
+                    return $context['class_id'] === '17' && $context['attached_rule_count'] === 2;
+                })
+            );
+
+        $this->patch->apply();
+
+        $this->assertCount(0, $this->connection->inserts);
+    }
+
+    public function testRuleCountProbeTargetsTaxCalculationTable(): void
+    {
+        $this->connection->existingClassId = '17';
+        $this->connection->attachedRuleCount = 1;
+
+        $this->patch->apply();
+
+        $this->assertSame('prefix_tax_calculation', $this->connection->ruleCountQueryTable);
+    }
+}
+
+/**
+ * Minimal scripted stand-in for Magento's DB adapter, covering only
+ * what the patch touches: select()->from()->where() chains consumed by
+ * fetchOne(), plus insert() and start/endSetup().
+ */
+class FakeConnection
+{
+    /** @var string|false class_id returned for the tax_class existence lookup */
+    public $existingClassId = false;
+
+    /** @var int rule count returned for the tax_calculation probe */
+    public $attachedRuleCount = 0;
+
+    /** @var array<int, array{0: string, 1: array}> recorded insert() calls */
+    public $inserts = [];
+
+    /** @var string|null class_id the rule-count probe filtered on */
+    public $ruleCountQueryClassId;
+
+    /** @var string|null table the rule-count probe selected from */
+    public $ruleCountQueryTable;
+
+    public function startSetup(): void
+    {
+    }
+
+    public function endSetup(): void
+    {
+    }
+
+    public function select(): FakeSelect
+    {
+        return new FakeSelect();
+    }
+
+    /**
+     * @param FakeSelect $select
+     * @return string|int|false
+     */
+    public function fetchOne($select)
+    {
+        if ($select->table === 'prefix_tax_class') {
+            return $this->existingClassId;
+        }
+        if ($select->table === 'prefix_tax_calculation') {
+            $this->ruleCountQueryTable = $select->table;
+            $this->ruleCountQueryClassId = $select->wheres['product_tax_class_id = ?'] ?? null;
+            return $this->attachedRuleCount;
+        }
+        return false;
+    }
+
+    public function insert(string $table, array $data): void
+    {
+        $this->inserts[] = [$table, $data];
+    }
+}
+
+/**
+ * Records the from/where chain so FakeConnection::fetchOne() can
+ * dispatch on the queried table and inspect bound values.
+ */
+class FakeSelect
+{
+    /** @var string|null */
+    public $table;
+
+    /** @var string|array|null */
+    public $columns;
+
+    /** @var array<string, mixed> condition => bound value */
+    public $wheres = [];
+
+    public function from($table, $columns = '*'): self
+    {
+        $this->table = $table;
+        $this->columns = $columns;
+        return $this;
+    }
+
+    public function where(string $condition, $value = null): self
+    {
+        $this->wheres[$condition] = $value;
+        return $this;
+    }
+}

--- a/Test/bootstrap.php
+++ b/Test/bootstrap.php
@@ -79,6 +79,22 @@ if (!interface_exists(\Magento\Framework\App\CacheInterface::class, false)) {
 if (!class_exists(\Magento\Framework\Serialize\Serializer\Json::class, false)) {
     require_once __DIR__ . '/Stubs/JsonSerializer.php';
 }
+// Tax rules engine API surface (TaxCalculationInterface, QuoteDetails*
+// data objects and their factories) with real signatures — required so
+// SurchargeTaxCalculator tests get functioning factories/data bags
+// instead of empty catch-all stubs. NoSuchEntityException must extend
+// LocalizedException/\Exception to be throwable, so this loads after
+// the LocalizedException stub above.
+if (!interface_exists(\Magento\Tax\Api\TaxCalculationInterface::class, false)) {
+    require_once __DIR__ . '/Stubs/LocalizedException.php';
+    require_once __DIR__ . '/Stubs/TaxEngine.php';
+}
+// Quote total-collection surface (AbstractTotal with typed collect()
+// signature, Total data bag, checkout Session magic bag) — required so
+// Model\Total\Surcharge can be instantiated and collected in tests.
+if (!class_exists(\Magento\Quote\Model\Quote\Address\Total::class, false)) {
+    require_once __DIR__ . '/Stubs/QuoteTotals.php';
+}
 
 // Catch-all autoloader for remaining Magento classes/interfaces.
 // Creates empty stubs so that type hints, extends, and implements resolve.

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -204,9 +204,17 @@
                     <config_path>payment/two_payment/surcharge_line_description</config_path>
                 </field>
 
+                <field id="surcharge_tax_class" translate="label comment" type="select" sortOrder="80"
+                       showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Surcharge Tax Class</label>
+                    <comment><![CDATA[Product Tax Class applied to the surcharge. When a class is selected, surcharge tax is resolved through Magento's Tax Rules (destination-aware, supports combined rates such as US state + local); <strong>None</strong> means the surcharge is never taxed. The default keeps using the legacy flat Surcharge Tax Rate below.]]></comment>
+                    <source_model>Two\Gateway\Model\Config\Source\SurchargeTaxClass</source_model>
+                    <config_path>payment/two_payment/surcharge_tax_class</config_path>
+                </field>
                 <field id="surcharge_tax_rate" translate="label comment" type="text" sortOrder="90" showInDefault="1"
                        showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Surcharge Tax Rate (%)</label>
+                    <comment>Legacy flat tax rate. Only used when Surcharge Tax Class above is set to the legacy option.</comment>
                     <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\SurchargeTaxRate</frontend_model>
                     <backend_model>Two\Gateway\Model\Config\Backend\LocaleDecimal</backend_model>
                     <validate>validate-zero-or-greater</validate>


### PR DESCRIPTION
## Summary
Adds an optional Product Tax Class-driven path for surcharge tax, using Magento's real `TaxCalculationInterface` (destination/customer-aware, correctly additive for stacked jurisdictions) instead of the existing flat `net * rate` math — following the same pattern as core's shipping-tax-class handling (TWO-25069). Legacy flat-rate config stays the default/first option — no migration needed, feature is still unreleased.

- New admin config `surcharge_tax_class`: legacy flat rate (default) / a real Product Tax Class / a dedicated "no tax" class (force-always-zero, provisioned by a data patch)
- New `Service/Order/SurchargeTaxCalculator` mirrors core's shipping-tax collector pattern (`QuoteDetailsItemInterface`, paired quote/base-currency `calculateTax()` calls)
- Deleted/misconfigured tax class always logged (not just when it happens to resolve non-zero tax) — never silently drops to zero
- Malformed/empty engine response throws rather than silently defaulting to zero tax
- Data patch guards against colliding with a pre-existing same-named class that already carries live tax rules

Went through 2 rounds of 4-persona adversarial review + 1 fix pass before this PR (found and fixed: silent zero-tax on deleted class escaping detection, malformed-response silent zero, quote/base currency cross-validation gap, name-collision with rule-bearing class, `$round` flag mismatch vs core).

**Known residual, not fixed**: the "no tax" class data-patch existence check is not concurrency-safe across parallel `setup:upgrade` runs on multiple pods (pre-existing TOCTOU, only partially addressed this round) — confirm this deploy's `setup:upgrade` runs single-writer before relying on it, or file a follow-up for a transaction/unique-index fix.

## Test plan
- [x] 250/250 unit tests pass (241 baseline + 9 new)
- [x] Core API surface (`TaxCalculationInterface`, `QuoteDetailsInterface` etc.) verified against real `magento/magento2` 2.4-develop source, not training memory
- [ ] Live-install verification — this repo has no vendored Magento core, so the engine integration hasn't been checkout-tested against a real Magento instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)