### PR TITLE
TWO-25191: config hygiene — drop dead admin_form flag, move hide-payment-section flag out of merchant namespace

### DIFF
--- a/Api/BrandOverlayRegistryInterface.php
+++ b/Api/BrandOverlayRegistryInterface.php
@@ -24,7 +24,7 @@ namespace Two\Gateway\Api;
  *     install. Admin shows `two_payment` as normal.
  *   - Non-empty registry = at least one overlay installed. Admin
  *     hides `two_payment` by default; merchant opts in to re-show
- *     via `payment/two_payment/hide_when_overlay_installed = 0`.
+ *     via `two_brand_synthesis/hide_payment_section/enabled = 0`.
  */
 interface BrandOverlayRegistryInterface
 {

--- a/Plugin/Config/Structure/HidePaymentSection.php
+++ b/Plugin/Config/Structure/HidePaymentSection.php
@@ -16,14 +16,41 @@ use Two\Gateway\Api\BrandOverlayRegistryInterface;
  * Hide every vanilla Two_Gateway admin config section (`two_general`,
  * `two_payment`, `two_search`, `two_version`) when:
  *   - At least one brand overlay (e.g. ABN_Gateway) is registered, AND
- *   - `payment/two_payment/hide_when_overlay_installed` resolves to truthy.
+ *   - `two_brand_synthesis/hide_payment_section/enabled` resolves to truthy.
  *
  * Both conditions default to true on overlay-installed merchants
- * (registry populated by overlay DI, config default = 1). Merchants
- * who want the parent-brand admin surfaces back can opt out with:
+ * (registry populated by overlay DI, flag default = 1). Merchants
+ * who want the parent-brand admin surfaces back can opt out by adding
+ * the value to `app/etc/env.php` (or `app/etc/config.php`) and flushing:
  *
- *     bin/magento config:set payment/two_payment/hide_when_overlay_installed 0
+ *     'system' => ['default' => ['two_brand_synthesis' =>
+ *         ['hide_payment_section' => ['enabled' => 0]]]]
+ *
  *     bin/magento cache:flush
+ *
+ * NOTE: `bin/magento config:set` does NOT work for this path, and never
+ * did for its predecessor either — `config:set`/`config:show` validate
+ * the path against the admin `system.xml` structure, and this flag has
+ * no admin field by design. Verified on Magento 2.4.6:
+ * `The "..." path doesn't exist. Verify and try again.` The old docblock
+ * and `etc/config.xml` comment both advertised a `config:set` recipe
+ * that could not have worked. A `core_config_data` row inserted by hand
+ * is the other route that ScopeConfig honours.
+ *
+ * The flag used to live at `payment/two_payment/hide_when_overlay_installed`
+ * (TWO-25191 moved it). That namespace is merchant-owned — every other
+ * key under it is a real merchant setting with an admin field — whereas
+ * this is a deploy/rollout switch, so it belongs next to the other
+ * `two_brand_synthesis` rollout knobs.
+ *
+ * Neither path carries an `etc/config.xml` default: the default lives in
+ * DEFAULT_HIDE below, so an absent (null) value is distinguishable from
+ * an explicit `0`, which is what makes the legacy-path fallback in
+ * `shouldHide()` work at all. Read order is new path, then legacy path,
+ * then DEFAULT_HIDE — so an install that set the old path before the move
+ * keeps its choice. The LEGACY_HIDE_FLAG_PATH read can be deleted once
+ * the brand-synthesis rollout completes and any remaining
+ * `core_config_data` / env.php entries on the old path are migrated.
  *
  * Plugs into `Section::isVisible()` rather than `Structure::getElement()`.
  * The sidebar render path iterates `Structure::getTabs()` and per-tab
@@ -44,7 +71,9 @@ use Two\Gateway\Api\BrandOverlayRegistryInterface;
  */
 class HidePaymentSection
 {
-    private const HIDE_FLAG_PATH = 'payment/two_payment/hide_when_overlay_installed';
+    private const HIDE_FLAG_PATH = 'two_brand_synthesis/hide_payment_section/enabled';
+    private const LEGACY_HIDE_FLAG_PATH = 'payment/two_payment/hide_when_overlay_installed';
+    private const DEFAULT_HIDE = true;
     private const TARGET_SECTIONS = ['two_general', 'two_payment', 'two_search', 'two_version'];
 
     public function __construct(
@@ -77,6 +106,17 @@ class HidePaymentSection
         if (!$this->overlayRegistry->isOverlayInstalled()) {
             return false;
         }
-        return (bool)$this->scopeConfig->getValue(self::HIDE_FLAG_PATH);
+
+        foreach ([self::HIDE_FLAG_PATH, self::LEGACY_HIDE_FLAG_PATH] as $path) {
+            $value = $this->scopeConfig->getValue($path);
+            // Only an ABSENT value falls through to the next path. `0` is a
+            // deliberate merchant opt-out and must win over the legacy read
+            // and over DEFAULT_HIDE alike.
+            if ($value !== null && $value !== '') {
+                return (bool)$value;
+            }
+        }
+
+        return self::DEFAULT_HIDE;
     }
 }

--- a/Test/Unit/Plugin/Config/Structure/HidePaymentSectionTest.php
+++ b/Test/Unit/Plugin/Config/Structure/HidePaymentSectionTest.php
@@ -11,15 +11,32 @@ use Two\Gateway\Plugin\Config\Structure\HidePaymentSection;
 
 class HidePaymentSectionTest extends TestCase
 {
-    private function plugin(bool $overlayInstalled, bool $hideFlag): HidePaymentSection
-    {
+    private const NEW_PATH = 'two_brand_synthesis/hide_payment_section/enabled';
+    private const LEGACY_PATH = 'payment/two_payment/hide_when_overlay_installed';
+
+    /**
+     * @param bool                      $overlayInstalled
+     * @param bool|null                 $hideFlag Convenience: value stored at the NEW path.
+     *                                            null = unset (nothing stored anywhere).
+     * @param array<string,string|null> $stored   Explicit path => stored value map, overrides
+     *                                            $hideFlag. Any path absent from the map reads
+     *                                            back as null, i.e. "never set".
+     */
+    private function plugin(
+        bool $overlayInstalled,
+        ?bool $hideFlag = null,
+        array $stored = []
+    ): HidePaymentSection {
         $registry = $this->createMock(BrandOverlayRegistryInterface::class);
         $registry->method('isOverlayInstalled')->willReturn($overlayInstalled);
 
+        if ($stored === [] && $hideFlag !== null) {
+            $stored = [self::NEW_PATH => $hideFlag ? '1' : '0'];
+        }
+
         $scope = $this->createMock(ScopeConfigInterface::class);
         $scope->method('getValue')
-            ->with('payment/two_payment/hide_when_overlay_installed')
-            ->willReturn($hideFlag ? '1' : '0');
+            ->willReturnCallback(static fn ($path) => $stored[$path] ?? null);
 
         return new HidePaymentSection($registry, $scope);
     }
@@ -90,5 +107,91 @@ class HidePaymentSectionTest extends TestCase
     {
         $plugin = $this->plugin(true, true);
         $this->assertFalse($plugin->afterIsVisible($this->section('two_search'), true));
+    }
+
+    // --- TWO-25191: flag moved to two_brand_synthesis/, legacy path still read ---
+
+    public function testNewPathSetToZeroShows(): void
+    {
+        $plugin = $this->plugin(true, null, [self::NEW_PATH => '0']);
+        $this->assertTrue($plugin->afterIsVisible($this->section('two_payment'), true));
+    }
+
+    public function testLegacyPathAloneIsHonoured(): void
+    {
+        $plugin = $this->plugin(true, null, [self::LEGACY_PATH => '0']);
+        $this->assertTrue(
+            $plugin->afterIsVisible($this->section('two_payment'), true),
+            'A merchant who ran the pre-TWO-25191 `config:set ... 0` must keep their opt-out.'
+        );
+    }
+
+    public function testLegacyPathSetToOneHides(): void
+    {
+        $plugin = $this->plugin(true, null, [self::LEGACY_PATH => '1']);
+        $this->assertFalse($plugin->afterIsVisible($this->section('two_payment'), true));
+    }
+
+    public function testNeitherPathSetDefaultsToHide(): void
+    {
+        $plugin = $this->plugin(true, null, []);
+        $this->assertFalse(
+            $plugin->afterIsVisible($this->section('two_payment'), true),
+            'Default is 1 (hide) — there is no etc/config.xml default, so the '
+            . 'code-side DEFAULT_HIDE must supply it.'
+        );
+    }
+
+    public function testNewPathZeroBeatsLegacyOne(): void
+    {
+        $plugin = $this->plugin(true, null, [
+            self::NEW_PATH => '0',
+            self::LEGACY_PATH => '1',
+        ]);
+        $this->assertTrue(
+            $plugin->afterIsVisible($this->section('two_payment'), true),
+            'The new path wins whenever it is set — the legacy read is a fallback only.'
+        );
+    }
+
+    public function testNewPathOneBeatsLegacyZero(): void
+    {
+        $plugin = $this->plugin(true, null, [
+            self::NEW_PATH => '1',
+            self::LEGACY_PATH => '0',
+        ]);
+        $this->assertFalse($plugin->afterIsVisible($this->section('two_payment'), true));
+    }
+
+    public function testEmptyStringTreatedAsUnset(): void
+    {
+        $plugin = $this->plugin(true, null, [
+            self::NEW_PATH => '',
+            self::LEGACY_PATH => '0',
+        ]);
+        $this->assertTrue(
+            $plugin->afterIsVisible($this->section('two_payment'), true),
+            'An empty stored value is not a deliberate 0; it must fall through to the legacy path.'
+        );
+    }
+
+    public function testConfigXmlDeclaresNoDefaultForEitherPath(): void
+    {
+        $configXml = dirname(__DIR__, 5) . '/etc/config.xml';
+        $this->assertFileExists($configXml);
+
+        $xml = simplexml_load_file($configXml);
+        $this->assertNotFalse($xml, 'etc/config.xml must parse');
+
+        $this->assertEmpty(
+            $xml->xpath('/config/default/payment/two_payment/hide_when_overlay_installed'),
+            'The legacy default was removed by TWO-25191; re-adding it would make the '
+            . 'legacy path never read back as null and pin every merchant to 1.'
+        );
+        $this->assertEmpty(
+            $xml->xpath('/config/default/two_brand_synthesis/hide_payment_section'),
+            'Declaring a default for the new path would make it never read back as null '
+            . 'and silently disable the legacy-path fallback in HidePaymentSection.'
+        );
     }
 }

--- a/Test/Unit/Plugin/Config/Structure/Reader/SynthesiseBrandAdminFormTest.php
+++ b/Test/Unit/Plugin/Config/Structure/Reader/SynthesiseBrandAdminFormTest.php
@@ -25,6 +25,12 @@ use Two\Gateway\Plugin\Magento\Config\Model\Config\Structure\Reader\SynthesiseBr
  * The fix removes the flag gate entirely. This test pins the
  * constructor signature so it can't grow a ScopeConfig dependency
  * again without an explicit decision.
+ *
+ * TWO-25191 additionally deleted the now-dead
+ * `two_brand_synthesis/admin_form/enabled` default from
+ * `etc/config.xml` — PR #181 left it behind, and its surviving
+ * comment told readers to "flip to 0 to debug" a gate that no longer
+ * existed. `testConfigXmlDeclaresNoAdminFormFlag` pins that removal.
  */
 class SynthesiseBrandAdminFormTest extends TestCase
 {
@@ -53,6 +59,21 @@ class SynthesiseBrandAdminFormTest extends TestCase
             $constants,
             'The FLAG_PATH constant was removed when the flag gate was dropped — '
             . 'its reappearance signals the regression has been reintroduced.'
+        );
+    }
+
+    public function testConfigXmlDeclaresNoAdminFormFlag(): void
+    {
+        $configXml = dirname(__DIR__, 6) . '/etc/config.xml';
+        self::assertFileExists($configXml);
+
+        $xml = simplexml_load_file($configXml);
+        self::assertNotFalse($xml, 'etc/config.xml must parse');
+
+        self::assertEmpty(
+            $xml->xpath('/config/default/two_brand_synthesis/admin_form'),
+            'etc/config.xml must not declare two_brand_synthesis/admin_form — '
+            . 'nothing reads it since the ABN-415 flag-gate removal (TWO-25191).'
         );
     }
 }

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -15,17 +15,6 @@
         <payment>
             <two_payment>
                 <active>1</active>
