### PR TITLE
ABN-463/fix: clear surcharge total when quote drops below min order

### DIFF
--- a/Model/GenericPaymentMethod.php
+++ b/Model/GenericPaymentMethod.php
@@ -28,6 +28,7 @@ use Two\Gateway\Service\Api\Adapter;
 use Two\Gateway\Service\Order\ComposeCapture;
 use Two\Gateway\Service\Order\ComposeOrder;
 use Two\Gateway\Service\Order\ComposeRefund;
+use Two\Gateway\Service\Order\MerchantMinimumResolver;
 use Two\Gateway\Service\Order\MinimumOrderGate;
 use Two\Gateway\Service\Order\MinimumOrderProvider;
 use Two\Gateway\Service\UrlCookie;
@@ -86,6 +87,7 @@ class GenericPaymentMethod extends Two
         LogRepository $logRepository,
         MinimumOrderGate $minimumOrderGate,
         MinimumOrderProvider $minimumOrderProvider,
+        MerchantMinimumResolver $merchantMinimumResolver,
         ConfigDataCollectionFactory $configDataCollectionFactory,
         ?AbstractResource $resource = null,
         ?AbstractDb $resourceCollection = null,
@@ -113,6 +115,7 @@ class GenericPaymentMethod extends Two
             $logRepository,
             $minimumOrderGate,
             $minimumOrderProvider,
+            $merchantMinimumResolver,
             $configDataCollectionFactory,
             $resource,
             $resourceCollection,

--- a/Model/Total/Surcharge.php
+++ b/Model/Total/Surcharge.php
@@ -8,15 +8,14 @@ declare(strict_types=1);
 namespace Two\Gateway\Model\Total;
 
 use Magento\Checkout\Model\Session as CheckoutSession;
-use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Quote\Api\Data\ShippingAssignmentInterface;
 use Magento\Quote\Model\Quote;
 use Magento\Quote\Model\Quote\Address\Total;
 use Magento\Quote\Model\Quote\Address\Total\AbstractTotal;
-use Magento\Store\Model\ScopeInterface;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
 use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
 use Two\Gateway\Model\Config\Source\SurchargeType;
+use Two\Gateway\Service\Order\MerchantMinimumResolver;
 use Two\Gateway\Service\Order\MinimumOrderGate;
 use Two\Gateway\Service\Order\MinimumOrderProvider;
 use Two\Gateway\Service\Order\SurchargeCalculator;
@@ -70,9 +69,9 @@ class Surcharge extends AbstractTotal
     private $minimumOrderProvider;
 
     /**
-     * @var ScopeConfigInterface
+     * @var MerchantMinimumResolver
      */
