### PR TITLE
fix(TWO-25193): fill address from payment-step company search

### DIFF
--- a/Test/Js/amd-harness.js
+++ b/Test/Js/amd-harness.js
@@ -108,6 +108,14 @@ function defaultMocks() {
         'Magento_Catalog/js/price-utils': { formatPrice: function (n) { return String(n); } },
         'Two_Gateway/js/model/surcharge': makeSurchargeMock(),
         'Two_Gateway/js/model/minimum-order-visibility': function () { return true; },
+        // Inert default. Tests that exercise the real company-search
+        // behaviour load the real module and pass it via extraMocks so
+        // they control the jQuery it closes over.
+        'Two_Gateway/js/model/company-search': {
+            buildSearchAjaxOptions: function () { return {}; },
+            lookupCompanyAddress: function () { return null; },
+            applyAddress: function () {}
+        },
         'Two_Gateway/js/model/brand-config': (function () {
             function getBrandConfig(code) {
                 return ((typeof window !== 'undefined' && window.checkoutConfig && window.checkoutConfig.payment) || {})[code] || {};
@@ -322,6 +330,11 @@ function loadAmdModule(relPath, extraMocks) {
         console: { log: function () {}, debug: function () {}, warn: function () {}, error: function () {} },
         setTimeout: setTimeout,
         clearTimeout: clearTimeout,
+        // Browser globals the module sources use directly.
+        URLSearchParams: URLSearchParams,
+        unescape: global.unescape,
+        Promise: Promise,
+        fetch: typeof fetch === 'function' ? fetch : function () { return Promise.resolve(); },
         // requirejs-config.js files just assign a top-level `var config`.
         // The harness loads them only to verify they parse; the assignment
         // is captured via the wider context.

--- a/Test/Js/company-search-address-lookup.test.js
+++ b/Test/Js/company-search-address-lookup.test.js
@@ -1,0 +1,340 @@
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ *
+ * TWO-25193: the payment-step company picker dropped `lookup_id` when
+ * mapping search results and never fired the company-detail request, so
+ * picking a company on the payment step filled nothing. The shipping-step
+ * picker did both. These tests pin the shared behaviour and both call sites.
+ */
+
+'use strict';
+
+const { loadAmdModule } = require('./amd-harness');
+
+/**
+ * jQuery test double that records $.ajax calls and the values written to
+ * address inputs, and lets a test drive select2 option/handler capture.
+ */
+function makeSpyJQuery(recorder) {
+    function $(selector) {
+        const obj = {
+            length: 0,
+            val: function (v) {
+                if (arguments.length) {
+                    recorder.written.push([selector, v]);
+                    return obj;
+                }
+                return recorder.values[selector];
+            },
+            trigger: function (evt) {
+                recorder.triggered.push([selector, evt]);
+                return obj;
+            },
+            prop: function () { return obj; },
+            text: function () { return obj; },
+            attr: function () { return obj; },
+            data: function () { return undefined; },
+            closest: function () { return obj; },
+            find: function () { return obj; },
+            append: function () { return obj; },
+            hide: function () { return obj; },
+            show: function () { return obj; },
+            select2: function (opts) {
+                if (typeof opts === 'object') {
+                    recorder.select2Options = opts;
+                }
+                return obj;
+            },
+            on: function (evt, handler) {
+                recorder.handlers[evt] = handler;
+                return obj;
+            }
+        };
+        return obj;
+    }
+    $.async = function (selector, fn) { fn(selector); };
+    $.ajax = function (opts) {
+        recorder.ajax.push(opts);
+        const jqxhr = {
+            done: function (cb) { recorder.doneCallbacks.push(cb); return jqxhr; },
+            fail: function () { return jqxhr; },
+            always: function () { return jqxhr; }
+        };
+        return jqxhr;
+    };
+    $.mage = { cookies: { get: function () { return null; } }, redirect: function () {} };
+    $.Deferred = function () {
+        const d = {
+            resolve: function () { return d; },
+            promise: function () { return d; },
+            done: function () { return d; },
+            fail: function () { return d; },
+            always: function () { return d; }
+        };
+        return d;
+    };
+    $.extend = Object.assign;
+    $.fn = {};
+    return $;
+}
+
+function makeRecorder() {
+    return {
+        ajax: [],
+        doneCallbacks: [],
+        written: [],
+        triggered: [],
+        values: {},
+        handlers: {},
+        select2Options: null
+    };
+}
+
+function loadCompanySearch($) {
+    return loadAmdModule('view/frontend/web/js/model/company-search.js', { jquery: $ });
+}
+
+const SEARCH_RESPONSE = {
+    items: [
+        {
+            name: 'Example Trading Ltd',
+            highlight: '<em>Example</em> Trading Ltd',
+            national_identifier: { id: '12345678' },
+            lookup_id: 'lookup-abc-123'
+        }
+    ]
+};
+
+const BASE_CONFIG = {
+    checkoutApiUrl: 'https://api.example.test',
+    companySearchLimit: 50,
+    isCompanySearchEnabled: true,
+    isAddressSearchEnabled: true
+};
+
+describe('company-search shared module', () => {
+    test('processResults carries lookup_id through as lookupId', () => {
+        const recorder = makeRecorder();
+        const companySearch = loadCompanySearch(makeSpyJQuery(recorder));
+
+        const ajaxOptions = companySearch.buildSearchAjaxOptions({
+            config: BASE_CONFIG,
+            getCountryCode: function () { return 'gb'; }
+        });
+        const results = ajaxOptions.processResults(SEARCH_RESPONSE).results;
+
+        expect(results).toHaveLength(1);
+        expect(results[0].lookupId).toBe('lookup-abc-123');
+        expect(results[0].companyId).toBe('12345678');
+    });
+
+    test('search url carries the uppercased country and paging window', () => {
+        const recorder = makeRecorder();
+        const companySearch = loadCompanySearch(makeSpyJQuery(recorder));
+
+        const ajaxOptions = companySearch.buildSearchAjaxOptions({
+            config: BASE_CONFIG,
+            getCountryCode: function () { return 'gb'; }
+        });
+        const url = ajaxOptions.url({ page: 2, term: 'example' });
+
+        expect(url).toContain('https://api.example.test/companies/v2/company?');
+        expect(url).toContain('country=GB');
+        expect(url).toContain('limit=50');
+        expect(url).toContain('offset=50');
+    });
+
+    test('lookupCompanyAddress fetches the company and fills the address form', () => {
+        const recorder = makeRecorder();
+        const companySearch = loadCompanySearch(makeSpyJQuery(recorder));
+
+        companySearch.lookupCompanyAddress(BASE_CONFIG, { lookupId: 'lookup-abc-123' });
+
+        expect(recorder.ajax).toHaveLength(1);
+        expect(recorder.ajax[0].url).toBe(
+            'https://api.example.test/companies/v2/company/lookup-abc-123'
+        );
+
+        recorder.doneCallbacks.forEach(function (cb) {
+            cb({
+                addresses: [
+                    { city: 'London', postal_code: 'EC1A 1BB', street_address: '1 Example Street' }
+                ]
+            });
+        });
+
+        expect(recorder.written).toEqual(
+            expect.arrayContaining([
+                ['input[name="city"]', 'London'],
+                ['input[name="postcode"]', 'EC1A 1BB'],
+                ['input[name="street[0]"]', '1 Example Street']
+            ])
+        );
+        expect(recorder.triggered).toEqual(
+            expect.arrayContaining([
+                ['input[name="city"], input[name="postcode"], input[name="street[0]"]', 'change']
+            ])
+        );
+    });
+
+    test('lookupCompanyAddress is a no-op when address search is disabled', () => {
+        const recorder = makeRecorder();
+        const companySearch = loadCompanySearch(makeSpyJQuery(recorder));
+
+        const result = companySearch.lookupCompanyAddress(
+            Object.assign({}, BASE_CONFIG, { isAddressSearchEnabled: false }),
+            { lookupId: 'lookup-abc-123' }
+        );
+
+        expect(result).toBeNull();
+        expect(recorder.ajax).toHaveLength(0);
+        expect(recorder.written).toHaveLength(0);
+    });
+
+    test('lookupCompanyAddress is a no-op when the result has no lookupId', () => {
+        const recorder = makeRecorder();
+        const companySearch = loadCompanySearch(makeSpyJQuery(recorder));
+
+        expect(companySearch.lookupCompanyAddress(BASE_CONFIG, {})).toBeNull();
+        expect(recorder.ajax).toHaveLength(0);
+    });
+});
+
+describe('payment-step company picker (gateway_method.js)', () => {
+    function loadRenderer(recorder, $) {
+        const companySearch = loadCompanySearch($);
+        return {
+            component: loadAmdModule(
+                'view/frontend/web/js/view/payment/method-renderer/gateway_method.js',
+                {
+                    jquery: $,
+                    'Two_Gateway/js/model/company-search': companySearch
+                }
+            ),
+            companySearch: companySearch
+        };
+    }
+
+    /**
+     * Minimal renderer `this` for enableCompanySearch(): it only touches
+     * selectors, the brand config, countryCode() and fillCompanyData().
+     */
+    function makeRendererContext(component, config, filled) {
+        return Object.assign(Object.create(component.prototype || {}), {
+            companyNameSelector: 'input#company_name',
+            companyIdSelector: 'input#company_id',
+            enterDetailsManuallyButton: '#billing_enter_details_manually',
+            searchForCompanyButton: '#billing_search_for_company',
+            enterDetailsManuallyText: 'Enter details manually',
+            searchForCompanyText: 'Search for company',
+            _brandConfig: config,
+            countryCode: function () { return 'gb'; },
+            companyName: function () { return ''; },
+            fillCompanyData: function (data) { filled.push(data); },
+            addressLookup: component.addressLookup,
+            enableCompanySearch: component.enableCompanySearch
+        });
+    }
+
+    test('captures lookupId and fills the address when both flags are on', () => {
+        const recorder = makeRecorder();
+        const $ = makeSpyJQuery(recorder);
+        const { component } = loadRenderer(recorder, $);
+        const filled = [];
+        const ctx = makeRendererContext(component, BASE_CONFIG, filled);
+
+        ctx.enableCompanySearch();
+
+        // The renderer must hand select2 an ajax block that keeps lookup_id.
+        expect(recorder.select2Options).not.toBeNull();
+        const mapped = recorder.select2Options.ajax.processResults(SEARCH_RESPONSE).results[0];
+        expect(mapped.lookupId).toBe('lookup-abc-123');
+
+        // Picking that result must fire the detail lookup and fill the form.
+        recorder.handlers['select2:select']({ params: { data: mapped } });
+
+        expect(filled).toEqual([
+            { companyId: '12345678', companyName: 'Example Trading Ltd' }
+        ]);
+        expect(recorder.ajax).toHaveLength(1);
+        expect(recorder.ajax[0].url).toBe(
+            'https://api.example.test/companies/v2/company/lookup-abc-123'
+        );
+
+        recorder.doneCallbacks.forEach(function (cb) {
+            cb({ addresses: [{ city: 'London', postal_code: 'EC1A 1BB', street_address: '1 Example Street' }] });
+        });
+        expect(recorder.written).toEqual(
+            expect.arrayContaining([['input[name="city"]', 'London']])
+        );
+    });
+
+    test('makes no detail call when address search is disabled', () => {
+        const recorder = makeRecorder();
+        const $ = makeSpyJQuery(recorder);
+        const { component } = loadRenderer(recorder, $);
+        const filled = [];
+        const ctx = makeRendererContext(
+            component,
+            Object.assign({}, BASE_CONFIG, { isAddressSearchEnabled: false }),
+            filled
+        );
+
+        ctx.enableCompanySearch();
+        const mapped = recorder.select2Options.ajax.processResults(SEARCH_RESPONSE).results[0];
+        recorder.handlers['select2:select']({ params: { data: mapped } });
+
+        // Company still selected, but no company-detail request and no writes.
+        expect(filled).toHaveLength(1);
+        expect(recorder.ajax).toHaveLength(0);
+        expect(recorder.written).toHaveLength(0);
+    });
+});
+
+describe('shipping-step company picker (address-autocomplete.js)', () => {
+    test('still routes selection through the shared address lookup', () => {
+        const recorder = makeRecorder();
+        const $ = makeSpyJQuery(recorder);
+        const companySearch = loadCompanySearch($);
+
+        // address-autocomplete.js reads its config at module scope via
+        // brandConfig.getActiveTwoBrandConfig().
+        const brandConfig = function () { return BASE_CONFIG; };
+        brandConfig.getActiveTwoBrandCode = function () { return 'two_payment'; };
+        brandConfig.getActiveTwoBrandConfig = function () { return BASE_CONFIG; };
+
+        const component = loadAmdModule('view/frontend/web/js/view/address-autocomplete.js', {
+            jquery: $,
+            'Two_Gateway/js/model/brand-config': brandConfig,
+            'Two_Gateway/js/model/company-search': companySearch
+        });
+
+        const ctx = Object.assign(Object.create(component.prototype || {}), {
+            countrySelector: '#shipping-new-address-form select[name="country_id"]',
+            companyNameSelector: '#shipping-new-address-form input[name="company"]',
+            companyIdSelector:
+                '#shipping-new-address-form input[name="custom_attributes[company_id]"]',
+            enterDetailsManuallyButton: '#shipping_enter_details_manually',
+            searchForCompanyButton: '#shipping_search_for_company',
+            enterDetailsManuallyText: 'Enter details manually',
+            searchForCompanyText: 'Search for company',
+            companyNamePlaceholder: 'Enter company name to search',
+            setCompanyData: function () {},
+            addressLookup: component.addressLookup,
+            enableCompanySearch: component.enableCompanySearch
+        });
+
+        ctx.enableCompanySearch();
+
+        const mapped = recorder.select2Options.ajax.processResults(SEARCH_RESPONSE).results[0];
+        expect(mapped.lookupId).toBe('lookup-abc-123');
+
+        recorder.handlers['select2:select']({ params: { data: mapped } });
+
+        expect(recorder.ajax).toHaveLength(1);
+        expect(recorder.ajax[0].url).toBe(
+            'https://api.example.test/companies/v2/company/lookup-abc-123'
+        );
+    });
+});

--- a/view/frontend/web/js/model/company-search.js
+++ b/view/frontend/web/js/model/company-search.js
@@ -1,0 +1,127 @@
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+/**
+ * Shared company-search primitives for the two select2 company pickers
+ * in checkout: the shipping-step one (`view/address-autocomplete.js`,
+ * a Magento_Ui form Component) and the payment-step one
+ * (`view/payment/method-renderer/gateway_method.js`, a payment
+ * renderer).
+ *
+ * Only the genuinely identical parts live here — the search request,
+ * the result mapping (including `lookup_id`, whose omission on the
+ * payment step was TWO-25193), the company-detail fetch and the
+ * address write-back. Everything else about the two pickers differs
+ * (selectors, placeholder/manual-entry chrome, KO observables vs
+ * customerData, order-intent side effects) and deliberately stays in
+ * the two call sites.
+ */
+define(['jquery'], function ($) {
+    'use strict';
+
+    return {
+        /**
+         * Build the select2 `ajax` option block for the company search.
+         *
+         * @param {object} options
+         * @param {object} options.config brand config subtree; needs
+         *        `checkoutApiUrl` and `companySearchLimit`
+         * @param {function(): (string|undefined)} options.getCountryCode
+         *        returns the current ISO country code (any case)
+         * @returns {object} select2 `ajax` options
+         */
+        buildSearchAjaxOptions: function (options) {
+            const config = options.config;
+            const getCountryCode = options.getCountryCode;
+
+            return {
+                dataType: 'json',
+                delay: 400,
+                url: function (params) {
+                    const queryParams = new URLSearchParams({
+                        country: getCountryCode()?.toUpperCase(),
+                        limit: config.companySearchLimit,
+                        offset: ((params.page || 1) - 1) * config.companySearchLimit,
+                        q: unescape(params.term)
+                    });
+                    return `${config.checkoutApiUrl}/companies/v2/company?${queryParams.toString()}`;
+                },
+                processResults: function (response) {
+                    const items = [];
+                    for (let i = 0; i < response.items.length; i++) {
+                        const item = response.items[i];
+                        items.push({
+                            id: item.name,
+                            text: item.name,
+                            html: `${item.highlight} (${item.national_identifier.id})`,
+                            companyId: item.national_identifier.id,
+                            // Required by lookupCompanyAddress(); dropping it
+                            // silently disables address autofill.
+                            lookupId: item.lookup_id
+                        });
+                    }
+                    return {
+                        results: items,
+                        pagination: {
+                            more: false
+                        }
+                    };
+                },
+                data: function () {
+                    return {};
+                }
+            };
+        },
+
+        /**
+         * Fetch the full company record for a search result and write its
+         * first address into the checkout address form.
+         *
+         * No-op unless `config.isAddressSearchEnabled` is true. That flag is
+         * server-side the AND of the company-search and address-search admin
+         * settings (Model\Config\Repository::isAddressSearchEnabled), so both
+         * pickers honour exactly one gate.
+         *
+         * @param {object} config brand config subtree
+         * @param {object} selectedCompany select2 result item (needs lookupId)
+         * @returns {object|null} the jqXHR, or null when gated off / no id
+         */
+        lookupCompanyAddress: function (config, selectedCompany) {
+            if (!config.isAddressSearchEnabled) return null;
+            if (!selectedCompany || !selectedCompany.lookupId) return null;
+
+            const self = this;
+            const addressResponse = $.ajax({
+                dataType: 'json',
+                url: `${config.checkoutApiUrl}/companies/v2/company/${selectedCompany.lookupId}`
+            });
+            addressResponse.done(function (response) {
+                if (response && response.addresses && response.addresses.length) {
+                    self.applyAddress(response.addresses[0]);
+                }
+            });
+            return addressResponse;
+        },
+
+        /**
+         * Write a company address into whichever checkout address form is on
+         * screen. The selectors are intentionally unscoped: the shipping step
+         * renders `#shipping-new-address-form` and the payment step renders
+         * `#billing-new-address-form`, and only one of them is present when a
+         * company is picked from that step's search box.
+         *
+         * @param {object} address company address record from the API
+         */
+        applyAddress: function (address) {
+            console.debug({ logger: 'companySearch.applyAddress', address });
+            $('input[name="city"]').val(address.city);
+            $('input[name="postcode"]').val(address.postal_code);
+            $('input[name="street[0]"]').val(address.street_address);
+            $('input[name="city"], input[name="postcode"], input[name="street[0]"]').trigger(
+                'change'
+            );
+        }
+    };
+});

--- a/view/frontend/web/js/view/address-autocomplete.js
+++ b/view/frontend/web/js/view/address-autocomplete.js
@@ -10,8 +10,19 @@ define([
     'Magento_Customer/js/customer-data',
     'Magento_Checkout/js/model/step-navigator',
     'uiRegistry',
-    'Two_Gateway/js/model/brand-config'
-], function ($, $t, _, Component, customerData, stepNavigator, uiRegistry, brandConfig) {
+    'Two_Gateway/js/model/brand-config',
+    'Two_Gateway/js/model/company-search'
+], function (
+    $,
+    $t,
+    _,
+    Component,
+    customerData,
+    stepNavigator,
+    uiRegistry,
+    brandConfig,
+    companySearch
+) {
     'use strict';
 
     // Resolve the active Two-family brand subtree so overlays
@@ -67,26 +78,10 @@ define([
             $(this.companyIdSelector).val(companyId);
         },
         setAddressData: function (address) {
-            console.debug({ logger: 'addressAutocomplete.setAddressData', address });
-            $('input[name="city"]').val(address.city);
-            $('input[name="postcode"]').val(address.postal_code);
-            $('input[name="street[0]"]').val(address.street_address);
-            $('input[name="city"], input[name="postcode"], input[name="street[0]"]').trigger(
-                'change'
-            );
+            companySearch.applyAddress(address);
         },
-        addressLookup: function (selectedCompany, countryCode) {
-            const self = this;
-            const addressResponse = $.ajax({
-                dataType: 'json',
-                url: `${config.checkoutApiUrl}/companies/v2/company/${selectedCompany.lookupId}`
-            });
-            addressResponse.done(function (response) {
-                // Use new address lookup by default
-                if (response.addresses) {
-                    self.setAddressData(response.addresses[0]);
-                }
-            });
+        addressLookup: function (selectedCompany) {
+            return companySearch.lookupCompanyAddress(config, selectedCompany);
         },
         enableCompanySearch: function () {
             if (!config.isCompanySearchEnabled) return;
@@ -106,44 +101,12 @@ define([
                             templateSelection: function (data) {
                                 return data.text || self.companyNamePlaceholder;
                             },
-                            ajax: {
-                                dataType: 'json',
-                                delay: 400,
-                                url: function (params) {
-                                    const queryParams = new URLSearchParams({
-                                        country: $(self.countrySelector).val()?.toUpperCase(),
-                                        limit: config.companySearchLimit,
-                                        offset:
-                                            ((params.page || 1) - 1) * config.companySearchLimit,
-                                        q: unescape(params.term)
-                                    });
-                                    return `${
-                                        config.checkoutApiUrl
-                                    }/companies/v2/company?${queryParams.toString()}`;
-                                },
-                                processResults: function (response, params) {
-                                    const items = [];
-                                    for (let i = 0; i < response.items.length; i++) {
-                                        const item = response.items[i];
-                                        items.push({
-                                            id: item.name,
-                                            text: item.name,
-                                            html: `${item.highlight} (${item.national_identifier.id})`,
-                                            companyId: item.national_identifier.id,
-                                            lookupId: item.lookup_id
-                                        });
-                                    }
-                                    return {
-                                        results: items,
-                                        pagination: {
-                                            more: false
-                                        }
-                                    };
-                                },
-                                data: function () {
-                                    return {};
+                            ajax: companySearch.buildSearchAjaxOptions({
+                                config: config,
+                                getCountryCode: function () {
+                                    return $(self.countrySelector).val();
                                 }
-                            }
+                            })
                         })
                         .on('select2:open', function () {
                             if ($(self.enterDetailsManuallyButton).length == 0) {
@@ -168,10 +131,10 @@ define([
                             const selectedItem = e.params.data;
                             $('.select2-selection__rendered').text(selectedItem.id);
                             self.setCompanyData(selectedItem.companyId, selectedItem.text);
-                            if (config.isAddressSearchEnabled) {
-                                const countryCode = $(self.countrySelector).val()?.toLowerCase();
-                                self.addressLookup(selectedItem, countryCode);
-                            }
+                            // Gate lives in companySearch.lookupCompanyAddress
+                            // (config.isAddressSearchEnabled), shared with the
+                            // payment-step picker.
+                            self.addressLookup(selectedItem);
                         });
                     // Set initial placeholder text for the company search
                     if (!$(self.companyNameSelector).val()) {

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -18,6 +18,7 @@ define([
     'Magento_Catalog/js/price-utils',
     'Two_Gateway/js/model/surcharge',
     'Two_Gateway/js/model/brand-config',
+    'Two_Gateway/js/model/company-search',
     'Two_Gateway/js/model/minimum-order-visibility',
     'Magento_Ui/js/lib/view/utils/async',
     'mage/validation',
@@ -37,6 +38,7 @@ define([
     priceUtils,
     surchargeModel,
     getBrandConfig,
+    companySearch,
     isAboveMinimums
 ) {
     'use strict';
@@ -739,6 +741,14 @@ define([
                 }
             };
         },
+        /**
+         * Fill the billing address form from a picked company. No-op unless
+         * the merchant has both company search and address search enabled
+         * (ConfigProvider exposes the AND of the two as isAddressSearchEnabled).
+         */
+        addressLookup: function (selectedCompany) {
+            return companySearch.lookupCompanyAddress(this._brandConfig, selectedCompany);
+        },
         enableCompanySearch: function () {
             let self = this;
             require(['Two_Gateway/select2-4.1.0/js/select2.min'], function () {
@@ -759,44 +769,12 @@ define([
                             templateSelection: function (data) {
                                 return data.text;
                             },
-                            ajax: {
-                                dataType: 'json',
-                                delay: 400,
-                                url: function (params) {
-                                    const queryParams = new URLSearchParams({
-                                        country: self.countryCode()?.toUpperCase(),
-                                        limit: self._brandConfig.companySearchLimit,
-                                        offset:
-                                            ((params.page || 1) - 1) *
-                                            self._brandConfig.companySearchLimit,
-                                        q: unescape(params.term)
-                                    });
-                                    return `${
-                                        self._brandConfig.checkoutApiUrl
-                                    }/companies/v2/company?${queryParams.toString()}`;
-                                },
-                                processResults: function (response, params) {
-                                    const items = [];
-                                    for (let i = 0; i < response.items.length; i++) {
-                                        const item = response.items[i];
-                                        items.push({
-                                            id: item.name,
-                                            text: item.name,
-                                            html: `${item.highlight} (${item.national_identifier.id})`,
-                                            companyId: item.national_identifier.id
-                                        });
-                                    }
-                                    return {
-                                        results: items,
-                                        pagination: {
-                                            more: false
-                                        }
-                                    };
-                                },
-                                data: function () {
-                                    return {};
+                            ajax: companySearch.buildSearchAjaxOptions({
+                                config: self._brandConfig,
+                                getCountryCode: function () {
+                                    return self.countryCode();
                                 }
-                            }
+                            })
                         })
                         .on('select2:open', function () {
                             if ($(self.enterDetailsManuallyButton).length == 0) {
@@ -819,6 +797,12 @@ define([
                             const companyId = selectedItem.companyId;
                             const companyName = selectedItem.text;
                             self.fillCompanyData({ companyId, companyName });
+                            // TWO-25193: the payment-step picker used to stop
+                            // here, leaving the billing address blank. Gate is
+                            // config.isAddressSearchEnabled, applied inside
+                            // lookupCompanyAddress — same one the shipping-step
+                            // picker uses.
+                            self.addressLookup(selectedItem);
                         });
                     $('#select2-company_name-container').text(self.companyName());
                     if ($(self.searchForCompanyButton).length == 0) {


### PR DESCRIPTION
## Problem

Picking a company from the **payment-step** company search filled nothing —
no city, postcode or street.

There are two copies of the same select2 company-search builder:

- `view/frontend/web/js/view/address-autocomplete.js` (shipping step)
- `view/frontend/web/js/view/payment/method-renderer/gateway_method.js` (payment step)

The shipping-step copy maps the API's `lookup_id` onto each result item and,
on `select2:select`, calls `GET {checkoutApiUrl}/companies/v2/company/{lookupId}`
and writes the first address into the form. The payment-step copy never mapped
`lookup_id` and never made the detail call, so selection was a dead end.

## Fix

Extracted the three genuinely identical pieces into a new RequireJS module
`Two_Gateway/js/model/company-search`:

| function | responsibility |
|---|---|
| `buildSearchAjaxOptions({config, getCountryCode})` | the select2 `ajax` block — search URL + result mapping, **including `lookupId`** |
| `lookupCompanyAddress(config, selectedCompany)` | `GET /companies/v2/company/{lookupId}`, gated on `config.isAddressSearchEnabled` |
| `applyAddress(address)` | write `city` / `postcode` / `street[0]` and fire `change` |

Both renderers now consume it; the payment-step select handler calls
`addressLookup(selectedItem)` after `fillCompanyData(...)`.

### Gating — unchanged, and now single-sourced

`Model/Config/Repository::isAddressSearchEnabled()` already requires **both**
`enable_company_search` **and** `enable_address_search`. `Model/Ui/ConfigProvider`
already exposed that computed flag on the payment-method subtree
(`_brandConfig.isAddressSearchEnabled`), so no config change was needed — the
payment step now honours exactly the gate the shipping step honours, and the
check lives in one place instead of two. Nothing was loosened.

## Judgement call: extract vs duplicate

**Extracted — but only the narrow shared core.** Reasoning, on evidence rather
than principle:

The two files are structurally unlike each other. `address-autocomplete.js` is
a `Magento_Ui/js/form/form` Component with `#shipping-new-address-form`-scoped
selectors, module-scope config from `brandConfig.getActiveTwoBrandConfig()`, and
`customerData` for state. `gateway_method.js` is a payment renderer with
`input#company_name` selectors, per-code config on `this._brandConfig`, KO
observables, and order-intent + sole-trader side effects hanging off selection.
Hoisting the whole picker would have dragged all of that into one module — the
"extraction drags unrelated coupling" case.

But that coupling is not *inside* the three pieces above. Diffed side by side,
they differed in exactly two parameters — where the config object comes from,
and how to read the current country code — both trivially injectable. They are
also precisely where the bug lived. So the right cut is: share the ~50 lines
that were provably identical, leave the divergent glue (placeholder text,
manual-entry / search-again chrome, `customerData` vs observables, order-intent
trigger) duplicated in the two call sites where it belongs.

Net effect is a *smaller* tree: the two consumers lose ~99 lines between them
for ~125 lines of shared module, and the failure mode that produced this ticket
(edit one copy, forget the other) can't recur for the search/lookup path.

`applyAddress()` keeps the shipping-step copy's deliberately unscoped
`input[name="city"]` selectors: only one address form is on screen when a
company is picked from that step's box, so the same selectors serve both.

## Tests

New `Test/Js/company-search-address-lookup.test.js` — 8 tests covering the
shared module directly plus both call sites driven end-to-end through a
select2-capturing jQuery double:

- `processResults` carries `lookup_id` through as `lookupId`
- search URL carries uppercased country + paging window
- `lookupCompanyAddress` fetches the company and writes city/postcode/street
- **no detail call and no writes when the address-search flag is off**
- no detail call when the result has no `lookupId`
- payment step: captures `lookupId`, fires the detail call, fills the address
- payment step: no detail call with the flag off (company still selected)
- shipping step: unchanged, still routes through the shared lookup

`Test/Js/amd-harness.js` gains the browser globals the shared module needs
(`URLSearchParams`, `unescape`) in its vm sandbox.

```
> jest --config Test/Js/jest.config.js

PASS Test/Js/company-search-address-lookup.test.js
PASS Test/Js/gateway-method-place-order-latch.test.js
PASS Test/Js/all-js-modules.test.js
PASS Test/Js/brand-config.test.js
PASS Test/Js/gateway-method-afterplaceorder.test.js
PASS Test/Js/payment-availability.test.js
PASS Test/Js/gateway-method-this-context.test.js
PASS Test/Js/minimum-order-visibility.test.js

Test Suites: 8 passed, 8 total
Tests:       74 passed, 74 total
```

`prettier` (the repo's `make format` config) reports all three touched JS files
unchanged.

## Docs

Grepped `docs/`, `README.md`, `e2e/README.md` and `.ai/` for company-search /
address-autocomplete behaviour. Only hit is one line in `e2e/README.md`
describing the e2e flow's ordering; still accurate, no update needed.

## Noted, not fixed (out of scope)

The payment-step `enableCompanySearch()` has never had a client-side
`isCompanySearchEnabled` early-return, unlike the shipping-step copy. This PR
doesn't change that either way — it only adds the address lookup and gates it
correctly. Worth a separate look.

Ticket: https://linear.app/two-inc/issue/TWO-25193

🤖 Generated with [Claude Code](https://claude.com/claude-code)
