### PR TITLE
TWO-25174/fix: render the invalid-email message once, not twice

### DIFF
--- a/Test/Js/gateway-method-place-order-latch.test.js
+++ b/Test/Js/gateway-method-place-order-latch.test.js
@@ -100,6 +100,13 @@ function makeContext(component, opts) {
             },
             addErrorMessage: function (m) {
                 errors.push(m.message);
+            },
+            errorMessages: {
+                remove: function (predicate) {
+                    for (let i = errors.length - 1; i >= 0; i--) {
+                        if (predicate(errors[i])) errors.splice(i, 1);
+                    }
+                }
             }
         },
         isPaymentTermsEnabled: 'termsEnabled' in opts ? opts.termsEnabled : true,
@@ -288,6 +295,47 @@ describe('gateway_method renderer defects (TWO-25174)', () => {
         ctx2.placeOrder.call(ctx2);
         expect(ctx2.placeOrderCalls).toBe(1);
         expect(ctx2.errors).toEqual([]);
+    });
+
+    test('renders the invalid-email message exactly once per rejected click', () => {
+        // validateEmails() both validates and displays; placeOrder() used to
+        // display the same message again on the false return, so the buyer saw
+        // the error twice — once auto-dismissing, once sticky.
+        jest.useFakeTimers();
+        try {
+            const component = loadComponent({});
+            const ctx = makeContext(component, {});
+            ctx.isInvoiceEmailsEnabled = true;
+            ctx.invoiceEmails = observable('not-an-email');
+            ctx.invalidEmailListMessage = 'One or more emails are invalid';
+            ctx.validateEmails = component.validateEmails;
+
+            ctx.placeOrder.call(ctx);
+
+            expect(ctx.placeOrderCalls).toBe(0);
+            expect(ctx.errors).toEqual(['One or more emails are invalid']);
+
+            // And the single message is the auto-dismissing one, so nothing is
+            // left stuck on screen after the buyer fixes the address.
+            jest.advanceTimersByTime(3000);
+            expect(ctx.errors).toEqual([]);
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    test('places the order when the forward-email list is valid', () => {
+        const component = loadComponent({});
+        const ctx = makeContext(component, {});
+        ctx.isInvoiceEmailsEnabled = true;
+        ctx.invoiceEmails = observable('a@b.com, c@d.com');
+        ctx.invalidEmailListMessage = 'One or more emails are invalid';
+        ctx.validateEmails = component.validateEmails;
+
+        ctx.placeOrder.call(ctx);
+
+        expect(ctx.placeOrderCalls).toBe(1);
+        expect(ctx.errors).toEqual([]);
     });
 
     test('showErrorMessage auto-dismisses after the requested duration', () => {

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -481,9 +481,11 @@ define([
                 return;
             }
 
-            // Validate emails on the forward list
+            // Validate emails on the forward list. validateEmails() displays the
+            // message itself, as processTermsNotAcceptedErrorResponse() above does
+            // for its own failure, so the caller only reacts to the false return
+            // — showing invalidEmailListMessage here too rendered it twice.
             if (this.isInvoiceEmailsEnabled && !this.validateEmails()) {
-                this.showErrorMessage(this.invalidEmailListMessage);
                 return;
             }
 


### PR DESCRIPTION
## Problem

`placeOrder()` in the Luma renderer displayed `invalidEmailListMessage` on the failure path of `validateEmails()` — but `validateEmails()` already displays that same message itself before returning false. Both statements run in the same click, so a buyer with a malformed forward-email address saw the error rendered **twice**: one copy with the helper's 3000ms auto-dismiss, one copy without a duration and therefore stuck on screen until the next `messageContainer.clear()`.

Verified empirically rather than by reading: the new test fails on `staging` with

```
Array [
    "One or more emails are invalid",
+   "One or more emails are invalid",
]
```

## Fix

Drop the display from `placeOrder()`. The helper owns validation *and* its message; the caller only reacts to the false return and returns.

That direction was chosen over the inverse (strip the display from the helper) because it matches the convention already in place directly above, where `processTermsNotAcceptedErrorResponse()` shows its own message and `placeOrder()` just returns. `validateEmails()` has no other call sites, so nothing loses a message.

## Tests

Two cases added to the existing `Test/Js/gateway-method-place-order-latch.test.js` rather than a parallel file: a rejected click renders exactly one message and that message is the auto-dismissing one; a valid list still places the order. `makeContext`'s stub message container gained an `errorMessages.remove` so the auto-dismiss timer has something to act on.

## Verification

- `npm run test:js` — 7 suites, 66 tests, all pass, no skips
- Codesniffer (`magento-coding-standard:latest --severity=6`) — 204/204 clean
- Prettier — both touched files clean
- phpstan / phpunit / di-compile left to CI; this change is JS-only

Part of TWO-25174 (fourth defect in this file; the other three shipped in PR #263).