-    private $scopeConfig;
+    private $merchantMinimumResolver;
 
     /**
      * @var array<string, true> set of payment-method codes (as keys) that
@@ -91,7 +90,7 @@ class Surcharge extends AbstractTotal
         LogRepository $logRepository,
         MinimumOrderGate $minimumOrderGate,
         MinimumOrderProvider $minimumOrderProvider,
-        ScopeConfigInterface $scopeConfig,
+        MerchantMinimumResolver $merchantMinimumResolver,
         array $allowedMethods = ['two_payment']
     ) {
         $this->checkoutSession = $checkoutSession;
@@ -101,7 +100,7 @@ class Surcharge extends AbstractTotal
         $this->logRepository = $logRepository;
         $this->minimumOrderGate = $minimumOrderGate;
         $this->minimumOrderProvider = $minimumOrderProvider;
-        $this->scopeConfig = $scopeConfig;
+        $this->merchantMinimumResolver = $merchantMinimumResolver;
         $this->allowedMethods = array_fill_keys($allowedMethods, true);
         $this->setCode('two_surcharge');
     }
@@ -153,8 +152,15 @@ class Surcharge extends AbstractTotal
         // while the surcharge it introduced keeps being recomputed and
         // re-applied against the still-selected (but now ineligible) method
         // on the quote, since nothing else deselects it.
+        $store = $quote->getStore();
+        $baseCurrency = $store !== null ? (string)$store->getBaseCurrencyCode() : '';
         $platformMinimum = $this->minimumOrderProvider->getMinimum($storeId);
-        $merchantMinimum = $this->buildMerchantMinimum($quote, $paymentMethod, $platformMinimum, $storeId);
+        $merchantMinimum = $this->merchantMinimumResolver->resolve(
+            $paymentMethod,
+            $baseCurrency,
+            $platformMinimum,
+            $storeId
+        );
         if (!$this->minimumOrderGate->isSatisfied($platformMinimum, $quote, $merchantMinimum)) {
             $this->logRepository->addDebugLog('TotalCollector: skipped (below minimum order)', []);
             $this->clearSessionSurcharge();
@@ -367,49 +373,6 @@ class Surcharge extends AbstractTotal
             return $sessionTerm;
         }
         return $this->configRepository->getDefaultPaymentTerm($storeId);
-    }
-
-    /**
-     * The merchant's own optional minimum-order tuple, in the store BASE
-     * currency, or null when unset (<= 0) or the base currency is unknown.
-     * Mirrors Two::buildMerchantMinimum() but keyed off the quote's live
-     * payment-method code (this collector may be shared across brand
-     * overlays) rather than a single bound method instance's `_code`.
-     *
-     * @param array<string, mixed>|null $platform Platform minimum, for basis fallback only.
-     * @return array{amount: float, currency: string, basis: string}|null
-     */
-    private function buildMerchantMinimum(
-        Quote $quote,
-        string $paymentMethod,
-        ?array $platform,
-        int $storeId
-    ): ?array {
-        $merchantValue = (float)$this->scopeConfig->getValue(
-            "payment/{$paymentMethod}/merchant_minimum_order",
-            ScopeInterface::SCOPE_STORE,
-            $storeId
-        );
-        if ($merchantValue <= 0) {
-            return null;
-        }
-        $store = $quote->getStore();
-        $baseCurrency = $store !== null ? (string)$store->getBaseCurrencyCode() : '';
-        if ($baseCurrency === '') {
-            return null;
-        }
-        $merchantBasis = (string)$this->scopeConfig->getValue(
-            "payment/{$paymentMethod}/merchant_minimum_order_basis",
-            ScopeInterface::SCOPE_STORE,
-            $storeId
-        );
-        return [
-            'amount' => $merchantValue,
-            'currency' => $baseCurrency,
-            'basis' => in_array($merchantBasis, ['net', 'gross'], true)
-                ? $merchantBasis
-                : ($platform['basis'] ?? 'gross'),
-        ];
     }
 
     /**

--- a/Model/Total/Surcharge.php
+++ b/Model/Total/Surcharge.php
@@ -8,13 +8,17 @@ declare(strict_types=1);
 namespace Two\Gateway\Model\Total;
 
 use Magento\Checkout\Model\Session as CheckoutSession;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Quote\Api\Data\ShippingAssignmentInterface;
 use Magento\Quote\Model\Quote;
 use Magento\Quote\Model\Quote\Address\Total;
 use Magento\Quote\Model\Quote\Address\Total\AbstractTotal;
+use Magento\Store\Model\ScopeInterface;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
 use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
 use Two\Gateway\Model\Config\Source\SurchargeType;
+use Two\Gateway\Service\Order\MinimumOrderGate;
+use Two\Gateway\Service\Order\MinimumOrderProvider;
 use Two\Gateway\Service\Order\SurchargeCalculator;
 use Two\Gateway\Service\Order\SurchargeTaxCalculator;
 
@@ -56,6 +60,21 @@ class Surcharge extends AbstractTotal
     private $logRepository;
 
     /**
+     * @var MinimumOrderGate
+     */
+    private $minimumOrderGate;
+
+    /**
+     * @var MinimumOrderProvider
+     */
+    private $minimumOrderProvider;
+
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    /**
      * @var array<string, true> set of payment-method codes (as keys) that
      *                          engage the surcharge collector. Populated via
      *                          DI; brand overlays append their own code.
@@ -70,6 +89,9 @@ class Surcharge extends AbstractTotal
         SurchargeCalculator $surchargeCalculator,
         SurchargeTaxCalculator $surchargeTaxCalculator,
         LogRepository $logRepository,
+        MinimumOrderGate $minimumOrderGate,
+        MinimumOrderProvider $minimumOrderProvider,
+        ScopeConfigInterface $scopeConfig,
         array $allowedMethods = ['two_payment']
     ) {
         $this->checkoutSession = $checkoutSession;
@@ -77,6 +99,9 @@ class Surcharge extends AbstractTotal
         $this->surchargeCalculator = $surchargeCalculator;
         $this->surchargeTaxCalculator = $surchargeTaxCalculator;
         $this->logRepository = $logRepository;
+        $this->minimumOrderGate = $minimumOrderGate;
+        $this->minimumOrderProvider = $minimumOrderProvider;
+        $this->scopeConfig = $scopeConfig;
         $this->allowedMethods = array_fill_keys($allowedMethods, true);
         $this->setCode('two_surcharge');
     }
@@ -119,6 +144,24 @@ class Surcharge extends AbstractTotal
         }
 
         $storeId = (int)$quote->getStoreId();
+
+        // Re-check the same min-order gate that decides whether the payment
+        // method is offered (Two::isAvailable() -> MinimumOrderGate). Totals
+        // recollect on every shipping-method change, so a shipping switch
+        // that drops the basket below the minimum must clear the surcharge
+        // here too — otherwise the payment method disappears from checkout
+        // while the surcharge it introduced keeps being recomputed and
+        // re-applied against the still-selected (but now ineligible) method
+        // on the quote, since nothing else deselects it.
+        $platformMinimum = $this->minimumOrderProvider->getMinimum($storeId);
+        $merchantMinimum = $this->buildMerchantMinimum($quote, $paymentMethod, $platformMinimum, $storeId);
+        if (!$this->minimumOrderGate->isSatisfied($platformMinimum, $quote, $merchantMinimum)) {
+            $this->logRepository->addDebugLog('TotalCollector: skipped (below minimum order)', []);
+            $this->clearSessionSurcharge();
+            $this->clearTotalSurcharge($total, $quote);
+            return $this;
+        }
+
         $surchargeType = $this->configRepository->getSurchargeType($storeId);
 
         if ($surchargeType === SurchargeType::NONE) {
@@ -324,6 +367,49 @@ class Surcharge extends AbstractTotal
             return $sessionTerm;
         }
         return $this->configRepository->getDefaultPaymentTerm($storeId);
+    }
+
+    /**
+     * The merchant's own optional minimum-order tuple, in the store BASE
+     * currency, or null when unset (<= 0) or the base currency is unknown.
+     * Mirrors Two::buildMerchantMinimum() but keyed off the quote's live
+     * payment-method code (this collector may be shared across brand
+     * overlays) rather than a single bound method instance's `_code`.
+     *
+     * @param array<string, mixed>|null $platform Platform minimum, for basis fallback only.
+     * @return array{amount: float, currency: string, basis: string}|null
+     */
+    private function buildMerchantMinimum(
+        Quote $quote,
+        string $paymentMethod,
+        ?array $platform,
+        int $storeId
+    ): ?array {
+        $merchantValue = (float)$this->scopeConfig->getValue(
+            "payment/{$paymentMethod}/merchant_minimum_order",
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+        if ($merchantValue <= 0) {
+            return null;
+        }
+        $store = $quote->getStore();
+        $baseCurrency = $store !== null ? (string)$store->getBaseCurrencyCode() : '';
+        if ($baseCurrency === '') {
+            return null;
+        }
+        $merchantBasis = (string)$this->scopeConfig->getValue(
+            "payment/{$paymentMethod}/merchant_minimum_order_basis",
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+        return [
+            'amount' => $merchantValue,
+            'currency' => $baseCurrency,
+            'basis' => in_array($merchantBasis, ['net', 'gross'], true)
+                ? $merchantBasis
+                : ($platform['basis'] ?? 'gross'),
+        ];
     }
 
     /**

--- a/Model/Two.php
+++ b/Model/Two.php
@@ -35,6 +35,7 @@ use Two\Gateway\Service\Api\Adapter;
 use Two\Gateway\Service\Order\ComposeCapture;
 use Two\Gateway\Service\Order\ComposeOrder;
 use Two\Gateway\Service\Order\ComposeRefund;
+use Two\Gateway\Service\Order\MerchantMinimumResolver;
 use Two\Gateway\Service\Order\MinimumOrderGate;
 use Two\Gateway\Service\Order\MinimumOrderProvider;
 use Two\Gateway\Service\UrlCookie;
@@ -132,6 +133,10 @@ class Two extends AbstractMethod
      */
     private $minimumOrderProvider;
     /**
+     * @var MerchantMinimumResolver
+     */
+    private $merchantMinimumResolver;
+    /**
      * @var ConfigDataCollectionFactory
      */
     private $configDataCollectionFactory;
@@ -165,6 +170,7 @@ class Two extends AbstractMethod
      * @param LogRepository $logRepository
      * @param MinimumOrderGate $minimumOrderGate
      * @param MinimumOrderProvider $minimumOrderProvider
+     * @param MerchantMinimumResolver $merchantMinimumResolver
      * @param ConfigDataCollectionFactory $configDataCollectionFactory
      * @param AbstractResource|null $resource
      * @param AbstractDb|null $resourceCollection
@@ -192,6 +198,7 @@ class Two extends AbstractMethod
         LogRepository $logRepository,
         MinimumOrderGate $minimumOrderGate,
         MinimumOrderProvider $minimumOrderProvider,
+        MerchantMinimumResolver $merchantMinimumResolver,
         ConfigDataCollectionFactory $configDataCollectionFactory,
         ?AbstractResource $resource = null,
         ?AbstractDb $resourceCollection = null,
@@ -223,6 +230,7 @@ class Two extends AbstractMethod
         $this->logRepository = $logRepository;
         $this->minimumOrderGate = $minimumOrderGate;
         $this->minimumOrderProvider = $minimumOrderProvider;
+        $this->merchantMinimumResolver = $merchantMinimumResolver;
         $this->configDataCollectionFactory = $configDataCollectionFactory;
     }
 
@@ -864,13 +872,13 @@ class Two extends AbstractMethod
     /**
      * The merchant's own optional minimum-order tuple, in the store BASE
      * currency, or null when unset (<= 0) or the base currency is unknown.
-     * Single source of truth shared by isAvailable()'s server gate,
-     * getMinimumOrderVisibility()'s client-display projection, and the
-     * authorize() placement backstop: they MUST agree on the constraint, so
-     * the construction lives in exactly one place. Amount is validated on save
-     * to meet/exceed the platform floor; basis falls back to the platform
-     * minimum's basis, then 'gross', when the admin value is neither 'net' nor
-     * 'gross'.
+     * Delegates to MerchantMinimumResolver — the single source of truth
+     * shared by isAvailable()'s server gate, getMinimumOrderVisibility()'s
+     * client-display projection, the authorize() placement backstop, and
+     * Total\Surcharge's totals-recollect gate: they MUST agree on the
+     * constraint. `$this->_code` is this instance's bound payment-method
+     * code (the resolver is parameterized by code so it can also serve
+     * Total\Surcharge, which is not bound to a single method instance).
      *
      * @param string $baseCurrency Store base currency the merchant amount is denominated in.
      * @param array<string, mixed>|null $platform Platform minimum, for basis fallback only.
@@ -879,18 +887,7 @@ class Two extends AbstractMethod
      */
     private function buildMerchantMinimum(string $baseCurrency, ?array $platform, ?int $storeId = null): ?array
     {
-        $merchantValue = (float)$this->getConfigData('merchant_minimum_order', $storeId);
-        if ($merchantValue <= 0 || $baseCurrency === '') {
-            return null;
-        }
-        $merchantBasis = (string)$this->getConfigData('merchant_minimum_order_basis', $storeId);
-        return [
-            'amount' => $merchantValue,
-            'currency' => $baseCurrency,
-            'basis' => in_array($merchantBasis, ['net', 'gross'], true)
-                ? $merchantBasis
-                : ($platform['basis'] ?? 'gross'),
-        ];
+        return $this->merchantMinimumResolver->resolve($this->_code, $baseCurrency, $platform, $storeId);
     }
 
     /**

--- a/Service/Order/MerchantMinimumResolver.php
+++ b/Service/Order/MerchantMinimumResolver.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Service\Order;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\ScopeInterface;
+
+/**
+ * Builds the merchant's own optional minimum-order tuple, in a given base
+ * currency, for a given payment-method code.
+ *
+ * Single source of truth shared by every consumer that must agree on the
+ * merchant's minimum-order constraint: Two::isAvailable()'s server gate,
+ * Two::getMinimumOrderVisibility()'s client-display projection,
+ * Two::assertOrderMeetsMinimum()'s placement backstop, and
+ * Total\Surcharge::collect()'s totals-recollect gate (ABN-463). A second ad
+ * hoc copy of this construction is exactly how ABN-463 happened: the
+ * totals-recollect gate silently diverged from the visibility gate because
+ * nothing forced them to agree. Extend this class, not a private copy.
+ */
+class MerchantMinimumResolver
+{
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    public function __construct(ScopeConfigInterface $scopeConfig)
+    {
+        $this->scopeConfig = $scopeConfig;
+    }
+
+    /**
+     * @param string $paymentMethod Payment-method code the admin config is scoped under.
+     * @param string $baseCurrency Store base currency the merchant amount is denominated in.
+     * @param array<string, mixed>|null $platform Platform minimum, for basis fallback only.
+     * @param int|null $storeId Scope for the admin config reads.
+     * @return array{amount: float, currency: string, basis: string}|null
+     */
+    public function resolve(
+        string $paymentMethod,
+        string $baseCurrency,
+        ?array $platform,
+        ?int $storeId = null
+    ): ?array {
+        $merchantValue = (float)$this->scopeConfig->getValue(
+            "payment/{$paymentMethod}/merchant_minimum_order",
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+        if ($merchantValue <= 0 || $baseCurrency === '') {
+            return null;
+        }
+        $merchantBasis = (string)$this->scopeConfig->getValue(
+            "payment/{$paymentMethod}/merchant_minimum_order_basis",
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+        return [
+            'amount' => $merchantValue,
+            'currency' => $baseCurrency,
+            'basis' => in_array($merchantBasis, ['net', 'gross'], true)
+                ? $merchantBasis
+                : ($platform['basis'] ?? 'gross'),
+        ];
+    }
+}

--- a/Test/Unit/Model/Total/SurchargeTest.php
+++ b/Test/Unit/Model/Total/SurchargeTest.php
@@ -16,8 +16,11 @@ use PHPUnit\Framework\TestCase;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
 use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
 use Two\Gateway\Model\Total\Surcharge;
+use Two\Gateway\Service\Order\MinimumOrderGate;
+use Two\Gateway\Service\Order\MinimumOrderProvider;
 use Two\Gateway\Service\Order\SurchargeCalculator;
 use Two\Gateway\Service\Order\SurchargeTaxCalculator;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 
 /**
  * TWO-25072 coverage for the quote total collector's tax branching,
@@ -49,6 +52,15 @@ class SurchargeTest extends TestCase
     /** @var SurchargeTaxCalculator|\PHPUnit\Framework\MockObject\MockObject */
     private $taxCalculator;
 
+    /** @var MinimumOrderGate|\PHPUnit\Framework\MockObject\MockObject */
+    private $minimumOrderGate;
+
+    /** @var MinimumOrderProvider|\PHPUnit\Framework\MockObject\MockObject */
+    private $minimumOrderProvider;
+
+    /** @var ScopeConfigInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $scopeConfig;
+
     /** @var Surcharge */
     private $collector;
 
@@ -58,13 +70,22 @@ class SurchargeTest extends TestCase
         $this->config = $this->createMock(ConfigRepository::class);
         $this->surchargeCalculator = $this->createMock(SurchargeCalculator::class);
         $this->taxCalculator = $this->createMock(SurchargeTaxCalculator::class);
+        $this->minimumOrderGate = $this->createMock(MinimumOrderGate::class);
+        // Existing tests exercise the tax-calculation branching; keep them
+        // unaffected by defaulting the min-order gate to satisfied.
+        $this->minimumOrderGate->method('isSatisfied')->willReturn(true);
+        $this->minimumOrderProvider = $this->createMock(MinimumOrderProvider::class);
+        $this->scopeConfig = $this->createMock(ScopeConfigInterface::class);
 
         $this->collector = new Surcharge(
             $this->session,
             $this->config,
             $this->surchargeCalculator,
             $this->taxCalculator,
-            $this->createMock(LogRepository::class)
+            $this->createMock(LogRepository::class),
+            $this->minimumOrderGate,
+            $this->minimumOrderProvider,
+            $this->scopeConfig
         );
     }
 
@@ -195,5 +216,42 @@ class SurchargeTest extends TestCase
         $this->assertEqualsWithDelta(21.0, $total->getData('two_surcharge_tax_rate'), 1e-9);
         $this->assertEqualsWithDelta(1121.0, $total->getGrandTotal(), 1e-9);
         $this->assertEqualsWithDelta(21.0, $this->session->getTwoSurchargeTax(), 1e-9);
+    }
+
+    /**
+     * ABN-463: a shipping-method change can drop the quote below the
+     * minimum order value without ever deselecting `two_payment` on the
+     * quote. The collector must clear the surcharge on that recollect
+     * pass rather than keep reapplying it because the method code alone
+     * still matches.
+     */
+    public function testSurchargeClearedWhenBelowMinimumOrderEvenWithPaymentMethodStillSelected(): void
+    {
+        $this->stubBaseline();
+        $this->config->method('getSurchargeTaxClassId')->willReturn(null);
+        $this->minimumOrderGate = $this->createMock(MinimumOrderGate::class);
+        $this->minimumOrderGate->method('isSatisfied')->willReturn(false);
+
+        $this->collector = new Surcharge(
+            $this->session,
+            $this->config,
+            $this->surchargeCalculator,
+            $this->taxCalculator,
+            $this->createMock(LogRepository::class),
+            $this->minimumOrderGate,
+            $this->minimumOrderProvider,
+            $this->scopeConfig
+        );
+
+        $this->session->setTwoSurchargeAmount(100.0);
+        $this->session->setTwoSurchargeTax(21.0);
+
+        $total = new Total(['grand_total' => 1000.0, 'base_grand_total' => 1000.0]);
+        $this->collector->collect($this->makeQuote(), $this->makeShippingAssignment(), $total);
+
+        $this->assertEqualsWithDelta(0.0, (float)$total->getData('two_surcharge_amount'), 1e-9);
+        $this->assertEqualsWithDelta(1000.0, $total->getGrandTotal(), 1e-9);
+        $this->assertEqualsWithDelta(0.0, (float)$this->session->getTwoSurchargeAmount(), 1e-9);
+        $this->assertEqualsWithDelta(0.0, (float)$this->session->getTwoSurchargeTax(), 1e-9);
     }
 }