-                <!--
-                    When a brand overlay (e.g. ABN_Gateway) is installed
-                    alongside Two_Gateway, hide the `two_payment` admin
-                    config section by default. Merchants who want both
-                    parent-brand and overlay-brand payment methods
-                    configurable in admin can disable the hide:
-                      bin/magento config:set payment/two_payment/hide_when_overlay_installed 0
-                      bin/magento cache:flush
-                    Has no effect when no overlay is registered.
-                -->
-                <hide_when_overlay_installed>1</hide_when_overlay_installed>
                 <version>2.1.2</version>
                 <title>Two - Buy Now Pay Later on Invoice Terms</title>
                 <sort_order>-10</sort_order>
@@ -72,9 +61,15 @@
             flips the default to 1 in lockstep with a brand overlay's
             data-only release (which deletes the overlay's renderer-bootstrap
             JS). Design v6 §16.3 specifies these as per-layer debugging
-            knobs, not a rollback mechanism. Layers shipped in
-            subsequent PRs (payment_xml, csp, admin_form) will add
-            their own siblings here.
+            knobs, not a rollback mechanism.
+
+            Admin-form synthesis deliberately has NO flag here: its
+            gate was removed in magento-plugin PR #181 (ABN-415) after
+            an `isSetFlag` read during a cold-cache admin request
+            no-op'd the plugin and poisoned the Structure cache.
+            Synthesis of the per-brand admin Configuration section is
+            unconditional; see
+            Plugin/Magento/Config/Model/Config/Structure/Reader/SynthesiseBrandAdminForm.php.
         -->
         <two_brand_synthesis>
             <checkout_renderers>
