### PR TITLE
fix: TWO-24868 drop orphaned two_telephone EAV attribute

### DIFF
--- a/Setup/Patch/Data/RemoveInternationalTelephone.php
+++ b/Setup/Patch/Data/RemoveInternationalTelephone.php
@@ -12,9 +12,10 @@ use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Eav\Setup\EavSetupFactory;
 
 /**
- * InternationalTelephone EAV Patch
+ * Removes the orphaned two_telephone customer_address EAV attribute
+ * added by InternationalTelephone. Nothing reads or writes it. TWO-24868.
  */
-class InternationalTelephone implements DataPatchInterface
+class RemoveInternationalTelephone implements DataPatchInterface
 {
     /**
      * @var ModuleDataSetupInterface
@@ -47,23 +48,7 @@ class InternationalTelephone implements DataPatchInterface
 
         $eavSetup = $this->eavSetupFactory->create(['setup' => $this->moduleDataSetup]);
 
-        // Deprecated: two_telephone attribute removed by RemoveInternationalTelephone patch, see TWO-24868
-        $eavSetup->addAttribute(
-            'customer_address',
-            'two_telephone',
-            [
-                'type' => 'varchar',
-                'input' => 'text',
-                'label' => 'International Telephone',
-                'visible' => true,
-                'required' => false,
-                'user_defined' => true,
-                'system'=> false,
-                'group'=> 'General',
-                'global' => true,
-                'visible_on_front' => true,
-            ]
-        );
+        $eavSetup->removeAttribute('customer_address', 'two_telephone');
 
         $this->moduleDataSetup->getConnection()->endSetup();
         return $this;
@@ -74,7 +59,7 @@ class InternationalTelephone implements DataPatchInterface
      */
     public static function getDependencies(): array
     {
-        return [];
+        return [InternationalTelephone::class];
     }
 
     /**

--- a/Test/Unit/Setup/Patch/Data/RemoveInternationalTelephoneTest.php
+++ b/Test/Unit/Setup/Patch/Data/RemoveInternationalTelephoneTest.php
@@ -1,0 +1,111 @@
+<?php
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Setup\Patch\Data;
+
+use Magento\Eav\Setup\EavSetupFactory;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Setup\Patch\Data\InternationalTelephone;
+use Two\Gateway\Setup\Patch\Data\RemoveInternationalTelephone;
+
+/**
+ * Coverage for the removal of the orphaned two_telephone
+ * customer_address EAV attribute (TWO-24868): apply() must remove
+ * exactly that attribute, and the patch must be ordered after the
+ * InternationalTelephone patch that introduced it.
+ */
+class RemoveInternationalTelephoneTest extends TestCase
+{
+    /** @var RecordingEavSetup */
+    private $eavSetup;
+
+    /** @var RemoveInternationalTelephone */
+    private $patch;
+
+    protected function setUp(): void
+    {
+        $moduleDataSetup = new class implements ModuleDataSetupInterface {
+            public function getConnection()
+            {
+                return new class {
+                    public function startSetup(): void
+                    {
+                    }
+
+                    public function endSetup(): void
+                    {
+                    }
+                };
+            }
+
+            public function getTable($tableName)
+            {
+                return $tableName;
+            }
+        };
+
+        $this->eavSetup = new RecordingEavSetup();
+        $eavSetup = $this->eavSetup;
+
+        $eavSetupFactory = new class($eavSetup) extends EavSetupFactory {
+            /** @var RecordingEavSetup */
+            private $eavSetup;
+
+            public function __construct($eavSetup)
+            {
+                $this->eavSetup = $eavSetup;
+            }
+
+            public function create(array $data = [])
+            {
+                return $this->eavSetup;
+            }
+        };
+
+        $this->patch = new RemoveInternationalTelephone($moduleDataSetup, $eavSetupFactory);
+    }
+
+    public function testApplyRemovesTwoTelephoneCustomerAddressAttribute(): void
+    {
+        $this->patch->apply();
+
+        $this->assertSame(
+            [['customer_address', 'two_telephone']],
+            $this->eavSetup->removedAttributes
+        );
+    }
+
+    public function testGetDependenciesReturnsInternationalTelephone(): void
+    {
+        $this->assertSame(
+            [InternationalTelephone::class],
+            RemoveInternationalTelephone::getDependencies()
+        );
+    }
+
+    public function testGetAliasesReturnsEmptyArray(): void
+    {
+        $this->assertSame([], $this->patch->getAliases());
+    }
+}
+
+/**
+ * Records removeAttribute() calls so the test can assert on the exact
+ * entity type / attribute code pair the patch removes.
+ */
+class RecordingEavSetup extends \Magento\Eav\Setup\EavSetup
+{
+    /** @var array<int, array{0: string, 1: string}> */
+    public $removedAttributes = [];
+
+    public function __construct()
+    {
+    }
+
+    public function removeAttribute($entityTypeId, $code): self
+    {
+        $this->removedAttributes[] = [$entityTypeId, $code];
+        return $this;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a NEW DataPatch `Setup/Patch/Data/RemoveInternationalTelephone.php` that removes the orphaned `customer_address` EAV attribute `two_telephone` (nothing reads/writes it — leftover from an earlier phone-validation approach superseded by checkout-api delegation).
- Does NOT edit the applied `InternationalTelephone.php` patch's logic — only adds a one-line deprecation comment (safe, non-executable, per the ticket's immutability principle for shipped patches).
- New patch depends on the original via `getDependencies()` so ordering is guaranteed.

## Test plan
- [x] New PHPUnit test `Test/Unit/Setup/Patch/Data/RemoveInternationalTelephoneTest.php` — asserts `apply()` calls `removeAttribute('customer_address', 'two_telephone')` and `getDependencies()` returns `[InternationalTelephone::class]`. 3/3 assertions pass.
- [x] Full Unit suite still green: 275/275 tests, 447 assertions.
- [x] `php -l` clean on all three changed/added files.
- [x] grep for `two_telephone` repo-wide: only the two patch files + new test reference it — confirms it was truly orphaned before, and scope is contained after.

Closes TWO-24868.

🤖 Generated with [Claude Code](https://claude.com/claude-code)