--- a/Test/Unit/Model/Total/SurchargeTest.php
+++ b/Test/Unit/Model/Total/SurchargeTest.php
@@ -16,11 +16,11 @@ use PHPUnit\Framework\TestCase;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
 use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
 use Two\Gateway\Model\Total\Surcharge;
+use Two\Gateway\Service\Order\MerchantMinimumResolver;
 use Two\Gateway\Service\Order\MinimumOrderGate;
 use Two\Gateway\Service\Order\MinimumOrderProvider;
 use Two\Gateway\Service\Order\SurchargeCalculator;
 use Two\Gateway\Service\Order\SurchargeTaxCalculator;
-use Magento\Framework\App\Config\ScopeConfigInterface;
 
 /**
  * TWO-25072 coverage for the quote total collector's tax branching,
@@ -58,8 +58,8 @@ class SurchargeTest extends TestCase
     /** @var MinimumOrderProvider|\PHPUnit\Framework\MockObject\MockObject */
     private $minimumOrderProvider;
 
-    /** @var ScopeConfigInterface|\PHPUnit\Framework\MockObject\MockObject */
-    private $scopeConfig;
+    /** @var MerchantMinimumResolver|\PHPUnit\Framework\MockObject\MockObject */
+    private $merchantMinimumResolver;
 
     /** @var Surcharge */
     private $collector;
