### PR TITLE
TWO-25099: fail loud on negative discount amounts before reaching Two API

### DIFF
--- a/Service/Order.php
+++ b/Service/Order.php
@@ -25,6 +25,7 @@ use Magento\Sales\Model\Order\Invoice\Item as InvoiceItem;
 use Magento\Sales\Model\Order\Item as OrderItem;
 use Magento\Store\Model\App\Emulation;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
+use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
 
 /**
  * Abstract order class
@@ -55,6 +56,10 @@ abstract class Order
      * @var OrderItemRepositoryInterface
      */
     private $orderItemRepository;
+    /**
+     * @var LogRepository
+     */
+    private $logRepository;
 
     /**
      * Order constructor.
@@ -65,6 +70,7 @@ abstract class Order
      * @param OrderItemRepositoryInterface $orderItemRepository
      * @param Emulation $appEmulation
      * @param Url $url
+     * @param LogRepository $logRepository
      */
     public function __construct(
         Image $imageHelper,
@@ -72,7 +78,8 @@ abstract class Order
         CategoryCollection $categoryCollectionFactory,
         OrderItemRepositoryInterface $orderItemRepository,
         Emulation $appEmulation,
-        Url $url
+        Url $url,
+        LogRepository $logRepository
     ) {
         $this->imageHelper = $imageHelper;
         $this->configRepository = $configRepository;
@@ -80,6 +87,7 @@ abstract class Order
         $this->orderItemRepository = $orderItemRepository;
         $this->appEmulation = $appEmulation;
         $this->url = $url;
+        $this->logRepository = $logRepository;
     }
 
     /**
@@ -295,13 +303,42 @@ abstract class Order
     /**
      * Get discount amount before tax
      *
+     * Fails loud (log + throw) on a genuinely negative discount instead of
+     * letting a bad value from an upstream cart-rule bug flow silently into
+     * the Two API payload. Never clamps.
+     *
      * @param OrderItem|InvoiceItem|CreditmemoItem $item
      *
      * @return float
+     * @throws LocalizedException when the discount is negative at currency precision
      */
     public function getDiscountAmountItem($item): float
     {
-        return (float)$item->getDiscountAmount() - (float)$item->getDiscountTaxCompensationAmount();
+        // Compute at native float precision — never round the inputs first.
+        // Early per-component rounding is the phantom-negative trap hit on
+        // PrestaShop (TWO-24741). The returned value stays native so the
+        // payload boundary keeps its single roundAmt() call.
+        $discountAmount = (float)$item->getDiscountAmount()
+            - (float)$item->getDiscountTaxCompensationAmount();
+
+        // Sign-check at the currency precision the payload will actually
+        // send: sub-cent float residue is not a data error; a discount that
+        // is still negative after the boundary round is.
+        if (round($discountAmount, 2) < 0) {
+            $message = sprintf(
+                'Negative discount amount %.6F for order item %s (sku %s): '
+                . 'discount %.6F - discount tax compensation %.6F',
+                $discountAmount,
+                $item->getId(),
+                $item->getSku(),
+                (float)$item->getDiscountAmount(),
+                (float)$item->getDiscountTaxCompensationAmount()
+            );
+            $this->logRepository->addErrorLog('NegativeDiscountGuard', $message);
+            throw new LocalizedException(__($message));
+        }
+
+        return $discountAmount;
     }
 
     /**
@@ -397,12 +434,36 @@ abstract class Order
     }
 
     /**
+     * Get shipping discount amount before tax
+     *
+     * Fails loud (log + throw) on a genuinely negative shipping discount —
+     * same guard as getDiscountAmountItem(), parallel surface.
+     *
      * @param OrderModel|CreditmemoModel $entity
      * @return float
+     * @throws LocalizedException when the discount is negative at currency precision
      */
     public function getDiscountAmountShipping($entity): float
     {
-        return (float)$entity->getShippingDiscountAmount() - (float)$entity->getShippingDiscountTaxCompensationAmount();
+        // Native-precision compute, single round at the payload boundary —
+        // see getDiscountAmountItem() for the rounding-order rationale.
+        $discountAmount = (float)$entity->getShippingDiscountAmount()
+            - (float)$entity->getShippingDiscountTaxCompensationAmount();
+
+        if (round($discountAmount, 2) < 0) {
+            $message = sprintf(
+                'Negative shipping discount amount %.6F for entity %s: '
+                . 'shipping discount %.6F - shipping discount tax compensation %.6F',
+                $discountAmount,
+                $entity->getIncrementId(),
+                (float)$entity->getShippingDiscountAmount(),
+                (float)$entity->getShippingDiscountTaxCompensationAmount()
+            );
+            $this->logRepository->addErrorLog('NegativeDiscountGuard', $message);
+            throw new LocalizedException(__($message));
+        }
+
+        return $discountAmount;
     }
 
     /**

--- a/Service/Order/ComposeOrder.php
+++ b/Service/Order/ComposeOrder.php
@@ -16,6 +16,7 @@ use Magento\Sales\Api\OrderItemRepositoryInterface;
 use Magento\Sales\Model\Order;
 use Magento\Store\Model\App\Emulation;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
+use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
 use Two\Gateway\Service\Order as OrderService;
 
 /**
@@ -35,9 +36,18 @@ class ComposeOrder extends OrderService
         OrderItemRepositoryInterface $orderItemRepository,
         Emulation $appEmulation,
         Url $url,
+        LogRepository $logRepository,
         CheckoutSession $checkoutSession
     ) {
-        parent::__construct($imageHelper, $configRepository, $categoryCollectionFactory, $orderItemRepository, $appEmulation, $url);
+        parent::__construct(
+            $imageHelper,
+            $configRepository,
+            $categoryCollectionFactory,
+            $orderItemRepository,
+            $appEmulation,
+            $url,
+            $logRepository
+        );
         $this->checkoutSession = $checkoutSession;
     }
 

--- a/Test/Unit/Service/Order/NegativeDiscountGuardTest.php
+++ b/Test/Unit/Service/Order/NegativeDiscountGuardTest.php
@@ -1,0 +1,253 @@
+<?php
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Service\Order;
+
+use Magento\Framework\Exception\LocalizedException;
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
+use Two\Gateway\Service\Order;
+
+/**
+ * TWO-25099 — fail loud on negative discount amounts before reaching the
+ * Two API (Magento mirror of the PrestaShop guard shipped in TWO-24741).
+ *
+ * Covers:
+ *  (a) legitimate positive discounts pass through untouched, at native
+ *      float precision (no early rounding of the return value);
+ *  (b) genuinely negative discounts log + throw (never silently clamp);
+ *  (c) the rounding-order regression — sub-cent float residue that is
+ *      negative at native precision but zero at the 2dp payload boundary
+ *      must NOT false-positive the guard.
+ */
+class NegativeDiscountGuardTest extends TestCase
+{
+    /** @var Order|\PHPUnit\Framework\MockObject\MockObject */
+    private $orderService;
+
+    /** @var LogRepository|\PHPUnit\Framework\MockObject\MockObject */
+    private $logRepository;
+
+    protected function setUp(): void
+    {
+        $this->orderService = $this->getMockForAbstractClass(
+            Order::class,
+            [],
+            '',
+            false // don't call constructor
+        );
+        $this->logRepository = $this->createMock(LogRepository::class);
+
+        // Constructor is skipped, so inject the logger directly.
+        $property = new \ReflectionProperty(Order::class, 'logRepository');
+        $property->setValue($this->orderService, $this->logRepository);
+    }
+
+    /**
+     * Item stub with the getters getDiscountAmountItem() consumes.
+     */
+    private function makeItem(float $discount, float $taxCompensation): object
+    {
+        return new class($discount, $taxCompensation) {
+            private $discount;
+            private $taxCompensation;
+
+            public function __construct(float $discount, float $taxCompensation)
+            {
+                $this->discount = $discount;
+                $this->taxCompensation = $taxCompensation;
+            }
+
+            public function getDiscountAmount(): float
+            {
+                return $this->discount;
+            }
+
+            public function getDiscountTaxCompensationAmount(): float
+            {
+                return $this->taxCompensation;
+            }
+
+            public function getId(): string
+            {
+                return '42';
+            }
+
+            public function getSku(): string
+            {
+                return 'TEST-SKU';
+            }
+        };
+    }
+
+    /**
+     * Order/creditmemo stub with the getters getDiscountAmountShipping() consumes.
+     */
+    private function makeEntity(float $shippingDiscount, float $taxCompensation): object
+    {
+        return new class($shippingDiscount, $taxCompensation) {
+            private $shippingDiscount;
+            private $taxCompensation;
+
+            public function __construct(float $shippingDiscount, float $taxCompensation)
+            {
+                $this->shippingDiscount = $shippingDiscount;
+                $this->taxCompensation = $taxCompensation;
+            }
+
+            public function getShippingDiscountAmount(): float
+            {
+                return $this->shippingDiscount;
+            }
+
+            public function getShippingDiscountTaxCompensationAmount(): float
+            {
+                return $this->taxCompensation;
+            }
+
+            public function getIncrementId(): string
+            {
+                return '100000042';
+            }
+        };
+    }
+
+    // ── (a) legitimate discounts pass through untouched ────────────────
+
+    public function testPositiveDiscountPassesThroughAtNativePrecision(): void
+    {
+        $this->logRepository->expects($this->never())->method('addErrorLog');
+
+        $item = $this->makeItem(10.50, 2.10);
+
+        $this->assertSame(10.50 - 2.10, $this->orderService->getDiscountAmountItem($item));
+    }
+
+    public function testPositiveDiscountReturnValueIsNotRoundedEarly(): void
+    {
+        // The guard must not round the value it returns — the single round
+        // belongs at the payload boundary (roundAmt).
+        $item = $this->makeItem(2.345678, 0.0);
+
+        $this->assertSame(2.345678, $this->orderService->getDiscountAmountItem($item));
+    }
+
+    public function testZeroDiscountPassesThrough(): void
+    {
+        $this->logRepository->expects($this->never())->method('addErrorLog');
+
+        $item = $this->makeItem(0.0, 0.0);
+
+        $this->assertSame(0.0, $this->orderService->getDiscountAmountItem($item));
+    }
+
+    public function testPositiveShippingDiscountPassesThrough(): void
+    {
+        $this->logRepository->expects($this->never())->method('addErrorLog');
+
+        $entity = $this->makeEntity(5.00, 1.00);
+
+        $this->assertSame(5.00 - 1.00, $this->orderService->getDiscountAmountShipping($entity));
+    }
+
+    // ── (b) genuinely negative discounts fail loud ─────────────────────
+
+    public function testNegativeItemDiscountLogsAndThrows(): void
+    {
+        $this->logRepository->expects($this->once())
+            ->method('addErrorLog')
+            ->with(
+                'NegativeDiscountGuard',
+                $this->logicalAnd(
+                    $this->stringContains('TEST-SKU'),
+                    $this->stringContains('Negative discount amount')
+                )
+            );
+
+        $item = $this->makeItem(0.00, 5.00); // native -5.00
+
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage('Negative discount amount');
+
+        $this->orderService->getDiscountAmountItem($item);
+    }
+
+    public function testNegativeShippingDiscountLogsAndThrows(): void
+    {
+        $this->logRepository->expects($this->once())
+            ->method('addErrorLog')
+            ->with(
+                'NegativeDiscountGuard',
+                $this->logicalAnd(
+                    $this->stringContains('100000042'),
+                    $this->stringContains('Negative shipping discount amount')
+                )
+            );
+
+        $entity = $this->makeEntity(-3.25, 0.0);
+
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage('Negative shipping discount amount');
+
+        $this->orderService->getDiscountAmountShipping($entity);
+    }
+
+    public function testHalfCentNegativeDiscountThrows(): void
+    {
+        // -0.005 rounds to -0.01 at the payload boundary — a payload the
+        // checkout-api would reject, so the guard must fire.
+        $item = $this->makeItem(0.000, 0.005);
+
+        $this->expectException(LocalizedException::class);
+
+        $this->orderService->getDiscountAmountItem($item);
+    }
+
+    // ── (c) rounding-order regression: float residue must not throw ────
+
+    public function testSubCentFloatResidueDoesNotFalsePositive(): void
+    {
+        // Classic binary-float residue: 0.3 - (0.1 + 0.2) is a tiny
+        // NEGATIVE number at native precision. A naive `< 0` sign check on
+        // the raw float — or any early per-component rounding scheme —
+        // would fail loud on a perfectly legitimate cart. The guard must
+        // evaluate the sign at the 2dp payload precision instead.
+        $discount = 0.3;
+        $compensation = 0.1 + 0.2; // 0.30000000000000004
+
+        // Premise guard: this case genuinely exercises the residue path.
+        $this->assertLessThan(0, $discount - $compensation);
+
+        $this->logRepository->expects($this->never())->method('addErrorLog');
+
+        $item = $this->makeItem($discount, $compensation);
+        $result = $this->orderService->getDiscountAmountItem($item);
+
+        // Value flows through natively; the payload boundary rounds it to 0.00.
+        $this->assertSame($discount - $compensation, $result);
+        $this->assertSame(0.0, round($result, 2) + 0.0);
+    }
+
+    public function testSubCentNegativeBelowHalfCentDoesNotThrow(): void
+    {
+        // -0.004 is zero at currency precision — not a data error.
+        $item = $this->makeItem(0.001, 0.005);
+
+        $this->logRepository->expects($this->never())->method('addErrorLog');
+
+        $this->assertSame(0.001 - 0.005, $this->orderService->getDiscountAmountItem($item));
+    }
+
+    public function testSubCentFloatResidueShippingDoesNotFalsePositive(): void
+    {
+        $discount = 0.3;
+        $compensation = 0.1 + 0.2;
+
+        $this->assertLessThan(0, $discount - $compensation);
+        $this->logRepository->expects($this->never())->method('addErrorLog');
+
+        $entity = $this->makeEntity($discount, $compensation);
+
+        $this->assertSame($discount - $compensation, $this->orderService->getDiscountAmountShipping($entity));
+    }
+}


