### PR TITLE
TWO-25174/fix: four defects in the Luma payment renderer

### DIFF
--- a/Test/Js/gateway-method-place-order-latch.test.js
+++ b/Test/Js/gateway-method-place-order-latch.test.js
@@ -26,34 +26,40 @@ function observable(initial) {
 /**
  * jQuery-deferred stand-in whose settlement the test drives explicitly, so a
  * request can be left permanently in flight.
+ *
+ * Callbacks are kept in one registration-ordered list, and a throw from any of
+ * them propagates and abandons the rest — which is what jQuery does (`always`
+ * is `.done(fn).fail(fn)`, appending to the same callback list, and
+ * Callbacks.fireWith invokes them synchronously). Registration order is
+ * therefore load-bearing behaviour, not an implementation detail, and the
+ * stand-in has to reproduce it for the .always()-before-.done() cover below to
+ * mean anything.
  */
 function makeDeferred() {
-    const doneCbs = [];
-    const alwaysCbs = [];
+    const cbs = [];
+    function fire(kinds) {
+        cbs.forEach(function (entry) {
+            if (kinds.indexOf(entry.kind) !== -1) entry.fn();
+        });
+    }
     const d = {
         done: function (fn) {
-            doneCbs.push(fn);
+            cbs.push({ kind: 'done', fn: fn });
             return d;
         },
-        fail: function () {
+        fail: function (fn) {
+            cbs.push({ kind: 'fail', fn: fn || function () {} });
             return d;
         },
         always: function (fn) {
-            alwaysCbs.push(fn);
+            cbs.push({ kind: 'always', fn: fn });
             return d;
         },
         resolve: function () {
-            doneCbs.forEach(function (fn) {
-                fn();
-            });
-            alwaysCbs.forEach(function (fn) {
-                fn();
-            });
+            fire(['done', 'always']);
         },
         reject: function () {
-            alwaysCbs.forEach(function (fn) {
-                fn();
-            });
+            fire(['fail', 'always']);
         }
     };
     return d;
@@ -96,15 +102,21 @@ function makeContext(component, opts) {
                 errors.push(m.message);
             }
         },
-        isPaymentTermsEnabled: true,
-        isPaymentTermsAccepted: observable(true),
+        isPaymentTermsEnabled: 'termsEnabled' in opts ? opts.termsEnabled : true,
+        isPaymentTermsAccepted: observable('termsAccepted' in opts ? opts.termsAccepted : true),
         isPlaceOrderActionAllowed: observable('allowed' in opts ? opts.allowed : true),
         isInvoiceEmailsEnabled: false,
         redirectAfterPlaceOrder: false,
         validate: function () {
             return true;
         },
-        afterPlaceOrder: function () {},
+        afterPlaceOrder: function () {
+            ctx.afterPlaceOrderCalls++;
+            if (opts.afterPlaceOrderThrows) {
+                throw new Error('afterPlaceOrder boom');
+            }
+        },
+        afterPlaceOrderCalls: 0,
         showErrorMessage: component.showErrorMessage,
         placeOrder: component.placeOrder,
         placeOrderBackend: component.placeOrderBackend,
@@ -197,5 +209,146 @@ describe('gateway_method place-order latch (TWO-24843)', () => {
         const ctx2 = makeContext(component, { allowed: false });
         ctx2.placeOrder.call(ctx2);
         expect(ctx2.placeOrderCalls).toBe(1);
+    });
+});
+
+describe('gateway_method renderer defects (TWO-25174)', () => {
+    test('places the order when payment terms are disabled and unaccepted', () => {
+        // No checkbox renders when the feature is off, so nothing ever writes the
+        // observable. Requiring acceptance anyway made the button silently dead.
+        const component = loadComponent({});
+        const ctx = makeContext(component, { termsEnabled: false, termsAccepted: false });
+
+        ctx.placeOrder.call(ctx);
+
+        expect(ctx.placeOrderCalls).toBe(1);
+        expect(ctx.errors).toEqual([]);
+    });
+
+    test('still refuses, with a message, when terms are enabled and unaccepted', () => {
+        const component = loadComponent({});
+        const ctx = makeContext(component, { termsEnabled: true, termsAccepted: false });
+        ctx.processTermsNotAcceptedErrorResponse = component.processTermsNotAcceptedErrorResponse;
+        ctx.termsNotAcceptedMessage = 'Please accept the payment terms';
+
+        ctx.placeOrder.call(ctx);
+
+        expect(ctx.placeOrderCalls).toBe(0);
+        expect(ctx.errors).toEqual(['Please accept the payment terms']);
+    });
+
+    test('two rapid clicks still yield exactly one place-order request', () => {
+        // The guarantee PR #262 established, re-asserted after re-keying the
+        // in-flight check off placeOrderInFlight.
+        const component = loadComponent({});
+        const ctx = makeContext(component, {});
+
+        ctx.placeOrder.call(ctx);
+        ctx.placeOrder.call(ctx);
+
+        expect(ctx.placeOrderCalls).toBe(1);
+        expect(ctx.errors.join(' ')).toMatch(/already being placed/i);
+    });
+
+    test('refuses a second click even if the shared latch is re-armed mid-request', () => {
+        // isPlaceOrderActionAllowed is prototype-shared and core's
+        // quote.billingAddress subscription can set it true while our request is
+        // still running. Keying the guard on that observable let the second click
+        // through to a second order-create POST; keying it on placeOrderInFlight
+        // does not.
+        const component = loadComponent({});
+        const ctx = makeContext(component, {});
+
+        ctx.placeOrder.call(ctx);
+        expect(ctx.placeOrderCalls).toBe(1);
+
+        ctx.isPlaceOrderActionAllowed(true); // core re-arms behind our back
+        ctx.placeOrder.call(ctx);
+
+        expect(ctx.placeOrderCalls).toBe(1);
+        expect(ctx.errors.join(' ')).toMatch(/already being placed/i);
+    });
+
+    test('clears the latch even when afterPlaceOrder() throws on success', () => {
+        const component = loadComponent({});
+        const ctx = makeContext(component, { afterPlaceOrderThrows: true });
+
+        ctx.placeOrder.call(ctx);
+        expect(ctx.isPlaceOrderActionAllowed()).toBe(false);
+
+        expect(() => ctx.deferred.resolve()).toThrow('afterPlaceOrder boom');
+
+        // .always() ran first, so both the observable and the module-scope
+        // in-flight flag are clear despite the throw...
+        expect(ctx.afterPlaceOrderCalls).toBe(1);
+        expect(ctx.isPlaceOrderActionAllowed()).toBe(true);
+
+        // ...and the next click is accepted rather than swallowed.
+        const ctx2 = makeContext(component, {});
+        ctx2.placeOrder.call(ctx2);
+        expect(ctx2.placeOrderCalls).toBe(1);
+        expect(ctx2.errors).toEqual([]);
+    });
+
+    test('showErrorMessage auto-dismisses after the requested duration', () => {
+        // Two definitions of showErrorMessage existed in the same object literal;
+        // the later, duration-less one won, so the auto-dismiss was dead code and
+        // validateEmails' timeout never fired.
+        jest.useFakeTimers();
+        try {
+            const component = loadComponent({});
+            const messages = [];
+            const ctx = {
+                messageContainer: {
+                    addErrorMessage: function (m) {
+                        messages.push(m.message);
+                    },
+                    errorMessages: {
+                        remove: function (predicate) {
+                            for (let i = messages.length - 1; i >= 0; i--) {
+                                if (predicate(messages[i])) messages.splice(i, 1);
+                            }
+                        }
+                    }
+                }
+            };
+
+            component.showErrorMessage.call(ctx, 'transient', 3000);
+            expect(messages).toEqual(['transient']);
+
+            jest.advanceTimersByTime(2999);
+            expect(messages).toEqual(['transient']);
+
+            jest.advanceTimersByTime(1);
+            expect(messages).toEqual([]);
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    test('showErrorMessage without a duration leaves the message in place', () => {
+        jest.useFakeTimers();
+        try {
+            const component = loadComponent({});
+            const messages = [];
+            const ctx = {
+                messageContainer: {
+                    addErrorMessage: function (m) {
+                        messages.push(m.message);
+                    },
+                    errorMessages: {
+                        remove: function () {
+                            throw new Error('must not be called');
+                        }
+                    }
+                }
+            };
+
+            component.showErrorMessage.call(ctx, 'sticky');
+            jest.advanceTimersByTime(60000);
+            expect(messages).toEqual(['sticky']);
+        } finally {
+            jest.useRealTimers();
+        }
     });
 });

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -262,7 +262,7 @@ define([
 
             const isValid = emailArray.every((email) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email));
             if (!isValid && emails) {
-                this.showErrorMessage(this.invalidEmailListMessage, 3);
+                this.showErrorMessage(this.invalidEmailListMessage, 3000);
                 return false;
             }
             return true;
@@ -504,15 +504,21 @@ define([
                 return;
             }
 
-            if (
-                this.validate() &&
-                additionalValidators.validate() &&
-                this.isPaymentTermsAccepted() === true
-            ) {
-                if (!this.isPlaceOrderActionAllowed()) {
-                    // After the re-arm above, only reachable while one of our own
-                    // requests is genuinely in flight. Say so instead of
-                    // swallowing the click.
+            // No isPaymentTermsAccepted() conjunct here: acceptance is a
+            // precondition only when the checkbox is actually rendered, which is
+            // exactly the isPaymentTermsEnabled gate above. Requiring it
+            // unconditionally made the button silently dead whenever terms are
+            // disabled — nothing renders the checkbox, no JS writes the
+            // observable, so it stays false, placeOrderBackend never runs and no
+            // error is shown. Only ConfigProvider hardcoding the flag to true
+            // kept that unreachable.
+            if (this.validate() && additionalValidators.validate()) {
+                if (placeOrderInFlight) {
+                    // Keyed on our own in-flight flag rather than on
+                    // isPlaceOrderActionAllowed: that observable is shared and
+                    // core's quote.billingAddress subscription can set it back to
+                    // true while our request is still running, which would let a
+                    // second click through to a second order-create POST.
                     this.showErrorMessage($t('Your order is already being placed. Please wait.'));
                     return;
                 }
@@ -533,16 +539,23 @@ define([
                 this.isPlaceOrderActionAllowed(true);
                 throw error;
             }
+            // .always() is registered BEFORE .done() on purpose. jQuery fires a
+            // deferred's callbacks in registration order and a throw from one
+            // aborts the rest of the list, so with .done() first an
+            // afterPlaceOrder() throw would strand both the latch and the
+            // in-flight flag — the one failure mode the recovery in placeOrder()
+            // cannot rescue. Clearing first is safe: JS is single-threaded, so no
+            // click can land between the clear and afterPlaceOrder() running.
             return deferred
+                .always(function () {
+                    placeOrderInFlight = false;
+                    self.isPlaceOrderActionAllowed(true);
+                })
                 .done(function () {
                     self.afterPlaceOrder();
                     if (self.redirectAfterPlaceOrder) {
                         redirectOnSuccessAction.execute();
                     }
-                })
-                .always(function () {
-                    placeOrderInFlight = false;
-                    self.isPlaceOrderActionAllowed(true);
                 });
         },
         processOrderIntentSuccessResponse: function (response) {
@@ -925,10 +938,6 @@ define([
             const windowFeatures =
                 'location=yes,resizable=yes,scrollbars=yes,status=yes, height=805, width=610';
             return window.open(URL, '_blank', windowFeatures);
-        },
-
-        showErrorMessage(message) {
-            this.messageContainer.addErrorMessage({ message });
         },
 
         registeredOrganisationMode() {


### PR DESCRIPTION
All four defects live in `view/frontend/web/js/view/payment/method-renderer/gateway_method.js`. Each was re-verified against `origin/staging` at `32a270f8` (post-merge of PR #262 in this repo) before being fixed — all four were still live.

## 1. Terms acceptance required even when the checkbox never renders

`placeOrder()`'s final conjunction required `isPaymentTermsAccepted() === true` unconditionally, while the checkbox only renders under `isPaymentTermsEnabled` and nothing else writes the observable. With terms disabled: no checkbox, observable stays `false`, `placeOrderBackend()` never runs, no error shown — a silently dead button. Currently unreachable only because `Model/Ui/ConfigProvider.php:191` hardcodes `isPaymentTermsEnabled => true` with no admin field, so this was a latent landmine rather than a live break.

The conjunct is removed. The `isPaymentTermsEnabled`-gated early return further up is the single precondition, which is exactly "required only when the checkbox is rendered".

## 2. `showErrorMessage` defined twice

Two definitions at the same brace depth in the same `Component.extend` literal. The later one (no `duration`) won, so the earlier one's `setTimeout` auto-dismiss was dead code. The duplicate is removed; the duration-capable definition survives. Its only duration caller, `validateEmails()`, passed `3` — three milliseconds — corrected to `3000`.

## 3. In-flight guard keyed on the wrong thing

The guard read `isPlaceOrderActionAllowed()`. That observable is prototype-shared and core's `quote.billingAddress` subscription sets it to `address !== null`, so it can go back to `true` while our request is still running; a second click then reached `placeOrderBackend()` and a second order-create POST. It now keys on the module-scope `placeOrderInFlight` flag. Pre-existing, not introduced by PR #262.

## 4. `.always()` registered after `.done()`

jQuery fires a deferred's callbacks in registration order (`always` is `.done(fn).fail(fn)`, appending to the same list) and a throw abandons the rest, so an `afterPlaceOrder()` throw stranded both the latch and the module flag — the one failure mode PR #262's recovery explicitly cannot rescue. `.always()` is now registered first. Clearing before `afterPlaceOrder()` runs is safe: JS is single-threaded, so no click can land in between.

## Double-submit: not reopened

Items 3 and 4 touch the machinery PR #262 hardened, whose central risk was double submission. Re-verified: the module-scope flag pairs with a prototype-shared `ko.observable`, and core's place-order action holds a full-screen loader over the request as an independent belt. Item 3 strictly narrows what gets through (it closes a path that previously allowed a second POST); item 4 only moves a clear that already happened on every settlement earlier in the same synchronous callback chain.

## Tests

Extends `Test/Js/gateway-method-place-order-latch.test.js` (PR #262's 6 cases, all kept intact) rather than starting a parallel file. Its deferred stand-in previously fired `done` then `always` regardless of registration order; it now keeps one registration-ordered callback list and lets a throw abandon the rest, matching jQuery, so registration order is genuinely under test.

New cases:
- placement succeeds when payment terms are disabled and unaccepted (item 1), with the enabled-and-unaccepted refusal kept as a control
- two rapid clicks yield exactly one place-order request
- a second click is still refused when the shared latch is re-armed mid-request (item 3)
- the latch and flag clear when `afterPlaceOrder()` throws on success, and the next click is accepted (item 4)
- `showErrorMessage` auto-dismisses after the requested duration, and does not without one (item 2)

Four of the seven new cases fail against `origin/staging` unchanged; the other three are controls that should pass both before and after.

`npm run test:js`: 7 suites, 64 tests passed.

## Hyvä

`magento-hyva-extension` is untouched. Item 1's shape does not exist there: there is no JS acceptance precondition on placement — validation is native `required` + `data-validate` through `hyva.formValidation` — and `ViewModel/CheckoutConfig.php:189` also hardcodes `true`. Worth recording for whoever eventually wires that switch up: Hyvä's terms container is `x-show`-hidden rather than removed from the DOM, so a `required` hidden checkbox would be the analogous trap.