### PR TITLE
TWO-24843/fix: recover the Luma Place Order button from a stale latch

### DIFF
--- a/Test/Js/amd-harness.js
+++ b/Test/Js/amd-harness.js
@@ -56,7 +56,9 @@ function defaultMocks() {
             billingAddress: makeObservable({}),
             getTotals: function () { return makeObservable({}); },
             getQuoteId: function () { return null; },
-            paymentMethod: makeObservable(null)
+            paymentMethod: makeObservable(null),
+            shippingMethod: makeObservable({ carrier_code: 'freeshipping' }),
+            isVirtual: function () { return false; }
         },
         'Magento_Customer/js/customer-data': {
             get: function () { return makeObservable({}); },

--- a/Test/Js/gateway-method-place-order-latch.test.js
+++ b/Test/Js/gateway-method-place-order-latch.test.js
@@ -1,0 +1,201 @@
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ *
+ * Regression cover for TWO-24843: on Luma the Place Order button stayed
+ * permanently greyed after a failed/blocked first attempt, and clicks on it
+ * were silently swallowed, so checkout could not be recovered without a reload.
+ */
+
+'use strict';
+
+const { loadAmdModule, defaultMocks } = require('./amd-harness');
+
+/**
+ * Minimal ko.observable stand-in with a settable value.
+ */
+function observable(initial) {
+    let value = initial;
+    return function (next) {
+        if (arguments.length === 0) return value;
+        value = next;
+        return undefined;
+    };
+}
+
+/**
+ * jQuery-deferred stand-in whose settlement the test drives explicitly, so a
+ * request can be left permanently in flight.
+ */
+function makeDeferred() {
+    const doneCbs = [];
+    const alwaysCbs = [];
+    const d = {
+        done: function (fn) {
+            doneCbs.push(fn);
+            return d;
+        },
+        fail: function () {
+            return d;
+        },
+        always: function (fn) {
+            alwaysCbs.push(fn);
+            return d;
+        },
+        resolve: function () {
+            doneCbs.forEach(function (fn) {
+                fn();
+            });
+            alwaysCbs.forEach(function (fn) {
+                fn();
+            });
+        },
+        reject: function () {
+            alwaysCbs.forEach(function (fn) {
+                fn();
+            });
+        }
+    };
+    return d;
+}
+
+/**
+ * Load the renderer with a quote whose shipping/virtual state the test picks.
+ * Each load gets its own module instance, and therefore its own in-flight flag.
+ */
+function loadComponent(quoteState) {
+    const quoteMock = defaultMocks()['Magento_Checkout/js/model/quote'];
+    return loadAmdModule('view/frontend/web/js/view/payment/method-renderer/gateway_method.js', {
+        'Magento_Checkout/js/model/quote': Object.assign({}, quoteMock, {
+            shippingMethod: observable(
+                'shippingMethod' in quoteState
+                    ? quoteState.shippingMethod
+                    : { carrier_code: 'free' }
+            ),
+            isVirtual: function () {
+                return !!quoteState.isVirtual;
+            }
+        })
+    });
+}
+
+/**
+ * Build the `this` context placeOrder runs against, reusing the component's own
+ * placeOrderBackend and showErrorMessage so the real code paths are exercised.
+ */
+function makeContext(component, opts) {
+    const errors = [];
+    const ctx = {
+        errors: errors,
+        placeOrderCalls: 0,
+        messageContainer: {
+            clear: function () {
+                errors.length = 0;
+            },
+            addErrorMessage: function (m) {
+                errors.push(m.message);
+            }
+        },
+        isPaymentTermsEnabled: true,
+        isPaymentTermsAccepted: observable(true),
+        isPlaceOrderActionAllowed: observable('allowed' in opts ? opts.allowed : true),
+        isInvoiceEmailsEnabled: false,
+        redirectAfterPlaceOrder: false,
+        validate: function () {
+            return true;
+        },
+        afterPlaceOrder: function () {},
+        showErrorMessage: component.showErrorMessage,
+        placeOrder: component.placeOrder,
+        placeOrderBackend: component.placeOrderBackend,
+        getPlaceOrderDeferredObject: function () {
+            ctx.placeOrderCalls++;
+            if (opts.throwSynchronously) {
+                throw new Error('boom');
+            }
+            ctx.deferred = makeDeferred();
+            return ctx.deferred;
+        }
+    };
+    return ctx;
+}
+
+describe('gateway_method place-order latch (TWO-24843)', () => {
+    test('refuses to post when a non-virtual quote has no shipping method', () => {
+        const component = loadComponent({ shippingMethod: null });
+        const ctx = makeContext(component, {});
+
+        ctx.placeOrder.call(ctx);
+
+        expect(ctx.placeOrderCalls).toBe(0);
+        expect(ctx.errors.join(' ')).toMatch(/shipping method is missing/i);
+        // The blocked attempt must not latch the button either.
+        expect(ctx.isPlaceOrderActionAllowed()).toBe(true);
+    });
+
+    test('still places a virtual quote, which legitimately has no shipping method', () => {
+        const component = loadComponent({ shippingMethod: null, isVirtual: true });
+        const ctx = makeContext(component, {});
+
+        ctx.placeOrder.call(ctx);
+
+        expect(ctx.placeOrderCalls).toBe(1);
+        expect(ctx.errors).toEqual([]);
+    });
+
+    test('re-arms the button after a failed placement', () => {
+        const component = loadComponent({});
+        const ctx = makeContext(component, {});
+
+        ctx.placeOrder.call(ctx);
+        expect(ctx.isPlaceOrderActionAllowed()).toBe(false);
+
+        ctx.deferred.reject();
+        expect(ctx.isPlaceOrderActionAllowed()).toBe(true);
+    });
+
+    test('recovers a latch left set while no request is in flight', () => {
+        // The state core's quote.billingAddress subscription leaves behind when
+        // the billing address is momentarily null: latched false, nothing in
+        // flight, and no writer that will ever set it back to true. Before the
+        // fix this click was swallowed in silence.
+        const component = loadComponent({});
+        const ctx = makeContext(component, { allowed: false });
+
+        ctx.placeOrder.call(ctx);
+
+        expect(ctx.placeOrderCalls).toBe(1);
+        expect(ctx.errors).toEqual([]);
+    });
+
+    test('does not double-submit, and says why, while a placement is in flight', () => {
+        const component = loadComponent({});
+        const ctx = makeContext(component, {});
+
+        ctx.placeOrder.call(ctx);
+        expect(ctx.placeOrderCalls).toBe(1);
+        expect(ctx.isPlaceOrderActionAllowed()).toBe(false);
+
+        // Second click with the first request still unsettled.
+        ctx.placeOrder.call(ctx);
+
+        expect(ctx.placeOrderCalls).toBe(1);
+        expect(ctx.errors.join(' ')).toMatch(/already being placed/i);
+    });
+
+    test('clears the latch when getPlaceOrderDeferredObject throws synchronously', () => {
+        const component = loadComponent({});
+        const ctx = makeContext(component, { throwSynchronously: true });
+
+        expect(() => ctx.placeOrder.call(ctx)).toThrow('boom');
+
+        // No .always() was ever attached, so without the try/catch the button
+        // would stay dead for the life of the page.
+        expect(ctx.isPlaceOrderActionAllowed()).toBe(true);
+
+        // And the next click still works.
+        const ctx2 = makeContext(component, { allowed: false });
+        ctx2.placeOrder.call(ctx2);
+        expect(ctx2.placeOrderCalls).toBe(1);
+    });
+});

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -43,6 +43,14 @@ define([
 
     window.quote = quote;
 
+    // True while a place-order request started by this renderer is in flight.
+    // Deliberately module-scope rather than per-instance, because the
+    // isPlaceOrderActionAllowed observable it guards is itself shared: it is
+    // declared on the prototype of Magento_Checkout/js/view/payment/default, so
+    // one ko.observable backs every payment renderer in the page and survives
+    // every renderer Magento re-creates when the payment-method list refreshes.
+    var placeOrderInFlight = false;
+
     return Component.extend({
         defaults: {
             template: 'Two_Gateway/payment/gateway_method'
@@ -438,6 +446,36 @@ define([
             // resubmits don't render outdated messages (e.g. terms-not-accepted
             // lingering after the box has been ticked).
             this.messageContainer.clear();
+
+            // Recover a stale place-order latch.
+            //
+            // isPlaceOrderActionAllowed has only two writers: this renderer, which
+            // sets it false before a place-order request and re-arms it in that
+            // request's .always(), and core's quote.billingAddress subscription in
+            // Magento_Checkout/js/view/payment/default, which sets it to
+            // `address !== null`. The latter has no path back to true other than a
+            // further billing-address change, so a transient null billing address
+            // — routine while the buyer edits an address, and around the
+            // renderer re-creation Luma performs whenever the payment-method list
+            // refreshes after a shipping-method save — leaves the observable false
+            // indefinitely. It is shared, too (declared on the prototype), so
+            // re-rendering does not reset it, and the template only greys the
+            // button with a CSS class rather than disabling it. Clicks therefore
+            // kept arriving here and were swallowed in silence: checkout was
+            // unrecoverable without a page reload.
+            //
+            // Re-arming is safe exactly when no request of ours is in flight, so
+            // the double-submit protection the latch provides is preserved. The
+            // one case this cannot rescue is a request that never settles at all
+            // (a hung response, or an earlier-registered fail handler that throws
+            // and aborts the rest of jQuery's callback list before our .always()).
+            // Nothing client-side safely can: "hung" and "still working" are
+            // indistinguishable from here, and guessing wrong duplicates an order.
+            // Avoiding that state is what the shipping-method check below is for.
+            if (!this.isPlaceOrderActionAllowed() && !placeOrderInFlight) {
+                this.isPlaceOrderActionAllowed(true);
+            }
+
             if (this.isPaymentTermsEnabled && !this.isPaymentTermsAccepted()) {
                 this.processTermsNotAcceptedErrorResponse();
                 return;
@@ -449,18 +487,53 @@ define([
                 return;
             }
 
+            // Refuse a placement the server is certain to reject.
+            // QuoteValidator::validateBeforeSubmit raises "The shipping method is
+            // missing" before any payment authorize, so posting a shipping-less
+            // quote can only fail — but it still costs a place-order request that
+            // holds Magento's per-cart CartMutex lock and keeps the button latched
+            // for as long as it runs, which is how a single mistimed click used to
+            // end in "The cart is locked for processing" on the retry. Keeping the
+            // failure client-side gives the buyer a message they can act on and
+            // never takes the lock. Virtual quotes have no shipping method by
+            // design and must not be blocked.
+            if (!quote.isVirtual() && !quote.shippingMethod()) {
+                this.showErrorMessage(
+                    $t('The shipping method is missing. Select the shipping method and try again.')
+                );
+                return;
+            }
+
             if (
                 this.validate() &&
                 additionalValidators.validate() &&
-                this.isPaymentTermsAccepted() === true &&
-                this.isPlaceOrderActionAllowed() === true
-            )
+                this.isPaymentTermsAccepted() === true
+            ) {
+                if (!this.isPlaceOrderActionAllowed()) {
+                    // After the re-arm above, only reachable while one of our own
+                    // requests is genuinely in flight. Say so instead of
+                    // swallowing the click.
+                    this.showErrorMessage($t('Your order is already being placed. Please wait.'));
+                    return;
+                }
                 this.placeOrderBackend();
+            }
         },
         placeOrderBackend: function () {
             const self = this;
+            let deferred;
+            placeOrderInFlight = true;
             this.isPlaceOrderActionAllowed(false);
-            return this.getPlaceOrderDeferredObject()
+            try {
+                deferred = this.getPlaceOrderDeferredObject();
+            } catch (error) {
+                // A synchronous throw would otherwise leave the latch set with no
+                // .always() attached to ever clear it.
+                placeOrderInFlight = false;
+                this.isPlaceOrderActionAllowed(true);
+                throw error;
+            }
+            return deferred
                 .done(function () {
                     self.afterPlaceOrder();
                     if (self.redirectAfterPlaceOrder) {
@@ -468,6 +541,7 @@ define([
                     }
                 })
                 .always(function () {
+                    placeOrderInFlight = false;
                     self.isPlaceOrderActionAllowed(true);
                 });
         },


### PR DESCRIPTION
Linear: [TWO-24843](https://linear.app/two-inc/issue/TWO-24843/bug-luma-checkout-place-order-stuck-disabled-after-missing-shipping)

## The bug

On the Luma checkout the Place Order button could stay greyed for the rest of the session, with every further click silently doing nothing, and a refresh-then-retry reporting "The cart is locked for processing".

## The state machine

`isPlaceOrderActionAllowed` has exactly two writers:

1. **This renderer** — set false before a place-order request, re-armed in that request's `.always()`.
2. **Core** — `quote.billingAddress.subscribe(function (address) { this.isPlaceOrderActionAllowed(address !== null); })` in `Magento_Checkout/js/view/payment/default`.

Writer 2 has no path back to true other than a further billing-address change. So a transient null billing address — routine while the buyer edits an address, and around the renderer re-creation Luma performs whenever the payment-method list refreshes after a shipping-method save — leaves the observable false indefinitely.

Two properties make that unrecoverable rather than cosmetic:

- The observable is declared **on the prototype** of core's `default.js`, not per instance. One `ko.observable` backs every payment renderer in the page and survives every re-render, so re-rendering does not reset it.
- The template greys the button with `css: {disabled: !isPlaceOrderActionAllowed()}` — a CSS class, not the `disabled` attribute. Clicks still fire. They arrived in `placeOrder()`, hit the `isPlaceOrderActionAllowed() === true` precondition, and were dropped **with no message**. Hence "T&C toggling doesn't help": nothing the buyer can do on that page writes the observable.

## Changes

- **Re-arm on click when nothing is in flight.** A module-scope in-flight flag pairs with the shared observable (module scope, because the observable it guards is itself shared). Re-arming is safe exactly when no request of ours is outstanding, so the double-submit protection is preserved, and a click that genuinely arrives mid-request now says so instead of being swallowed.
- **Refuse a placement with no shipping method** (non-virtual quotes only). `QuoteValidator::validateBeforeSubmit` raises "The shipping method is missing" before any payment authorize, so such a request can only fail — but it still holds Magento's per-cart `CartMutex` lock and keeps the button latched for as long as it runs. That is how one mistimed click ended in "The cart is locked for processing" on the retry. Keeping the failure client-side never takes the lock and gives the buyer an actionable message.
- **`placeOrderBackend()` re-arms on a synchronous throw** out of `getPlaceOrderDeferredObject()`, which would otherwise leave the latch set with no `.always()` attached to ever clear it.

### Known limitation, stated deliberately

A request that never settles at all still latches the button until reload. Nothing client-side can safely fix that: "hung" and "still working" are indistinguishable from the browser, and guessing wrong duplicates an order. The shipping-method check removes the trigger reported in this ticket from that path.

## No server-side change — the ticket's Fault B does not hold

The ticket proposed running `RestoreQuote::execute()` on every `Two::order()` failure path to release the lock. Reading it through:

- The string is core `Magento\Quote\Model\CartMutex`: `__('The cart is locked for processing. Please try again later.')`. It acquires with `lock($name, 0)` and releases in a **`finally`**. There is no plugin-side lock state to clear, and the plugin cannot release a core lock.
- `QuoteManagement::submitQuote()` runs `QuoteValidator::validateBeforeSubmit()` **before** any payment authorize, so a shipping-less quote never reaches `Two::authorize()` or the Two API at all. The Two call is not what fails here.
- `RestoreQuote` is wired only into the hosted-checkout return controllers (`Confirm`, `Cancel`, `Verificationfailed`, via `OrderService::restoreQuote()`), which is correct. On an `authorize()` throw the `submitQuote` transaction rolls back — the quote was never converted, so there is nothing to restore. Calling it there would be wrong.

A retry can therefore only hit that lock while the first request is genuinely still holding it. If it recurs after this fix, the thing to pull is the `critical` log line `The cart is locked for processing, the request has been aborted. Quote ID: N` and whether the deploy uses persistent MySQL connections (a process killed mid-callable skips the `finally`, and a persistent connection would carry the `GET_LOCK` into the next request).

## Tests

New `Test/Js/gateway-method-place-order-latch.test.js`, 6 cases on the existing AMD-in-Jest harness. Verified against the pre-fix source: **4 fail, 2 pass** — the 2 that pass are the deliberate no-regression controls (virtual quote still places; a normal failed placement still re-arms).

```
✕ refuses to post when a non-virtual quote has no shipping method
✓ still places a virtual quote, which legitimately has no shipping method
✓ re-arms the button after a failed placement
✕ recovers a latch left set while no request is in flight
✕ does not double-submit, and says why, while a placement is in flight
✕ clears the latch when getPlaceOrderDeferredObject throws synchronously
```

Post-fix, the full Jest gate (the suite CI runs):

```
Test Suites: 7 passed, 7 total
Tests:       57 passed, 57 total
```

e2e was considered and rejected for the regression: Luma's shipping step will not advance without a shipping method, so the Playwright suite cannot reach the pre-fix state without faking it, and the fault is a JS state machine that the Jest harness drives directly and deterministically. `e2e/tests/checkout-luma.spec.ts` already covers the happy path this must not regress.

## Not touched

- **Hyva** (`magento-hyva-extension`) — checked, not affected. Its Two component owns only the order-intent flow; Hyva Checkout owns the place-order button and its own loading state. No `isPlaceOrderActionAllowed` equivalent. No ticket needed.
- `registeredOrganisationMode()`'s duplicate `enableCompanySearch()` / `fillCustomerData()` subscriptions (TWO-24867) — **not** the mechanism here. The latch is a single shared observable with two writers; duplicate subscriptions cannot latch it. Not a shared root cause.

## Noted in passing, not fixed

- `placeOrder()` requires `isPaymentTermsAccepted() === true` unconditionally, but the checkbox only renders under `<!-- ko if: isPaymentTermsEnabled -->`. With payment terms disabled the observable can never become true and the order can never be placed. Left exactly as-is to keep this diff to the reported fault.
- `showErrorMessage` is defined twice in `gateway_method.js` (~:234 with a duration argument, ~:856 without). The later definition wins, so the duration argument at the `validateEmails` call site is silently ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)