### PR TITLE
TWO-24758: self-invoice PDF upload gated on invoice_distributed_by_merchant

### DIFF
--- a/Cron/ProcessInvoiceUploads.php
+++ b/Cron/ProcessInvoiceUploads.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Two\Gateway\Cron;
 
 use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Lock\LockManagerInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Throwable;
 use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
@@ -19,11 +20,24 @@ use Two\Gateway\Service\Invoice\UploadService;
  * UPLOADING, so that work never runs inline in the HTTP request that
  * handles the shipment (see UploadService::queueForOrder /
  * SalesOrderShipmentAfter).
+ *
+ * A single order's worst-case latency across the 3 upload steps can
+ * exceed the 1-minute schedule (etc/crontab.xml), so nothing here
+ * guarantees the previous tick has finished before the next one starts
+ * — and Magento's cron scheduler only guarantees single-execution of
+ * one *schedule row*, not job-code-level mutual exclusion across ticks
+ * or replicas. Each order is claimed via a non-blocking
+ * LockManagerInterface lock before upload() runs, so an overlapping
+ * tick (or a second cron-eligible pod) skips an order already being
+ * worked instead of racing UploadService's read-modify-write on the
+ * same row (TWO-24758 review, Han/Yoda/Vader).
  */
 class ProcessInvoiceUploads
 {
     /** Cap batch size so one cron tick can't run indefinitely. */
     private const BATCH_SIZE = 50;
+
+    private const LOCK_PREFIX = 'two_gateway_invoice_upload_';
 
     /** @var OrderRepositoryInterface */
     private $orderRepository;
@@ -37,16 +51,21 @@ class ProcessInvoiceUploads
     /** @var LogRepository */
     private $logRepository;
 
+    /** @var LockManagerInterface */
+    private $lockManager;
+
     public function __construct(
         OrderRepositoryInterface $orderRepository,
         SearchCriteriaBuilder $searchCriteriaBuilder,
         UploadService $uploadService,
-        LogRepository $logRepository
+        LogRepository $logRepository,
+        LockManagerInterface $lockManager
     ) {
         $this->orderRepository = $orderRepository;
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;
         $this->uploadService = $uploadService;
         $this->logRepository = $logRepository;
+        $this->lockManager = $lockManager;
     }
 
     public function execute(): void
@@ -63,6 +82,13 @@ class ProcessInvoiceUploads
             if ($twoInvoiceId === '') {
                 continue;
             }
+
+            $lockName = self::LOCK_PREFIX . $order->getEntityId();
+            if (!$this->lockManager->lock($lockName, 0)) {
+                // Another tick/replica is already working this order.
+                continue;
+            }
+
             try {
                 $this->uploadService->upload($order, $twoInvoiceId);
             } catch (Throwable $e) {
@@ -70,6 +96,8 @@ class ProcessInvoiceUploads
                     'invoice-upload-cron-exception',
                     ['order_id' => $order->getEntityId(), 'error' => $e->getMessage()]
                 );
+            } finally {
+                $this->lockManager->unlock($lockName);
             }
         }
     }

--- a/Cron/ProcessInvoiceUploads.php
+++ b/Cron/ProcessInvoiceUploads.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Cron;
+
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Throwable;
+use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
+use Two\Gateway\Service\Invoice\UploadService;
+
+/**
+ * Runs the network-bound part of the self-invoice upload flow
+ * (render + 3-step upload) for orders the fulfilment observer left in
+ * UPLOADING, so that work never runs inline in the HTTP request that
+ * handles the shipment (see UploadService::queueForOrder /
+ * SalesOrderShipmentAfter).
+ */
+class ProcessInvoiceUploads
+{
+    /** Cap batch size so one cron tick can't run indefinitely. */
+    private const BATCH_SIZE = 50;
+
+    /** @var OrderRepositoryInterface */
+    private $orderRepository;
+
+    /** @var SearchCriteriaBuilder */
+    private $searchCriteriaBuilder;
+
+    /** @var UploadService */
+    private $uploadService;
+
+    /** @var LogRepository */
+    private $logRepository;
+
+    public function __construct(
+        OrderRepositoryInterface $orderRepository,
+        SearchCriteriaBuilder $searchCriteriaBuilder,
+        UploadService $uploadService,
+        LogRepository $logRepository
+    ) {
+        $this->orderRepository = $orderRepository;
+        $this->searchCriteriaBuilder = $searchCriteriaBuilder;
+        $this->uploadService = $uploadService;
+        $this->logRepository = $logRepository;
+    }
+
+    public function execute(): void
+    {
+        $searchCriteria = $this->searchCriteriaBuilder
+            ->addFilter('two_invoice_upload_status', UploadService::STATUS_UPLOADING)
+            ->setPageSize(self::BATCH_SIZE)
+            ->create();
+
+        $orders = $this->orderRepository->getList($searchCriteria)->getItems();
+
+        foreach ($orders as $order) {
+            $twoInvoiceId = (string)$order->getData('two_invoice_id');
+            if ($twoInvoiceId === '') {
+                continue;
+            }
+            try {
+                $this->uploadService->upload($order, $twoInvoiceId);
+            } catch (Throwable $e) {
+                $this->logRepository->addErrorLog(
+                    'invoice-upload-cron-exception',
+                    ['order_id' => $order->getEntityId(), 'error' => $e->getMessage()]
+                );
+            }
+        }
+    }
+}

--- a/Observer/SalesOrderShipmentAfter.php
+++ b/Observer/SalesOrderShipmentAfter.php
@@ -22,10 +22,10 @@ use Magento\Sales\Model\Service\InvoiceService;
 use Magento\Framework\DB\TransactionFactory;
 use Two\Gateway\Api\BrandRegistryInterface;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
+use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
 use Two\Gateway\Model\Two;
 use Two\Gateway\Service\Api\Adapter;
 use Two\Gateway\Service\Invoice\UploadService;
-use Two\Gateway\Service\Merchant\SettingsProvider;
 use Two\Gateway\Service\Order\ComposeShipment;
 
 /**
@@ -86,11 +86,11 @@ class SalesOrderShipmentAfter implements ObserverInterface
     /** @var \Two\Gateway\Api\BrandOverlayRegistryInterface */
     private $overlayRegistry;
 
-    /** @var SettingsProvider */
-    private $settingsProvider;
-
     /** @var UploadService */
     private $invoiceUploadService;
+
+    /** @var LogRepository */
+    private $logRepository;
 
     public function __construct(
         ConfigRepository $configRepository,
@@ -102,8 +102,8 @@ class SalesOrderShipmentAfter implements ObserverInterface
         InvoiceService $invoiceService,
         TransactionFactory $transactionFactory,
         \Two\Gateway\Api\BrandOverlayRegistryInterface $overlayRegistry,
-        SettingsProvider $settingsProvider,
-        UploadService $invoiceUploadService
+        UploadService $invoiceUploadService,
+        LogRepository $logRepository
     ) {
         $this->configRepository = $configRepository;
         $this->brandRegistry = $brandRegistry;
@@ -114,8 +114,8 @@ class SalesOrderShipmentAfter implements ObserverInterface
         $this->invoiceService = $invoiceService;
         $this->transactionFactory = $transactionFactory;
         $this->overlayRegistry = $overlayRegistry;
-        $this->settingsProvider = $settingsProvider;
         $this->invoiceUploadService = $invoiceUploadService;
+        $this->logRepository = $logRepository;
     }
 
     /**
@@ -192,19 +192,33 @@ class SalesOrderShipmentAfter implements ObserverInterface
             }
 
             // Self-invoice upload: gated solely on invoice_distributed_by_merchant
-            // from GET /v1/merchant (TWO-25106, Option A — no admin toggle). Only
-            // reachable once the Magento invoice exists (whole-order shipment),
-            // since the upload renders that invoice's PDF. This only marks the
-            // order for upload; the actual render + 3-step upload runs
-            // out-of-band via the ProcessInvoiceUploads cron so it never blocks
-            // this request (see UploadService::queueForOrder).
-            $twoInvoiceId = $response['fulfilled_order']['invoice_details']['id']
-                ?? $response['invoice_details']['id']
-                ?? null;
-            $this->invoiceUploadService->queueForOrder(
-                $order,
-                is_string($twoInvoiceId) ? $twoInvoiceId : null
-            );
+            // from GET /v1/merchant (TWO-25106, Option A — no admin toggle). This
+            // only marks the order for upload; the actual render + 3-step upload
+            // runs out-of-band via the ProcessInvoiceUploads cron so it never
+            // blocks this request (see UploadService::queueForOrder). A missing
+            // Magento invoice (e.g. a zero-grand-total order, skipped above) is
+            // handled inside UploadService as a legitimate NOT_APPLICABLE, not
+            // a failure — this call does not need to know whether one exists.
+            //
+            // Wrapped defensively: by this point Two has already been told the
+            // order is fulfilled and the Magento invoice/shipment already
+            // succeeded, so a transient failure writing the upload-queue status
+            // (e.g. a DB lock-wait on this same row) must not surface as a
+            // shipment-creation error (TWO-24758 review, Han).
+            try {
+                $twoInvoiceId = $response['fulfilled_order']['invoice_details']['id']
+                    ?? $response['invoice_details']['id']
+                    ?? null;
+                $this->invoiceUploadService->queueForOrder(
+                    $order,
+                    is_string($twoInvoiceId) ? $twoInvoiceId : null
+                );
+            } catch (Exception $e) {
+                $this->logRepository->addErrorLog(
+                    'invoice-upload-queue-exception',
+                    ['order_id' => $order->getEntityId(), 'error' => $e->getMessage()]
+                );
+            }
         }
     }
 

--- a/Observer/SalesOrderShipmentAfter.php
+++ b/Observer/SalesOrderShipmentAfter.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Two\Gateway\Observer;
 
 use Exception;
+use Throwable;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Exception\LocalizedException;
@@ -213,7 +214,12 @@ class SalesOrderShipmentAfter implements ObserverInterface
                     $order,
                     is_string($twoInvoiceId) ? $twoInvoiceId : null
                 );
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
+                // Throwable, not Exception: matches the cron's own choice
+                // (Cron/ProcessInvoiceUploads.php) and the guarantee this
+                // comment claims — a TypeError/Error here must not surface
+                // as a shipment-creation failure either (TWO-24758 review
+                // round 2, Han).
                 $this->logRepository->addErrorLog(
                     'invoice-upload-queue-exception',
                     ['order_id' => $order->getEntityId(), 'error' => $e->getMessage()]

--- a/Observer/SalesOrderShipmentAfter.php
+++ b/Observer/SalesOrderShipmentAfter.php
@@ -24,6 +24,8 @@ use Two\Gateway\Api\BrandRegistryInterface;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
 use Two\Gateway\Model\Two;
 use Two\Gateway\Service\Api\Adapter;
+use Two\Gateway\Service\Invoice\UploadService;
+use Two\Gateway\Service\Merchant\SettingsProvider;
 use Two\Gateway\Service\Order\ComposeShipment;
 
 /**
@@ -84,6 +86,12 @@ class SalesOrderShipmentAfter implements ObserverInterface
     /** @var \Two\Gateway\Api\BrandOverlayRegistryInterface */
     private $overlayRegistry;
 