@@ -87,24 +82,19 @@
                 <enabled>0</enabled>
             </csp>
             <!--
-                Layer C/3: per-brand admin Configuration section
-                synthesis. While enabled, the Structure\Reader plugin
-                clones the etc/adminhtml/brand_form_template.xml,
-                stamps in each brand's identity, and appends a section
-                per brand. Skips any brand whose intended section id
-                already exists statically (so a brand whose overlay
-                module still ships its own etc/adminhtml/system.xml
-                stays on the static surface — first-writer-wins).
-                Default 1 since the brand overlay strip-down: the
-                overlay no longer ships its own system.xml, so synthesis
-                is the sole source of the per-brand admin tab. Flip to
-                0 only to debug — vanilla Two installs have no overlay
-                brands registered, so synthesis is a no-op for them
-                regardless.
+                `two_brand_synthesis/hide_payment_section/enabled` is
+                deliberately NOT declared here. It is a rollout switch
+                (hide the vanilla two_* admin sections when a brand
+                overlay is installed), moved out of the merchant-owned
+                `payment/two_payment/` namespace by TWO-25191. Its
+                default (1 = hide) lives in
+                Plugin/Config/Structure/HidePaymentSection.php so that
+                an unset value stays distinguishable from an explicit
+                `0` — which is what lets that class fall back to the
+                legacy `payment/two_payment/hide_when_overlay_installed`
+                path for merchants who set it before the move.
+                Declaring a default here would break that fallback.
             -->