### PR DESCRIPTION
## Summary

Adds a negative-discount validation guard to `Service/Order.php`, mirroring the PrestaShop guard shipped under TWO-24741. A negative discount produced by an upstream cart-rule bug now logs a clear diagnostic (`NegativeDiscountGuard` error log with item/entity identifiers and the raw components) and throws a `LocalizedException` — fail loud, never clamp — instead of silently posting a bad payload to the Two API.

- Guard lives in `getDiscountAmountItem()` and `getDiscountAmountShipping()`, so all four assemblers (`ComposeOrder`, `ComposeCapture`, `ComposeShipment`, `ComposeRefund`) are covered at once.
- `LogRepository` added to the abstract `Order` constructor (auto-wired DI; `ComposeOrder` is the only subclass with its own constructor and was updated; no `di.xml` entries reference these classes).

## Rounding-order discipline (the PS phantom-negative trap)

The discount is computed at **native float precision** — no early rounding of inputs — and the sign is evaluated at the 2dp precision the payload boundary will actually send (`round($discount, 2) < 0`). A naive `< 0` check on the raw float would fail loud on legitimate carts due to sub-cent binary residue (e.g. `0.3 - (0.1 + 0.2)` is a tiny negative number). This matches the merged PrestaShop implementation, which rounds to currency precision before its sign check for exactly this reason ("sub-cent float residue … is not a data error"). The returned value stays unrounded; `roundAmt()` at payload assembly remains the single rounding point.

## Validation

PHPUnit (`Test/Unit/Service/Order/NegativeDiscountGuardTest.php`, 10 tests / 23 assertions):
- (a) legitimate positive/zero discounts pass through untouched at native precision (return value not rounded early);
- (b) genuinely negative item and shipping discounts log + throw with identifiable messages; half-cent-negative (rounds to −0.01) throws;
- (c) rounding-order regression: native-precision float residue that is negative only below currency precision does **not** false-positive (item + shipping), with a premise assertion proving the case genuinely exercises the residue path.

Full unit suite: 282 tests / 467 assertions green. Baseline cross-check: with the guard stashed, the 10 new tests fail — they target the change.

Manual QA still owed per ticket: discounted checkout on a Magento staging shop.

Ticket: [TWO-25099](https://linear.app/two-inc/issue/TWO-25099)

🤖 Generated with [Claude Code](https://claude.com/claude-code)