@@ -75,7 +75,7 @@ class SurchargeTest extends TestCase
         // unaffected by defaulting the min-order gate to satisfied.
         $this->minimumOrderGate->method('isSatisfied')->willReturn(true);
         $this->minimumOrderProvider = $this->createMock(MinimumOrderProvider::class);
-        $this->scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $this->merchantMinimumResolver = $this->createMock(MerchantMinimumResolver::class);
 
         $this->collector = new Surcharge(
             $this->session,
@@ -85,7 +85,7 @@ class SurchargeTest extends TestCase
             $this->createMock(LogRepository::class),
             $this->minimumOrderGate,
             $this->minimumOrderProvider,
-            $this->scopeConfig
+            $this->merchantMinimumResolver
         );
     }
 
@@ -100,6 +100,16 @@ class SurchargeTest extends TestCase
             public function getStoreId()
             {
                 return 1;
+            }
+
+            public function getStore()
+            {
+                return new class extends DataObject {
+                    public function getBaseCurrencyCode()
+                    {
+                        return 'USD';
+                    }
+                };
             }
 
             public function getQuoteCurrencyCode()
@@ -240,7 +250,7 @@ class SurchargeTest extends TestCase
             $this->createMock(LogRepository::class),
             $this->minimumOrderGate,
             $this->minimumOrderProvider,