-            <admin_form>
-                <enabled>1</enabled>
-            </admin_form>
         </two_brand_synthesis>
     </default>
 </config>


### PR DESCRIPTION
## Context

Linear TWO-25191 (parent Linear TWO-24739) — config hygiene in `etc/config.xml`. Two independent changes, one PR, one commit each.

## 1. Delete the dead `two_brand_synthesis/admin_form/enabled` node (`TWO-25191/chore`)

magento-plugin PR #181 (ABN-415) removed the flag gate from `SynthesiseBrandAdminForm` and deliberately left the config default behind as harmless. It is harmless — but the 16-line comment sitting above it is not: it describes a live kill switch and tells the reader to "flip to `0` only to debug". Nothing reads the path, so flipping it does nothing. Both node and comment are gone.

The section header comment also listed `admin_form` among layers that "will add their own siblings here"; it now records why admin-form synthesis is unconditional instead.

The three live nodes (`checkout_renderers/enabled`, `payment_xml/enabled`, `csp/enabled`) are untouched.

**`SynthesiseBrandAdminFormTest` stays as-is.** Its two assertions pin the *class shape* — no `ScopeConfigInterface` in the constructor, no `FLAG_PATH` constant — not the config path. The path appears only in the explanatory docblock, which is updated. A third test (`testConfigXmlDeclaresNoAdminFormFlag`) now pins the config.xml removal so the node cannot quietly reappear.

## 2. Move `hide_when_overlay_installed` out of the merchant namespace (`TWO-25191/refactor`)

`payment/two_payment/hide_when_overlay_installed` → `two_brand_synthesis/hide_payment_section/enabled`.

Every other key under `payment/two_payment/` is a real merchant setting with an admin field. This one is a deploy/rollout switch with no admin field, read only by `Plugin/Config/Structure/HidePaymentSection.php`. It belongs with the other brand-synthesis rollout knobs.

### Read-fallback

`shouldHide()` reads the new path, falls back to the legacy path when the new one is **absent**, then applies a code-side default of `1` (hide). "Absent" is `null`/empty-string — *not* falsy — so an explicit `0` on either path wins.

