### PR TITLE
refactor(config): remove dead days_on_invoice config key (TWO-24859)

### DIFF
--- a/Api/Config/RepositoryInterface.php
+++ b/Api/Config/RepositoryInterface.php
@@ -25,7 +25,6 @@ interface RepositoryInterface
     public const XML_PATH_TITLE = 'payment/two_payment/title';
     public const XML_PATH_MODE = 'payment/two_payment/mode';
     public const XML_PATH_API_KEY = 'payment/two_payment/api_key';
-    public const XML_PATH_DAYS_ON_INVOICE = 'payment/two_payment/days_on_invoice';
     public const XML_PATH_FULFILL_TRIGGER = 'payment/two_payment/fulfill_trigger';
     public const XML_PATH_FULFILL_ORDER_STATUS = 'payment/two_payment/fulfill_order_status';
     public const XML_PATH_ENABLE_COMPANY_SEARCH = 'payment/two_payment/enable_company_search';
@@ -98,15 +97,6 @@ interface RepositoryInterface
      * @return bool
      */
     public function isDebugMode(?int $storeId = null, ?string $scope = null): bool;
-
-    /**
-     * Get invoice due in days
-     *
-     * @param int|null $storeId
-     *
-     * @return int
-     */
-    public function getDueInDays(?int $storeId = null): int;
 
     /**
      * Get Fulfill Trigger (invoice or shipment or complete)

--- a/Model/Config/Repository.php
+++ b/Model/Config/Repository.php
@@ -179,14 +179,6 @@ class Repository implements RepositoryInterface
     /**
      * @inheritDoc
      */
-    public function getDueInDays(?int $storeId = null): int
-    {
-        return (int)$this->getConfig($this->path('days_on_invoice'), $storeId);
-    }
-
-    /**
-     * @inheritDoc
-     */
     public function getFulfillTrigger(?int $storeId = null): string
     {
         return (string)$this->getConfig($this->path('fulfill_trigger'), $storeId);

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -32,7 +32,6 @@
                 <mode>sandbox</mode>
                 <invoice_type>FUNDED_INVOICE</invoice_type>
                 <merchant_minimum_order_basis>gross</merchant_minimum_order_basis>
-                <days_on_invoice>14</days_on_invoice>
                 <finalize_purchase>1</finalize_purchase>
                 <enable_order_intent>1</enable_order_intent>
                 <enable_invoice_emails>0</enable_invoice_emails>


### PR DESCRIPTION
## What

Deletes the dead `days_on_invoice` store-config key from the Magento plugin: the path constant, the getter (interface declaration + implementation), and the `etc/config.xml` default.

## Proof it is dead

`grep -rni 'days_on_invoice|daysOnInvoice'` over the repo returned exactly three hits, and `grep -rn 'getDueInDays|XML_PATH_DAYS_ON_INVOICE'` returned only the declaration/definition sites:

| Site | Status |
|---|---|
| `Api/Config/RepositoryInterface.php:28` — `XML_PATH_DAYS_ON_INVOICE` | zero references, including from the getter itself, which built the path inline via `$this->path('days_on_invoice')` |
| `Api/Config/RepositoryInterface.php:109` — `getDueInDays()` declaration | zero callers |
| `Model/Config/Repository.php:182` — `getDueInDays()` implementation | zero callers |
| `etc/config.xml:35` — `<days_on_invoice>14</days_on_invoice>` | no matching field in any `system.xml`, so no merchant could ever change it |

No reader in `Model/`, `Observer/`, `Plugin/`, `Controller/`, `Block/`, `view/` or `Test/`. Payment terms are sourced from the merchant record (`GET /v1/merchant`) via the settings/record providers, not from store config, so there is nothing to migrate and no behaviour to preserve.

Note for reviewers: `XML_PATH_DAYS_ON_INVOICE` lived on an `Api\` interface, so in principle a third-party module could reference it. It is unused inside this repo and inside the ABN overlay's own consumers of this interface is not affected (the overlay does not reference it either — the constant name does not appear outside this repo's history).

## Docs

Grepped `README.md`, `AGENTS.md`, `CLAUDE.md` (no `.ai/` dir in this repo) for `days_on_invoice`, `getDueInDays` and "due in days" — no doc describes this key, nothing to update.

## Verification

- `php -l` on both changed PHP files — no syntax errors.
- `etc/config.xml` parses as well-formed XML.
- Codesniffer, the exact CI command (`docker run … michielgerritsen/magento-coding-standard:latest --severity=6`): 204/204 files, no violations.

The phpstan / di-compile / upgrade-smoke legs need the Magento CI container and run on the PR.

## Note on Linear TWO-24859

TWO-24859 as written would break term resolution — it treats this key as a live input to term selection, which it is not (here it is dead; on WooCommerce it is the merchant's own default due-in-days, renamed under a separate PR). The ticket needs amending. Not edited from here — leaving that to Doug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)