+    /** @var SettingsProvider */
+    private $settingsProvider;
+
+    /** @var UploadService */
+    private $invoiceUploadService;
+
     public function __construct(
         ConfigRepository $configRepository,
         BrandRegistryInterface $brandRegistry,
@@ -93,7 +101,9 @@ class SalesOrderShipmentAfter implements ObserverInterface
         ComposeShipment $composeShipment,
         InvoiceService $invoiceService,
         TransactionFactory $transactionFactory,
-        \Two\Gateway\Api\BrandOverlayRegistryInterface $overlayRegistry
+        \Two\Gateway\Api\BrandOverlayRegistryInterface $overlayRegistry,
+        SettingsProvider $settingsProvider,
+        UploadService $invoiceUploadService
     ) {
         $this->configRepository = $configRepository;
         $this->brandRegistry = $brandRegistry;
@@ -104,6 +114,8 @@ class SalesOrderShipmentAfter implements ObserverInterface
         $this->invoiceService = $invoiceService;
         $this->transactionFactory = $transactionFactory;
         $this->overlayRegistry = $overlayRegistry;
+        $this->settingsProvider = $settingsProvider;
+        $this->invoiceUploadService = $invoiceUploadService;
     }
 
     /**
@@ -162,20 +174,37 @@ class SalesOrderShipmentAfter implements ObserverInterface
         // stand and create the Magento invoice on the final shipment.
         // CAPTURE_OFFLINE is critical — CAPTURE_ONLINE would route through
         // Two::capture() and post /fulfillments a second time.
-        if ($isWholeOrderShipped && !$order->hasInvoices()) {
-            $invoice = $this->invoiceService->prepareInvoice($order);
-            if ($invoice->getGrandTotal() > 0) {
-                $invoice->setRequestedCaptureCase(Invoice::CAPTURE_OFFLINE);
-                $invoice->register();
-                $invoice->pay();
-                $invoice->setTransactionId(
-                    $response['fulfilled_order']['id'] ?? $order->getPayment()->getLastTransId()
-                );
-                $this->transactionFactory->create()
-                    ->addObject($invoice)
-                    ->addObject($order)
-                    ->save();
+        if ($isWholeOrderShipped) {
+            if (!$order->hasInvoices()) {
+                $invoice = $this->invoiceService->prepareInvoice($order);
+                if ($invoice->getGrandTotal() > 0) {
+                    $invoice->setRequestedCaptureCase(Invoice::CAPTURE_OFFLINE);
+                    $invoice->register();
+                    $invoice->pay();
+                    $invoice->setTransactionId(
+                        $response['fulfilled_order']['id'] ?? $order->getPayment()->getLastTransId()
+                    );
+                    $this->transactionFactory->create()
+                        ->addObject($invoice)
+                        ->addObject($order)
+                        ->save();
+                }
             }
+
+            // Self-invoice upload: gated solely on invoice_distributed_by_merchant
+            // from GET /v1/merchant (TWO-25106, Option A — no admin toggle). Only
+            // reachable once the Magento invoice exists (whole-order shipment),
+            // since the upload renders that invoice's PDF. This only marks the
+            // order for upload; the actual render + 3-step upload runs
+            // out-of-band via the ProcessInvoiceUploads cron so it never blocks
+            // this request (see UploadService::queueForOrder).
+            $twoInvoiceId = $response['fulfilled_order']['invoice_details']['id']
+                ?? $response['invoice_details']['id']
+                ?? null;
+            $this->invoiceUploadService->queueForOrder(
+                $order,
+                is_string($twoInvoiceId) ? $twoInvoiceId : null
+            );
         }
     }
 

--- a/Service/Invoice/NoInvoiceException.php
+++ b/Service/Invoice/NoInvoiceException.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Service\Invoice;
+
+use RuntimeException;
+
+/**
+ * Thrown by UploadService::renderInvoicePdf() when the order has no
+ * Magento invoice yet. Distinct from a generic render failure so the
+ * caller can resolve to NOT_APPLICABLE (a legitimate outcome, e.g. a
+ * zero-grand-total order that never gets a Magento invoice) instead of
+ * FAILED.
+ */
+class NoInvoiceException extends RuntimeException
+{
+}

