### PR TITLE
fix(checkout): hold invalid-email error for 15s not 3s (TWO-25174)

### DIFF
--- a/Test/Js/gateway-method-place-order-latch.test.js
+++ b/Test/Js/gateway-method-place-order-latch.test.js
@@ -316,8 +316,11 @@ describe('gateway_method renderer defects (TWO-25174)', () => {
             expect(ctx.errors).toEqual(['One or more emails are invalid']);
 
             // And the single message is the auto-dismissing one, so nothing is
-            // left stuck on screen after the buyer fixes the address.
+            // left stuck on screen after the buyer fixes the address — but it
+            // survives well past the old 3s window, which was too short to read.
             jest.advanceTimersByTime(3000);
+            expect(ctx.errors).toEqual(['One or more emails are invalid']);
+            jest.advanceTimersByTime(12000);
             expect(ctx.errors).toEqual([]);
         } finally {
             jest.useRealTimers();

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -262,7 +262,10 @@ define([
 
             const isValid = emailArray.every((email) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email));
             if (!isValid && emails) {
-                this.showErrorMessage(this.invalidEmailListMessage, 3000);
+                // 15s, not 3s: 3s dismissed the message before a buyer who was
+                // still typing in the forward-email field had read it, and a sticky
+                // message stayed on screen long after the address was corrected.
+                this.showErrorMessage(this.invalidEmailListMessage, 15000);
                 return false;
             }
             return true;


### PR DESCRIPTION
## What

Linear TWO-25174. The invalid-forward-email error on the Two payment block auto-dismissed after 3000ms. Doug's call: 3s is too short to read while the buyer is still typing in the field, and a permanent message is too sticky once the address is corrected. Set to 15000ms.

## Exact changes

- `view/frontend/web/js/view/payment/method-renderer/gateway_method.js:265` (now 268) — `this.showErrorMessage(this.invalidEmailListMessage, 3000)` → `15000`, with a comment recording why neither 3s nor sticky.
- `Test/Js/gateway-method-place-order-latch.test.js` — the "renders the invalid-email message exactly once per rejected click" test advanced fake timers by 3000 and asserted the message was gone. Now asserts it is *still present* at 3000ms and gone after a further 12000ms, so the 15s window is pinned by a test rather than incidental.

No other timeout touched. Every other `showErrorMessage()` caller in the file passes no `duration` and is sticky by design; the generic `showErrorMessage auto-dismisses after the requested duration` unit test keeps its own arbitrary 3000ms argument because it exercises the mechanism, not the email message.

## Docs

Grepped `.ai/`, `README.md`, `CHANGELOG` and `docs/` for the dismissal behaviour — no doc describes it, nothing to update.

## Verification

`npm run test:js` (the Jest CI job's command): 7 suites, 66 tests, all passing. No PHP touched, so phpstan/phpcs/di-compile surfaces are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)