-            $this->scopeConfig
+            $this->merchantMinimumResolver
         );
 
         $this->session->setTwoSurchargeAmount(100.0);

--- a/Test/Unit/Model/TwoAssertOrderMeetsMinimumTest.php
+++ b/Test/Unit/Model/TwoAssertOrderMeetsMinimumTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Two\Gateway\Test\Unit\Model;
 
 use Magento\Directory\Model\Currency;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Sales\Model\Order;
 use Magento\Store\Model\Store;
@@ -12,6 +13,7 @@ use Two\Gateway\Api\BrandRegistryInterface;
 use Two\Gateway\Api\CurrencyRatesProviderInterface;
 use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
 use Two\Gateway\Model\Two;
+use Two\Gateway\Service\Order\MerchantMinimumResolver;
 use Two\Gateway\Service\Order\MinimumOrderGate;
 use Two\Gateway\Service\Order\MinimumOrderProvider;
 
@@ -61,11 +63,26 @@ class TwoAssertOrderMeetsMinimumTest extends TestCase
             }
         };
 
+        // buildMerchantMinimum() now delegates to MerchantMinimumResolver;
+        // back it with a scope-config stub reading the same $configData the
+        // model's own getConfigData() override reads, so tests keep driving
+        // the admin-config values through one property.
+        $model = $this->model;
+        $scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $scopeConfig->method('getValue')->willReturnCallback(
+            static function (string $path) use ($model) {
+                $field = substr($path, strrpos($path, '/') + 1);
+                return $model->configData[$field] ?? null;
+            }
+        );
+        $merchantMinimumResolver = new MerchantMinimumResolver($scopeConfig);
+
         $ref = new \ReflectionClass(Two::class);
         $injected = [
             'minimumOrderGate' => $gate,
             'minimumOrderProvider' => $this->minimumOrderProvider,
             'brandRegistry' => $brandRegistry,
+            'merchantMinimumResolver' => $merchantMinimumResolver,
         ];
         foreach ($injected as $name => $value) {
             $ref->getProperty($name)->setValue($this->model, $value);

--- a/Test/Unit/Model/TwoMinimumOrderVisibilityTest.php
+++ b/Test/Unit/Model/TwoMinimumOrderVisibilityTest.php
@@ -3,12 +3,14 @@ declare(strict_types=1);
 
 namespace Two\Gateway\Test\Unit\Model;
 
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Quote\Model\Quote;
 use Magento\Store\Model\Store;
 use PHPUnit\Framework\TestCase;
 use Two\Gateway\Api\CurrencyRatesProviderInterface;
 use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
 use Two\Gateway\Model\Two;
+use Two\Gateway\Service\Order\MerchantMinimumResolver;
 use Two\Gateway\Service\Order\MinimumOrderGate;
 use Two\Gateway\Service\Order\MinimumOrderProvider;
 
@@ -54,8 +56,27 @@ class TwoMinimumOrderVisibilityTest extends TestCase
             }
         };
 
