### PR TITLE
PLAT-1939/ci: drop Linear from claude-review (public repo, no minting)

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -38,8 +38,6 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
     steps:
       - uses: two-inc/actions-public/claude-reviewer@main
-        env:
-          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_app_client_id: ${{ vars.TWO_INC_APP_CLIENT_ID }}


### PR DESCRIPTION
Removes the persisted `secrets.LINEAR_API_KEY` from this public repo's Claude reviewer workflow. Being a public repo, WIF token minting is not available here, so the Linear env var is simply dropped rather than replaced with a minted short-lived token (per the PLAT-1939 sweep spec for public/drop repos).

The org-level secret stays until all repos have migrated (PLAT-1939). Ref canary checkout-api#12562.