### PR TITLE
fix: run setup:di:compile before deploy:mode:set developer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,11 @@ install: clean
 	# it). Even un-licensed it should be quiet at runtime in dev.
 	docker exec $(CONTAINER) php bin/magento module:enable Two_Gateway
 	docker exec $(CONTAINER) php bin/magento setup:upgrade
-	docker exec $(CONTAINER) php bin/magento deploy:mode:set developer
 	docker exec $(CONTAINER) php bin/magento setup:di:compile
+	docker exec $(CONTAINER) php bin/magento deploy:mode:set developer
+	# di:compile resets Magento to production mode as a side effect, so
+	# deploy:mode:set developer must run AFTER it, or developer mode gets
+	# silently clobbered back to production. See magento-abn-plugin 66062d8.
 	# Local-dev perf: merge + minify JS/CSS so RequireJS doesn't fan out into
 	# ~200 individual file fetches. Stays in developer mode (no static deploy
 	# step), but the request count drops to ~20 and the storefront's KO


### PR DESCRIPTION
## Summary
- `make install` ran `deploy:mode:set developer` before `setup:di:compile`. `di:compile` resets Magento back to production mode as a side effect, so the developer-mode setting was silently undone right after install.
- Swapped the order: `setup:di:compile` now runs first, `deploy:mode:set developer` runs last, so developer mode actually sticks.
- Same bug was fixed once before in magento-abn-plugin (commit 66062d8) but got reintroduced here by a later Makefile/install script refactor.

## Test plan
- [x] Reasoned through the `install` target ordering — no other step between these two lines depends on mode being set early.
- [ ] `make install` run locally to confirm developer mode persists after install (deploy-tooling change, not covered by CI test suite).