+        // buildMerchantMinimum() now delegates to MerchantMinimumResolver;
+        // back it with a scope-config stub reading the same $configData the
+        // model's own getConfigData() override reads, so tests keep driving
+        // the admin-config values through one property.
+        $model = $this->model;
+        $scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $scopeConfig->method('getValue')->willReturnCallback(
+            static function (string $path) use ($model) {
+                $field = substr($path, strrpos($path, '/') + 1);
+                return $model->configData[$field] ?? null;
+            }
+        );
+        $merchantMinimumResolver = new MerchantMinimumResolver($scopeConfig);
+
         $ref = new \ReflectionClass(Two::class);
-        foreach (['minimumOrderGate' => $gate, 'minimumOrderProvider' => $this->minimumOrderProvider] as $name => $value) {
+        $properties = [
+            'minimumOrderGate' => $gate,
+            'minimumOrderProvider' => $this->minimumOrderProvider,
+            'merchantMinimumResolver' => $merchantMinimumResolver,
+        ];
+        foreach ($properties as $name => $value) {
             $ref->getProperty($name)->setValue($this->model, $value);
         }
     }

--- a/Test/Unit/Service/Order/MerchantMinimumResolverTest.php
+++ b/Test/Unit/Service/Order/MerchantMinimumResolverTest.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Service\Order;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\ScopeInterface;
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Service\Order\MerchantMinimumResolver;
+
+class MerchantMinimumResolverTest extends TestCase
+{
+    /** @var ScopeConfigInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $scopeConfig;
+
+    /** @var MerchantMinimumResolver */
+    private $resolver;
+
+    protected function setUp(): void
+    {
+        $this->scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $this->resolver = new MerchantMinimumResolver($this->scopeConfig);
+    }
+
+    private function stubConfig(float $amount, string $basis = ''): void
+    {
+        $this->scopeConfig->method('getValue')->willReturnMap([
+            ['payment/two_payment/merchant_minimum_order', ScopeInterface::SCOPE_STORE, 1, $amount],
+            ['payment/two_payment/merchant_minimum_order_basis', ScopeInterface::SCOPE_STORE, 1, $basis],
+        ]);
+    }
+
+    public function testNullWhenNoMerchantMinimumConfigured(): void
+    {
+        $this->stubConfig(0.0);
+        $this->assertNull($this->resolver->resolve('two_payment', 'GBP', null, 1));
+    }
+
+    public function testNullWhenBaseCurrencyUnresolved(): void
+    {
+        $this->stubConfig(35.0);
+        $this->assertNull($this->resolver->resolve('two_payment', '', null, 1));
+    }
+
+    public function testResolvesConfiguredMerchantMinimum(): void
+    {
+        $this->stubConfig(35.0, 'net');
+        $this->assertSame(
+            ['amount' => 35.0, 'currency' => 'GBP', 'basis' => 'net'],
+            $this->resolver->resolve('two_payment', 'GBP', null, 1)
+        );
+    }
+
+    public function testBasisFallsBackToPlatformBasisWhenAdminValueInvalid(): void
+    {
+        $this->stubConfig(35.0, 'invalid');
+        $this->assertSame(
+            ['amount' => 35.0, 'currency' => 'GBP', 'basis' => 'gross'],
+            $this->resolver->resolve('two_payment', 'GBP', ['basis' => 'gross'], 1)
+        );
+    }
+
+    public function testBasisFallsBackToGrossWhenNoPlatformMinimumEither(): void
+    {
+        $this->stubConfig(35.0, '');
+        $this->assertSame(
+            ['amount' => 35.0, 'currency' => 'GBP', 'basis' => 'gross'],
+            $this->resolver->resolve('two_payment', 'GBP', null, 1)
+        );
+    }
+
+    public function testScopedByPaymentMethodCode(): void
+    {
+        $this->scopeConfig->method('getValue')->willReturnMap([
+            ['payment/acme_payment/merchant_minimum_order', ScopeInterface::SCOPE_STORE, 1, 50.0],
+            ['payment/acme_payment/merchant_minimum_order_basis', ScopeInterface::SCOPE_STORE, 1, 'net'],
+            ['payment/two_payment/merchant_minimum_order', ScopeInterface::SCOPE_STORE, 1, 0.0],
+        ]);
+
+        $this->assertNull($this->resolver->resolve('two_payment', 'GBP', null, 1));
+        $this->assertSame(
+            ['amount' => 50.0, 'currency' => 'GBP', 'basis' => 'net'],
+            $this->resolver->resolve('acme_payment', 'GBP', null, 1)
+        );
+    }
+}