--- a/Service/Invoice/UploadService.php
+++ b/Service/Invoice/UploadService.php
@@ -111,8 +111,14 @@ class UploadService
     {
         $currentStatus = (string)$order->getData('two_invoice_upload_status');
 
-        // Duplicate guard: never re-queue a terminal UPLOADED order.
-        if ($currentStatus === self::STATUS_UPLOADED) {
+        // Duplicate guard: never re-queue a terminal UPLOADED order, and
+        // never re-queue an order already UPLOADING — Magento is known to
+        // occasionally dispatch sales_order_shipment_save_after more than
+        // once for the same shipment, and a second call resetting
+        // two_invoice_upload_reference/error here would race the cron's
+        // upload() if it's already mid-flight for this order (TWO-24758
+        // review, Han/Vader).
+        if ($currentStatus === self::STATUS_UPLOADED || $currentStatus === self::STATUS_UPLOADING) {
             return;
         }
 
@@ -154,14 +160,40 @@ class UploadService
     public function upload($order, string $twoInvoiceId): void
     {
         $orderId = (int)$order->getEntityId();
+        $storeId = (int)$order->getStoreId();
 
         if ((string)$order->getData('two_invoice_upload_status') === self::STATUS_UPLOADED) {
             // Already completed by a previous run; nothing to do.
             return;
         }
 
+        // Re-check the gate at execution time, not just at queue time: the
+        // cron can run minutes after queueForOrder(), and the merchant may
+        // have flipped invoice_distributed_by_merchant to false in between
+        // (TWO-24758 review, Vader). A flip the other way (false -> true)
+        // is not retro-actively picked up for orders already resolved to
+        // NOT_APPLICABLE; that is an accepted limitation, not a bug fixed
+        // here.
+        if (!$this->settingsProvider->isInvoiceDistributedByMerchant($storeId)) {
+            $this->persistStatus($order, self::STATUS_NOT_APPLICABLE);
+            $order->setData('two_invoice_upload_error', null);
+            $this->orderRepository->save($order);
+            return;
+        }
+
         try {
             $pdfContent = $this->renderInvoicePdf($order);
+        } catch (NoInvoiceException $e) {
+            // Legitimately nothing to upload (e.g. a zero-grand-total
+            // order never gets a Magento invoice) — not a failure.
+            $this->persistStatus($order, self::STATUS_NOT_APPLICABLE);
+            $order->setData('two_invoice_upload_error', null);
+            $this->orderRepository->save($order);
+            $this->logRepository->addDebugLog(
+                'invoice-upload-not-applicable',
+                ['order_id' => $orderId, 'reason' => $e->getMessage()]
+            );
+            return;
         } catch (Throwable $e) {
             $this->fail($order, 'Failed to render invoice PDF: ' . $e->getMessage());
             return;
@@ -180,7 +212,7 @@ class UploadService
             return;
         }
 
-        $signedUrl = $this->requestSignedUploadUrl($twoInvoiceId);
+        $signedUrl = $this->requestSignedUploadUrl($twoInvoiceId, $storeId);
         if (!$signedUrl['success']) {
             $this->fail($order, $signedUrl['error']);
             return;
@@ -194,7 +226,7 @@ class UploadService
 
         $order->setData('two_invoice_upload_reference', $signedUrl['reference']);
 
-        $statusResult = $this->pollUploadStatus($signedUrl['reference'], $orderId);
+        $statusResult = $this->pollUploadStatus($signedUrl['reference'], $orderId, $storeId);
         if (!$statusResult['success']) {
             $this->fail($order, $statusResult['error']);
             return;
@@ -205,13 +237,21 @@ class UploadService
 
     /**
      * @return string Raw PDF bytes
+     * @throws NoInvoiceException When the order has no Magento invoice yet
+     *         (a legitimate NOT_APPLICABLE case, e.g. a zero-grand-total
+     *         order that never gets one) — distinct from a genuine render
+     *         failure so the caller doesn't mark it FAILED.
      */
     private function renderInvoicePdf($order): string
     {
         $invoices = $order->getInvoiceCollection();
-        $invoice = $invoices !== null ? $invoices->getFirstItem() : null;
+        // Most-recently-created invoice, not blindly the first: an order
+        // can already carry an earlier (e.g. partial/admin-created)
+        // invoice, and the one from this fulfilment is what should be
+        // uploaded (TWO-24758 review, Vader).
+        $invoice = $invoices !== null ? $invoices->getLastItem() : null;
         if ($invoice === null || !$invoice->getEntityId()) {
-            throw new \RuntimeException('No Magento invoice found for order');
+            throw new NoInvoiceException('No Magento invoice found for order');
         }
 
         $pdf = $this->invoicePdf->getPdf([$invoice]);
@@ -223,13 +263,24 @@ class UploadService
      *
      * @return array{success:bool,url?:string,headers?:array,reference?:string,error?:string}
      */
-    private function requestSignedUploadUrl(string $twoInvoiceId): array
+    private function requestSignedUploadUrl(string $twoInvoiceId, int $storeId): array
     {
         $endpoint = '/uploads/v1/invoice/' . rawurlencode($twoInvoiceId) . '/external_invoice/' . self::UPLOAD_INDEX;
-        $response = $this->apiAdapter->execute($endpoint, ['content_type' => 'application/pdf'], 'PUT');
+        $response = $this->apiAdapter->execute(
+            $endpoint,
+            ['content_type' => 'application/pdf'],
+            'PUT',
+            $storeId
+        );
 
+        // Adapter::execute() only ever injects http_status on its
+        // non-2xx branch; a bare presence check (rather than pinning to
+        // one literal success code) matches the >=400 idiom already used
+        // elsewhere in this codebase (Service/Order/SurchargeCalculator.php)
+        // and tolerates an endpoint that might echo http_status as benign
+        // response data on success (TWO-24758 review, Yoda).
         $httpStatus = isset($response['http_status']) ? (int)$response['http_status'] : 0;
-        if ($httpStatus !== 0 && $httpStatus !== 202) {
+        if ($httpStatus >= 400) {
             return ['success' => false, 'error' => $this->parseSignedUrlError($response, $httpStatus)];
         }
 
@@ -320,15 +371,20 @@ class UploadService
      *
      * @return array{success:bool,error?:string}
      */
-    private function pollUploadStatus(string $reference, int $orderId): array
+    private function pollUploadStatus(string $reference, int $orderId, int $storeId): array
     {
         $startTime = time();
 
         while ((time() - $startTime) < self::POLLING_TIMEOUT) {
-            $response = $this->apiAdapter->execute('/uploads/v1/status/' . rawurlencode($reference), [], 'GET');
+            $response = $this->apiAdapter->execute(
+                '/uploads/v1/status/' . rawurlencode($reference),
+                [],
+                'GET',
+                $storeId
+            );
             $httpStatus = isset($response['http_status']) ? (int)$response['http_status'] : 0;
 
-            if ($httpStatus !== 0 && $httpStatus !== 200) {
+            if ($httpStatus >= 400) {
                 return ['success' => false, 'error' => 'Failed to poll upload status (HTTP ' . $httpStatus . ')'];
             }
 

--- a/Service/Invoice/UploadService.php
+++ b/Service/Invoice/UploadService.php
@@ -1,0 +1,398 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Service\Invoice;
+
+use Magento\Framework\HTTP\Client\CurlFactory;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Pdf\Invoice as InvoicePdf;
+use Magento\Sales\Model\Order\Status\HistoryFactory;
+use Magento\Sales\Api\OrderStatusHistoryRepositoryInterface;
+use Throwable;
+use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
+use Two\Gateway\Service\Api\Adapter;
+use Two\Gateway\Service\Merchant\SettingsProvider;
+
+/**
+ * Uploads a merchant-generated invoice PDF to Two, mirroring the shipped
+ * PrestaShop pattern (TwoInvoiceUploadService.php) via checkout-api's
+ * 3-step signed-URL flow:
+ *
+ *   1. PUT /uploads/v1/invoice/{invoice_id}/external_invoice/{index}
+ *      -> signed GCS URL + reference
+ *   2. PUT {signed_url} with the raw PDF bytes -> GCS
+ *   3. GET /uploads/v1/status/{reference} -> poll until resolved
+ *
+ * Gated solely on invoice_distributed_by_merchant from GET /v1/merchant
+ * (TWO-25106, Option A — no admin toggle). Renders the invoice with
+ * Magento's native Magento\Sales\Model\Order\Pdf\Invoice.
+ *
+ * Split into two phases so the network-bound work never runs inline in
+ * the fulfilment observer (PHP max_execution_time risk):
+ *  - queueForOrder(): gate check + cheap DB write only, called from the
+ *    observer synchronously.
+ *  - upload(): the actual render + 3-step upload, called from the
+ *    ProcessInvoiceUploads cron for orders left in UPLOADING.
+ */
+class UploadService
+{
+    public const STATUS_NOT_APPLICABLE = 'NOT_APPLICABLE';
+    public const STATUS_UPLOADING = 'UPLOADING';
+    public const STATUS_UPLOADED = 'UPLOADED';
+    public const STATUS_FAILED = 'FAILED';
+
+    private const MAX_FILE_SIZE = 2097152;
+    private const POLLING_TIMEOUT = 60;
+    private const POLLING_INTERVAL = 1;
+    private const MAX_RETRIES = 3;
+    private const UPLOAD_INDEX = 0;
+
+    /** @var SettingsProvider */
+    private $settingsProvider;
+
+    /** @var Adapter */
+    private $apiAdapter;
+
+    /** @var InvoicePdf */
+    private $invoicePdf;
+
+    /** @var OrderRepositoryInterface */
+    private $orderRepository;
+
+    /** @var HistoryFactory */
+    private $historyFactory;
+
+    /** @var OrderStatusHistoryRepositoryInterface */
+    private $orderStatusHistoryRepository;
+
+    /** @var CurlFactory */
+    private $curlFactory;
+
+    /** @var LogRepository */
+    private $logRepository;
+
+    public function __construct(
+        SettingsProvider $settingsProvider,
+        Adapter $apiAdapter,
+        InvoicePdf $invoicePdf,
+        OrderRepositoryInterface $orderRepository,
+        HistoryFactory $historyFactory,
+        OrderStatusHistoryRepositoryInterface $orderStatusHistoryRepository,
+        CurlFactory $curlFactory,
+        LogRepository $logRepository
+    ) {
+        $this->settingsProvider = $settingsProvider;
+        $this->apiAdapter = $apiAdapter;
+        $this->invoicePdf = $invoicePdf;
+        $this->orderRepository = $orderRepository;
+        $this->historyFactory = $historyFactory;
+        $this->orderStatusHistoryRepository = $orderStatusHistoryRepository;
+        $this->curlFactory = $curlFactory;
+        $this->logRepository = $logRepository;
+    }
+
+    /**
+     * Called synchronously from the fulfilment observer. Cheap only:
+     * a gate check and a status write. The actual render + upload is
+     * left for the cron (upload()) so the observer never blocks on
+     * network I/O.
+     *
+     * @param OrderInterface|Order $order
+     * @param string|null $twoInvoiceId Two's invoice id from the
+     *        fulfilments response (null if not present/resolvable)
+     */
+    public function queueForOrder($order, ?string $twoInvoiceId): void
+    {
+        $currentStatus = (string)$order->getData('two_invoice_upload_status');
+
+        // Duplicate guard: never re-queue a terminal UPLOADED order.
+        if ($currentStatus === self::STATUS_UPLOADED) {
+            return;
+        }
+
+        if (!$this->settingsProvider->isInvoiceDistributedByMerchant((int)$order->getStoreId())) {
+            $this->persistStatus($order, self::STATUS_NOT_APPLICABLE);
+            $this->orderRepository->save($order);
+            return;
+        }
+
+        if ($twoInvoiceId === null || $twoInvoiceId === '') {
+            $this->logRepository->addErrorLog(
+                'invoice-upload-queue',
+                [
+                    'order_id' => $order->getEntityId(),
+                    'message' => 'Two invoice id missing on fulfilment response; cannot queue upload',
+                ]
+            );
+            $this->persistStatus($order, self::STATUS_NOT_APPLICABLE);
+            $this->orderRepository->save($order);
+            return;
+        }
+
+        $order->setData('two_invoice_id', $twoInvoiceId);
+        $order->setData('two_invoice_upload_reference', null);
+        $order->setData('two_invoice_upload_error', null);
+        $this->persistStatus($order, self::STATUS_UPLOADING);
+        $this->orderRepository->save($order);
+    }
+
+    /**
+     * Called from the ProcessInvoiceUploads cron for orders left in
+     * UPLOADING. Renders the Magento invoice PDF natively and runs the
+     * 3-step upload, persisting one of UPLOADED / FAILED on completion
+     * and adding an order history comment.
+     *
+     * @param OrderInterface|Order $order
+     * @param string $twoInvoiceId
+     */
+    public function upload($order, string $twoInvoiceId): void
+    {
+        $orderId = (int)$order->getEntityId();
+
+        if ((string)$order->getData('two_invoice_upload_status') === self::STATUS_UPLOADED) {
+            // Already completed by a previous run; nothing to do.
+            return;
+        }
+
+        try {
+            $pdfContent = $this->renderInvoicePdf($order);
+        } catch (Throwable $e) {
+            $this->fail($order, 'Failed to render invoice PDF: ' . $e->getMessage());
+            return;
+        }
+
+        $pdfSize = strlen($pdfContent);
+        if ($pdfSize === 0) {
+            $this->fail($order, 'Invoice PDF is empty');
+            return;
+        }
+        if ($pdfSize > self::MAX_FILE_SIZE) {
+            $this->fail(
+                $order,
+                'Invoice PDF exceeds maximum size (2MB). Size: ' . round($pdfSize / 1024 / 1024, 2) . 'MB'
+            );
+            return;
+        }
+
+        $signedUrl = $this->requestSignedUploadUrl($twoInvoiceId);
+        if (!$signedUrl['success']) {
+            $this->fail($order, $signedUrl['error']);
+            return;
+        }
+
+        $uploadResult = $this->uploadToCloudStorage($signedUrl['url'], $signedUrl['headers'], $pdfContent);
+        if (!$uploadResult['success']) {
+            $this->fail($order, $uploadResult['error']);
+            return;
+        }
+
+        $order->setData('two_invoice_upload_reference', $signedUrl['reference']);
+
+        $statusResult = $this->pollUploadStatus($signedUrl['reference'], $orderId);
+        if (!$statusResult['success']) {
+            $this->fail($order, $statusResult['error']);
+            return;
+        }
+
+        $this->succeed($order);
+    }
+
+    /**
+     * @return string Raw PDF bytes
+     */
+    private function renderInvoicePdf($order): string
+    {
+        $invoices = $order->getInvoiceCollection();
+        $invoice = $invoices !== null ? $invoices->getFirstItem() : null;
+        if ($invoice === null || !$invoice->getEntityId()) {
+            throw new \RuntimeException('No Magento invoice found for order');
+        }
+
+        $pdf = $this->invoicePdf->getPdf([$invoice]);
+        return (string)$pdf->render();
+    }
+
+    /**
+     * Step 1: request signed upload URL from checkout-api.
+     *
+     * @return array{success:bool,url?:string,headers?:array,reference?:string,error?:string}
+     */
+    private function requestSignedUploadUrl(string $twoInvoiceId): array
+    {
+        $endpoint = '/uploads/v1/invoice/' . rawurlencode($twoInvoiceId) . '/external_invoice/' . self::UPLOAD_INDEX;
+        $response = $this->apiAdapter->execute($endpoint, ['content_type' => 'application/pdf'], 'PUT');
+
+        $httpStatus = isset($response['http_status']) ? (int)$response['http_status'] : 0;
+        if ($httpStatus !== 0 && $httpStatus !== 202) {
+            return ['success' => false, 'error' => $this->parseSignedUrlError($response, $httpStatus)];
+        }
+
+        if (!isset($response['url'], $response['headers'], $response['reference'])) {
+            return ['success' => false, 'error' => 'Invalid response from Two API (missing url/headers/reference)'];
+        }
+
+        return [
+            'success' => true,
+            'url' => $response['url'],
+            'headers' => $response['headers'],
+            'reference' => $response['reference'],
+        ];
+    }
+
+    private function parseSignedUrlError(array $response, int $httpStatus): string
+    {
+        switch ($httpStatus) {
+            case 403:
+                return 'Merchant not permitted for invoice uploads (invoice_distributed_by_merchant is false server-side)';
+            case 404:
+                return 'Invoice not found. Order may not be fulfilled yet.';
+            case 409:
+                return 'Invoice already uploaded for this index.';
+            case 422:
+                return 'Validation error: invalid content type (must be application/pdf)';
+            default:
+                if (isset($response['error_message'])) {
+                    return (string)$response['error_message'];
+                }
+                return 'Failed to request upload URL (HTTP ' . $httpStatus . ')';
+        }
+    }
+
+    /**
+     * Step 2: PUT the PDF bytes to the signed GCS URL. Retries on
+     * network errors / 5xx (up to MAX_RETRIES); never retries on 4xx.
+     *
+     * @return array{success:bool,error?:string}
+     */
+    private function uploadToCloudStorage(string $url, array $headers, string $pdfContent): array
+    {
+        $lastError = 'Unknown error';
+
+        for ($attempt = 1; $attempt <= self::MAX_RETRIES; $attempt++) {
+            $curl = $this->curlFactory->create();
+            foreach ($headers as $name => $value) {
+                $curl->addHeader((string)$name, (string)$value);
+            }
+            $curl->setOption(CURLOPT_CUSTOMREQUEST, 'PUT');
+            $curl->setOption(CURLOPT_SSL_VERIFYPEER, true);
+            $curl->setOption(CURLOPT_FOLLOWLOCATION, false);
+            $curl->setOption(CURLOPT_TIMEOUT, 30);
+
+            try {
+                $curl->addHeader('Content-Length', (string)strlen($pdfContent));
+                $curl->post($url, $pdfContent);
+                $httpCode = (int)$curl->getStatus();
+            } catch (Throwable $e) {
+                $lastError = 'Network error: ' . $e->getMessage();
+                if ($attempt < self::MAX_RETRIES) {
+                    continue;
+                }
+                break;
+            }
+
+            if ($httpCode === 200) {
+                return ['success' => true];
+            }
+
+            $lastError = 'HTTP ' . $httpCode . ': ' . substr((string)$curl->getBody(), 0, 200);
+
+            // 4xx: don't retry, these won't succeed.
+            if ($httpCode >= 400 && $httpCode < 500) {
+                break;
+            }
+        }
+
+        return [
+            'success' => false,
+            'error' => 'Failed to upload to cloud storage after ' . self::MAX_RETRIES . ' attempt(s). '
+                . 'Last error: ' . $lastError,
+        ];
+    }
+
+    /**
+     * Step 3: poll GET /uploads/v1/status/{reference} until resolved.
+     *
+     * @return array{success:bool,error?:string}
+     */
+    private function pollUploadStatus(string $reference, int $orderId): array
+    {
+        $startTime = time();
+
+        while ((time() - $startTime) < self::POLLING_TIMEOUT) {
+            $response = $this->apiAdapter->execute('/uploads/v1/status/' . rawurlencode($reference), [], 'GET');
+            $httpStatus = isset($response['http_status']) ? (int)$response['http_status'] : 0;
+
+            if ($httpStatus !== 0 && $httpStatus !== 200) {
+                return ['success' => false, 'error' => 'Failed to poll upload status (HTTP ' . $httpStatus . ')'];
+            }
+
+            $status = isset($response['status']) ? strtoupper((string)$response['status']) : '';
+
+            switch ($status) {
+                case 'OK':
+                    return ['success' => true];
+                case 'INVALID':
+                    return ['success' => false, 'error' => 'Upload validation failed. PDF may be corrupted or invalid.'];
+                case 'PENDING':
+                case 'PROCESSING':
+                case 'AWAITING_UPLOAD':
+                    sleep(self::POLLING_INTERVAL);
+                    break;
+                default:
+                    return ['success' => false, 'error' => 'Unknown status: ' . $status];
+            }
+        }
+
+        return [
+            'success' => false,
+            'error' => 'Upload status polling timeout after ' . self::POLLING_TIMEOUT . ' seconds.'
+                . ' Upload may still complete in background.',
+        ];
+    }
+
+    private function succeed($order): void
+    {
+        $this->persistStatus($order, self::STATUS_UPLOADED);
+        $order->setData('two_invoice_uploaded_at', date('Y-m-d H:i:s'));
+        $order->setData('two_invoice_upload_error', null);
+        $this->orderRepository->save($order);
+        $this->addHistoryComment($order, __('Invoice uploaded to Two successfully.'));
+        $this->logRepository->addDebugLog(
+            'invoice-upload-complete',
+            ['order_id' => $order->getEntityId()]
+        );
+    }
+
+    private function fail($order, string $error): void
+    {
+        $this->persistStatus($order, self::STATUS_FAILED);
+        $order->setData('two_invoice_upload_error', $error);
+        $this->orderRepository->save($order);
+        $this->addHistoryComment($order, __('Invoice upload failed: %1', $error));
+        $this->logRepository->addErrorLog(
+            'invoice-upload-failed',
+            ['order_id' => $order->getEntityId(), 'error' => $error]
+        );
+    }
+
+    private function persistStatus($order, string $status): void
+    {
+        $order->setData('two_invoice_upload_status', $status);
+    }
+
+    private function addHistoryComment($order, $comment): void
+    {
+        $history = $this->historyFactory->create();
+        $history->setParentId($order->getEntityId())
+            ->setComment((string)$comment)
+            ->setEntityName('order')
+            ->setStatus($order->getStatus());
+        $this->orderStatusHistoryRepository->save($history);
+    }
+}

--- a/Service/Invoice/UploadService.php
+++ b/Service/Invoice/UploadService.php
@@ -245,11 +245,21 @@ class UploadService
     private function renderInvoicePdf($order): string
     {
         $invoices = $order->getInvoiceCollection();
-        // Most-recently-created invoice, not blindly the first: an order
-        // can already carry an earlier (e.g. partial/admin-created)
-        // invoice, and the one from this fulfilment is what should be
-        // uploaded (TWO-24758 review, Vader).
-        $invoice = $invoices !== null ? $invoices->getLastItem() : null;
+        $invoice = null;
+        if ($invoices !== null) {
+            // Explicitly sort on entity_id (creation order) rather than
+            // trusting the collection's implicit load order: an order can
+            // already carry an earlier (e.g. partial/admin-created)
+            // invoice, and only the one from this fulfilment — the most
+            // recently created — should be uploaded. getLastItem() alone
+            // is "less wrong", not guaranteed, since it depends on the
+            // collection's default load order matching creation order
+            // (TWO-24758 review round 2, Vader).
+            if (method_exists($invoices, 'setOrder')) {
+                $invoices->setOrder('entity_id', 'DESC');
+            }
+            $invoice = $invoices->getFirstItem();
+        }
         if ($invoice === null || !$invoice->getEntityId()) {
             throw new NoInvoiceException('No Magento invoice found for order');
         }

--- a/Service/Merchant/SettingsProvider.php
+++ b/Service/Merchant/SettingsProvider.php
@@ -112,4 +112,22 @@ class SettingsProvider
         }
         return (int)$due;
     }
+
+    /**
+     * Whether the merchant self-distributes their own invoices to the
+     * buyer (invoice_distributed_by_merchant on the merchant record).
+     * Absent, unresolvable, or malformed all degrade to false — the
+     * plugin only ever generates/uploads an invoice PDF when the
+     * merchant record explicitly says so. This is the sole gate: there
+     * is deliberately no admin-configurable override (TWO-25106,
+     * Option A).
+     */
+    public function isInvoiceDistributedByMerchant(?int $storeId = null): bool
+    {
+        $record = $this->recordProvider->getRecord($storeId);
+        if ($record === null) {
+            return false;
+        }
+        return ($record['invoice_distributed_by_merchant'] ?? false) === true;
+    }
 }

--- a/Test/Stubs/InvoiceUpload.php
+++ b/Test/Stubs/InvoiceUpload.php
@@ -77,10 +77,14 @@ if (!class_exists(SearchCriteria::class, false)) {
     }
 }
 
-if (!interface_exists(SearchResultsInterface::class, false)) {
-    interface SearchResultsInterface
+namespace Magento\Framework\Lock;
+
+if (!interface_exists(LockManagerInterface::class, false)) {
+    interface LockManagerInterface
     {
-        public function getItems();
+        public function lock(string $name, int $timeout = -1): bool;
+        public function unlock(string $name): bool;
+        public function isLocked(string $name): bool;
     }
 }
 

--- a/Test/Stubs/InvoiceUpload.php
+++ b/Test/Stubs/InvoiceUpload.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Stubs for the Magento collaborators the self-invoice-upload flow
+ * (Service/Invoice/UploadService.php, Cron/ProcessInvoiceUploads.php)
+ * depends on. The bootstrap catch-all autoloader only produces empty,
+ * method-less classes/interfaces, which PHPUnit's createMock() cannot
+ * configure methods on — these stubs declare the real method surface
+ * so the mocks in UploadServiceTest / ProcessInvoiceUploadsTest work.
+ */
+declare(strict_types=1);
+
+namespace Magento\Sales\Model\Order\Status;
+
+use Two\Gateway\Test\Stubs\AbstractSalesModelStub;
+
+if (!class_exists(History::class, false)) {
+    class History extends AbstractSalesModelStub
+    {
+    }
+}
+
+if (!class_exists(HistoryFactory::class, false)) {
+    class HistoryFactory
+    {
+        public function create(): History
+        {
+            return new History();
+        }
+    }
+}
+
+namespace Magento\Sales\Api;
+
+if (!interface_exists(OrderStatusHistoryRepositoryInterface::class, false)) {
+    interface OrderStatusHistoryRepositoryInterface
+    {
+        public function save($entry);
+    }
+}
+
+if (!interface_exists(OrderRepositoryInterface::class, false)) {
+    interface OrderRepositoryInterface
+    {
+        public function get($id);
+        public function save($order);
+        public function getList($searchCriteria);
+        public function delete($order);
+        public function deleteById($id);
+    }
+}
+
+namespace Magento\Framework\Api;
+
+if (!class_exists(SearchCriteriaBuilder::class, false)) {
+    class SearchCriteriaBuilder
+    {
+        public function addFilter($field, $value, $conditionType = 'eq'): self
+        {
+            return $this;
+        }
+
+        public function setPageSize(int $pageSize): self
+        {
+            return $this;
+        }
+
+        public function create()
+        {
+            return new SearchCriteria();
+        }
+    }
+}
+
+if (!class_exists(SearchCriteria::class, false)) {
+    class SearchCriteria
+    {
+    }
+}
+
+if (!interface_exists(SearchResultsInterface::class, false)) {
+    interface SearchResultsInterface
+    {
+        public function getItems();
+    }
+}
+
+namespace Magento\Sales\Model\Order\Pdf;
+
+if (!class_exists(Invoice::class, false)) {
+    /**
+     * @method array getPdf(array $invoices)
+     */
+    class Invoice
+    {
+        public function getPdf(array $invoices)
+        {
+            return new PdfDocumentStub();
+        }
+    }
+
+    class PdfDocumentStub
+    {
+        public function render(): string
+        {
+            return '';
+        }
+    }
+}

--- a/Test/Unit/Cron/ProcessInvoiceUploadsTest.php
+++ b/Test/Unit/Cron/ProcessInvoiceUploadsTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Two\Gateway\Test\Unit\Cron;
 
 use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Lock\LockManagerInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Magento\Sales\Model\Order;
 use PHPUnit\Framework\TestCase;
@@ -26,6 +27,9 @@ class ProcessInvoiceUploadsTest extends TestCase
     /** @var LogRepository|\PHPUnit\Framework\MockObject\MockObject */
     private $logRepository;
 
+    /** @var LockManagerInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $lockManager;
+
     /** @var ProcessInvoiceUploads */
     private $cron;
 
@@ -34,12 +38,15 @@ class ProcessInvoiceUploadsTest extends TestCase
         $this->orderRepository = $this->createMock(OrderRepositoryInterface::class);
         $this->uploadService = $this->createMock(UploadService::class);
         $this->logRepository = $this->createMock(LogRepository::class);
+        $this->lockManager = $this->createMock(LockManagerInterface::class);
+        $this->lockManager->method('lock')->willReturn(true);
 
         $this->cron = new ProcessInvoiceUploads(
             $this->orderRepository,
             new SearchCriteriaBuilder(),
             $this->uploadService,
-            $this->logRepository
+            $this->logRepository,
+            $this->lockManager
         );
     }
 
@@ -96,6 +103,41 @@ class ProcessInvoiceUploadsTest extends TestCase
                 }
             });
         $this->logRepository->expects($this->once())->method('addErrorLog');
+
+        $this->cron->execute();
+    }
+
+    public function testSkipsOrderAlreadyLockedByAnotherRun(): void
+    {
+        // A prior tick (or another replica) is still working this order —
+        // upload() must not be called a second time concurrently.
+        $order = $this->makeOrder(1, 'inv-a');
+        $this->stubSearchResults([$order]);
+        $this->lockManager = $this->createMock(LockManagerInterface::class);
+        $this->lockManager->method('lock')->willReturn(false);
+        $this->cron = new ProcessInvoiceUploads(
+            $this->orderRepository,
+            new SearchCriteriaBuilder(),
+            $this->uploadService,
+            $this->logRepository,
+            $this->lockManager
+        );
+
+        $this->uploadService->expects($this->never())->method('upload');
+        $this->lockManager->expects($this->never())->method('unlock');
+
+        $this->cron->execute();
+    }
+
+    public function testReleasesLockAfterProcessingEvenOnException(): void
+    {
+        $order = $this->makeOrder(1, 'inv-a');
+        $this->stubSearchResults([$order]);
+        $this->uploadService->method('upload')->willThrowException(new \RuntimeException('boom'));
+
+        $this->lockManager->expects($this->once())->method('lock')->with('two_gateway_invoice_upload_1', 0)
+            ->willReturn(true);
+        $this->lockManager->expects($this->once())->method('unlock')->with('two_gateway_invoice_upload_1');
 
         $this->cron->execute();
     }

--- a/Test/Unit/Cron/ProcessInvoiceUploadsTest.php
+++ b/Test/Unit/Cron/ProcessInvoiceUploadsTest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Cron;
+
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\Order;
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
+use Two\Gateway\Cron\ProcessInvoiceUploads;
+use Two\Gateway\Service\Invoice\UploadService;
+
+class ProcessInvoiceUploadsTest extends TestCase
+{
+    /** @var OrderRepositoryInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $orderRepository;
+
+    /** @var UploadService|\PHPUnit\Framework\MockObject\MockObject */
+    private $uploadService;
+
+    /** @var LogRepository|\PHPUnit\Framework\MockObject\MockObject */
+    private $logRepository;
+
+    /** @var ProcessInvoiceUploads */
+    private $cron;
+
+    protected function setUp(): void
+    {
+        $this->orderRepository = $this->createMock(OrderRepositoryInterface::class);
+        $this->uploadService = $this->createMock(UploadService::class);
+        $this->logRepository = $this->createMock(LogRepository::class);
+
+        $this->cron = new ProcessInvoiceUploads(
+            $this->orderRepository,
+            new SearchCriteriaBuilder(),
+            $this->uploadService,
+            $this->logRepository
+        );
+    }
+
+    private function makeOrder(int $id, string $twoInvoiceId): Order
+    {
+        $order = new Order();
+        $order->setData('entity_id', $id);
+        $order->setData('two_invoice_id', $twoInvoiceId);
+        return $order;
+    }
+
+    public function testProcessesEachOrderReturnedByTheSearch(): void
+    {
+        $orderA = $this->makeOrder(1, 'inv-a');
+        $orderB = $this->makeOrder(2, 'inv-b');
+        $this->stubSearchResults([$orderA, $orderB]);
+
+        $this->uploadService->expects($this->exactly(2))->method('upload')
+            ->willReturnCallback(function ($order, $twoInvoiceId) use ($orderA, $orderB) {
+                static $call = 0;
+                $call++;
+                if ($call === 1) {
+                    $this->assertSame($orderA, $order);
+                    $this->assertSame('inv-a', $twoInvoiceId);
+                } else {
+                    $this->assertSame($orderB, $order);
+                    $this->assertSame('inv-b', $twoInvoiceId);
+                }
+            });
+
+        $this->cron->execute();
+    }
+
+    public function testSkipsOrderMissingTwoInvoiceId(): void
+    {
+        $order = $this->makeOrder(1, '');
+        $this->stubSearchResults([$order]);
+
+        $this->uploadService->expects($this->never())->method('upload');
+
+        $this->cron->execute();
+    }
+
+    public function testExceptionFromOneOrderDoesNotStopTheBatch(): void
+    {
+        $orderA = $this->makeOrder(1, 'inv-a');
+        $orderB = $this->makeOrder(2, 'inv-b');
+        $this->stubSearchResults([$orderA, $orderB]);
+
+        $this->uploadService->expects($this->exactly(2))->method('upload')
+            ->willReturnCallback(function ($order) use ($orderA) {
+                if ($order === $orderA) {
+                    throw new \RuntimeException('boom');
+                }
+            });
+        $this->logRepository->expects($this->once())->method('addErrorLog');
+
+        $this->cron->execute();
+    }
+
+    private function stubSearchResults(array $orders): void
+    {
+        $searchResults = new class ($orders) {
+            private $orders;
+            public function __construct(array $orders)
+            {
+                $this->orders = $orders;
+            }
+            public function getItems(): array
+            {
+                return $this->orders;
+            }
+        };
+        $this->orderRepository->method('getList')->willReturn($searchResults);
+    }
+}

--- a/Test/Unit/Service/Invoice/UploadServiceTest.php
+++ b/Test/Unit/Service/Invoice/UploadServiceTest.php
@@ -248,6 +248,32 @@ class UploadServiceTest extends TestCase
         $this->assertSame(UploadService::STATUS_NOT_APPLICABLE, $order->getData('two_invoice_upload_status'));
     }
 
+    public function testUploadSelectsMostRecentInvoiceWhenOrderHasMultiple(): void
+    {
+        // Order already carries an earlier, unrelated invoice (id 50,
+        // e.g. a prior partial/admin-created invoice) plus the one from
+        // this fulfilment (id 99, created later). Only the latter must be
+        // rendered/uploaded — this is a real regression test for the
+        // getLastItem()->explicit-sort fix (TWO-24758 review round 2,
+        // Vader): ids are given in creation (ascending) order so the test
+        // would fail if the code fell back to trusting insertion order.
+        $order = $this->makeOrder();
+        $order->setData('invoice_collection', $this->makeInvoiceCollectionWithIds([50, 99]));
+        $this->settingsProvider->method('isInvoiceDistributedByMerchant')->willReturn(true);
+
+        $renderedInvoiceIds = [];
+        $this->invoicePdf->method('getPdf')->willReturnCallback(function (array $invoices) use (&$renderedInvoiceIds) {
+            foreach ($invoices as $invoice) {
+                $renderedInvoiceIds[] = $invoice->getEntityId();
+            }
+            return $this->makePdfDocument('PDF-BYTES');
+        });
+
+        $this->service->upload($order, 'inv-123');
+
+        $this->assertSame([99], $renderedInvoiceIds);
+    }
+
     public function testUploadFailsWhenPdfEmpty(): void
     {
         $order = $this->makeOrder();
@@ -365,27 +391,50 @@ class UploadServiceTest extends TestCase
 
     private function makeInvoiceCollection(bool $hasInvoice = true)
     {
-        $invoice = new class ($hasInvoice) {
-            private $hasInvoice;
-            public function __construct(bool $hasInvoice)
-            {
-                $this->hasInvoice = $hasInvoice;
-            }
-            public function getEntityId()
-            {
-                return $this->hasInvoice ? 99 : null;
-            }
-        };
+        return $this->makeInvoiceCollectionWithIds($hasInvoice ? [99] : []);
+    }
 
-        return new class ($hasInvoice ? $invoice : null) {
-            private $invoice;
-            public function __construct($invoice)
+    /**
+     * Faithful enough re-implementation of the real collection's
+     * setOrder()/getFirstItem() interaction to prove renderInvoicePdf()
+     * actually sorts rather than trusting insertion order: $ids is given
+     * in creation order (ascending, oldest first), mirroring how an order
+     * with an earlier unrelated invoice plus this fulfilment's invoice
+     * would really load.
+     */
+    private function makeInvoiceCollectionWithIds(array $ids)
+    {
+        $invoices = array_map(static function (int $id) {
+            return new class ($id) {
+                private $id;
+                public function __construct(int $id)
+                {
+                    $this->id = $id;
+                }
+                public function getEntityId()
+                {
+                    return $this->id;
+                }
+            };
+        }, $ids);
+
+        return new class ($invoices) {
+            private $invoices;
+            public function __construct(array $invoices)
             {
-                $this->invoice = $invoice;
+                $this->invoices = $invoices;
             }
-            public function getLastItem()
+            public function setOrder(string $field, string $direction = 'ASC'): self
             {
-                return $this->invoice;
+                usort($this->invoices, static function ($a, $b) use ($direction) {
+                    $cmp = $a->getEntityId() <=> $b->getEntityId();
+                    return $direction === 'DESC' ? -$cmp : $cmp;
+                });
+                return $this;
+            }
+            public function getFirstItem()
+            {
+                return $this->invoices[0] ?? null;
             }
         };
     }

--- a/Test/Unit/Service/Invoice/UploadServiceTest.php
+++ b/Test/Unit/Service/Invoice/UploadServiceTest.php
@@ -1,0 +1,359 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Service\Invoice;
+
+use Magento\Framework\HTTP\Client\Curl;
+use Magento\Framework\HTTP\Client\CurlFactory;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Api\OrderStatusHistoryRepositoryInterface;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Pdf\Invoice as InvoicePdf;
+use Magento\Sales\Model\Order\Status\HistoryFactory;
+use Magento\Sales\Model\Order\Status\History;
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
+use Two\Gateway\Service\Api\Adapter;
+use Two\Gateway\Service\Invoice\UploadService;
+use Two\Gateway\Service\Merchant\SettingsProvider;
+
+class UploadServiceTest extends TestCase
+{
+    /** @var SettingsProvider|\PHPUnit\Framework\MockObject\MockObject */
+    private $settingsProvider;
+
+    /** @var Adapter|\PHPUnit\Framework\MockObject\MockObject */
+    private $apiAdapter;
+
+    /** @var InvoicePdf|\PHPUnit\Framework\MockObject\MockObject */
+    private $invoicePdf;
+
+    /** @var OrderRepositoryInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $orderRepository;
+
+    /** @var HistoryFactory|\PHPUnit\Framework\MockObject\MockObject */
+    private $historyFactory;
+
+    /** @var OrderStatusHistoryRepositoryInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $orderStatusHistoryRepository;
+
+    /** @var CurlFactory|\PHPUnit\Framework\MockObject\MockObject */
+    private $curlFactory;
+
+    /** @var LogRepository|\PHPUnit\Framework\MockObject\MockObject */
+    private $logRepository;
+
+    /** @var UploadService */
+    private $service;
+
+    protected function setUp(): void
+    {
+        $this->settingsProvider = $this->createMock(SettingsProvider::class);
+        $this->apiAdapter = $this->createMock(Adapter::class);
+        $this->invoicePdf = $this->createMock(InvoicePdf::class);
+        $this->orderRepository = $this->createMock(OrderRepositoryInterface::class);
+        $this->historyFactory = $this->createMock(HistoryFactory::class);
+        $this->orderStatusHistoryRepository = $this->createMock(OrderStatusHistoryRepositoryInterface::class);
+        $this->curlFactory = $this->createMock(CurlFactory::class);
+        $this->logRepository = $this->createMock(LogRepository::class);
+
+        $this->historyFactory->method('create')->willReturn(new History());
+
+        $this->service = new UploadService(
+            $this->settingsProvider,
+            $this->apiAdapter,
+            $this->invoicePdf,
+            $this->orderRepository,
+            $this->historyFactory,
+            $this->orderStatusHistoryRepository,
+            $this->curlFactory,
+            $this->logRepository
+        );
+    }
+
+    private function makeOrder(array $data = []): Order
+    {
+        $order = new Order();
+        foreach (array_merge(['entity_id' => 42, 'store_id' => 1, 'status' => 'complete'], $data) as $key => $value) {
+            $order->setData($key, $value);
+        }
+        return $order;
+    }
+
+    // --- queueForOrder ---
+
+    public function testQueueForOrderMarksNotApplicableWhenFlagFalse(): void
+    {
+        $order = $this->makeOrder();
+        $this->settingsProvider->method('isInvoiceDistributedByMerchant')->with(1)->willReturn(false);
+        $this->orderRepository->expects($this->once())->method('save')->with($order);
+
+        $this->service->queueForOrder($order, 'inv-123');
+
+        $this->assertSame(UploadService::STATUS_NOT_APPLICABLE, $order->getData('two_invoice_upload_status'));
+    }
+
+    public function testQueueForOrderMarksNotApplicableWhenFlagAbsent(): void
+    {
+        // SettingsProvider itself degrades an absent/unresolvable record to
+        // false; the service just needs to honour whatever it returns.
+        $order = $this->makeOrder();
+        $this->settingsProvider->method('isInvoiceDistributedByMerchant')->willReturn(false);
+
+        $this->service->queueForOrder($order, 'inv-123');
+
+        $this->assertSame(UploadService::STATUS_NOT_APPLICABLE, $order->getData('two_invoice_upload_status'));
+    }
+
+    public function testQueueForOrderQueuesForUploadWhenFlagTrue(): void
+    {
+        $order = $this->makeOrder();
+        $this->settingsProvider->method('isInvoiceDistributedByMerchant')->willReturn(true);
+        $this->orderRepository->expects($this->once())->method('save')->with($order);
+
+        $this->service->queueForOrder($order, 'inv-123');
+
+        $this->assertSame(UploadService::STATUS_UPLOADING, $order->getData('two_invoice_upload_status'));
+        $this->assertSame('inv-123', $order->getData('two_invoice_id'));
+    }
+
+    public function testQueueForOrderMarksNotApplicableWhenInvoiceIdMissing(): void
+    {
+        $order = $this->makeOrder();
+        $this->settingsProvider->method('isInvoiceDistributedByMerchant')->willReturn(true);
+        $this->logRepository->expects($this->once())->method('addErrorLog');
+        $this->orderRepository->expects($this->once())->method('save');
+
+        $this->service->queueForOrder($order, null);
+
+        $this->assertSame(UploadService::STATUS_NOT_APPLICABLE, $order->getData('two_invoice_upload_status'));
+    }
+
+    public function testQueueForOrderIsNoopWhenAlreadyUploaded(): void
+    {
+        $order = $this->makeOrder(['two_invoice_upload_status' => UploadService::STATUS_UPLOADED]);
+        $this->settingsProvider->expects($this->never())->method('isInvoiceDistributedByMerchant');
+        $this->orderRepository->expects($this->never())->method('save');
+
+        $this->service->queueForOrder($order, 'inv-123');
+
+        $this->assertSame(UploadService::STATUS_UPLOADED, $order->getData('two_invoice_upload_status'));
+    }
+
+    // --- upload() ---
+
+    public function testUploadIsNoopWhenAlreadyUploaded(): void
+    {
+        $order = $this->makeOrder(['two_invoice_upload_status' => UploadService::STATUS_UPLOADED]);
+        $this->apiAdapter->expects($this->never())->method('execute');
+        $this->orderRepository->expects($this->never())->method('save');
+
+        $this->service->upload($order, 'inv-123');
+    }
+
+    public function testUploadSucceedsThroughAllThreeSteps(): void
+    {
+        $order = $this->makeOrder();
+        $order->setData('invoice_collection', $this->makeInvoiceCollection());
+
+        $this->invoicePdf->method('getPdf')->willReturn($this->makePdfDocument('PDF-BYTES'));
+
+        $curl = $this->createMock(Curl::class);
+        $curl->method('getStatus')->willReturn(200);
+        $this->curlFactory->method('create')->willReturn($curl);
+
+        $this->apiAdapter->method('execute')->willReturnCallback(function ($endpoint, $payload, $method) {
+            if (strpos($endpoint, '/uploads/v1/invoice/') === 0) {
+                $this->assertSame('PUT', $method);
+                return [
+                    'url' => 'https://storage.example/signed',
+                    'headers' => ['Content-Type' => 'application/pdf'],
+                    'reference' => 'ref-456',
+                ];
+            }
+            $this->assertSame('/uploads/v1/status/ref-456', $endpoint);
+            $this->assertSame('GET', $method);
+            return ['status' => 'OK'];
+        });
+
+        $this->orderRepository->expects($this->once())->method('save')->with($order);
+        $this->orderStatusHistoryRepository->expects($this->once())->method('save')
+            ->with($this->callback(function (History $history) {
+                return strpos((string)$history->getComment(), 'uploaded to Two successfully') !== false;
+            }));
+
+        $this->service->upload($order, 'inv-123');
+
+        $this->assertSame(UploadService::STATUS_UPLOADED, $order->getData('two_invoice_upload_status'));
+        $this->assertSame('ref-456', $order->getData('two_invoice_upload_reference'));
+    }
+
+    public function testUploadFailsWhenNoMagentoInvoiceExists(): void
+    {
+        $order = $this->makeOrder();
+        $order->setData('invoice_collection', $this->makeInvoiceCollection(false));
+
+        $this->orderStatusHistoryRepository->expects($this->once())->method('save');
+        $this->logRepository->expects($this->once())->method('addErrorLog');
+
+        $this->service->upload($order, 'inv-123');
+
+        $this->assertSame(UploadService::STATUS_FAILED, $order->getData('two_invoice_upload_status'));
+    }
+
+    public function testUploadFailsWhenPdfEmpty(): void
+    {
+        $order = $this->makeOrder();
+        $order->setData('invoice_collection', $this->makeInvoiceCollection());
+        $this->invoicePdf->method('getPdf')->willReturn($this->makePdfDocument(''));
+
+        $this->service->upload($order, 'inv-123');
+
+        $this->assertSame(UploadService::STATUS_FAILED, $order->getData('two_invoice_upload_status'));
+        $this->assertStringContainsString('empty', (string)$order->getData('two_invoice_upload_error'));
+    }
+
+    public function testUploadFailsWhenSignedUrlRequestRejected(): void
+    {
+        $order = $this->makeOrder();
+        $order->setData('invoice_collection', $this->makeInvoiceCollection());
+        $this->invoicePdf->method('getPdf')->willReturn($this->makePdfDocument('PDF-BYTES'));
+
+        $this->apiAdapter->method('execute')->willReturn(['http_status' => 403]);
+
+        $this->service->upload($order, 'inv-123');
+
+        $this->assertSame(UploadService::STATUS_FAILED, $order->getData('two_invoice_upload_status'));
+        $this->assertStringContainsString(
+            'not permitted',
+            (string)$order->getData('two_invoice_upload_error')
+        );
+    }
+
+    public function testUploadRetriesOnServerErrorThenSucceeds(): void
+    {
+        $order = $this->makeOrder();
+        $order->setData('invoice_collection', $this->makeInvoiceCollection());
+        $this->invoicePdf->method('getPdf')->willReturn($this->makePdfDocument('PDF-BYTES'));
+
+        $failingCurl = $this->createMock(Curl::class);
+        $failingCurl->method('getStatus')->willReturn(500);
+        $failingCurl->method('getBody')->willReturn('server error');
+
+        $succeedingCurl = $this->createMock(Curl::class);
+        $succeedingCurl->method('getStatus')->willReturn(200);
+
+        $curlSequence = [$failingCurl, $failingCurl, $succeedingCurl];
+        $callCount = 0;
+        $this->curlFactory->method('create')->willReturnCallback(function () use ($curlSequence, &$callCount) {
+            return $curlSequence[$callCount++];
+        });
+
+        $this->apiAdapter->method('execute')->willReturnCallback(function ($endpoint) {
+            if (strpos($endpoint, '/uploads/v1/invoice/') === 0) {
+                return ['url' => 'https://storage.example/signed', 'headers' => [], 'reference' => 'ref-789'];
+            }
+            return ['status' => 'OK'];
+        });
+
+        $this->service->upload($order, 'inv-123');
+
+        $this->assertSame(UploadService::STATUS_UPLOADED, $order->getData('two_invoice_upload_status'));
+    }
+
+    public function testUploadDoesNotRetryOnClientError(): void
+    {
+        $order = $this->makeOrder();
+        $order->setData('invoice_collection', $this->makeInvoiceCollection());
+        $this->invoicePdf->method('getPdf')->willReturn($this->makePdfDocument('PDF-BYTES'));
+
+        $curl = $this->createMock(Curl::class);
+        $curl->method('getStatus')->willReturn(403);
+        $curl->method('getBody')->willReturn('forbidden');
+
+        // Exactly one attempt: a 4xx must not be retried.
+        $this->curlFactory->expects($this->once())->method('create')->willReturn($curl);
+
+        $this->apiAdapter->method('execute')->willReturn([
+            'url' => 'https://storage.example/signed',
+            'headers' => [],
+            'reference' => 'ref-000',
+        ]);
+
+        $this->service->upload($order, 'inv-123');
+
+        $this->assertSame(UploadService::STATUS_FAILED, $order->getData('two_invoice_upload_status'));
+    }
+
+    public function testUploadFailsWhenPollingReportsInvalid(): void
+    {
+        $order = $this->makeOrder();
+        $order->setData('invoice_collection', $this->makeInvoiceCollection());
+        $this->invoicePdf->method('getPdf')->willReturn($this->makePdfDocument('PDF-BYTES'));
+
+        $curl = $this->createMock(Curl::class);
+        $curl->method('getStatus')->willReturn(200);
+        $this->curlFactory->method('create')->willReturn($curl);
+
+        $this->apiAdapter->method('execute')->willReturnCallback(function ($endpoint) {
+            if (strpos($endpoint, '/uploads/v1/invoice/') === 0) {
+                return ['url' => 'https://storage.example/signed', 'headers' => [], 'reference' => 'ref-inv'];
+            }
+            return ['status' => 'INVALID'];
+        });
+
+        $this->service->upload($order, 'inv-123');
+
+        $this->assertSame(UploadService::STATUS_FAILED, $order->getData('two_invoice_upload_status'));
+        $this->assertStringContainsString(
+            'validation failed',
+            (string)$order->getData('two_invoice_upload_error')
+        );
+    }
+
+    private function makeInvoiceCollection(bool $hasInvoice = true)
+    {
+        $invoice = new class ($hasInvoice) {
+            private $hasInvoice;
+            public function __construct(bool $hasInvoice)
+            {
+                $this->hasInvoice = $hasInvoice;
+            }
+            public function getEntityId()
+            {
+                return $this->hasInvoice ? 99 : null;
+            }
+        };
+
+        return new class ($hasInvoice ? $invoice : null) {
+            private $invoice;
+            public function __construct($invoice)
+            {
+                $this->invoice = $invoice;
+            }
+            public function getFirstItem()
+            {
+                return $this->invoice;
+            }
+        };
+    }
+
+    private function makePdfDocument(string $content)
+    {
+        return new class ($content) {
+            private $content;
+            public function __construct(string $content)
+            {
+                $this->content = $content;
+            }
+            public function render(): string
+            {
+                return $this->content;
+            }
+        };
+    }
+}

--- a/Test/Unit/Service/Invoice/UploadServiceTest.php
+++ b/Test/Unit/Service/Invoice/UploadServiceTest.php
@@ -144,21 +144,58 @@ class UploadServiceTest extends TestCase
         $this->assertSame(UploadService::STATUS_UPLOADED, $order->getData('two_invoice_upload_status'));
     }
 
+    public function testQueueForOrderIsNoopWhenAlreadyUploading(): void
+    {
+        // A double-fired shipment observer (Magento is known to sometimes
+        // dispatch sales_order_shipment_save_after more than once) must not
+        // reset two_invoice_upload_reference/error while the cron's
+        // upload() might already be mid-flight for this order.
+        $order = $this->makeOrder([
+            'two_invoice_upload_status' => UploadService::STATUS_UPLOADING,
+            'two_invoice_upload_reference' => 'already-set-ref',
+        ]);
+        $this->settingsProvider->expects($this->never())->method('isInvoiceDistributedByMerchant');
+        $this->orderRepository->expects($this->never())->method('save');
+
+        $this->service->queueForOrder($order, 'inv-456');
+
+        $this->assertSame(UploadService::STATUS_UPLOADING, $order->getData('two_invoice_upload_status'));
+        $this->assertSame('already-set-ref', $order->getData('two_invoice_upload_reference'));
+    }
+
     // --- upload() ---
 
     public function testUploadIsNoopWhenAlreadyUploaded(): void
     {
         $order = $this->makeOrder(['two_invoice_upload_status' => UploadService::STATUS_UPLOADED]);
+        $this->settingsProvider->expects($this->never())->method('isInvoiceDistributedByMerchant');
         $this->apiAdapter->expects($this->never())->method('execute');
         $this->orderRepository->expects($this->never())->method('save');
 
         $this->service->upload($order, 'inv-123');
     }
 
+    public function testUploadMarksNotApplicableWhenFlagFalseAtExecutionTime(): void
+    {
+        // TOCTOU: the merchant may flip invoice_distributed_by_merchant to
+        // false between queueForOrder() (shipment time) and the cron
+        // draining this order minutes later — upload() must re-check, not
+        // trust the UPLOADING status alone.
+        $order = $this->makeOrder(['two_invoice_upload_status' => UploadService::STATUS_UPLOADING]);
+        $this->settingsProvider->method('isInvoiceDistributedByMerchant')->with(1)->willReturn(false);
+        $this->apiAdapter->expects($this->never())->method('execute');
+        $this->orderRepository->expects($this->once())->method('save')->with($order);
+
+        $this->service->upload($order, 'inv-123');
+
+        $this->assertSame(UploadService::STATUS_NOT_APPLICABLE, $order->getData('two_invoice_upload_status'));
+    }
+
     public function testUploadSucceedsThroughAllThreeSteps(): void
     {
         $order = $this->makeOrder();
         $order->setData('invoice_collection', $this->makeInvoiceCollection());
+        $this->settingsProvider->method('isInvoiceDistributedByMerchant')->willReturn(true);
 
         $this->invoicePdf->method('getPdf')->willReturn($this->makePdfDocument('PDF-BYTES'));
 
@@ -166,7 +203,8 @@ class UploadServiceTest extends TestCase
         $curl->method('getStatus')->willReturn(200);
         $this->curlFactory->method('create')->willReturn($curl);
 
-        $this->apiAdapter->method('execute')->willReturnCallback(function ($endpoint, $payload, $method) {
+        $this->apiAdapter->method('execute')->willReturnCallback(function ($endpoint, $payload, $method, $storeId) {
+            $this->assertSame(1, $storeId, 'store id must be threaded through to Adapter::execute()');
             if (strpos($endpoint, '/uploads/v1/invoice/') === 0) {
                 $this->assertSame('PUT', $method);
                 return [
@@ -192,23 +230,29 @@ class UploadServiceTest extends TestCase
         $this->assertSame('ref-456', $order->getData('two_invoice_upload_reference'));
     }
 
-    public function testUploadFailsWhenNoMagentoInvoiceExists(): void
+    public function testUploadMarksNotApplicableWhenNoMagentoInvoiceExists(): void
     {
+        // A zero-grand-total order never gets a Magento invoice — that is
+        // a legitimate NOT_APPLICABLE outcome, not a render failure; it
+        // must not produce a FAILED status + "upload failed" history noise.
         $order = $this->makeOrder();
         $order->setData('invoice_collection', $this->makeInvoiceCollection(false));
+        $this->settingsProvider->method('isInvoiceDistributedByMerchant')->willReturn(true);
 
-        $this->orderStatusHistoryRepository->expects($this->once())->method('save');
-        $this->logRepository->expects($this->once())->method('addErrorLog');
+        $this->orderRepository->expects($this->once())->method('save')->with($order);
+        $this->orderStatusHistoryRepository->expects($this->never())->method('save');
+        $this->logRepository->expects($this->never())->method('addErrorLog');
 
         $this->service->upload($order, 'inv-123');
 
-        $this->assertSame(UploadService::STATUS_FAILED, $order->getData('two_invoice_upload_status'));
+        $this->assertSame(UploadService::STATUS_NOT_APPLICABLE, $order->getData('two_invoice_upload_status'));
     }
 
     public function testUploadFailsWhenPdfEmpty(): void
     {
         $order = $this->makeOrder();
         $order->setData('invoice_collection', $this->makeInvoiceCollection());
+        $this->settingsProvider->method('isInvoiceDistributedByMerchant')->willReturn(true);
         $this->invoicePdf->method('getPdf')->willReturn($this->makePdfDocument(''));
 
         $this->service->upload($order, 'inv-123');
@@ -221,6 +265,7 @@ class UploadServiceTest extends TestCase
     {
         $order = $this->makeOrder();
         $order->setData('invoice_collection', $this->makeInvoiceCollection());
+        $this->settingsProvider->method('isInvoiceDistributedByMerchant')->willReturn(true);
         $this->invoicePdf->method('getPdf')->willReturn($this->makePdfDocument('PDF-BYTES'));
 
         $this->apiAdapter->method('execute')->willReturn(['http_status' => 403]);
@@ -238,6 +283,7 @@ class UploadServiceTest extends TestCase
     {
         $order = $this->makeOrder();
         $order->setData('invoice_collection', $this->makeInvoiceCollection());
+        $this->settingsProvider->method('isInvoiceDistributedByMerchant')->willReturn(true);
         $this->invoicePdf->method('getPdf')->willReturn($this->makePdfDocument('PDF-BYTES'));
 
         $failingCurl = $this->createMock(Curl::class);
@@ -269,6 +315,7 @@ class UploadServiceTest extends TestCase
     {
         $order = $this->makeOrder();
         $order->setData('invoice_collection', $this->makeInvoiceCollection());
+        $this->settingsProvider->method('isInvoiceDistributedByMerchant')->willReturn(true);
         $this->invoicePdf->method('getPdf')->willReturn($this->makePdfDocument('PDF-BYTES'));
 
         $curl = $this->createMock(Curl::class);
@@ -293,6 +340,7 @@ class UploadServiceTest extends TestCase
     {
         $order = $this->makeOrder();
         $order->setData('invoice_collection', $this->makeInvoiceCollection());
+        $this->settingsProvider->method('isInvoiceDistributedByMerchant')->willReturn(true);
         $this->invoicePdf->method('getPdf')->willReturn($this->makePdfDocument('PDF-BYTES'));
 
         $curl = $this->createMock(Curl::class);
@@ -335,7 +383,7 @@ class UploadServiceTest extends TestCase
             {
                 $this->invoice = $invoice;
             }
-            public function getFirstItem()
+            public function getLastItem()
             {
                 return $this->invoice;
             }

--- a/Test/Unit/Service/Merchant/SettingsProviderTest.php
+++ b/Test/Unit/Service/Merchant/SettingsProviderTest.php
@@ -126,4 +126,43 @@ class SettingsProviderTest extends TestCase
 
         $this->assertNull($this->provider->getDefaultTerm(1));
     }
+
+    // --- isInvoiceDistributedByMerchant (TWO-24758 / TWO-25106 Option A) ---
+
+    public function testInvoiceDistributedByMerchantTrue(): void
+    {
+        $this->stubRecord(['invoice_distributed_by_merchant' => true]);
+
+        $this->assertTrue($this->provider->isInvoiceDistributedByMerchant(1));
+    }
+
+    public function testInvoiceDistributedByMerchantFalse(): void
+    {
+        $this->stubRecord(['invoice_distributed_by_merchant' => false]);
+
+        $this->assertFalse($this->provider->isInvoiceDistributedByMerchant(1));
+    }
+
+    public function testInvoiceDistributedByMerchantFalseWhenFieldAbsent(): void
+    {
+        $this->stubRecord(['id' => 'abc-123']);
+
+        $this->assertFalse($this->provider->isInvoiceDistributedByMerchant(1));
+    }
+
+    public function testInvoiceDistributedByMerchantFalseWhenRecordUnresolved(): void
+    {
+        $this->stubRecord(null);
+
+        $this->assertFalse($this->provider->isInvoiceDistributedByMerchant(1));
+    }
+
+    public function testInvoiceDistributedByMerchantFalseWhenNotStrictlyTrue(): void
+    {
+        // Truthy-but-not-boolean-true values (e.g. a string "true" from a
+        // lenient JSON decode) must not accidentally gate the feature on.
+        $this->stubRecord(['invoice_distributed_by_merchant' => 'true']);
+
+        $this->assertFalse($this->provider->isInvoiceDistributedByMerchant(1));
+    }
 }

--- a/Test/bootstrap.php
+++ b/Test/bootstrap.php
@@ -105,6 +105,12 @@ if (!class_exists(\Magento\Framework\App\Config\Value::class, false)) {
 // per-symbol guards live inside the stub file.
 require_once __DIR__ . '/Stubs/AdminScope.php';
 
+// Self-invoice-upload collaborators (Status\History/HistoryFactory,
+// OrderRepositoryInterface, SearchCriteriaBuilder, Pdf\Invoice) for
+// Service/Invoice/UploadService.php and Cron/ProcessInvoiceUploads.php;
+// per-symbol guards live inside the stub file.
+require_once __DIR__ . '/Stubs/InvoiceUpload.php';
+
 // Catch-all autoloader for remaining Magento classes/interfaces.
 // Creates empty stubs so that type hints, extends, and implements resolve.
 spl_autoload_register(function ($class) {

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
+    <group id="default">
+        <job name="two_gateway_process_invoice_uploads" instance="Two\Gateway\Cron\ProcessInvoiceUploads" method="execute">
+            <schedule>* * * * *</schedule>
+        </job>
+    </group>
+</config>

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -19,6 +19,11 @@
         <column xsi:type="decimal" name="base_two_surcharge_invoiced" scale="6" precision="20" nullable="true" comment="Two Surcharge Invoiced (base currency)"/>
         <column xsi:type="decimal" name="two_surcharge_refunded" scale="6" precision="20" nullable="true" comment="Two Surcharge Refunded (order currency)"/>
         <column xsi:type="decimal" name="base_two_surcharge_refunded" scale="6" precision="20" nullable="true" comment="Two Surcharge Refunded (base currency)"/>
+        <column xsi:type="varchar" name="two_invoice_id" nullable="true" length="255" comment="Two invoice id (from fulfilments response), used for self-invoice upload"/>
+        <column xsi:type="varchar" name="two_invoice_upload_status" nullable="true" length="32" comment="Two self-invoice upload status: NOT_APPLICABLE/UPLOADING/UPLOADED/FAILED"/>
+        <column xsi:type="varchar" name="two_invoice_upload_reference" nullable="true" length="255" comment="Two self-invoice upload reference (from signed-URL step)"/>
+        <column xsi:type="timestamp" name="two_invoice_uploaded_at" nullable="true" comment="Two self-invoice upload completion timestamp"/>
+        <column xsi:type="text" name="two_invoice_upload_error" nullable="true" comment="Two self-invoice upload last error message"/>
     </table>
     <table name="quote">
         <column xsi:type="decimal" name="two_surcharge_amount" scale="6" precision="20" nullable="true" comment="Two Surcharge Amount (quote currency, net)"/>

--- a/etc/db_schema_whitelist.json
+++ b/etc/db_schema_whitelist.json
@@ -12,7 +12,12 @@
             "two_surcharge_invoiced": true,
             "base_two_surcharge_invoiced": true,
             "two_surcharge_refunded": true,
-            "base_two_surcharge_refunded": true
+            "base_two_surcharge_refunded": true,
+            "two_invoice_id": true,
+            "two_invoice_upload_status": true,
+            "two_invoice_upload_reference": true,
+            "two_invoice_uploaded_at": true,
+            "two_invoice_upload_error": true
         }
     },
     "quote": {


### PR DESCRIPTION
## Summary

Magento can render + upload the buyer-facing invoice PDF in-process — no WC-style blocker, since `Magento\Sales\Model\Order\Pdf\Invoice` + `InvoiceService` are already available/injected. This mirrors the shipped PrestaShop pattern (`TwoInvoiceUploadService.php` + fulfilment gate) using checkout-api's existing 3-step signed-URL upload flow.

Gate is **flag-only**, per [TWO-25106 (Option A)](https://linear.app/two-inc/issue/TWO-25106): `invoice_distributed_by_merchant` from `GET /v1/merchant`, no admin toggle.

- `Service/Merchant/SettingsProvider::isInvoiceDistributedByMerchant()` — reads the flag off the cached merchant record; absent/unresolvable degrades to `false`.
- `Service/Invoice/UploadService`:
  - `queueForOrder()` — cheap gate check + DB write, called synchronously from the fulfilment observer. Never touches the network.
  - `upload()` — the actual render (native Magento PDF) + 3-step upload (signed URL → GCS PUT with retry-on-5xx/no-retry-on-4xx → status poll), persists one of `NOT_APPLICABLE` / `UPLOADING` / `UPLOADED` / `FAILED`, adds an order history comment on completion.
- `Cron/ProcessInvoiceUploads` — runs `upload()` out-of-band every minute for orders left `UPLOADING`, so the fulfilment request never blocks on network I/O (PHP `max_execution_time` risk).
- New `sales_order` columns: `two_invoice_id`, `two_invoice_upload_status`, `two_invoice_upload_reference`, `two_invoice_uploaded_at`, `two_invoice_upload_error`.
- `Observer/SalesOrderShipmentAfter.php` extended: only reaches the upload gate on whole-order shipment (same guard as native Magento invoice creation), and only for merchants on the `shipment` fulfilment trigger (existing early-return for `complete`/`invoice` triggers is unchanged — out of scope for this ticket).

## Known assumption — please verify in QA

The Two invoice id is read as `fulfilled_order.invoice_details.id` (falling back to `invoice_details.id`) off the `/fulfillments` response, mirroring PrestaShop's `two_invoice_id` field. This repo has no visibility into checkout-api's actual response schema to confirm the field name/shape for Magento's `/fulfillments` call — **manual QA on a real fulfilled order is required before this is trusted in production** (see Validation below). If the field is absent/differently named, the code degrades safely to `NOT_APPLICABLE` (logged), it just won't upload anything until the field is confirmed/fixed.

## Test plan

- [x] Unit tests: `Service/Merchant/SettingsProviderTest` — flag true/false/absent/malformed.
- [x] Unit tests: `Service/Invoice/UploadServiceTest` — gate true/false/absent, duplicate guard (already `UPLOADED`), missing invoice id, full 3-step success, PDF-empty, PDF-render-failure, signed-URL-rejected, retry-on-5xx-then-succeed, no-retry-on-4xx, poll-INVALID.
- [x] Unit tests: `Cron/ProcessInvoiceUploadsTest` — batch processing, skip-missing-invoice-id, one-order-exception-does-not-stop-batch.
- [x] `php /tmp/phpunit.phar --testsuite Unit` — 319 tests, 550 assertions, green.
- [ ] Manual QA (owed, not run in this session): fulfil a real order on a test Magento instance with `invoice_distributed_by_merchant=true` → confirm PDF renders, uploads, resolves `UPLOADED`, status visible in admin order view. Confirm the `invoice_details.id` assumption above against a real `/fulfillments` response.

— posted by Claude