This requires **not** declaring an `etc/config.xml` default for either path: a declared default is never `null`, which would make the fallback dead code. The default therefore lives in `HidePaymentSection::DEFAULT_HIDE`, and `testConfigXmlDeclaresNoDefaultForEitherPath` pins the absence of both nodes so a future "let's add the default back" cannot silently disable the fallback.

**The legacy path read can be dropped once the brand-synthesis rollout completes** and any remaining `core_config_data` rows / `env.php` entries on the old path are migrated.

New unit tests: new path set, legacy path set alone (both `0` and `1`), neither set (defaults to hide), new `0` beats legacy `1`, new `1` beats legacy `0`, empty string treated as unset.

### Finding: the documented opt-out recipe never worked

Both the old docblock and the old `etc/config.xml` comment advertised:

```
bin/magento config:set payment/two_payment/hide_when_overlay_installed 0
```

That has never worked. `config:set` and `config:show` validate the path against the admin `system.xml` structure, and this flag has no admin field by design. Verified on Magento 2.4.6 in the CI image — **both** the old and new paths return:

```
The "payment/two_payment/hide_when_overlay_installed" path doesn't exist. Verify and try again.
```

(same for `--lock-env`). The route that *does* work, also verified via a `ScopeConfigInterface` probe in the container, is a `system.default.*` entry in `app/etc/env.php` (or `app/etc/config.php`) plus `cache:flush`:

```php
'system' => ['default' => ['two_brand_synthesis' =>
    ['hide_payment_section' => ['enabled' => 0]]]]
```

→ `getValue('two_brand_synthesis/hide_payment_section/enabled')` returns `int(0)`.

The docblock now documents that instead. This lowers the practical blast radius of the move considerably (a shop cannot have set the old path via the advertised command), but the fallback is kept because a hand-inserted `core_config_data` row or an env.php entry on the old path is still possible.

## Related, not fixed here (out of scope)

`etc/di.xml` (~line 147) tells readers a synthesis layer flag can be flipped "via `bin/magento config:set` + `cache:flush`". Same falsehood, same reason — none of the `two_brand_synthesis/*` paths are in `system.xml`. Flagging rather than fixing to keep this diff to the ticket.

## Cross-repo check

Grepped `magento-abn-plugin` `origin/staging` for both paths. **Docs and comments only, no code:**
- `docs/brand-overlay-design-v6.md` — describes the per-layer flags and already states "**No `admin_form` flag**" (§16.3), which this PR makes true of `etc/config.xml` as well. No update needed.
- `plugin/Model/ApiTranslator/AbnApiTranslator.php:42` — prose mention of "the `hide_when_overlay_installed` flag", no path, no read. No update needed.

No second PR required.

Docs in this repo: grepped `docs/`, `README.md`, `.ai/` for both paths and the removed comment's claims — no hits.

## Validation

All run locally against this branch.

| Gate | Result |
|---|---|
| `php -l` sweep (CI `lint`) | `LINT OK` — clean, PHP 8.5 host |
| Codesniffer (`michielgerritsen/magento-coding-standard:latest --severity=6`) | `204 / 204 (100%)`, no violations |
| PHPUnit 10.5.64 / PHP 8.3 | `Tests: 389, Assertions: 670` — OK. 2 PHPUnit deprecations, **pre-existing** (confirmed identical on a stashed working tree) |
| PHPStan (Magento 2.4.6 / PHP 8.2 container) | `[OK] No errors` |
| `setup:di:compile` (Magento 2.4.6 / PHP 8.2 container) | `Generated code and dependency injection configuration successfully.` |
| Install-time smoke (CI `di-compile` job's ABN-423 M3 step) | `module:enable` + `setup:upgrade` + `cache:flush` clean; `config:set/show payment/two_payment/title` round-trip returned `CI smoke` |

New test detail:

```
 ✔ New path set to zero shows
 ✔ Legacy path alone is honoured
 ✔ Legacy path set to one hides
 ✔ Neither path set defaults to hide
 ✔ New path zero beats legacy one
 ✔ New path one beats legacy zero
 ✔ Empty string treated as unset
 ✔ Config xml declares no default for either path
 ✔ Config xml declares no admin form flag
```

**Not run locally:** the `jest` job (`npm run test:js`) — no `node_modules` in this environment; no JS changed by this PR. The `upgrade-smoke` job and the full Magento × PHP matrix legs — single-combo (2.4.6 / PHP 8.2) coverage only locally; CI fans them out.

## Merge

**Do not squash-merge** — the two commits are independently revertable and should stay that way.

## Ticket

- https://linear.app/tillit/issue/TWO-25191