### PR DESCRIPTION
## Context

Reported flow: min order value £35 net, non-zero buyer surcharge, free shipping + £5 shipping option configured. Basket £34 (below min). Selecting £5 shipping correctly reveals the payment method; selecting terms with a surcharge correctly shows the surcharge line. Switching back to free shipping correctly hides the payment method again — but the surcharge line stays visible in the order summary until a different payment method is manually selected.

Root cause: two independent eligibility gates that are never synchronized.

- **Visibility gate** — `Two::isAvailable()` (`Model/Two.php`) via `MinimumOrderGate::isSatisfied()`. The Hyvä `MethodList` component re-evaluates this on `shipping_method_selected` and correctly hides the radio button. Pure render-time check — never touches quote state.
- **Totals-application gate** — `Surcharge::collect()` (`Model/Total/Surcharge.php`). Its only eligibility check was whether `quote->getPayment()->getMethod()` still equals `two_payment`. It never called `MinimumOrderGate`.

Switching shipping re-runs `collectTotals()`, which re-runs the surcharge collector — but nothing clears the quote's stored payment method, so the collector still sees `two_payment` selected and keeps reapplying the surcharge. The price-summary template just renders whatever the totals fetch returns, so it looked buggy but was just fed stale data. The only thing that cleared it in the field was manually picking a different payment method, since that's the only action that actually rewrites the quote's payment-method code.

