### PR TITLE
TWO-25197/feat: stamp deployed commit SHA onto client_v telemetry

### DIFF
--- a/Block/Adminhtml/System/Config/Field/Version.php
+++ b/Block/Adminhtml/System/Config/Field/Version.php
@@ -15,6 +15,7 @@ use Magento\Framework\Filesystem\DirectoryList;
 use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
 use Two\Gateway\Api\BrandRegistryInterface;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
+use Two\Gateway\Model\Provenance;
 
 /**
  * Renders the admin "Version" panel: one row per gateway-stack module
@@ -50,6 +51,16 @@ class Version extends Field
     private DirectoryList $directoryList;
     private TimezoneInterface $timezone;
     private BrandRegistryInterface $brandRegistry;
+
+    /**
+     * Commit-SHA resolution, shared with Model\Config\Repository (which
+     * stamps the same SHA onto the `client_v` telemetry parameter).
+     * Protected so a constructor-free test double can supply it.
+     *
+     * @var Provenance
+     */
+    protected $provenance;
+
     private string $moduleName;
 
     /**
@@ -64,6 +75,7 @@ class Version extends Field
      *        exposes it via `getModuleLabelChain()`. A partner overlay
      *        adds its own brand rows; vanilla Two ships only
      *        the parent-runtime rows.
+     * @param Provenance $provenance Shared commit-SHA resolver.
      * @param string $moduleName Primary module — used by getVersion() fallback
      *                           and for any caller still expecting a single
      *                           module identity. Defaults to Two_Gateway
@@ -79,6 +91,7 @@ class Version extends Field
         DirectoryList $directoryList,
         TimezoneInterface $timezone,
         BrandRegistryInterface $brandRegistry,
+        Provenance $provenance,
         string $moduleName = 'Two_Gateway',
         array $data = []
     ) {
@@ -87,6 +100,7 @@ class Version extends Field
         $this->directoryList = $directoryList;
         $this->timezone = $timezone;
         $this->brandRegistry = $brandRegistry;
+        $this->provenance = $provenance;
         $this->moduleName = $moduleName;
         parent::__construct($context, $data);
     }
@@ -256,93 +270,16 @@ class Version extends Field
     }
 
     /**
-     * 7-char SHA of the gitSync-pulled commit.
+     * 7-char SHA of the commit this module's code was built from, or ''.
      *
-     * gitSync v4 writes worktrees at `<root>/.git/worktrees/<sha>/` and
-     * names each worktree directory after the SHA it points at. The
-     * module's `.git` file (a single line `gitdir: <relpath>`) references
-     * that directory. Read it directly — robust whether the module path
-     * is a symlink straight to the worktree (older layout) or a real
-     * directory whose contents were copied/hardlinked at init (current
-     * Magento init job behaviour, which makes the realpath of
-     * registration.php contain no worktree segment).
+     * Delegates to the shared Provenance service, which owns both
+     * resolution paths (Composer installed-registry reference for
+     * Packagist deploys, gitlink worktree parse for gitSync dev installs).
+     * Kept as a protected method so subclasses/tests retain the seam.
      */
     protected function extractCommit(string $modulePath): string
     {
-        // Composer-installed deploys (Packagist/dist — the current 2.0
-        // distribution model) put the module under vendor/ with NO .git
-        // worktree, so the path-based resolution below finds nothing. The
-        // installed registry records the exact source/dist commit, which is
-        // authoritative and layout-independent — prefer it.
-        $fromComposer = $this->commitFromComposer($modulePath);
-        if ($fromComposer !== null) {
-            return $fromComposer;
-        }
-
-        $gitFile = $modulePath . '/.git';
-        if (is_file($gitFile)) {
-            // .git is always `gitdir: <relpath>\n`; cap the read defensively
-            // and trim before anchoring the regex to end-of-string so a
-            // worktrees/<sha> segment elsewhere in the path can't shadow
-            // the real SHA at the tail.
-            $content = @file_get_contents($gitFile, false, null, 0, 1024);
-            if ($content !== false
-                && preg_match('#worktrees/([a-f0-9]{7,40})/?$#', trim($content), $m)
-            ) {
-                return substr($m[1], 0, 7);
-            }
-        }
-        // Legacy fallback: module path is a symlink through the worktree.
-        $real = @realpath($modulePath . '/registration.php');
-        if ($real && preg_match('#\.worktrees/([a-f0-9]{7,40})/#', $real, $m)) {
-            return substr($m[1], 0, 7);
-        }
-        return '';
-    }
-
-    /**
-     * 7-char commit SHA from Composer's installed registry, or null when the
-     * module isn't composer-installed or carries no hex source reference.
-     *
-     * Reads the package name from composer.json (checking the module dir and
-     * one level up — monorepo sub-path modules keep composer.json a level up,
-     * mirroring readComposerVersion()), then asks the installed registry for
-     * that package's source/dist reference. A path-repo or branch install may
-     * carry a non-SHA reference; the hex guard rejects those so the caller
-     * falls back to the .git/worktree resolution.
-     */
-    protected function commitFromComposer(string $modulePath): ?string
-    {
-        foreach ([$modulePath, dirname($modulePath)] as $dir) {
-            $composer = @file_get_contents($dir . '/composer.json');
-            if ($composer === false) {
-                continue;
-            }
-            $data = json_decode($composer, true);
-            $name = is_array($data) ? ($data['name'] ?? null) : null;
-            if (!is_string($name) || $name === '') {
-                continue;
-            }
-            $ref = $this->composerReference($name);
-            if (is_string($ref) && preg_match('/^[a-f0-9]{7,40}$/', $ref)) {
-                return substr($ref, 0, 7);
-            }
-        }
-        return null;
-    }
-
-    /**
-     * The installed package's source/dist reference (commit SHA), or null.
-     * Wraps the static Composer registry as an override seam for testing.
-     */
-    protected function composerReference(string $packageName): ?string
-    {
-        if (!class_exists(\Composer\InstalledVersions::class)
-            || !\Composer\InstalledVersions::isInstalled($packageName)
-        ) {
-            return null;
-        }
-        return \Composer\InstalledVersions::getReference($packageName);
+        return $this->provenance->commitForPath($modulePath);
     }
 
     private function getCodeTs(string $modulePath): int

