### PR TITLE
feat: TWO-25103 swap FX conversion to /refdata/v1/fx-rates

### DIFF
--- a/Api/CurrencyRatesProviderInterface.php
+++ b/Api/CurrencyRatesProviderInterface.php
@@ -10,31 +10,31 @@ namespace Two\Gateway\Api;
 /**
  * Service contract for currency exchange rate lookups.
  *
- * Magento ships no read-side service contract for currency rate lookups — its
- * rate data is only reachable via the legacy Currency active-record model
- * (Magento\Directory\Model\Currency::load). This interface wraps that access
- * so callers see a clean contract, and the one internal implementation is
- * the single place where the phpstan "service contracts" rule is suppressed.
+ * Rates are sourced from Two's EUR-pivot spot-rate table
+ * (GET /refdata/v1/fx-rates), cached with a 6h background refresh and a
+ * last-known-good fallback, so conversions use the same rates Two applies
+ * server-side. Callers depend on this contract; the fetch/cache protocol
+ * lives behind the single implementation.
  */
 interface CurrencyRatesProviderInterface
 {
     /**
-     * Get the exchange rate from one currency to another, resolved via the
-     * store's configured base-currency rate table.
+     * Get the exchange rate from one currency to another, computed through
+     * the EUR pivot of Two's spot-rate table: one unit of $fromCurrency is
+     * worth `rate` units of $toCurrency.
      *
-     * Rates are always computed through base:
-     * - from == to           → 1.0
-     * - from == base         → base-to-target rate (from DB)
-     * - to == base           → inverse of base-to-source rate
-     * - neither is base      → cross-rate via base: (base→to) / (base→from)
-     *
-     * This avoids the stale-direct-cross-rate trap where admins only
-     * maintain base→* rates but historic DB entries exist for other pairs.
+     * Null means the pair cannot currently be converted — a currency absent
+     * from the table, or no table has ever been fetched (e.g. no API key
+     * configured, or the very first fetch failed). Once a table has been
+     * fetched, lookups keep resolving from the last-known-good table even
+     * when refreshes fail; callers apply their own posture to null
+     * (minimum-order platform floor fails closed, merchant bar fails open,
+     * display conversions fail soft).
      *
      * @param string $fromCurrency ISO 4217 code
      * @param string $toCurrency   ISO 4217 code
-     * @param int|null $storeId    Store scope; null = current store
-     * @return float|null Rate, or null when no rate is configured for the pair
+     * @param int|null $storeId    Store scope for API-key resolution; null = default scope
+     * @return float|null Rate, or null when the pair cannot be resolved
      */
     public function getRate(string $fromCurrency, string $toCurrency, ?int $storeId = null): ?float;
 }

