### PR TITLE
fix(e2e): advance the Luma checkout to the payment step before asserting availability

### DIFF
--- a/e2e/tests/_helpers.ts
+++ b/e2e/tests/_helpers.ts
@@ -47,6 +47,49 @@ async function shippingAmount(page: Page): Promise<number> {
     );
 }
 
+// Whether the checkout has reached the payment step, per Magento's own
+// step-navigator (the authority the checkout renders from).
+async function onPaymentStep(page: Page): Promise<boolean> {
+    return page.evaluate(
+        () =>
+            new Promise<boolean>((resolve) => {
+                (window as any).require(
+                    ['Magento_Checkout/js/model/step-navigator'],
+                    (nav: any) => {
+                        resolve(
+                            (nav.steps() || []).some(
+                                (s: any) => s.code === 'payment' && s.isVisible()
+                            )
+                        );
+                    }
+                );
+            })
+    );
+}
+
+// Advance the Luma checkout from the shipping step to the payment step.
+//
+// This is a required step of the journey, not a convenience: on a non-virtual
+// quote Magento leaves `checkoutConfig.paymentMethods` empty on page load and
+// only populates payment-service from the shipping-information POST that this
+// button triggers. Reading availableMethods() while still on the shipping step
+// therefore returns [] no matter what the store offers.
+export async function goToPaymentStep(page: Page) {
+    if (await onPaymentStep(page)) {
+        return;
+    }
+    await waitIdle(page);
+    const next = page.locator(
+        '#shipping-method-buttons-container button[data-role="opc-continue"]'
+    );
+    await expect(next).toBeEnabled({ timeout: 20_000 });
+    await next.click();
+    // The step flips on the shipping-information response, a network round trip
+    // after the click, so poll the navigator rather than reading it once.
+    await expect.poll(() => onPaymentStep(page), { timeout: 30_000 }).toBe(true);
+    await waitIdle(page);
+}
+
 // Native click on the shipping radio — Playwright's .check()/.click() on the
 // styled input doesn't fire Magento's shipping-change handler that recalculates
 // totals, so wait for the radio to load, then drive it in-page like a real click.

--- a/e2e/tests/checkout-luma.spec.ts
+++ b/e2e/tests/checkout-luma.spec.ts
@@ -1,5 +1,12 @@
 import { test, expect } from '@playwright/test';
-import { addToCart, availableMethods, fillCheckout, selectShipping, waitIdle } from './_helpers';
+import {
+    addToCart,
+    availableMethods,
+    fillCheckout,
+    goToPaymentStep,
+    selectShipping,
+    waitIdle
+} from './_helpers';
 
 const OUT = process.env.OUT_DIR || 'screenshots';
 
@@ -10,6 +17,7 @@ test('magento checkout journey', async ({ page }) => {
     await fillCheckout(page);
 
     await selectShipping(page, 'freeshipping');
+    await goToPaymentStep(page);
     await expect.poll(() => availableMethods(page), { timeout: 25_000 }).toContain('two_payment');
 
     // Select the Two method and wait for its expanded form to render.


### PR DESCRIPTION
## Why

The `playwright` (e2e) job has been red on every run since 2026-07-13 (last green 2026-07-06), blocking review of anything that touches `e2e/**` — currently PR #272, whose diff is comment-only. Fix lives here, not there.

Decisive failure line (run 30348868464):

```
Error: expect(received).toContain(expected) // indexOf
Expected value: "two_payment"
Received array: []
- Timeout 25000ms exceeded while waiting on the predicate
  at e2e/tests/checkout-luma.spec.ts:13:74
```

The received array is **empty**, not "missing `two_payment` among others".

## Root cause

The method is not gated off — this is not a min-order / terms / merchant-config problem:

1. A server-side REST probe of the same quote against the staging store (guest cart, `24-WB04`, £45, GB, freeshipping) returns `payment_methods: ['two_payment', 'checkmo']`.
2. Reproducing the spec locally, `Magento_Checkout/js/model/step-navigator` reports `["shipping:true", "payment:false"]` at the moment of the assertion — the checkout is still on the **shipping** step. `paymentService.getAvailablePaymentMethods()` is legitimately `[]` there: on a non-virtual quote Magento leaves `checkoutConfig.paymentMethods` empty on page load and only populates payment-service from the `shipping-information` POST that the Next button triggers.
3. Clicking Next in the same repro immediately gives `["two_payment","checkmo"]`, step state `["shipping:false","payment:true"]`, and a visible `#two_payment` tile.

The spec never clicked Next. It only ever passed because the reactive payment-availability refresher (`view/frontend/web/js/view/payment-availability.js`) pushed the server's method list into payment-service as a side effect while still on the shipping step. That component now correctly no-ops when its availability key (grand total + tax) is unchanged — and on this store selecting free shipping leaves the totals at `grand=45.0000 / tax=0.0000` (verified in the browser), so the key never changes, the refresher never fires, and nothing populates the list before Next.

## What changed

- `_helpers.ts`: new `goToPaymentStep()` — clicks the store's real `[data-role="opc-continue"]` Next button and polls Magento's own step-navigator until the payment step is visible. Idempotent (returns early if already there).
- `checkout-luma.spec.ts`: call it between `selectShipping()` and the availability poll.

No skip, no `test.skip`, no retry-wrap, no weakened assertion — this adds the user step the journey was missing.

## Verification

Full spec run locally against `https://magento.staging.two.inc` (includes the real place-order through to the confirmation page):

```
Running 1 test using 1 worker
  ✓  1 [chromium] › tests/checkout-luma.spec.ts:13:5 › magento checkout journey (31.6s)
  1 passed (32.6s)
```

CI `e2e` result on this branch is the thing being proven — see the checks below.

## Noted, not fixed (out of scope)

- A `TypeError: Assignment to constant variable.` page error fires on the deployed staging checkout when the payment step renders. Needs its own investigation.
- `min-order.spec.ts`'s skip reason is stale — it says the reactive refresh "was reverted", but it was rebuilt and merged on 2026-07-06/07. Separately, a local probe found flat-rate and free shipping producing the *same* grand total on this store, which that test's threshold arithmetic depends on.

Refs TWO-25214 (child of TWO-24739)
