### PR TITLE
TWO-25205/feat: add .two-deployed-commit stamp, gitlink-first provenance order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 # Artifacts
 index.html
 *.zip
+# Build-time provenance stamp injected into the release zip by `make archive`.
+# Normally written to a temp dir outside the repo; ignored here so a manual or
+# in-tree stamp can never be committed.
+.two-deployed-commit
 
 # Direnv
 .direnv/

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ install: clean
 	docker exec $(CONTAINER) php bin/magento deploy:mode:set developer
 	# di:compile resets Magento to production mode as a side effect, so
 	# deploy:mode:set developer must run AFTER it, or developer mode gets
-	# silently clobbered back to production. See magento-abn-plugin 66062d8.
+	# silently clobbered back to production. See overlay repo commit 66062d8.
 	# Local-dev perf: merge + minify JS/CSS so RequireJS doesn't fan out into
 	# ~200 individual file fetches. Stays in developer mode (no static deploy
 	# step), but the request count drops to ~20 and the storefront's KO

--- a/Makefile
+++ b/Makefile
@@ -196,8 +196,19 @@ logs:
 # ==============================================================================
 
 ## Create a versioned zip archive
+# The zip carries a `.two-deployed-commit` build stamp: a zip-dropped
+# install (unpacked straight into app/code) has neither a .git gitlink nor a
+# Composer registry entry, so the stamp is the only provenance signal
+# Model/Provenance.php can find there. It is written into a mktemp dir OUTSIDE
+# the repo and injected with `git archive --add-file`, so the working tree is
+# never dirtied and the stamp can't accidentally get committed.
 archive:
-	eval $$(bumpver show --environ) && git archive --format zip HEAD > magento-plugin-$${CURRENT_VERSION}.zip
+	eval $$(bumpver show --environ) \
+	  && stampdir=$$(mktemp -d) \
+	  && trap 'rm -rf "$$stampdir"' EXIT \
+	  && git rev-parse --short HEAD > "$$stampdir/.two-deployed-commit" \
+	  && git archive --format zip --add-file="$$stampdir/.two-deployed-commit" HEAD \
+	       > magento-plugin-$${CURRENT_VERSION}.zip
 bumpver-%:
 	SKIP=commit-msg bumpver update --$*
 ## Bump patch version

--- a/Model/Provenance.php
+++ b/Model/Provenance.php
@@ -25,7 +25,7 @@ use Magento\Framework\Component\ComponentRegistrar;
  *     installed registry records the exact source/dist reference —
  *     `Composer\InstalledVersions::getReference('two-inc/magento2')`
  *     returns the full release SHA.
- *  3. Zip drop. The ABN overlay ships as a release-asset / GCS zip that is
+ *  3. Zip drop. A branding overlay may ship as a release-asset / GCS zip that is
  *     unpacked straight into `app/code`, carrying neither a `.git` nor a
  *     Composer registry entry — so neither signal above exists. `make
  *     archive` stamps a `.two-deployed-commit` file into the zip at build
@@ -33,7 +33,7 @@ use Magento\Framework\Component\ComponentRegistrar;
  *
  * Resolution order is `.git` gitlink → Composer reference →
  * `.two-deployed-commit` stamp, one org-wide order shared by all six Two