--- a/Block/Adminhtml/System/Config/Field/SurchargeGrid.php
+++ b/Block/Adminhtml/System/Config/Field/SurchargeGrid.php
@@ -295,7 +295,7 @@ class SurchargeGrid extends Field
 
         return (string)__(
             'Warning: The fixed fee limit of %1 %2 cannot be enforced correctly because no exchange rate is '
-            . 'configured from %3 to %4. Configure exchange rates in Stores → Currency → Currency Rates.',
+            . 'currently available from %3 to %4.',
             $limitCurrency,
             $limitAmount,
             $limitCurrency,
@@ -305,8 +305,8 @@ class SurchargeGrid extends Field
 
     /**
      * Convert an amount from one currency to another. Rate lookup is routed
-     * through the service contract so all cross-rates resolve via the base
-     * currency's rate table.
+     * through the service contract so all cross-rates resolve via Two's
+     * EUR-pivot FX rate table.
      */
     private function convertAmount(float $amount, string $from, string $to): float
     {

--- a/Cron/RefreshFxRates.php
+++ b/Cron/RefreshFxRates.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Cron;
+
+use Magento\Store\Model\StoreManagerInterface;
+use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
+use Two\Gateway\Service\Fx\RateTableProvider;
+
+/**
+ * Background refresh of the cached FX rate table (every 6 hours).
+ *
+ * Keeps checkout rate lookups off the fetch path: the read side serves
+ * the cached table and only fetches itself when the table is missing or
+ * this job has not kept it fresh. One refresh per distinct API key —
+ * store scopes sharing a key share a cache entry, so refreshing it twice
+ * would only duplicate the call.
+ */
+class RefreshFxRates
+{
+    /** @var RateTableProvider */
+    private $rateTableProvider;
+
+    /** @var StoreManagerInterface */
+    private $storeManager;
+
+    /** @var ConfigRepository */
+    private $configRepository;
+
+    public function __construct(
+        RateTableProvider $rateTableProvider,
+        StoreManagerInterface $storeManager,
+        ConfigRepository $configRepository
+    ) {
+        $this->rateTableProvider = $rateTableProvider;
+        $this->storeManager = $storeManager;
+        $this->configRepository = $configRepository;
+    }
+
+    public function execute(): void
+    {
+        $seen = [];
+        foreach ($this->storeScopes() as $storeId) {
+            $apiKey = (string)$this->configRepository->getApiKey($storeId);
+            if ($apiKey === '') {
+                continue;
+            }
+            $keyHash = hash('sha256', $apiKey);
+            if (isset($seen[$keyHash])) {
+                continue;
+            }
+            $seen[$keyHash] = true;
+            $this->rateTableProvider->refresh($storeId);
+        }
+    }
+
+    /**
+     * Default scope plus every store view: API keys are store-scoped, so
+     * each scope may resolve a different key (sandbox vs production, or a
+     * different merchant per store).
+     *
+     * @return array<int,int|null>
+     */
+    private function storeScopes(): array
+    {
+        $scopes = [null];
+        foreach ($this->storeManager->getStores() as $store) {
+            $scopes[] = (int)$store->getId();
+        }
+        return $scopes;
+    }
+}

--- a/Model/CurrencyRatesProvider.php
+++ b/Model/CurrencyRatesProvider.php
@@ -36,6 +36,8 @@ class CurrencyRatesProvider implements CurrencyRatesProviderInterface
      */
     public function getRate(string $fromCurrency, string $toCurrency, ?int $storeId = null): ?float
     {
+        $fromCurrency = strtoupper($fromCurrency);
+        $toCurrency = strtoupper($toCurrency);
         if ($fromCurrency === $toCurrency) {
             return 1.0;
         }
@@ -45,6 +47,9 @@ class CurrencyRatesProvider implements CurrencyRatesProviderInterface
             return null;
         }
 
+        // Table keys are upper-cased on fetch (RateTableProvider::fetchTable);
+        // upper-case the query side too so a lowercase/mixed-case caller
+        // resolves instead of silently missing the table.
         $rates = $table['rates'];
         $fromInEur = $rates[$fromCurrency] ?? 0.0;
         $toInEur = $rates[$toCurrency] ?? 0.0;

--- a/Model/CurrencyRatesProvider.php
+++ b/Model/CurrencyRatesProvider.php
@@ -7,41 +7,28 @@ declare(strict_types=1);
 
 namespace Two\Gateway\Model;
 
-use Magento\Directory\Model\CurrencyFactory;
-use Magento\Store\Model\StoreManagerInterface;
 use Two\Gateway\Api\CurrencyRatesProviderInterface;
+use Two\Gateway\Service\Fx\RateTableProvider;
 
 /**
- * Reads currency exchange rates via the store's base-currency rate table.
+ * Resolves exchange rates from Two's EUR-pivot spot-rate table
+ * (GET /refdata/v1/fx-rates), replacing the retired Magento Directory
+ * rate-table source (TWO-25103).
  *
- * This is the single class in the plugin permitted to call
- * Currency::load(); the phpstan service-contract rule is suppressed here
- * and here only. All other callers depend on
- * {@see CurrencyRatesProviderInterface}.
+ * The table maps each currency to the EUR value of one unit, so any
+ * cross rate is computed through the EUR pivot without depending on the
+ * store's base currency or admin-maintained Directory rates. Fetching
+ * and caching (6h background refresh, last-known-good fallback) is owned
+ * by {@see RateTableProvider}.
  */
 class CurrencyRatesProvider implements CurrencyRatesProviderInterface
 {
-    /** @var CurrencyFactory */
-    private $currencyFactory;
+    /** @var RateTableProvider */
+    private $rateTableProvider;
 
-    /** @var StoreManagerInterface */
-    private $storeManager;
-
-    /**
-     * Rate-table loads memoised per base currency: getRate() sits on the
-     * payment-method isAvailable() hot path (many calls per page view)
-     * and the rate table is static within a request.
-     *
-     * @var array<string,\Magento\Directory\Model\Currency|null>
-     */
-    private $baseCurrencyCache = [];
-
-    public function __construct(
-        CurrencyFactory $currencyFactory,
-        StoreManagerInterface $storeManager
-    ) {
-        $this->currencyFactory = $currencyFactory;
-        $this->storeManager = $storeManager;
+    public function __construct(RateTableProvider $rateTableProvider)
+    {
+        $this->rateTableProvider = $rateTableProvider;
     }
 
     /**
@@ -53,53 +40,21 @@ class CurrencyRatesProvider implements CurrencyRatesProviderInterface
             return 1.0;
         }
 
-        $baseCurrency = $this->resolveBaseCurrency($storeId);
-        $base = $this->loadBaseCurrency($baseCurrency);
-        if ($base === null) {
+        $table = $this->rateTableProvider->getRateTable($storeId);
+        if ($table === null) {
             return null;
         }
 
-        if ($fromCurrency === $baseCurrency) {
-            $rate = (float)$base->getRate($toCurrency);
-            return $rate > 0 ? $rate : null;
-        }
-        if ($toCurrency === $baseCurrency) {
-            $rate = (float)$base->getRate($fromCurrency);
-            return $rate > 0 ? 1.0 / $rate : null;
-        }
-
-        $rateFrom = (float)$base->getRate($fromCurrency);
-        $rateTo = (float)$base->getRate($toCurrency);
-        return ($rateFrom > 0 && $rateTo > 0) ? ($rateTo / $rateFrom) : null;
-    }
-
-    private function resolveBaseCurrency(?int $storeId): string
-    {
-        try {
-            return (string)$this->storeManager->getStore($storeId)->getBaseCurrencyCode();
-        } catch (\Exception $e) {
-            return '';
-        }
-    }
-
-    /**
-     * Load the base currency's rate table. Confined to this method so the
-     * phpstan suppression scope stays minimal.
-     *
-     * @return \Magento\Directory\Model\Currency|null
-     */
-    private function loadBaseCurrency(string $baseCurrency)
-    {
-        if ($baseCurrency === '') {
+        $rates = $table['rates'];
+        $fromInEur = $rates[$fromCurrency] ?? 0.0;
+        $toInEur = $rates[$toCurrency] ?? 0.0;
+        if ($fromInEur <= 0 || $toInEur <= 0) {
             return null;
         }
-        if (array_key_exists($baseCurrency, $this->baseCurrencyCache)) {
-            return $this->baseCurrencyCache[$baseCurrency];
-        }
-        try {
-            return $this->baseCurrencyCache[$baseCurrency] = $this->currencyFactory->create()->load($baseCurrency);
-        } catch (\Exception $e) {
-            return $this->baseCurrencyCache[$baseCurrency] = null;
-        }
+
+        // rates[CCY] is the EUR value of 1 CCY, so units of `to` per one
+        // `from` is rate(from) / rate(to) — the same computation the
+        // endpoint performs for its single cross-rate form.
+        return $fromInEur / $toInEur;
     }
 }

--- a/Service/Fx/RateTableProvider.php
+++ b/Service/Fx/RateTableProvider.php
@@ -123,11 +123,7 @@ class RateTableProvider
             return $this->memo[$cacheKey]['table'];
         }
 
-        $entry = null;
-        $cached = $this->cache->load($cacheKey);
-        if ($cached !== false) {
-            $entry = $this->json->unserialize($cached);
-        }
+        $entry = $this->loadEntry($cacheKey);
 
         $age = $entry === null ? null : time() - (int)$entry['fetched_at'];
         if ($entry !== null && $age < self::REFRESH_INTERVAL) {
@@ -182,6 +178,43 @@ class RateTableProvider
 
         $this->persist($cacheKey, $fresh);
         return true;
+    }
+
+    /**
+     * The cached entry, or null when absent or unusable. A corrupt or
+     * wrong-shaped cache value must degrade to "missing" (refetch), never
+     * throw — this sits on the payment method's isAvailable() hot path.
+     *
+     * @return array{rates: array<string,float>, as_of: ?string, fetched_at: int}|null
+     */
+    private function loadEntry(string $cacheKey): ?array
+    {
+        $cached = $this->cache->load($cacheKey);
+        if ($cached === false) {
+            return null;
+        }
+        try {
+            $entry = $this->json->unserialize($cached);
+        } catch (\InvalidArgumentException $e) {
+            $this->logRepository->addDebugLog(
+                'RateTableProvider: discarding corrupt cached rate table',
+                ['error' => $e->getMessage()]
+            );
+            return null;
+        }
+        if (!is_array($entry)
+            || !isset($entry['fetched_at'])
+            || !isset($entry['rates'])
+            || !is_array($entry['rates'])
+            || $entry['rates'] === []
+        ) {
+            $this->logRepository->addDebugLog(
+                'RateTableProvider: discarding malformed cached rate table',
+                ['entry' => $entry]
+            );
+            return null;
+        }
+        return $entry;
     }
 
     /**

--- a/Service/Fx/RateTableProvider.php
+++ b/Service/Fx/RateTableProvider.php
@@ -24,10 +24,14 @@ use Two\Gateway\Service\Api\Adapter;
  * merchant's API key and made server-side only (never from browser JS).
  *
  * Cache protocol (last-known-good):
- * - A fetched table is written to the cross-request cache with NO expiry.
- *   It is the last-known-good table and must survive until replaced — gate
+ * - A fetched table is written to the cross-request cache with NO expiry, so
+ *   it is never evicted by age alone and survives a refresh outage — gate
  *   conversions (minimum order) are specified to use last-known-good and
- *   fail closed only when no table has EVER been fetched.
+ *   fail closed only when no table has EVER been fetched. Note this is
+ *   "no TTL-based eviction", not an unconditional guarantee: a `cache:flush`
+ *   (part of this repo's standard deploy workflow — see AGENTS.md) clears
+ *   the entry like any other cache data, and the very next lookup then
+ *   fetches synchronously and falls closed if that fetch also fails.
  * - A table older than REFRESH_INTERVAL (6h) is refreshed in the background
  *   by cron ({@see \Two\Gateway\Cron\RefreshFxRates}); the read path also
  *   refreshes opportunistically when it sees a stale or missing table, so a

--- a/Service/Fx/RateTableProvider.php
+++ b/Service/Fx/RateTableProvider.php
@@ -1,0 +1,254 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Service\Fx;
+
+use Magento\Framework\App\CacheInterface;
+use Magento\Framework\Serialize\Serializer\Json;
+use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
+use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
+use Two\Gateway\Service\Api\Adapter;
+
+/**
+ * Fetches and caches Two's EUR-pivot FX spot-rate table from
+ * GET /refdata/v1/fx-rates.
+ *
+ * The endpoint returns the full table in one call — `rates[CCY]` is the
+ * value of one unit of CCY in EUR — plus an `as_of` staleness floor, so a
+ * single fetch covers every currency a checkout can present; there is no
+ * per-currency refresh list to maintain. The call is authenticated with the
+ * merchant's API key and made server-side only (never from browser JS).
+ *
+ * Cache protocol (last-known-good):
+ * - A fetched table is written to the cross-request cache with NO expiry.
+ *   It is the last-known-good table and must survive until replaced — gate
+ *   conversions (minimum order) are specified to use last-known-good and
+ *   fail closed only when no table has EVER been fetched.
+ * - A table older than REFRESH_INTERVAL (6h) is refreshed in the background
+ *   by cron ({@see \Two\Gateway\Cron\RefreshFxRates}); the read path also
+ *   refreshes opportunistically when it sees a stale or missing table, so a
+ *   dead cron degrades freshness, never availability.
+ * - A failed fetch never overwrites the cached table; the stale table keeps
+ *   serving. A short failure cooldown stops the hot path (the payment
+ *   method's isAvailable()) from re-attempting the fetch on every call
+ *   while the API is unreachable.
+ * - The cache key includes the API-key hash so a key swap (different
+ *   merchant, or sandbox <-> production) never serves rates fetched under
+ *   the old key's mode.
+ */
+class RateTableProvider
+{
+    public const ENDPOINT = '/refdata/v1/fx-rates';
+
+    /** Age (seconds) beyond which the cached table is refreshed: 6 hours. */
+    public const REFRESH_INTERVAL = 21600;
+
+    private const CACHE_KEY_PREFIX = 'two_gateway_fx_rate_table_';
+    private const FAILURE_COOLDOWN_SUFFIX = '_cooldown';
+
+    /** Seconds between fetch attempts after a failure. */
+    private const FAILURE_COOLDOWN = 300;
+
+    /**
+     * @var Adapter
+     */
+    private $apiAdapter;
+
+    /**
+     * @var ConfigRepository
+     */
+    private $configRepository;
+
+    /**
+     * @var CacheInterface
+     */
+    private $cache;
+
+    /**
+     * @var Json
+     */
+    private $json;
+
+    /**
+     * @var LogRepository
+     */
+    private $logRepository;
+
+    /**
+     * Per-request memo, keyed like the cache. Holds ['table' => ?array]
+     * wrappers so a resolved "no table" is distinguishable from "not yet
+     * resolved" — rate lookups sit on the isAvailable() hot path and must
+     * cost at most one cache read (or fetch) per request.
+     *
+     * @var array<string,array{table: ?array}>
+     */
+    private $memo = [];
+
+    public function __construct(
+        Adapter $apiAdapter,
+        ConfigRepository $configRepository,
+        CacheInterface $cache,
+        Json $json,
+        LogRepository $logRepository
+    ) {
+        $this->apiAdapter = $apiAdapter;
+        $this->configRepository = $configRepository;
+        $this->cache = $cache;
+        $this->json = $json;
+        $this->logRepository = $logRepository;
+    }
+
+    /**
+     * The current FX rate table, refreshed opportunistically when stale.
+     *
+     * Returns the freshest table available — a stale table is still
+     * returned when a refresh attempt fails (last-known-good). Returns
+     * null only when no table has ever been fetched under the current
+     * API key and one cannot be fetched now.
+     *
+     * @return array{rates: array<string,float>, as_of: ?string, fetched_at: int}|null
+     */
+    public function getRateTable(?int $storeId = null): ?array
+    {
+        $cacheKey = $this->cacheKey($storeId);
+        if ($cacheKey === null) {
+            return null;
+        }
+
+        if (isset($this->memo[$cacheKey])) {
+            return $this->memo[$cacheKey]['table'];
+        }
+
+        $entry = null;
+        $cached = $this->cache->load($cacheKey);
+        if ($cached !== false) {
+            $entry = $this->json->unserialize($cached);
+        }
+
+        $age = $entry === null ? null : time() - (int)$entry['fetched_at'];
+        if ($entry !== null && $age < self::REFRESH_INTERVAL) {
+            $this->memo[$cacheKey] = ['table' => $entry];
+            return $entry;
+        }
+
+        // Missing or stale. Attempt a fetch unless a recent one failed —
+        // the cooldown keeps an API outage from adding a fetch round-trip
+        // to every page view.
+        if ($this->cache->load($cacheKey . self::FAILURE_COOLDOWN_SUFFIX) === false) {
+            $fresh = $this->fetchTable($storeId);
+            if ($fresh !== null) {
+                $this->persist($cacheKey, $fresh);
+                return $fresh;
+            }
+            $this->cache->save('1', $cacheKey . self::FAILURE_COOLDOWN_SUFFIX, [], self::FAILURE_COOLDOWN);
+            if ($entry !== null) {
+                $this->logRepository->addDebugLog(
+                    'RateTableProvider: refresh failed, serving last-known-good table',
+                    ['as_of' => $entry['as_of'] ?? null, 'age_seconds' => $age]
+                );
+            }
+        }
+
+        // Last-known-good stale table, or null when never fetched.
+        $this->memo[$cacheKey] = ['table' => $entry];
+        return $entry;
+    }
+
+    /**
+     * Force-refresh the cached table (cron entry point). A failed fetch
+     * leaves the existing cached table untouched.
+     *
+     * @return bool whether a fresh table was fetched and cached
+     */
+    public function refresh(?int $storeId = null): bool
+    {
+        $cacheKey = $this->cacheKey($storeId);
+        if ($cacheKey === null) {
+            return false;
+        }
+
+        $fresh = $this->fetchTable($storeId);
+        if ($fresh === null) {
+            $this->logRepository->addErrorLog(
+                'RateTableProvider: background FX rate refresh failed, keeping last-known-good table',
+                ['store_id' => $storeId]
+            );
+            return false;
+        }
+
+        $this->persist($cacheKey, $fresh);
+        return true;
+    }
+
+    /**
+     * The cache key for the current API key, or null when no key is
+     * configured (nothing to authenticate the fetch with).
+     */
+    private function cacheKey(?int $storeId): ?string
+    {
+        $apiKey = (string)$this->configRepository->getApiKey($storeId);
+        if ($apiKey === '') {
+            return null;
+        }
+        return self::CACHE_KEY_PREFIX . hash('sha256', $apiKey);
+    }
+
+    /**
+     * @param array{rates: array<string,float>, as_of: ?string, fetched_at: int} $entry
+     */
+    private function persist(string $cacheKey, array $entry): void
+    {
+        // No expiry (null lifetime): the table is the last-known-good source
+        // for gate conversions and must outlive any refresh outage. Staleness
+        // is tracked via fetched_at, not cache eviction.
+        $this->cache->save($this->json->serialize($entry), $cacheKey, [], null);
+        $this->memo[$cacheKey] = ['table' => $entry];
+    }
+
+    /**
+     * @return array{rates: array<string,float>, as_of: ?string, fetched_at: int}|null
+     */
+    private function fetchTable(?int $storeId): ?array
+    {
+        $response = $this->apiAdapter->execute(self::ENDPOINT, [], 'GET', $storeId);
+
+        // Adapter::execute always returns an array; a failure is signalled
+        // by an error_code / http_status marker (never present on a real
+        // rates payload). Treat those — and a payload without a usable
+        // rates map — as a failed fetch.
+        if (!is_array($response)
+            || isset($response['error_code'])
+            || isset($response['http_status'])
+            || !isset($response['rates'])
+            || !is_array($response['rates'])
+        ) {
+            $this->logRepository->addDebugLog(
+                'RateTableProvider: FX rates fetch failed',
+                is_array($response) ? $response : ['response' => $response]
+            );
+            return null;
+        }
+
+        $rates = [];
+        foreach ($response['rates'] as $currency => $value) {
+            $rate = (float)$value;
+            if (is_string($currency) && $currency !== '' && $rate > 0) {
+                $rates[strtoupper($currency)] = $rate;
+            }
+        }
+        if ($rates === []) {
+            $this->logRepository->addDebugLog('RateTableProvider: FX rates payload contained no usable rates', $response);
+            return null;
+        }
+
+        return [
+            'rates' => $rates,
+            'as_of' => isset($response['as_of']) ? (string)$response['as_of'] : null,
+            'fetched_at' => time(),
+        ];
+    }
+}

--- a/Service/Order/MinimumOrderGate.php
+++ b/Service/Order/MinimumOrderGate.php
@@ -21,10 +21,11 @@ use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
  * total minus tax) or gross value per the declared basis — always
  * explicit, since funding-partner rules and platform country defaults
  * may differ. Baskets in a different currency are converted to the
- * minimum's currency via the store's exchange rates before comparing.
- * When no rate is configured the gate fails closed: the method is
- * hidden rather than offered on an order we cannot prove satisfies the
- * funding partner's product minimum.
+ * minimum's currency via Two's FX rate table before comparing.
+ * When no rate is resolvable the platform floor fails closed — the
+ * method is hidden rather than offered on an order we cannot prove
+ * satisfies the funding partner's product minimum — while the
+ * merchant's own bar fails open (skipped).
  */
 class MinimumOrderGate
 {
@@ -83,12 +84,18 @@ class MinimumOrderGate
         }
 
         // The platform minimum is the funding-partner floor; the merchant
-        // minimum (admin setting, validated to meet or exceed the floor on save)
-        // may only raise the bar — both must be satisfied.
-        foreach ([$platformMinimum, $merchantMinimum] as $minimum) {
-            if ($minimum !== null && !$this->satisfiesMinimum($quote, $minimum)) {
-                return false;
-            }
+        // minimum (admin setting, validated to meet or exceed the floor on
+        // save) may only raise the bar — both must be satisfied. The two
+        // carry opposite conversion-failure postures (TWO-25103 spec): the
+        // floor fails CLOSED — never offer an order we cannot prove meets
+        // the funding partner's product minimum — while the merchant's own
+        // bar fails OPEN — a merchant preference must not hide the method
+        // when a rate is unavailable.
+        if ($platformMinimum !== null && !$this->satisfiesMinimum($quote, $platformMinimum, true)) {
+            return false;
+        }
+        if ($merchantMinimum !== null && !$this->satisfiesMinimum($quote, $merchantMinimum, false)) {
+            return false;
         }
 
         return true;
@@ -96,8 +103,11 @@ class MinimumOrderGate
 
     /**
      * @param array{amount: float, currency: string, basis: string} $minimum
+     * @param bool $failClosed posture when the basket cannot be converted
+     *             into the minimum's currency: true = treat as unsatisfied
+     *             (platform floor), false = treat as satisfied (merchant bar)
      */
-    private function satisfiesMinimum(Quote $quote, array $minimum): bool
+    private function satisfiesMinimum(Quote $quote, array $minimum, bool $failClosed): bool
     {
         $basketValue = $this->basketValue($quote, $minimum['basis']);
         $store = $quote->getStore();
@@ -105,8 +115,7 @@ class MinimumOrderGate
             ?: ($store !== null ? $store->getBaseCurrencyCode() : ''));
 
         if ($quoteCurrency === '') {
-            $this->reportFailClosed('(unresolved)', $minimum['currency']);
-            return false;
+            return $this->unresolvableConversion('(unresolved)', $minimum['currency'], $failClosed);
         }
 
         if ($quoteCurrency === $minimum['currency']) {
@@ -119,13 +128,31 @@ class MinimumOrderGate
             $quote->getStoreId() !== null ? (int)$quote->getStoreId() : null
         );
         if ($rate === null || $rate <= 0) {
-            $this->reportFailClosed($quoteCurrency, $minimum['currency']);
-            return false;
+            return $this->unresolvableConversion($quoteCurrency, $minimum['currency'], $failClosed);
         }
 
         // Compare at currency precision: full-precision arithmetic,
         // rounded once at the decision boundary (the plugin-wide model).
         return round($basketValue * $rate, 2) >= $minimum['amount'];
+    }
+
+    /**
+     * The satisfiesMinimum() outcome for an unconvertible basket, per the
+     * minimum's posture: platform floor fails closed (unsatisfied),
+     * merchant bar fails open (satisfied — the bar is skipped).
+     */
+    private function unresolvableConversion(string $from, string $to, bool $failClosed): bool
+    {
+        if ($failClosed) {
+            $this->reportFailClosed($from, $to);
+            return false;
+        }
+        $this->logRepository->addDebugLog(
+            'MinimumOrderGate: cannot convert basket to merchant minimum currency, '
+            . 'skipping merchant bar (fail-open)',
+            ['from' => $from, 'to' => $to]
+        );
+        return true;
     }
 
     /**

--- a/Service/Order/SurchargeCalculator.php
+++ b/Service/Order/SurchargeCalculator.php
@@ -215,7 +215,12 @@ class SurchargeCalculator
         ];
 
         if ($hasFixed) {
-            $payload['surcharge'] = $this->convertAmount((float)$config['fixed'], $fixedCurrency, $orderCurrency);
+            $payload['surcharge'] = $this->convertAmount(
+                (float)$config['fixed'],
+                $fixedCurrency,
+                $orderCurrency,
+                $storeId
+            );
         }
 
         // `cap` only applies where the fee has a percentage component. The admin
@@ -224,7 +229,12 @@ class SurchargeCalculator
         // a stored limit left over from a previous surcharge type must not leak into
         // a fixed-only request and clamp the fee.
         if ($hasPercentage && $config['limit'] !== null) {
-            $payload['cap'] = $this->convertAmount((float)$config['limit'], $fixedCurrency, $orderCurrency);
+            $payload['cap'] = $this->convertAmount(
+                (float)$config['limit'],
+                $fixedCurrency,
+                $orderCurrency,
+                $storeId
+            );
         }
 
         // `rounding` snaps the final buyer line item to a clean increment, computed
@@ -293,20 +303,23 @@ class SurchargeCalculator
     /**
      * Convert an amount between currencies if needed.
      *
-     * @throws LocalizedException if Magento has no exchange rate for the pair
+     * @throws LocalizedException when no FX rate is resolvable for the pair
      */
-    private function convertAmount(float $amount, string $fromCurrency, string $toCurrency): float
-    {
+    private function convertAmount(
+        float $amount,
+        string $fromCurrency,
+        string $toCurrency,
+        ?int $storeId = null
+    ): float {
         if ($amount === 0.0 || $fromCurrency === '' || $fromCurrency === $toCurrency) {
             return $amount;
         }
 
-        $rate = $this->ratesProvider->getRate($fromCurrency, $toCurrency);
+        $rate = $this->ratesProvider->getRate($fromCurrency, $toCurrency, $storeId);
         if ($rate === null) {
             throw new LocalizedException(
                 __(
-                    'Cannot convert surcharge from %1 to %2. '
-                    . 'Please configure currency exchange rates under Stores > Currency Rates.',
+                    'Cannot convert surcharge from %1 to %2: no exchange rate is currently available.',
                     $fromCurrency,
                     $toCurrency
                 )

--- a/Test/Stubs/AdminScope.php
+++ b/Test/Stubs/AdminScope.php
@@ -43,6 +43,8 @@ namespace Magento\Store\Model {
         {
             public function getStore($storeId = null);
 
+            public function getStores($withDefault = false, $codeKey = false);
+
             public function getWebsite($websiteId = null);
 
             public function getGroup($groupId = null);

--- a/Test/Unit/Cron/RefreshFxRatesTest.php
+++ b/Test/Unit/Cron/RefreshFxRatesTest.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Cron;
+
+use Magento\Store\Api\Data\StoreInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
+use Two\Gateway\Cron\RefreshFxRates;
+use Two\Gateway\Service\Fx\RateTableProvider;
+
+class RefreshFxRatesTest extends TestCase
+{
+    /** @var RateTableProvider|\PHPUnit\Framework\MockObject\MockObject */
+    private $rateTableProvider;
+
+    /** @var StoreManagerInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $storeManager;
+
+    /** @var ConfigRepository|\PHPUnit\Framework\MockObject\MockObject */
+    private $configRepository;
+
+    protected function setUp(): void
+    {
+        $this->rateTableProvider = $this->createMock(RateTableProvider::class);
+        $this->storeManager = $this->createMock(StoreManagerInterface::class);
+        $this->configRepository = $this->createMock(ConfigRepository::class);
+    }
+
+    private function cron(): RefreshFxRates
+    {
+        return new RefreshFxRates($this->rateTableProvider, $this->storeManager, $this->configRepository);
+    }
+
+    /**
+     * @return StoreInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private function store(int $id)
+    {
+        $store = $this->createMock(StoreInterface::class);
+        $store->method('getId')->willReturn($id);
+        return $store;
+    }
+
+    public function testRefreshesOncePerDistinctApiKey(): void
+    {
+        // Default scope and store 1 share a key (one cache entry — one
+        // refresh); store 2 has its own key and gets its own refresh.
+        $this->storeManager->method('getStores')->willReturn([$this->store(1), $this->store(2)]);
+        $this->configRepository->method('getApiKey')->willReturnMap([
+            [null, 'key-a'],
+            [1, 'key-a'],
+            [2, 'key-b'],
+        ]);
+        $calls = [];
+        $this->rateTableProvider->method('refresh')->willReturnCallback(
+            function (?int $storeId) use (&$calls) {
+                $calls[] = $storeId;
+                return true;
+            }
+        );
+
+        $this->cron()->execute();
+
+        $this->assertSame([null, 2], $calls);
+    }
+
+    public function testScopesWithoutApiKeyAreSkipped(): void
+    {
+        $this->storeManager->method('getStores')->willReturn([$this->store(1)]);
+        $this->configRepository->method('getApiKey')->willReturn('');
+        $this->rateTableProvider->expects($this->never())->method('refresh');
+
+        $this->cron()->execute();
+    }
+}

--- a/Test/Unit/Model/CurrencyRatesProviderTest.php
+++ b/Test/Unit/Model/CurrencyRatesProviderTest.php
@@ -1,0 +1,91 @@
+<?php
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Model;
+
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Model\CurrencyRatesProvider;
+use Two\Gateway\Service\Fx\RateTableProvider;
+
+class CurrencyRatesProviderTest extends TestCase
+{
+    /** @var RateTableProvider|\PHPUnit\Framework\MockObject\MockObject */
+    private $rateTableProvider;
+
+    /** @var CurrencyRatesProvider */
+    private $provider;
+
+    protected function setUp(): void
+    {
+        $this->rateTableProvider = $this->createMock(RateTableProvider::class);
+        $this->provider = new CurrencyRatesProvider($this->rateTableProvider);
+    }
+
+    private function stubTable(array $rates): void
+    {
+        $this->rateTableProvider->method('getRateTable')->willReturn([
+            'rates' => $rates,
+            'as_of' => '2026-07-15',
+            'fetched_at' => time(),
+        ]);
+    }
+
+    public function testSameCurrencyIsUnityWithoutTableLookup(): void
+    {
+        $this->rateTableProvider->expects($this->never())->method('getRateTable');
+
+        $this->assertSame(1.0, $this->provider->getRate('EUR', 'EUR', 1));
+    }
+
+    public function testRateToEurReadsThePivotDirectly(): void
+    {
+        $this->stubTable(['EUR' => 1.0, 'GBP' => 1.17]);
+
+        $this->assertEqualsWithDelta(1.17, $this->provider->getRate('GBP', 'EUR', 1), 1e-9);
+    }
+
+    public function testRateFromEurInvertsThePivot(): void
+    {
+        $this->stubTable(['EUR' => 1.0, 'GBP' => 1.17]);
+
+        $this->assertEqualsWithDelta(1 / 1.17, $this->provider->getRate('EUR', 'GBP', 1), 1e-9);
+    }
+
+    public function testCrossCurrencyAmountUsesTheEndpointRateNotTheDirectoryTable(): void
+    {
+        // The ticket's cross-currency scenario: with the endpoint's
+        // EUR-pivot table (1 GBP = 1.17 EUR, 1 NOK = 0.085 EUR), a
+        // GBP 100.00 basket converts at 1.17 / 0.085 to NOK 1376.47.
+        // The old Magento Directory rate table no longer participates —
+        // the provider has no dependency left through which it could.
+        $this->stubTable(['EUR' => 1.0, 'GBP' => 1.17, 'NOK' => 0.085]);
+
+        $rate = $this->provider->getRate('GBP', 'NOK', 1);
+
+        $this->assertEqualsWithDelta(13.7647058824, $rate, 1e-9);
+        $this->assertSame(1376.47, round(100.00 * $rate, 2));
+    }
+
+    public function testCurrencyAbsentFromTableResolvesToNull(): void
+    {
+        $this->stubTable(['EUR' => 1.0, 'GBP' => 1.17]);
+
+        $this->assertNull($this->provider->getRate('GBP', 'XXX', 1));
+        $this->assertNull($this->provider->getRate('XXX', 'GBP', 1));
+    }
+
+    public function testNoTableEverFetchedResolvesToNull(): void
+    {
+        $this->rateTableProvider->method('getRateTable')->willReturn(null);
+
+        $this->assertNull($this->provider->getRate('GBP', 'EUR', 1));
+    }
+
+    public function testStoreScopeIsForwardedToTheTableProvider(): void
+    {
+        $this->rateTableProvider->expects($this->once())->method('getRateTable')
+            ->with(7)->willReturn(null);
+
+        $this->provider->getRate('GBP', 'EUR', 7);
+    }
+}

--- a/Test/Unit/Service/Fx/RateTableProviderTest.php
+++ b/Test/Unit/Service/Fx/RateTableProviderTest.php
@@ -1,0 +1,263 @@
+<?php
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Service\Fx;
+
+use Magento\Framework\App\CacheInterface;
+use Magento\Framework\Serialize\Serializer\Json;
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
+use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
+use Two\Gateway\Service\Api\Adapter;
+use Two\Gateway\Service\Fx\RateTableProvider;
+
+class RateTableProviderTest extends TestCase
+{
+    private const RATES_RESPONSE = [
+        'base' => 'EUR',
+        'as_of' => '2026-07-15',
+        'rates' => ['EUR' => 1.0, 'GBP' => 1.17, 'NOK' => 0.085, 'SEK' => 0.088],
+    ];
+
+    /** @var Adapter|\PHPUnit\Framework\MockObject\MockObject */
+    private $apiAdapter;
+
+    protected function setUp(): void
+    {
+        $this->apiAdapter = $this->createMock(Adapter::class);
+    }
+
+    /**
+     * @param CacheInterface|\PHPUnit\Framework\MockObject\MockObject|null $cache
+     */
+    private function provider($cache = null, string $apiKey = 'test-api-key'): RateTableProvider
+    {
+        if ($cache === null) {
+            $cache = $this->createMock(CacheInterface::class);
+            $cache->method('load')->willReturn(false);
+        }
+        $configRepository = $this->createMock(ConfigRepository::class);
+        $configRepository->method('getApiKey')->willReturn($apiKey);
+
+        return new RateTableProvider(
+            $this->apiAdapter,
+            $configRepository,
+            $cache,
+            new Json(),
+            $this->createMock(LogRepository::class)
+        );
+    }
+
+    /**
+     * A cache mock whose main-key load returns $entry (JSON) and whose
+     * failure-cooldown load returns $cooldown.
+     *
+     * @return CacheInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private function cacheWith(?array $entry, $cooldown = false)
+    {
+        $cache = $this->createMock(CacheInterface::class);
+        $json = new Json();
+        $cache->method('load')->willReturnCallback(
+            function (string $key) use ($entry, $cooldown, $json) {
+                if (strpos($key, '_cooldown') !== false) {
+                    return $cooldown;
+                }
+                return $entry === null ? false : $json->serialize($entry);
+            }
+        );
+        return $cache;
+    }
+
+    private function freshEntry(): array
+    {
+        return [
+            'rates' => ['EUR' => 1.0, 'GBP' => 1.17],
+            'as_of' => '2026-07-15',
+            'fetched_at' => time(),
+        ];
+    }
+
+    private function staleEntry(): array
+    {
+        return [
+            'rates' => ['EUR' => 1.0, 'GBP' => 1.10],
+            'as_of' => '2026-07-10',
+            'fetched_at' => time() - RateTableProvider::REFRESH_INTERVAL - 60,
+        ];
+    }
+
+    // ── Fetch and cache ──────────────────────────────────────────────
+
+    public function testFetchesTableFromEndpointWhenUncached(): void
+    {
+        $this->apiAdapter->expects($this->once())->method('execute')
+            ->with('/refdata/v1/fx-rates', [], 'GET', 1)
+            ->willReturn(self::RATES_RESPONSE);
+
+        $table = $this->provider()->getRateTable(1);
+
+        $this->assertSame(self::RATES_RESPONSE['rates'], $table['rates']);
+        $this->assertSame('2026-07-15', $table['as_of']);
+    }
+
+    public function testCachesFetchedTableWithoutExpiry(): void
+    {
+        // The table is the last-known-good source for gate conversions:
+        // it must be written with NO lifetime, so a refresh outage can
+        // never evict it.
+        $this->apiAdapter->method('execute')->willReturn(self::RATES_RESPONSE);
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->method('load')->willReturn(false);
+        $cache->expects($this->once())->method('save')->with(
+            $this->stringContains('"rates"'),
+            $this->stringContains('two_gateway_fx_rate_table_'),
+            [],
+            null
+        );
+
+        $this->provider($cache)->getRateTable(1);
+    }
+
+    public function testSecondLookupInsideWindowHitsCacheNotEndpoint(): void
+    {
+        // Core over-fetch guard: a cached table younger than the 6h window
+        // is served as-is; the endpoint must not be called at all.
+        $this->apiAdapter->expects($this->never())->method('execute');
+
+        $table = $this->provider($this->cacheWith($this->freshEntry()))->getRateTable(1);
+
+        $this->assertSame(1.17, $table['rates']['GBP']);
+    }
+
+    public function testMemoisesWithinTheRequest(): void
+    {
+        // getRate() sits on the payment method's isAvailable() hot path —
+        // many lookups per page view must cost one fetch, not one each.
+        $this->apiAdapter->expects($this->once())->method('execute')->willReturn(self::RATES_RESPONSE);
+
+        $provider = $this->provider();
+        $first = $provider->getRateTable(1);
+        $second = $provider->getRateTable(1);
+
+        $this->assertSame($first, $second);
+    }
+
+    public function testNoApiKeyShortCircuitsWithoutApiCall(): void
+    {
+        $this->apiAdapter->expects($this->never())->method('execute');
+
+        $this->assertNull($this->provider(null, '')->getRateTable(1));
+    }
+
+    // ── Staleness ────────────────────────────────────────────────────
+
+    public function testStaleTableIsRefreshedFromEndpoint(): void
+    {
+        $this->apiAdapter->expects($this->once())->method('execute')->willReturn(self::RATES_RESPONSE);
+
+        $table = $this->provider($this->cacheWith($this->staleEntry()))->getRateTable(1);
+
+        // The fresh endpoint rate (1.17), not the stale cached one (1.10).
+        $this->assertSame(1.17, $table['rates']['GBP']);
+    }
+
+    public function testServesLastKnownGoodWhenRefreshFails(): void
+    {
+        // Gate conversions are specified to use last-known-good: a failed
+        // refresh serves the stale table, never null.
+        $this->apiAdapter->method('execute')->willReturn(['error_code' => 400, 'error_message' => 'boom']);
+
+        $table = $this->provider($this->cacheWith($this->staleEntry()))->getRateTable(1);
+
+        $this->assertSame(1.10, $table['rates']['GBP']);
+    }
+
+    public function testFailedRefreshDoesNotOverwriteLastKnownGood(): void
+    {
+        $this->apiAdapter->method('execute')->willReturn(['http_status' => 503]);
+        $cache = $this->cacheWith($this->staleEntry());
+        // Only the failure cooldown is written — never the table key.
+        $cache->expects($this->once())->method('save')->with(
+            $this->anything(),
+            $this->stringContains('_cooldown'),
+            [],
+            300
+        );
+
+        $this->provider($cache)->getRateTable(1);
+    }
+
+    public function testFailureCooldownSuppressesRefetch(): void
+    {
+        // While the cooldown is live, the stale table is served without
+        // touching the endpoint — an API outage must not add a fetch
+        // round-trip to every page view.
+        $this->apiAdapter->expects($this->never())->method('execute');
+
+        $table = $this->provider($this->cacheWith($this->staleEntry(), '1'))->getRateTable(1);
+
+        $this->assertSame(1.10, $table['rates']['GBP']);
+    }
+
+    public function testNeverFetchedAndFetchFailingResolvesToNull(): void
+    {
+        // Only case that yields null: no table has EVER been fetched and
+        // one cannot be fetched now (callers fail closed / soft on null).
+        $this->apiAdapter->method('execute')->willReturn(['error_code' => 400]);
+
+        $this->assertNull($this->provider()->getRateTable(1));
+    }
+
+    public function testMalformedPayloadIsAFailedFetch(): void
+    {
+        $this->apiAdapter->method('execute')->willReturn(['base' => 'EUR', 'as_of' => '2026-07-15']);
+
+        $this->assertNull($this->provider()->getRateTable(1));
+    }
+
+    public function testNonPositiveAndBogusRatesAreDropped(): void
+    {
+        $this->apiAdapter->method('execute')->willReturn([
+            'as_of' => '2026-07-15',
+            'rates' => ['EUR' => 1.0, 'GBP' => -1.17, 'NOK' => 0, 'SEK' => 'abc'],
+        ]);
+
+        $table = $this->provider()->getRateTable(1);
+
+        $this->assertSame(['EUR' => 1.0], $table['rates']);
+    }
+
+    // ── Background refresh (cron path) ───────────────────────────────
+
+    public function testRefreshPersistsFreshTable(): void
+    {
+        $this->apiAdapter->method('execute')->willReturn(self::RATES_RESPONSE);
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->method('load')->willReturn(false);
+        $cache->expects($this->once())->method('save')->with(
+            $this->stringContains('"as_of":"2026-07-15"'),
+            $this->stringContains('two_gateway_fx_rate_table_'),
+            [],
+            null
+        );
+
+        $this->assertTrue($this->provider($cache)->refresh(1));
+    }
+
+    public function testRefreshFailureLeavesCacheUntouched(): void
+    {
+        $this->apiAdapter->method('execute')->willReturn(['error_code' => 500]);
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects($this->never())->method('save');
+
+        $this->assertFalse($this->provider($cache)->refresh(1));
+    }
+
+    public function testRefreshWithoutApiKeyIsANoop(): void
+    {
+        $this->apiAdapter->expects($this->never())->method('execute');
+
+        $this->assertFalse($this->provider(null, '')->refresh(1));
+    }
+}

--- a/Test/Unit/Service/Fx/RateTableProviderTest.php
+++ b/Test/Unit/Service/Fx/RateTableProviderTest.php
@@ -150,13 +150,56 @@ class RateTableProviderTest extends TestCase
         $this->assertNull($this->provider(null, '')->getRateTable(1));
     }
 
-    // ── Staleness ────────────────────────────────────────────────────
+    // ── Cache-entry robustness ───────────────────────────────────────
 
-    public function testStaleTableIsRefreshedFromEndpoint(): void
+    public function testCorruptCacheEntryIsDiscardedAndRefetched(): void
+    {
+        // A corrupt cache value must degrade to "missing" and refetch —
+        // never throw on the isAvailable() hot path.
+        $this->apiAdapter->expects($this->once())->method('execute')->willReturn(self::RATES_RESPONSE);
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->method('load')->willReturnCallback(
+            fn (string $key) => strpos($key, '_cooldown') !== false ? false : 'not-json{{'
+        );
+        $cache->expects($this->once())->method('save')->with(
+            $this->stringContains('"rates"'),
+            $this->stringContains('two_gateway_fx_rate_table_'),
+            [],
+            null
+        );
+
+        $table = $this->provider($cache)->getRateTable(1);
+
+        $this->assertSame(1.17, $table['rates']['GBP']);
+    }
+
+    public function testWrongShapedCacheEntryIsDiscardedAndRefetched(): void
     {
         $this->apiAdapter->expects($this->once())->method('execute')->willReturn(self::RATES_RESPONSE);
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->method('load')->willReturnCallback(
+            fn (string $key) => strpos($key, '_cooldown') !== false ? false : '{"unexpected":true}'
+        );
 
-        $table = $this->provider($this->cacheWith($this->staleEntry()))->getRateTable(1);
+        $table = $this->provider($cache)->getRateTable(1);
+
+        $this->assertSame(1.17, $table['rates']['GBP']);
+    }
+
+    // ── Staleness ────────────────────────────────────────────────────
+
+    public function testStaleTableIsRefreshedFromEndpointAndPersisted(): void
+    {
+        $this->apiAdapter->expects($this->once())->method('execute')->willReturn(self::RATES_RESPONSE);
+        $cache = $this->cacheWith($this->staleEntry());
+        $cache->expects($this->once())->method('save')->with(
+            $this->stringContains('"as_of":"2026-07-15"'),
+            $this->stringContains('two_gateway_fx_rate_table_'),
+            [],
+            null
+        );
+
+        $table = $this->provider($cache)->getRateTable(1);
 
         // The fresh endpoint rate (1.17), not the stale cached one (1.10).
         $this->assertSame(1.17, $table['rates']['GBP']);

--- a/Test/Unit/Service/Order/MinimumOrderGateTest.php
+++ b/Test/Unit/Service/Order/MinimumOrderGateTest.php
@@ -210,6 +210,38 @@ class MinimumOrderGateTest extends TestCase
         $this->assertTrue($this->gate->isSatisfied(self::EUR_250_NET, $this->quote(400.0, 'EUR'), $merchantMinimum));
     }
 
+    // ── Conversion-failure posture (TWO-25103 spec) ──────────────────
+    // Platform floor fails CLOSED; merchant bar fails OPEN.
+
+    public function testMerchantBarFailsOpenWhenRateUnresolvable(): void
+    {
+        // The merchant's own bar is a preference, not a funding-partner
+        // requirement: an unresolvable rate skips the bar rather than
+        // hiding the payment method.
+        $this->ratesProvider->method('getRate')->willReturn(null);
+        $merchantMinimum = ['amount' => 500.0, 'currency' => 'EUR', 'basis' => 'gross'];
+
+        $this->assertTrue($this->gate->isSatisfied(null, $this->quote(10.0, 'SEK'), $merchantMinimum));
+    }
+
+    public function testSatisfiedPlatformFloorWithUnconvertibleMerchantBarStaysOpen(): void
+    {
+        // Platform floor satisfied in the basket currency; the merchant bar
+        // needs a conversion that fails — the bar is skipped, the floor's
+        // verdict stands.
+        $this->ratesProvider->method('getRate')->willReturn(null);
+        $merchantMinimum = ['amount' => 400.0, 'currency' => 'USD', 'basis' => 'net'];
+
+        $this->assertTrue($this->gate->isSatisfied(self::EUR_250_NET, $this->quote(300.0, 'EUR'), $merchantMinimum));
+    }
+
+    public function testMerchantBarFailsOpenWhenBasketCurrencyUnresolvable(): void
+    {
+        $merchantMinimum = ['amount' => 500.0, 'currency' => 'EUR', 'basis' => 'gross'];
+
+        $this->assertTrue($this->gate->isSatisfied(null, $this->quote(10.0, null), $merchantMinimum));
+    }
+
     public function testGrossBasisComparesGrandTotal(): void
     {
         $minimum = ['amount' => 250.0, 'currency' => 'EUR', 'basis' => 'gross'];

--- a/Test/Unit/Service/Order/SurchargeCalculatorTest.php
+++ b/Test/Unit/Service/Order/SurchargeCalculatorTest.php
@@ -693,6 +693,22 @@ class SurchargeCalculatorTest extends TestCase
         $this->calculator->calculate(1000.0, 30, 'NO', 'GBP');
     }
 
+    public function testConversionForwardsStoreScopeToRateLookup(): void
+    {
+        // FX rates are fetched with the store-scoped API key (TWO-25103):
+        // dropping the store id would resolve the default scope's key and
+        // break multi-store installs with per-store keys.
+        $this->stubCommonConfig(SurchargeType::FIXED);
+        $this->stubSurchargeConfig(0, 10);
+        $this->stubFixedCurrency('NOK');
+        $this->ratesProvider->expects($this->atLeastOnce())->method('getRate')
+            ->with('NOK', 'SEK', 7)
+            ->willReturn(1.1);
+        $this->adapter->method('execute')->willReturn(['buyer_fee_share' => 11.0]);
+
+        $this->calculator->calculate(1000.0, 30, 'NO', 'SEK', 7);
+    }
+
     public function testNoConversionWhenFixedCurrencyEmpty(): void
     {
         $this->stubCommonConfig(SurchargeType::FIXED);

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
+    <group id="default">
+        <!-- 6h background refresh of the FX rate table (TWO-25103); the
+             read path serves last-known-good between refreshes. -->
+        <job name="two_gateway_refresh_fx_rates"
+             instance="Two\Gateway\Cron\RefreshFxRates"
+             method="execute">
+            <schedule>0 */6 * * *</schedule>
+        </job>
+    </group>
+</config>

--- a/i18n/nb_NO.csv
+++ b/i18n/nb_NO.csv
@@ -230,7 +230,7 @@
 "Pay within 30 days","Betal innen 30 dager"
 "Refund Two Surcharge","Refunder tilleggsavgift"
 "Select the payment term(s) you want to offer.","Velg betalingsvilkår du vil tilby."
-"Warning: The fixed fee limit of %1 %2 cannot be enforced correctly because no exchange rate is configured from %3 to %4. Configure exchange rates in Stores → Currency → Currency Rates.","Advarsel: Den faste avgiftsgrensen %1 %2 kan ikke håndheves korrekt fordi ingen valutakurs er konfigurert fra %3 til %4. Konfigurer valutakurser i Stores → Currency → Currency Rates."
+"Warning: The fixed fee limit of %1 %2 cannot be enforced correctly because no exchange rate is currently available from %3 to %4.","Advarsel: Den faste avgiftsgrensen %1 %2 kan ikke håndheves korrekt fordi ingen valutakurs er tilgjengelig fra %3 til %4."
 
 "Surcharge Rounding","Avrunding av tillegg"
 "Rounding Step","Avrundingssteg"

--- a/i18n/nb_NO.csv
+++ b/i18n/nb_NO.csv
@@ -199,6 +199,7 @@
 "All Allowed Countries","Alle tillatte land"
 "Amounts are shown in %1.","Beløpet vises i %1."
 "Cannot convert surcharge from %1 to %2.","Kan ikke konvertere gebyr fra %1 til %2."
+"Cannot convert surcharge from %1 to %2: no exchange rate is currently available.","Kan ikke konvertere tilleggsavgift fra %1 til %2: ingen valutakurs er tilgjengelig for øyeblikket."
 "City is not valid.","By er ikke gyldig."
 "Country is not valid.","Land er ikke gyldig."
 "Developed by Magmodules.","Utviklet av Magmodules."

--- a/i18n/nl_NL.csv
+++ b/i18n/nl_NL.csv
@@ -18,6 +18,7 @@
 "Add Order Note Field","Bestelnotitieveld toevoegen"
 "Add Project Field","Projectveld toevoegen"
 "Allowed Countries","Toegestane landen"
+"Cannot convert surcharge from %1 to %2: no exchange rate is currently available.","Kan de toeslag niet converteren van %1 naar %2: er is momenteel geen wisselkoers beschikbaar."
 "Choose whether to enable this payment method for all allowed countries or only specific ones.","Kies of je de betaalmethode voor alle toegestane of specifieke landen wilt inschakelen."
 "Country Availability","Beschikbaarheid per land"
 "Select the countries where this payment method should be available.","Selecteer de landen waar deze betaalmethode beschikbaar moet zijn."

--- a/i18n/nl_NL.csv
+++ b/i18n/nl_NL.csv
@@ -221,7 +221,7 @@
 "Select the payment term(s) you want to offer.","Selecteer de betaaltermijn(en) die je wilt aanbieden."
 "Specific Countries","Specifieke landen"
 "Street Address is not valid.","Adres is niet geldig."
-"Warning: The fixed fee limit of %1 %2 cannot be enforced correctly because no exchange rate is configured from %3 to %4. Configure exchange rates in Stores → Currency → Currency Rates.","Waarschuwing: de vaste toeslaglimiet van %1 %2 kan niet correct worden toegepast omdat er geen wisselkoers is geconfigureerd van %3 naar %4. Configureer wisselkoersen in Winkels → Valuta → Valutakoersen."
+"Warning: The fixed fee limit of %1 %2 cannot be enforced correctly because no exchange rate is currently available from %3 to %4.","Waarschuwing: de vaste toeslaglimiet van %1 %2 kan niet correct worden toegepast omdat er momenteel geen wisselkoers beschikbaar is van %3 naar %4."
 "Yes","Ja"
 "Zip/Postal Code is not valid.","Postcode is niet geldig."
 "payment terms","betaalvoorwaarden"

--- a/i18n/sv_SE.csv
+++ b/i18n/sv_SE.csv
@@ -196,6 +196,7 @@
 "All Allowed Countries","Alla tillåtna länder"
 "Amounts are shown in %1.","Belopp visas i %1."
 "Cannot convert surcharge from %1 to %2.","Kan inte konvertera tillägg från %1 till %2."
+"Cannot convert surcharge from %1 to %2: no exchange rate is currently available.","Det går inte att konvertera tilläggsavgiften från %1 till %2: ingen växelkurs är tillgänglig just nu."
 "City is not valid.","Stad är inte giltig."
 "Country is not valid.","Land är inte giltigt."
 "Developed by Magmodules.","Utvecklad av Magmodules."

--- a/i18n/sv_SE.csv
+++ b/i18n/sv_SE.csv
@@ -227,7 +227,7 @@
 "Pay within 30 days","Betala inom 30 dagar"
 "Refund Two Surcharge","Återbetala tilläggsavgift"
 "Select the payment term(s) you want to offer.","Välj betalningsvillkor du vill erbjuda."
-"Warning: The fixed fee limit of %1 %2 cannot be enforced correctly because no exchange rate is configured from %3 to %4. Configure exchange rates in Stores → Currency → Currency Rates.","Varning: Den fasta avgiftsgränsen %1 %2 kan inte upprätthållas korrekt eftersom ingen växelkurs är konfigurerad från %3 till %4. Konfigurera växelkurser i Stores → Currency → Currency Rates."
+"Warning: The fixed fee limit of %1 %2 cannot be enforced correctly because no exchange rate is currently available from %3 to %4.","Varning: Den fasta avgiftsgränsen %1 %2 kan inte upprätthållas korrekt eftersom ingen växelkurs är tillgänglig från %3 till %4."
 
 "Surcharge Rounding","Avrundning av tillägg"
 "Rounding Step","Avrundningssteg"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,8 +4,6 @@ parameters:
     ignoreErrors:
         - '#Variable \$block might not be defined.#'
         - '#Undefined variable: \$block#'
-        # Currency model has no service contract replacement for loading by ISO code
-        - '#Use service contracts to persist entities in favour of Magento\\Directory\\Model\\Currency::load\(\) method#'
         # Monolog 3 (shipped with Magento 2.4.8) added an @final PHPDoc marker on
         # Monolog\Logger. The Magento convention for declaring a per-module log
         # channel is to subclass Logger; Magento\Framework\Logger\Monolog itself


### PR DESCRIPTION
## Summary

Swaps `CurrencyRatesProvider` off Magento's native Directory exchange-rate table onto Two's live EUR-pivot spot-rate endpoint `GET /refdata/v1/fx-rates` (TWO-24776, merged and live), so surcharge / minimum-order / admin-config conversions use the same rates Two applies server-side.

[TWO-25103](https://linear.app/two-inc/issue/TWO-25103)

## Implementation

- **`Service/Fx/RateTableProvider`** — fetches the full EUR-pivot table (one call covers every currency; no per-currency refresh list) with the merchant's store-scoped API key via the existing `Adapter`, server-side only. Cache protocol:
  - Fetched table cached with **no expiry** — it is the last-known-good source and must survive refresh outages; staleness is tracked via `fetched_at`, not eviction.
  - 6h staleness window; stale/missing tables are refreshed opportunistically on the read path, guarded by a 5-minute failure cooldown so an API outage never adds a fetch round-trip to every `isAvailable()` call.
  - Cache key includes the API-key hash — a key swap (merchant change, sandbox ↔ production) never serves the old key's rates.
- **Cron `two_gateway_refresh_fx_rates`** (every 6h) — background refresh, once per distinct store-scoped API key; a failed refresh keeps the last-known-good table.
- **`CurrencyRatesProvider`** — now computes cross rates through the EUR pivot (`rates[from]/rates[to]`, the endpoint's own cross-rate formula). `CurrencyRatesProviderInterface` is unchanged, so all call sites (surcharge, min-order, admin config backends) are untouched.
- **Fail semantics (per spec)** — gate conversions use last-known-good and return null only when no table has *ever* been fetched; `MinimumOrderGate` platform floor fails **closed**, merchant bar now fails **open** (separate commit — this is the posture fix flagged in TWO-24739), display conversions fail soft at their existing call sites.
- Native Directory-rate path fully retired: no remaining `Magento\Directory` currency dependency; the `Currency::load` phpstan suppression is removed.

## Validation

- PHPUnit: 17 new tests covering cache/staleness behaviour (a second lookup inside the window hits cache, not the endpoint; stale + failed refresh serves last-known-good; failure cooldown suppresses refetch; never-fetched → null), the cross-currency scenario (GBP 100.00 → NOK 1376.47 from the endpoint rate, with no Directory dependency left), cron key-dedup, and the gate posture split. Full suite: 325 tests green.
- Codesniffer (Magento standard, severity 6): clean.
- Manual staging QA (display currency ≠ base currency shows live endpoint rates) still owed after merge, per ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)