--- a/Model/Config/Repository.php
+++ b/Model/Config/Repository.php
@@ -16,6 +16,7 @@ use Magento\Tax\Model\Calculation as TaxCalculation;
 use Two\Gateway\Api\BrandRegistryInterface;
 use Two\Gateway\Api\Config\RepositoryInterface;
 use Two\Gateway\Model\Config\Source\SurchargeTaxClass as SurchargeTaxClassSource;
+use Two\Gateway\Model\Provenance;
 use Two\Gateway\Service\Merchant\SettingsProvider;
 
 /**
@@ -23,6 +24,13 @@ use Two\Gateway\Service\Merchant\SettingsProvider;
  */
 class Repository implements RepositoryInterface
 {
+    /**
+     * Module whose deployed commit stamps the reported `client_v`. The
+     * base gateway runtime is what the API cares about; brand overlays
+     * ship on top of it and are surfaced per-module in the admin panel.
+     */
+    private const PROVENANCE_MODULE = 'Two_Gateway';
+
     /**
      * @var ScopeConfigInterface
      */
@@ -59,6 +67,14 @@ class Repository implements RepositoryInterface
     private $settingsProvider;
 
     /**
+     * @var Provenance Resolves the commit the deployed module was built
+     *                 from, so outbound telemetry (`client_v`) identifies
+     *                 the exact code running, not just the release line.
+     *                 Shared with the admin Version panel.
+     */
+    private $provenance;
+
+    /**
      * @var string|null Optional explicit override. Null = resolve
      *                  lazily from BrandRegistryInterface::getCode().
      *                  Kept as a ctor arg for unit-test injection and
@@ -84,6 +100,7 @@ class Repository implements RepositoryInterface
         TaxCalculation $taxCalculation,
         BrandRegistryInterface $brandRegistry,
         SettingsProvider $settingsProvider,
+        Provenance $provenance,
         ?string $code = null
     ) {
         $this->scopeConfig = $scopeConfig;
@@ -93,6 +110,7 @@ class Repository implements RepositoryInterface
         $this->taxCalculation = $taxCalculation;
         $this->brandRegistry = $brandRegistry;
         $this->settingsProvider = $settingsProvider;
+        $this->provenance = $provenance;
         $this->code = $code;
     }
 
@@ -401,6 +419,45 @@ class Repository implements RepositoryInterface
     }
 
     /**
+     * Extension version as recorded in config (`payment/<code>/version`),
+     * with no provenance suffix. This is the release line only.
+     */
+    private function getConfiguredVersion()
+    {
+        return $this->getConfig($this->path('version'));
+    }
+
+    /**
+     * Version string reported to the API: the configured release version
+     * suffixed with `+<sha7>` of the commit the deployed code was built
+     * from, e.g. `2.0.1+6f8534e` (TWO-25197).
+     *
+     * The suffix is appended ONLY when a SHA actually resolves — a bare
+     * trailing `+` would be worse than no provenance at all, since it
+     * reads as a truncated value rather than an absent one. An install
+     * with neither Composer metadata nor a git checkout reports the bare
+     * version, unchanged from before.
+     *
+     * `+` is not URL-safe in a query value (it decodes to a space), but
+     * addVersionDataInURL() emits this through http_build_query(), which
+     * percent-encodes it as `%2B`.
+     */
+    private function getReportedVersion(): ?string
+    {
+        $version = $this->getConfiguredVersion();
+        if ($version === null) {
+            return null;
+        }
+        $version = (string)$version;
+        if ($version === '') {
+            return '';
+        }
+        $commit = $this->provenance->commitForModule(self::PROVENANCE_MODULE);
+
+        return $commit === '' ? $version : $version . '+' . $commit;
+    }
+
+    /**
      * Returns extension version Array
      *
      * @return array
@@ -409,7 +466,7 @@ class Repository implements RepositoryInterface
     {
         return [
             'client' => 'Magento',
-            'client_v' => $this->getConfig($this->path('version'))
+            'client_v' => $this->getReportedVersion()
         ];
     }
 
@@ -418,12 +475,12 @@ class Repository implements RepositoryInterface
      */
     public function getExtensionDBVersion(): ?string
     {
-        $versionData = $this->getExtensionVersionData();
-        if (isset($versionData['client_v'])) {
-            return $versionData['client_v'];
-        }
+        // Deliberately the bare configured version, NOT the `+<sha>`
+        // provenance-stamped one: this is the DB/config schema version
+        // that callers compare against release numbers.
+        $version = $this->getConfiguredVersion();
 
-        return null;
+        return $version === null ? null : (string)$version;
     }
 
     /**

--- a/Model/Provenance.php
+++ b/Model/Provenance.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Model;
+
+use Magento\Framework\Component\ComponentRegistrar;
+
+/**
+ * Resolves the commit a deployed Two module was built from.
+ *
+ * Two deployment shapes exist in the wild and both must resolve:
+ *
+ *  1. Composer/Packagist install (the 2.0 merchant distribution). The
+ *     module lives under vendor/ with no .git of any kind; Composer's
+ *     installed registry records the exact source/dist reference —
+ *     `Composer\InstalledVersions::getReference('two-inc/magento2')`
+ *     returns the full release SHA. Authoritative and layout-independent,
+ *     so it is preferred.
+ *  2. gitSync dev install. No composer package at all; `app/code/Two/Gateway`
+ *     is a symlink to the synced checkout, whose `.git` is a gitlink FILE
+ *     (`gitdir: ../../.git/worktrees/<sha>`) — gitSync v4 names each
+ *     worktree directory after the SHA it points at.
+ *
+ * Neither present (a plain source drop) is a legitimate state: every entry
+ * point returns '' rather than throwing, so callers degrade to a bare
+ * version string and the admin panel still renders.
+ *
+ * This class is the single owner of that logic. The admin Version block and
+ * the config Repository (which stamps the SHA onto the `client_v` telemetry
+ * parameter) both consume it; neither duplicates the parsing.
+ */
+class Provenance
+{
+    private ComponentRegistrar $componentRegistrar;
+
+    /**
+     * Per-request memo, keyed by module path. Resolution touches the
+     * filesystem and this is called on every outbound API URL build.
+     *
+     * @var array<string, string>
+     */
+    private array $commitCache = [];
+
+    public function __construct(ComponentRegistrar $componentRegistrar)
+    {
+        $this->componentRegistrar = $componentRegistrar;
+    }
+
+    /**
+     * 7-char commit SHA for a registered module, or '' when it cannot be
+     * determined (module not registered, or neither provenance signal
+     * present).
+     */
+    public function commitForModule(string $moduleName): string
+    {
+        try {
+            $path = $this->componentRegistrar->getPath(ComponentRegistrar::MODULE, $moduleName);
+        } catch (\Throwable $e) {
+            return '';
+        }
+        if (!$path) {
+            return '';
+        }
+        return $this->commitForPath($path);
+    }
+
+    /**
+     * 7-char commit SHA for a module directory, or '' when undeterminable.
+     *
+     * Never throws: provenance is diagnostic metadata, and a broken admin
+     * page or a failed API call would be a wildly disproportionate cost for
+     * an unreadable dotfile.
+     */
+    public function commitForPath(string $modulePath): string
+    {
+        if (isset($this->commitCache[$modulePath])) {
+            return $this->commitCache[$modulePath];
+        }
+        try {
+            $commit = $this->resolve($modulePath);
+        } catch (\Throwable $e) {
+            $commit = '';
+        }
+        $this->commitCache[$modulePath] = $commit;
+        return $commit;
+    }
+
+    private function resolve(string $modulePath): string
+    {
+        // Composer-installed deploys (Packagist/dist — the current 2.0
+        // distribution model) put the module under vendor/ with NO .git
+        // worktree, so the path-based resolution below finds nothing. The
+        // installed registry records the exact source/dist commit, which is
+        // authoritative and layout-independent — prefer it.
+        $fromComposer = $this->commitFromComposer($modulePath);
+        if ($fromComposer !== null) {
+            return $fromComposer;
+        }
+
+        // The gitlink lives at the checkout root. For a top-level module
+        // that IS the module directory; for a monorepo sub-path module
+        // (the ABN overlay ships its gateway at <repo>/plugin) it is one
+        // level up — same two-place lookup composer.json needs.
+        foreach ([$modulePath, dirname($modulePath)] as $dir) {
+            $gitFile = $dir . '/.git';
+            if (!is_file($gitFile)) {
+                continue;
+            }
+            // .git is always `gitdir: <relpath>\n`; cap the read defensively
+            // and trim before anchoring the regex to end-of-string so a
+            // worktrees/<sha> segment elsewhere in the path can't shadow
+            // the real SHA at the tail.
+            $content = @file_get_contents($gitFile, false, null, 0, 1024);
+            if ($content !== false
+                && preg_match('#worktrees/([a-f0-9]{7,40})/?$#', trim($content), $m)
+            ) {
+                return substr($m[1], 0, 7);
+            }
+        }
+        // Legacy fallback: module path is a symlink through the worktree.
+        $real = @realpath($modulePath . '/registration.php');
+        if ($real && preg_match('#\.worktrees/([a-f0-9]{7,40})/#', $real, $m)) {
+            return substr($m[1], 0, 7);
+        }
+        return '';
+    }
+
+    /**
+     * 7-char commit SHA from Composer's installed registry, or null when the
+     * module isn't composer-installed or carries no hex source reference.
+     *
+     * Reads the package name from composer.json (checking the module dir and
+     * one level up — monorepo sub-path modules keep composer.json a level up,
+     * mirroring the version lookup in the admin Version block), then asks the
+     * installed registry for that package's source/dist reference. A path-repo
+     * or branch install may carry a non-SHA reference; the hex guard rejects
+     * those so the caller falls back to the .git/worktree resolution.
+     */
+    public function commitFromComposer(string $modulePath): ?string
+    {
+        foreach ([$modulePath, dirname($modulePath)] as $dir) {
+            $composer = @file_get_contents($dir . '/composer.json');
+            if ($composer === false) {
+                continue;
+            }
+            $data = json_decode($composer, true);
+            $name = is_array($data) ? ($data['name'] ?? null) : null;
+            if (!is_string($name) || $name === '') {
+                continue;
+            }
+            $ref = $this->composerReference($name);
+            if (is_string($ref) && preg_match('/^[a-f0-9]{7,40}$/', $ref)) {
+                return substr($ref, 0, 7);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * The installed package's source/dist reference (commit SHA), or null.
+     * Wraps the static Composer registry as an override seam for testing.
+     */
+    protected function composerReference(string $packageName): ?string
+    {
+        if (!class_exists(\Composer\InstalledVersions::class)
+            || !\Composer\InstalledVersions::isInstalled($packageName)
+        ) {
+            return null;
+        }
+        return \Composer\InstalledVersions::getReference($packageName);
+    }
+}

--- a/Test/Stubs/ComponentRegistrar.php
+++ b/Test/Stubs/ComponentRegistrar.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * ComponentRegistrar stub with the getPaths surface intact — required
- * before the catch-all autoloader so Loader tests can mock module
+ * ComponentRegistrar stub with the getPaths/getPath surface intact
+ * — required before the catch-all autoloader so Loader tests can mock module
  * enumeration (the catch-all would stub an empty class without the
  * method, and onlyMethods() refuses methods that don't exist).
  *
@@ -18,6 +18,11 @@ namespace Magento\Framework\Component {
             public function getPaths($type)
             {
                 return [];
+            }
+
+            public function getPath($type, $componentName)
+            {
+                return null;
             }
         }
     }

--- a/Test/Unit/Block/Adminhtml/System/Config/Field/VersionTest.php
+++ b/Test/Unit/Block/Adminhtml/System/Config/Field/VersionTest.php
@@ -5,131 +5,61 @@ namespace Two\Gateway\Test\Unit\Block\Adminhtml\System\Config\Field;
 
 use PHPUnit\Framework\TestCase;
 use Two\Gateway\Block\Adminhtml\System\Config\Field\Version;
+use Two\Gateway\Model\Provenance;
 
 /**
- * Tests for commit-SHA resolution in the admin Version panel.
+ * The admin Version panel's per-module commit column.
  *
- * The regression (TWO-25020): composer-installed deploys put the module under
- * vendor/ with no .git worktree, so the path-based resolution returned '' and
- * the panel showed '—'. extractCommit() now prefers Composer's installed
- * registry (source/dist reference), falling back to the .git/worktree parse.
+ * The resolution logic itself moved to Two\Gateway\Model\Provenance in
+ * TWO-25197 (Model\Config\Repository needs the same SHA for `client_v`);
+ * see Test\Unit\Model\ProvenanceTest for the composer / gitlink / neither
+ * cases. What matters here is that the block still resolves per module
+ * path, so an overlay row reports the overlay's own commit rather than
+ * the base module's.
  */
 class VersionTest extends TestCase
 {
-    /** @var string */
-    private $tmpDir;
-
-    protected function setUp(): void
+    public function testExtractCommitResolvesPerModulePath(): void
     {
-        $this->tmpDir = sys_get_temp_dir() . '/two-version-test-' . uniqid();
-        mkdir($this->tmpDir, 0777, true);
-    }
+        $provenance = $this->createMock(Provenance::class);
+        $provenance->method('commitForPath')->willReturnMap([
+            ['/app/code/Two/Gateway', '6f8534e'],
+            ['/app/code/ABN/Gateway', 'cd9edfb'],
+        ]);
 
-    protected function tearDown(): void
-    {
-        foreach (['/.git', '/composer.json', '/registration.php'] as $f) {
-            @unlink($this->tmpDir . $f);
-        }
-        @rmdir($this->tmpDir);
-    }
-
-    private function writeComposerJson(string $name): void
-    {
-        file_put_contents(
-            $this->tmpDir . '/composer.json',
-            json_encode(['name' => $name])
-        );
-    }
-
-    public function testCommitResolvedFromComposerReference(): void
-    {
-        $this->writeComposerJson('two-inc/magento2');
         $block = new VersionTestable();
-        $block->stubRef = '0aa21947d6ed57bcf6b35f73a5ed192fc6a9a0dd';
+        $block->setProvenance($provenance);
 
-        $this->assertSame('0aa2194', $block->commitFromComposerPublic($this->tmpDir));
+        $this->assertSame('6f8534e', $block->extractCommitPublic('/app/code/Two/Gateway'));
+        $this->assertSame('cd9edfb', $block->extractCommitPublic('/app/code/ABN/Gateway'));
     }
 
-    public function testComposerReferenceIsPreferredOverGitWorktree(): void
+    public function testUnresolvableCommitIsEmptyNotAnException(): void
     {
-        // Both signals present: composer wins (it's the authoritative,
-        // layout-independent source for a composer-installed module).
-        $this->writeComposerJson('two-inc/magento2');
-        file_put_contents($this->tmpDir . '/.git', "gitdir: /repo/.git/worktrees/deadbeef1234\n");
+        $provenance = $this->createMock(Provenance::class);
+        $provenance->method('commitForPath')->willReturn('');
+
         $block = new VersionTestable();
-        $block->stubRef = '0aa21947d6ed57bcf6b35f73a5ed192fc6a9a0dd';
+        $block->setProvenance($provenance);
 
-        $this->assertSame('0aa2194', $block->extractCommitPublic($this->tmpDir));
-    }
-
-    public function testFallsBackToGitWorktreeWhenNotComposerInstalled(): void
-    {
-        // composer.json present but the package resolves no reference (null) —
-        // e.g. a git-sync/dev checkout — so the .git worktree parse takes over.
-        $this->writeComposerJson('two-inc/magento2');
-        file_put_contents($this->tmpDir . '/.git', "gitdir: /repo/.git/worktrees/abcdef1234567\n");
-        $block = new VersionTestable();
-        $block->stubRef = null;
-
-        $this->assertSame('abcdef1', $block->extractCommitPublic($this->tmpDir));
-    }
-
-    public function testNonHexReferenceIsRejected(): void
-    {
-        // A path-repo / branch install can carry a non-SHA reference; it must
-        // not be shown as a commit — return null so the caller falls back.
-        $this->writeComposerJson('two-inc/magento2');
-        $block = new VersionTestable();
-        $block->stubRef = 'dev-main';
-
-        $this->assertNull($block->commitFromComposerPublic($this->tmpDir));
-    }
-
-    public function testEmptyWhenNoComposerAndNoGit(): void
-    {
-        $block = new VersionTestable();
-        $block->stubRef = null;
-
-        $this->assertSame('', $block->extractCommitPublic($this->tmpDir));
-    }
-
-    public function testPackageNameReadFromParentDirForMonorepoSubpath(): void
-    {
-        // Monorepo sub-path modules keep composer.json one level up.
-        $sub = $this->tmpDir . '/plugin';
-        mkdir($sub);
-        $this->writeComposerJson('two-inc/magento2');
-        $block = new VersionTestable();
-        $block->stubRef = '0aa21947d6ed57bcf6b35f73a5ed192fc6a9a0dd';
-
-        $this->assertSame('0aa2194', $block->commitFromComposerPublic($sub));
-        @rmdir($sub);
+        $this->assertSame('', $block->extractCommitPublic('/app/code/Two/Gateway'));
     }
 }
 
 /**
- * Constructor-free subclass exposing the protected resolution methods and
- * stubbing the static Composer registry lookup.
+ * Constructor-free subclass exposing the protected commit lookup. The
+ * heavy Field base constructor is skipped — this exercises resolution
+ * wiring only, which needs no injected framework dependencies.
  */
 class VersionTestable extends Version
 {
-    /** @var string|null */
-    public $stubRef = null;
-
-    // Skip the heavy Field base constructor — these tests exercise pure
-    // resolution logic that needs no injected dependencies.
     public function __construct()
     {
     }
 
-    protected function composerReference(string $packageName): ?string
+    public function setProvenance(Provenance $provenance): void
     {
-        return $this->stubRef;
-    }
-
-    public function commitFromComposerPublic(string $modulePath): ?string
-    {
-        return $this->commitFromComposer($modulePath);
+        $this->provenance = $provenance;
     }
 
     public function extractCommitPublic(string $modulePath): string

--- a/Test/Unit/Model/Config/RepositoryPaymentTermsTest.php
+++ b/Test/Unit/Model/Config/RepositoryPaymentTermsTest.php
@@ -12,6 +12,7 @@ use Magento\Tax\Model\Calculation as TaxCalculation;
 use PHPUnit\Framework\TestCase;
 use Two\Gateway\Api\BrandRegistryInterface;
 use Two\Gateway\Model\Config\Repository;
+use Two\Gateway\Model\Provenance;
 use Two\Gateway\Service\Merchant\SettingsProvider;
 
 class RepositoryPaymentTermsTest extends TestCase
@@ -51,7 +52,8 @@ class RepositoryPaymentTermsTest extends TestCase
             $this->createMock(ProductMetadataInterface::class),
             $this->taxCalculation,
             $brandRegistry,
-            $this->settingsProvider
+            $this->settingsProvider,
+            $this->createMock(Provenance::class)
         );
     }
 

--- a/Test/Unit/Model/Config/RepositoryUrlTest.php
+++ b/Test/Unit/Model/Config/RepositoryUrlTest.php
@@ -11,6 +11,7 @@ use Magento\Tax\Model\Calculation as TaxCalculation;
 use PHPUnit\Framework\TestCase;
 use Two\Gateway\Api\BrandRegistryInterface;
 use Two\Gateway\Model\Config\Repository;
+use Two\Gateway\Model\Provenance;
 use Two\Gateway\Service\Merchant\SettingsProvider;
 
 /**
@@ -44,7 +45,8 @@ class RepositoryUrlTest extends TestCase
             $productMetadata,
             $this->createMock(TaxCalculation::class),
             $brand,
-            $this->createMock(SettingsProvider::class)
+            $this->createMock(SettingsProvider::class),
+            $this->createMock(Provenance::class)
         );
     }
 

--- a/Test/Unit/Model/Config/RepositoryVersionStampTest.php
+++ b/Test/Unit/Model/Config/RepositoryVersionStampTest.php
@@ -1,0 +1,97 @@
+<?php
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Model\Config;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\ProductMetadataInterface;
+use Magento\Framework\Encryption\EncryptorInterface;
+use Magento\Framework\UrlInterface;
+use Magento\Tax\Model\Calculation as TaxCalculation;
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Api\BrandRegistryInterface;
+use Two\Gateway\Model\Config\Repository;
+use Two\Gateway\Model\Provenance;
+
+/**
+ * TWO-25197: the `client_v` telemetry parameter carries the deployed
+ * commit, so a support enquiry can be tied to exact running code rather
+ * than a release line that may cover many builds.
+ */
+class RepositoryVersionStampTest extends TestCase
+{
+    /** @var ScopeConfigInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $scopeConfig;
+
+    protected function setUp(): void
+    {
+        $this->scopeConfig = $this->createMock(ScopeConfigInterface::class);
+    }
+
+    private function repository(?string $version, string $commit): Repository
+    {
+        $this->scopeConfig->method('getValue')->willReturn($version);
+        $brand = $this->createMock(BrandRegistryInterface::class);
+        $brand->method('getCode')->willReturn('two_payment');
+        $provenance = $this->createMock(Provenance::class);
+        $provenance->method('commitForModule')->willReturn($commit);
+
+        return new Repository(
+            $this->scopeConfig,
+            $this->createMock(EncryptorInterface::class),
+            $this->createMock(UrlInterface::class),
+            $this->createMock(ProductMetadataInterface::class),
+            $this->createMock(TaxCalculation::class),
+            $brand,
+            $this->createMock(\Two\Gateway\Service\Merchant\SettingsProvider::class),
+            $provenance
+        );
+    }
+
+    public function testCommitIsAppendedToClientVersion(): void
+    {
+        $url = $this->repository('2.0.1', '6f8534e')
+            ->addVersionDataInURL('https://api.two.inc/v1/order');
+
+        // `+` MUST arrive percent-encoded: a literal `+` in a query value
+        // decodes to a space server-side. http_build_query handles this.
+        $this->assertStringContainsString('client_v=2.0.1%2B6f8534e', $url);
+        $this->assertStringNotContainsString('+', $url);
+
+        parse_str((string)parse_url($url, PHP_URL_QUERY), $q);
+        $this->assertSame('2.0.1+6f8534e', $q['client_v']);
+        $this->assertSame('Magento', $q['client']);
+    }
+
+    public function testNoTrailingPlusWhenCommitCannotBeResolved(): void
+    {
+        $url = $this->repository('2.0.1', '')
+            ->addVersionDataInURL('https://api.two.inc/v1/order');
+
+        parse_str((string)parse_url($url, PHP_URL_QUERY), $q);
+        $this->assertSame('2.0.1', $q['client_v']);
+        $this->assertStringNotContainsString('%2B', $url);
+        $this->assertStringNotContainsString('+', $url);
+    }
+
+    public function testAbsentVersionStaysAbsentEvenWithACommit(): void
+    {
+        // No configured version and a resolvable SHA must not produce a
+        // bare `+6f8534e`.
+        $url = $this->repository(null, '6f8534e')
+            ->addVersionDataInURL('https://api.two.inc/v1/order');
+
+        $this->assertStringNotContainsString('client_v', $url);
+        $this->assertStringContainsString('client=Magento', $url);
+    }
+
+    public function testDbVersionStaysUnstamped(): void
+    {
+        // getExtensionDBVersion() is the schema/release version callers
+        // compare against release numbers — no provenance suffix.
+        $this->assertSame(
+            '2.0.1',
+            $this->repository('2.0.1', '6f8534e')->getExtensionDBVersion()
+        );
+    }
+}

--- a/Test/Unit/Model/ProvenanceTest.php
+++ b/Test/Unit/Model/ProvenanceTest.php
@@ -1,0 +1,191 @@
+<?php
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Model;
+
+use Magento\Framework\Component\ComponentRegistrar;
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Model\Provenance;
+
+/**
+ * Commit-SHA resolution for the deployed module (TWO-25197).
+ *
+ * Two deploy shapes must resolve, plus a third that must degrade quietly:
+ *  - Packagist/composer install: no .git at all; the installed registry
+ *    carries the release SHA (the regression fixed in TWO-25020).
+ *  - gitSync dev install: no composer package; `.git` is a gitlink FILE
+ *    naming the worktree after its SHA.
+ *  - neither: bare '' with no exception.
+ *
+ * Logic previously lived in the admin Version block; this suite is its
+ * home now that Model\Config\Repository consumes it too.
+ */
+class ProvenanceTest extends TestCase
+{
+    /** @var string */
+    private $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/two-provenance-test-' . uniqid();
+        mkdir($this->tmpDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (['/.git', '/composer.json', '/registration.php'] as $f) {
+            @unlink($this->tmpDir . $f);
+        }
+        @rmdir($this->tmpDir);
+    }
+
+    private function writeComposerJson(string $name): void
+    {
+        file_put_contents(
+            $this->tmpDir . '/composer.json',
+            json_encode(['name' => $name])
+        );
+    }
+
+    private function provenance(?string $stubRef): ProvenanceTestable
+    {
+        $p = new ProvenanceTestable($this->createMock(ComponentRegistrar::class));
+        $p->stubRef = $stubRef;
+
+        return $p;
+    }
+
+    public function testCommitResolvedFromComposerReference(): void
+    {
+        $this->writeComposerJson('two-inc/magento2');
+        $p = $this->provenance('6f8534ed11ce70d739b3cd910e27d991d508b3f6');
+
+        $this->assertSame('6f8534e', $p->commitFromComposer($this->tmpDir));
+        $this->assertSame('6f8534e', $p->commitForPath($this->tmpDir));
+    }
+
+    public function testComposerReferenceIsPreferredOverGitWorktree(): void
+    {
+        // Both signals present: composer wins (it's the authoritative,
+        // layout-independent source for a composer-installed module).
+        $this->writeComposerJson('two-inc/magento2');
+        file_put_contents($this->tmpDir . '/.git', "gitdir: /repo/.git/worktrees/deadbeef1234\n");
+        $p = $this->provenance('0aa21947d6ed57bcf6b35f73a5ed192fc6a9a0dd');
+
+        $this->assertSame('0aa2194', $p->commitForPath($this->tmpDir));
+    }
+
+    public function testFallsBackToGitlinkWorktreeWhenNotComposerInstalled(): void
+    {
+        // composer.json present but the package resolves no reference (null) —
+        // e.g. a git-sync/dev checkout — so the .git worktree parse takes over.
+        $this->writeComposerJson('two-inc/magento2');
+        file_put_contents($this->tmpDir . '/.git', "gitdir: /repo/.git/worktrees/abcdef1234567\n");
+
+        $this->assertSame('abcdef1', $this->provenance(null)->commitForPath($this->tmpDir));
+    }
+
+    public function testGitlinkResolvesWithNoComposerJsonAtAll(): void
+    {
+        // The live gitSync dev install shape: symlinked module directory,
+        // no composer package, `.git` a relative gitlink file.
+        file_put_contents(
+            $this->tmpDir . '/.git',
+            "gitdir: ../../.git/worktrees/cd9edfbbdc4d54f1db1c47996b51084edea7c51c\n"
+        );
+
+        $this->assertSame('cd9edfb', $this->provenance(null)->commitForPath($this->tmpDir));
+    }
+
+    public function testGitlinkFoundOneLevelUpForMonorepoSubpathModule(): void
+    {
+        // The ABN overlay's gateway module sits at <repo>/plugin; the
+        // gitlink is at the checkout root, one level up. Without the
+        // parent-dir lookup the overlay row on a gitSync install shows no
+        // commit at all (TWO-25197).
+        $sub = $this->tmpDir . '/plugin';
+        mkdir($sub);
+        file_put_contents($this->tmpDir . '/.git', "gitdir: ../../.git/worktrees/abcdef1234567\n");
+
+        $this->assertSame('abcdef1', $this->provenance(null)->commitForPath($sub));
+        @rmdir($sub);
+    }
+
+    public function testNonHexReferenceIsRejected(): void
+    {
+        // A path-repo / branch install can carry a non-SHA reference; it must
+        // not be shown as a commit — return null so the caller falls back.
+        $this->writeComposerJson('two-inc/magento2');
+
+        $this->assertNull($this->provenance('dev-main')->commitFromComposer($this->tmpDir));
+    }
+
+    public function testEmptyWhenNeitherComposerNorGitPresent(): void
+    {
+        $this->assertSame('', $this->provenance(null)->commitForPath($this->tmpDir));
+    }
+
+    public function testEmptyForUnknownModuleName(): void
+    {
+        $registrar = $this->createMock(ComponentRegistrar::class);
+        $registrar->method('getPath')->willReturn(null);
+        $p = new ProvenanceTestable($registrar);
+
+        $this->assertSame('', $p->commitForModule('Two_NotInstalled'));
+    }
+
+    public function testCommitForModuleResolvesRegisteredPath(): void
+    {
+        $this->writeComposerJson('two-inc/magento2');
+        $registrar = $this->createMock(ComponentRegistrar::class);
+        $registrar->method('getPath')->willReturn($this->tmpDir);
+        $p = new ProvenanceTestable($registrar);
+        $p->stubRef = '6f8534ed11ce70d739b3cd910e27d991d508b3f6';
+
+        $this->assertSame('6f8534e', $p->commitForModule('Two_Gateway'));
+    }
+
+    public function testPackageNameReadFromParentDirForMonorepoSubpath(): void
+    {
+        // Monorepo sub-path modules (e.g. the ABN overlay at <repo>/plugin)
+        // keep composer.json one level up.
+        $sub = $this->tmpDir . '/plugin';
+        mkdir($sub);
+        $this->writeComposerJson('abn-amro/magento-abn-plugin');
+        $p = $this->provenance('0aa21947d6ed57bcf6b35f73a5ed192fc6a9a0dd');
+
+        $this->assertSame('0aa2194', $p->commitFromComposer($sub));
+        @rmdir($sub);
+    }
+
+    public function testResultIsMemoisedPerPath(): void
+    {
+        $this->writeComposerJson('two-inc/magento2');
+        $p = $this->provenance('6f8534ed11ce70d739b3cd910e27d991d508b3f6');
+
+        $this->assertSame('6f8534e', $p->commitForPath($this->tmpDir));
+        $this->assertSame(1, $p->refCalls);
+        $p->commitForPath($this->tmpDir);
+        $this->assertSame(1, $p->refCalls, 'second lookup should hit the memo');
+    }
+}
+
+/**
+ * Stubs the static Composer registry lookup, which cannot be exercised
+ * against a temp directory in a unit test.
+ */
+class ProvenanceTestable extends Provenance
+{
+    /** @var string|null */
+    public $stubRef = null;
+
+    /** @var int */
+    public $refCalls = 0;
+
+    protected function composerReference(string $packageName): ?string
+    {
+        $this->refCalls++;
+
+        return $this->stubRef;
+    }
+}


### PR DESCRIPTION
Linear: TWO-25197

## Problem

`client_v` reported `payment/<code>/version` alone, so a support enquiry
could be tied to a release line but not to the exact code running. And
on a gitSync install the admin Version panel showed no commit for a
monorepo sub-path overlay module.

## What changed

**1. `client_v` carries the SHA.** `<version>+<sha7>`, e.g.
`2.1.2+795f8ca`. Appended **only** when a SHA actually resolves — never
a trailing `+`, never a bare `+sha` when no version is configured.

**2. Resolution logic extracted to a shared service.** It lived in
`Block/Adminhtml/System/Config/Field/Version.php`; it now lives in
`Two\Gateway\Model\Provenance`, injected into both the block and
`Model\Config\Repository`. One owner of the regex, no Repository →
Block dependency. Behaviour of `extractCommit()` is unchanged — the
block delegates.

Both deploy shapes still resolve:

| Shape | Signal |
|---|---|
| Packagist/composer (vendor/, no `.git`) | `Composer\InstalledVersions::getReference()` |
| gitSync dev (symlink, no composer pkg) | `.git` gitlink file → `worktrees/<sha>` |
| neither | `''` → bare version, no exception |

**3. Overlay commits on the admin panel.** The base block already
renders one row per module from the active brand's
`<module_label_chain>`, and `magento-abn-plugin`'s `brand.xml` already
declares `ABN_Gateway` / `ABN_GatewayHyva` — so multi-row was already
in place and **no change to `magento-abn-plugin` is needed**. What was
broken: for a monorepo sub-path module (the ABN overlay ships its
gateway at `<repo>/plugin`) the gitlink sits at the checkout root, one
level up, so `extractCommit()` found nothing on a gitSync install.
Provenance now checks the parent directory too, mirroring the
composer.json lookup that already did.

**4. `getExtensionDBVersion()` deliberately stays unstamped** — callers
compare it against release numbers.

## The `+` encoding question

A literal `+` in a query value decodes to a space server-side.
`addVersionDataInURL()` emits via `http_build_query`, which
percent-encodes it as `%2B`. Verified end-to-end against a real Magento
2.4.8 / PHP 8.3 install with the module composer-installed:

```
commitForModule(Two_Gateway) = '795f8ca'
getExtensionDBVersion()      = '2.1.2'
addVersionDataInURL()        = https://api.two.inc/v1/order?client=Magento&client_v=2.1.2%2B795f8ca
decoded client_v             = '2.1.2+795f8ca'
```

A unit test asserts both the encoded form and the decoded round-trip.

## Verification

All CI gates run locally, same commands as `.github/workflows/ci.yml`:

- **PHPUnit 10.5.64 / PHP 8.3.31** — `Tests: 391, Assertions: 677` OK
  (baseline on `staging` was 380; +11 new). The 2 PHPUnit deprecations
  are pre-existing and present on `staging` too.
- **PHPStan** (Magento 2.4.8 / php83-fpm container, CI's exact
  invocation) — `[OK] No errors`
- **`setup:di:compile`** (same container) — `Generated code and
  dependency injection configuration successfully.` The known failure
  mode here is a constructor change without its `GenericPaymentMethod`
  mirror; `Two.php` / `GenericPaymentMethod` are untouched (the new
  dependency lands on `Config\Repository`, which is consumed through
  `ConfigRepository` interface and has no subclass or virtualType).
- **`config:set` / `config:show` smoke** (CI's ABN-423 M3 step) —
  round-tripped `CI smoke`.
- **Codesniffer** `--severity=6` — 207 files, clean.

## Note for the reviewer

Pre-existing and unchanged, but worth knowing: a composer **path
repository** install yields a 40-hex `reference` that is not a git
commit, and the hex guard accepts it (the existing comment claiming
path-repo refs are rejected is only true for `dev-*` branch refs). It
affects local/CI path installs, not the Packagist deploy this feature
targets. Left alone rather than widened in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)