- * plugin artifacts (Magento, Magento ABN, WooCommerce, WooCommerce ABN,
+ * plugin artifacts (Magento, Magento overlay, WooCommerce, WooCommerce overlay,
  * PrestaShop, OpenCart). The order is freshness-ranked, not
  * confidence-ranked: the gitlink is the only signal that reflects what is
  * checked out *right now*, the Composer reference is recorded once at
@@ -46,7 +46,7 @@ use Magento\Framework\Component\ComponentRegistrar;
  * bare version string and the admin panel still renders.
  *
  * Note the SHA is repo-wide, not module-unique: for a repo that ships two
- * modules from sub-paths (the ABN overlay's `plugin/` and `hyva/`) both
+ * modules from sub-paths (an overlay package's `plugin/` and `hyva/`) both
  * legitimately report the same commit.
  *
  * This class is the single owner of that logic. The admin Version block and
@@ -118,7 +118,7 @@ class Provenance
         //
         // The gitlink lives at the checkout root. For a top-level module
         // that IS the module directory; for a monorepo sub-path module
-        // (the ABN overlay ships its gateway at <repo>/plugin) it is one
+        // (an overlay package ships its gateway at <repo>/plugin) it is one
         // level up — same two-place lookup composer.json needs. It can also
         // sit INSIDE the module dir, hence checking both.
         foreach ([$modulePath, dirname($modulePath)] as $dir) {
@@ -147,7 +147,7 @@ class Provenance
             return $fromComposer;
         }
 
-        // THIRD: the build stamp. A zip-dropped module (the ABN overlay's
+        // THIRD: the build stamp. A zip-dropped module (an overlay package's
         // GCS/release-asset zips) has neither of the above; `make archive`
         // writes the build commit into the zip. Frozen at build time, hence
         // last of the three.
@@ -200,7 +200,7 @@ class Provenance
      * when absent, unreadable or malformed.
      *
      * `make archive` writes the build commit into the release zip, which is
-     * how a zip-dropped module (the ABN overlay's GCS zips) reports its
+     * how a zip-dropped module (an overlay package's GCS zips) reports its
      * provenance at all — it carries neither a `.git` nor a Composer
      * registry entry. Checks the module dir and one level up, mirroring the
      * gitlink and composer.json lookups: a sub-path module's stamp is written

--- a/Model/Provenance.php
+++ b/Model/Provenance.php
@@ -10,24 +10,44 @@ namespace Two\Gateway\Model;
 use Magento\Framework\Component\ComponentRegistrar;
 
 /**
- * Resolves the commit a deployed Two module was built from.
+ * Resolves the commit a deployed Two module is running.
  *
- * Two deployment shapes exist in the wild and both must resolve:
+ * Three deployment shapes exist in the wild and all three must resolve:
  *
- *  1. Composer/Packagist install (the 2.0 merchant distribution). The
+ *  1. gitSync dev install. No composer package at all; `app/code/Two/Gateway`
+ *     is a symlink to the synced checkout, whose `.git` is a gitlink FILE
+ *     (`gitdir: ../../.git/worktrees/<sha>`) — gitSync v4 names each
+ *     worktree directory after the SHA it points at. The `gitdir:` target is
+ *     typically DANGLING inside the container, so the SHA is string-parsed
+ *     out of the gitlink; never shell out to `git`.
+ *  2. Composer/Packagist install (the 2.0 merchant distribution). The
  *     module lives under vendor/ with no .git of any kind; Composer's
  *     installed registry records the exact source/dist reference —
  *     `Composer\InstalledVersions::getReference('two-inc/magento2')`
- *     returns the full release SHA. Authoritative and layout-independent,
- *     so it is preferred.
- *  2. gitSync dev install. No composer package at all; `app/code/Two/Gateway`
- *     is a symlink to the synced checkout, whose `.git` is a gitlink FILE
- *     (`gitdir: ../../.git/worktrees/<sha>`) — gitSync v4 names each
- *     worktree directory after the SHA it points at.
+ *     returns the full release SHA.
+ *  3. Zip drop. The ABN overlay ships as a release-asset / GCS zip that is
+ *     unpacked straight into `app/code`, carrying neither a `.git` nor a
+ *     Composer registry entry — so neither signal above exists. `make
+ *     archive` stamps a `.two-deployed-commit` file into the zip at build
+ *     time to close that gap.
  *
- * Neither present (a plain source drop) is a legitimate state: every entry
- * point returns '' rather than throwing, so callers degrade to a bare
- * version string and the admin panel still renders.
+ * Resolution order is `.git` gitlink → Composer reference →
+ * `.two-deployed-commit` stamp, one org-wide order shared by all six Two
+ * plugin artifacts (Magento, Magento ABN, WooCommerce, WooCommerce ABN,
+ * PrestaShop, OpenCart). The order is freshness-ranked, not
+ * confidence-ranked: the gitlink is the only signal that reflects what is
+ * checked out *right now*, the Composer reference is recorded once at
+ * install time, and the build stamp is frozen at build time and so is the
+ * most likely of the three to be stale. Whichever is freshest and present
+ * wins; a malformed signal falls through to the next rather than winning.
+ *
+ * None present (a plain source drop with no stamp) is a legitimate state:
+ * every entry point returns '' rather than throwing, so callers degrade to a
+ * bare version string and the admin panel still renders.
+ *
+ * Note the SHA is repo-wide, not module-unique: for a repo that ships two
+ * modules from sub-paths (the ABN overlay's `plugin/` and `hyva/`) both
+ * legitimately report the same commit.
  *
  * This class is the single owner of that logic. The admin Version block and
  * the config Repository (which stamps the SHA onto the `client_v` telemetry
@@ -91,20 +111,16 @@ class Provenance
 
     private function resolve(string $modulePath): string
     {
-        // Composer-installed deploys (Packagist/dist — the current 2.0
-        // distribution model) put the module under vendor/ with NO .git
-        // worktree, so the path-based resolution below finds nothing. The
-        // installed registry records the exact source/dist commit, which is
-        // authoritative and layout-independent — prefer it.
-        $fromComposer = $this->commitFromComposer($modulePath);
-        if ($fromComposer !== null) {
-            return $fromComposer;
-        }
-
+        // FIRST: the gitlink. It is the only signal that tracks what is
+        // checked out right now — a gitSync pull moves it on every deploy,
+        // where the Composer reference is fixed at install time and the
+        // build stamp at build time.
+        //
         // The gitlink lives at the checkout root. For a top-level module
         // that IS the module directory; for a monorepo sub-path module
         // (the ABN overlay ships its gateway at <repo>/plugin) it is one
-        // level up — same two-place lookup composer.json needs.
+        // level up — same two-place lookup composer.json needs. It can also
+        // sit INSIDE the module dir, hence checking both.
         foreach ([$modulePath, dirname($modulePath)] as $dir) {
             $gitFile = $dir . '/.git';
             if (!is_file($gitFile)) {
@@ -121,6 +137,25 @@ class Provenance
                 return substr($m[1], 0, 7);
             }
         }
+
+        // SECOND: Composer-installed deploys (Packagist/dist — the current
+        // 2.0 merchant distribution model) put the module under vendor/ with
+        // NO .git worktree. The installed registry records the exact
+        // source/dist commit, recorded once at install time.
+        $fromComposer = $this->commitFromComposer($modulePath);
+        if ($fromComposer !== null) {
+            return $fromComposer;
+        }
+
+        // THIRD: the build stamp. A zip-dropped module (the ABN overlay's
+        // GCS/release-asset zips) has neither of the above; `make archive`
+        // writes the build commit into the zip. Frozen at build time, hence
+        // last of the three.
+        $fromStamp = $this->commitFromStamp($modulePath);
+        if ($fromStamp !== null) {
+            return $fromStamp;
+        }
+
         // Legacy fallback: module path is a symlink through the worktree.
         $real = @realpath($modulePath . '/registration.php');
         if ($real && preg_match('#\.worktrees/([a-f0-9]{7,40})/#', $real, $m)) {
@@ -155,6 +190,38 @@ class Provenance
             $ref = $this->composerReference($name);
             if (is_string($ref) && preg_match('/^[a-f0-9]{7,40}$/', $ref)) {
                 return substr($ref, 0, 7);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 7-char commit SHA from the `.two-deployed-commit` build stamp, or null
+     * when absent, unreadable or malformed.
+     *
+     * `make archive` writes the build commit into the release zip, which is
+     * how a zip-dropped module (the ABN overlay's GCS zips) reports its
+     * provenance at all — it carries neither a `.git` nor a Composer
+     * registry entry. Checks the module dir and one level up, mirroring the
+     * gitlink and composer.json lookups: a sub-path module's stamp is written
+     * at the repo root the archive was taken from.
+     *
+     * Never throws, and a malformed or empty stamp returns null so the
+     * caller falls THROUGH to the remaining fallback rather than surfacing
+     * junk as a commit.
+     */
+    public function commitFromStamp(string $modulePath): ?string
+    {
+        foreach ([$modulePath, dirname($modulePath)] as $dir) {
+            // Cap the read: a legitimate stamp is one short hex line, and
+            // this runs on every outbound API URL build.
+            $raw = @file_get_contents($dir . '/.two-deployed-commit', false, null, 0, 128);
+            if ($raw === false) {
+                continue;
+            }
+            $candidate = trim($raw);
+            if (preg_match('/^[a-f0-9]{7,40}$/i', $candidate)) {
+                return strtolower(substr($candidate, 0, 7));
             }
         }
         return null;

--- a/Test/Unit/Model/ProvenanceTest.php
+++ b/Test/Unit/Model/ProvenanceTest.php
@@ -8,14 +8,22 @@ use PHPUnit\Framework\TestCase;
 use Two\Gateway\Model\Provenance;
 
 /**
- * Commit-SHA resolution for the deployed module (TWO-25197).
+ * Commit-SHA resolution for the deployed module (TWO-25197, TWO-25205).
  *
- * Two deploy shapes must resolve, plus a third that must degrade quietly:
- *  - Packagist/composer install: no .git at all; the installed registry
- *    carries the release SHA (the regression fixed in TWO-25020).
+ * Three deploy shapes must resolve, plus a fourth that must degrade quietly:
  *  - gitSync dev install: no composer package; `.git` is a gitlink FILE
  *    naming the worktree after its SHA.
- *  - neither: bare '' with no exception.
+ *  - Packagist/composer install: no .git at all; the installed registry
+ *    carries the release SHA (the regression fixed in TWO-25020).
+ *  - zip drop (the ABN overlay's GCS/release-asset zips): neither a .git nor
+ *    a Composer registry entry, only the `.two-deployed-commit` build stamp
+ *    `make archive` injects (TWO-25205).
+ *  - none of the three: bare '' with no exception.
+ *
+ * Order is gitlink → composer → stamp, one org-wide order across all six Two
+ * plugin artifacts, ranked by freshness: the gitlink tracks what is checked
+ * out right now, the composer reference is fixed at install time, the stamp
+ * is frozen at build time. A malformed signal must fall THROUGH, not win.
  *
  * Logic previously lived in the admin Version block; this suite is its
  * home now that Model\Config\Repository consumes it too.
@@ -33,7 +41,7 @@ class ProvenanceTest extends TestCase
 
     protected function tearDown(): void
     {
-        foreach (['/.git', '/composer.json', '/registration.php'] as $f) {
+        foreach (['/.git', '/composer.json', '/registration.php', '/.two-deployed-commit'] as $f) {
             @unlink($this->tmpDir . $f);
         }
         @rmdir($this->tmpDir);
@@ -45,6 +53,11 @@ class ProvenanceTest extends TestCase
             $this->tmpDir . '/composer.json',
             json_encode(['name' => $name])
         );
+    }
+
+    private function writeStamp(string $contents, ?string $dir = null): void
+    {
+        file_put_contents(($dir ?? $this->tmpDir) . '/.two-deployed-commit', $contents);
     }
 
     private function provenance(?string $stubRef): ProvenanceTestable
@@ -64,15 +77,112 @@ class ProvenanceTest extends TestCase
         $this->assertSame('6f8534e', $p->commitForPath($this->tmpDir));
     }
 
-    public function testComposerReferenceIsPreferredOverGitWorktree(): void
+    public function testGitlinkIsPreferredOverComposerReference(): void
     {
-        // Both signals present: composer wins (it's the authoritative,
-        // layout-independent source for a composer-installed module).
+        // Both signals present: the gitlink wins (TWO-25205). It reflects
+        // what is checked out right now; the composer reference was recorded
+        // once at install time and can be older.
         $this->writeComposerJson('two-inc/magento2');
         file_put_contents($this->tmpDir . '/.git', "gitdir: /repo/.git/worktrees/deadbeef1234\n");
         $p = $this->provenance('0aa21947d6ed57bcf6b35f73a5ed192fc6a9a0dd');
 
+        $this->assertSame('deadbee', $p->commitForPath($this->tmpDir));
+    }
+
+    public function testGitlinkIsPreferredOverStamp(): void
+    {
+        // Gitlink beats the build stamp: the stamp is frozen at build time
+        // and is the staler of the two after any gitSync pull.
+        file_put_contents($this->tmpDir . '/.git', "gitdir: /repo/.git/worktrees/deadbeef1234\n");
+        $this->writeStamp("fedcba9876543210fedcba9876543210fedcba98\n");
+
+        $this->assertSame('deadbee', $this->provenance(null)->commitForPath($this->tmpDir));
+    }
+
+    public function testComposerReferenceIsPreferredOverStamp(): void
+    {
+        // No gitlink, so composer (install time) beats the stamp (build time).
+        $this->writeComposerJson('two-inc/magento2');
+        $this->writeStamp("fedcba9876543210fedcba9876543210fedcba98\n");
+        $p = $this->provenance('0aa21947d6ed57bcf6b35f73a5ed192fc6a9a0dd');
+
         $this->assertSame('0aa2194', $p->commitForPath($this->tmpDir));
+    }
+
+    public function testStampResolvesWhenNeitherGitNorComposerPresent(): void
+    {
+        // The zip-drop shape: the ABN overlay's GCS/release-asset zips carry
+        // no .git and no Composer registry entry, so the `make archive`
+        // stamp is the only provenance signal that exists (TWO-25205).
+        $this->writeStamp("fedcba9876543210fedcba9876543210fedcba98\n");
+
+        $this->assertSame('fedcba9', $this->provenance(null)->commitForPath($this->tmpDir));
+    }
+
+    public function testStampAcceptsShortShaAsWrittenByMakeArchive(): void
+    {
+        // `make archive` writes `git rev-parse --short HEAD` — 7 chars, not 40.
+        $this->writeStamp("e26ee58\n");
+
+        $this->assertSame('e26ee58', $this->provenance(null)->commitForPath($this->tmpDir));
+    }
+
+    public function testStampFoundOneLevelUpForSubPathModule(): void
+    {
+        // A repo shipping modules from sub-paths (the ABN overlay's plugin/
+        // and hyva/) has the stamp at the archive root, one level up — the
+        // same two-place lookup the gitlink and composer.json use.
+        $sub = $this->tmpDir . '/plugin';
+        mkdir($sub);
+        $this->writeStamp("fedcba9876543210fedcba9876543210fedcba98\n");
+
+        $this->assertSame('fedcba9', $this->provenance(null)->commitForPath($sub));
+        @rmdir($sub);
+    }
+
+    /**
+     * @dataProvider malformedStampProvider
+     */
+    public function testMalformedStampFallsThroughRatherThanWinning(string $contents): void
+    {
+        // Junk must never surface as a commit, and must not block the
+        // remaining resolution: with no other signal the result is ''.
+        $this->writeStamp($contents);
+        $p = $this->provenance(null);
+
+        $this->assertNull($p->commitFromStamp($this->tmpDir));
+        $this->assertSame('', $p->commitForPath($this->tmpDir));
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function malformedStampProvider(): array
+    {
+        return [
+            'empty' => [''],
+            'whitespace only' => ["  \n"],
+            'too short' => ["abc123\n"],
+            'non-hex' => ["not-a-sha\n"],
+            'branch ref' => ["dev-main\n"],
+            'too long' => [str_repeat('a', 41) . "\n"],
+            'trailing junk' => ["e26ee58 dirty\n"],
+        ];
+    }
+
+    public function testMalformedStampStillLetsComposerWin(): void
+    {
+        // A broken stamp must not shadow a good signal either.
+        $this->writeComposerJson('two-inc/magento2');
+        $this->writeStamp("not-a-sha\n");
+        $p = $this->provenance('0aa21947d6ed57bcf6b35f73a5ed192fc6a9a0dd');
+
+        $this->assertSame('0aa2194', $p->commitForPath($this->tmpDir));
+    }
+
+    public function testStampReadDoesNotThrowOnUnreadablePath(): void
+    {
+        $this->assertNull($this->provenance(null)->commitFromStamp('/nonexistent/two/module'));
     }
 
     public function testFallsBackToGitlinkWorktreeWhenNotComposerInstalled(): void

--- a/Test/Unit/Model/ProvenanceTest.php
+++ b/Test/Unit/Model/ProvenanceTest.php
@@ -15,7 +15,7 @@ use Two\Gateway\Model\Provenance;
  *    naming the worktree after its SHA.
  *  - Packagist/composer install: no .git at all; the installed registry
  *    carries the release SHA (the regression fixed in TWO-25020).
- *  - zip drop (the ABN overlay's GCS/release-asset zips): neither a .git nor
+ *  - zip drop (an overlay package's GCS/release-asset zips): neither a .git nor
  *    a Composer registry entry, only the `.two-deployed-commit` build stamp
  *    `make archive` injects (TWO-25205).
  *  - none of the three: bare '' with no exception.
@@ -111,7 +111,7 @@ class ProvenanceTest extends TestCase
 
     public function testStampResolvesWhenNeitherGitNorComposerPresent(): void
     {
-        // The zip-drop shape: the ABN overlay's GCS/release-asset zips carry
+        // The zip-drop shape: an overlay package's GCS/release-asset zips carry
         // no .git and no Composer registry entry, so the `make archive`
         // stamp is the only provenance signal that exists (TWO-25205).
         $this->writeStamp("fedcba9876543210fedcba9876543210fedcba98\n");
@@ -129,7 +129,7 @@ class ProvenanceTest extends TestCase
 
     public function testStampFoundOneLevelUpForSubPathModule(): void
     {
-        // A repo shipping modules from sub-paths (the ABN overlay's plugin/
+        // A repo shipping modules from sub-paths (an overlay package's plugin/
         // and hyva/) has the stamp at the archive root, one level up — the
         // same two-place lookup the gitlink and composer.json use.
         $sub = $this->tmpDir . '/plugin';
@@ -209,7 +209,7 @@ class ProvenanceTest extends TestCase
 
     public function testGitlinkFoundOneLevelUpForMonorepoSubpathModule(): void
     {
-        // The ABN overlay's gateway module sits at <repo>/plugin; the
+        // An overlay package's gateway module sits at <repo>/plugin; the
         // gitlink is at the checkout root, one level up. Without the
         // parent-dir lookup the overlay row on a gitSync install shows no
         // commit at all (TWO-25197).
@@ -257,11 +257,11 @@ class ProvenanceTest extends TestCase
 
     public function testPackageNameReadFromParentDirForMonorepoSubpath(): void
     {
-        // Monorepo sub-path modules (e.g. the ABN overlay at <repo>/plugin)
+        // Monorepo sub-path modules (e.g. a branding overlay at <repo>/plugin)
         // keep composer.json one level up.
         $sub = $this->tmpDir . '/plugin';
         mkdir($sub);
-        $this->writeComposerJson('abn-amro/magento-abn-plugin');
+        $this->writeComposerJson('example-partner/magento-overlay');
         $p = $this->provenance('0aa21947d6ed57bcf6b35f73a5ed192fc6a9a0dd');
 
         $this->assertSame('0aa2194', $p->commitFromComposer($sub));


### PR DESCRIPTION
Linear: **TWO-25205** (parent TWO-24739; extends TWO-25197)

## Problem

`Model/Provenance.php` (added in #269) resolved a module's commit from only two signals: the Composer installed-registry reference, then the `.git` gitlink file. A **zip-dropped** module therefore reported no commit at all — a branding overlay ships as a release-asset / GCS zip unpacked straight into `app/code`, and carries neither a `.git` nor a Composer registry entry. That is exactly the gap a build stamp closes.

## The org-wide order

One resolution order now applies across all six Two plugin artifacts:

```
.git gitlink  ->  Composer reference  ->  .two-deployed-commit stamp
```

The order is **freshness-ranked, not confidence-ranked**:

| Signal | Written when | Staleness |
|---|---|---|
| `.git` gitlink | moves on every gitSync pull | reflects what is checked out **right now** |
| Composer reference | recorded once at install time | can lag the running code |
| `.two-deployed-commit` | frozen at build time | most likely of the three to be stale |

This **flips** the previous composer-first order in this repo. PrestaShop (PR #92) and WooCommerce (PR #380) are already flipped to match.

A legacy realpath fallback stays last. None present is still a legitimate state: `''`, never an exception.

## Changes

- **`Model/Provenance.php`** — `resolve()` reordered to gitlink → Composer → stamp → legacy realpath. New `commitFromStamp()`: checks both `$modulePath` and `dirname($modulePath)` (the same two-place lookup the gitlink and `composer.json` lookups already do, since a sub-path module's stamp sits at the archive root), caps the read at 128 bytes, validates `/^[a-f0-9]{7,40}$/i`, uses `@`, never throws, returns the 7-char prefix. A malformed or empty stamp falls **through** to the next signal rather than winning.
- Class docblock rewritten: three deployment shapes (gitSync, Composer/Packagist, zip drop) instead of two, the new order plus its rationale, and two live-behaviour notes — the gitlink's `gitdir:` target is typically dangling in-container so the SHA must be string-parsed (never shell out to `git`), and the SHA is repo-wide so two sibling sub-path modules legitimately report the same commit.
- **`Makefile`** `archive` — stamps `git rev-parse --short HEAD` into the zip. Written to a `mktemp -d` **outside the repo** and injected via `git archive --add-file`, so the working tree is never dirtied and the stamp cannot be accidentally committed.
- **`.gitignore`** — `.two-deployed-commit`, as a second guard.
- **`Test/Unit/Model/ProvenanceTest.php`** — 11 → 25 tests. Precedence at each boundary (gitlink beats Composer, gitlink beats stamp, Composer beats stamp), stamp-only resolution, short-SHA stamp as `make archive` actually writes it, the `dirname` sub-path lookup, a 7-case malformed-stamp data provider asserting fall-through, malformed stamp not shadowing a good signal, and no-throw on an unreadable path. The old `testComposerReferenceIsPreferredOverGitWorktree` is inverted to `testGitlinkIsPreferredOverComposerReference`.

No constructor or DI signature changed, so the `GenericPaymentMethod` ctor-mirror gotcha does not apply — verified by diffing for signature lines and by a real `di:compile` run.

## Verification

Gates run locally with CI's own commands:

- **PHPUnit** (10.5.64 / PHP 8.2, as CI pins) — `414 tests, 712 assertions, OK`. The 2 PHPUnit deprecations are **pre-existing** (present on the base commit too, 11 tests / 2 deprecations).
- **PHP lint** — CI's `find … -print0 | xargs -0 -n1 -P4 php -l`, exit 0, no syntax errors.
- **Codesniffer** — `michielgerritsen/magento-coding-standard --severity=6`, `207/207`, exit 0.
- **DI compile** (Magento 2.4.6 / PHP 8.2, full container) — `Generated code and dependency injection configuration successfully.`
- **PHPStan** (same container) — `[OK] No errors`.
- **`make archive`** — stamp lands in the zip as `.two-deployed-commit` = `e26ee58`, matching `git rev-parse --short HEAD`; `git status --porcelain` showed no stray files afterwards.

Not run locally: **Jest** (no JS changed) and the **upgrade-smoke** leg (needs a prior-major clone + two full Magento installs); both run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