## Changes

- `Surcharge::collect()` now re-runs the same `MinimumOrderGate` check `Two::isAvailable()` uses (platform + merchant minimum) and clears the surcharge whenever it fails — not just when the payment-method code changes.
- Added `buildMerchantMinimum()` to `Surcharge`, mirroring `Two::buildMerchantMinimum()` but keyed off the quote's live payment-method code (read via `ScopeConfigInterface` directly) rather than a single bound method instance, since the collector can be shared across brand overlays.

## Scope / Non-goals

- Doesn't touch the Amasty OneStepCheckout render-time bypass in `Two::isAvailable()` — that's a stale-render workaround unrelated to this totals-collect timing issue (totals collection always sees the live quote).
- Doesn't attempt to deselect the quote's payment method when it becomes ineligible — clearing the totals-side effect is sufficient and lower-risk than mutating payment selection during collectTotals().

## Validation

- `make test` (PHPUnit 9.6.34 in Docker): `OK (347 tests, 605 assertions)`
- Added `testSurchargeClearedWhenBelowMinimumOrderEvenWithPaymentMethodStillSelected` reproducing the bug directly (min-order gate fails while `two_payment` stays selected on the quote) and asserting the surcharge clears.
- `php -l Model/Total/Surcharge.php`: no syntax errors.

## Ticket

- https://linear.app/two-inc/issue/ABN-463/surcharge-total-stays-visible-after-shipping-change-makes-payment