### PR TITLE
feat(TWO-25218)!: replace the three-state intent-approved notice with an explicit boolean switch

### DIFF
--- a/Api/BrandRegistryInterface.php
+++ b/Api/BrandRegistryInterface.php
@@ -52,19 +52,28 @@ interface BrandRegistryInterface
     public function getSurchargeRoundingSteps(): array;
 
     /**
-     * Per-brand override for the buyer-facing "order intent approved"
-     * reassurance notice rendered inline in the checkout payment tile.
-     * Sourced from brand.xml <intent_approved_notice>.
+     * Whether the buyer-facing "order intent approved" reassurance
+     * notice is rendered at all. Sourced from brand.xml
+     * <intent_approved_notice_enabled>; absent means the documented
+     * default `true`, so a brand overlay that declares nothing keeps the
+     * notice ON.
      *
-     *  - `null`  — element absent: platform default translated copy,
-     *              notice ON.
-     *  - `''`    — element present and empty: notice suppressed
-     *              entirely, no DOM element emitted at all.
+     * `false` suppresses the notice entirely — no DOM element is emitted
+     * at all, not an empty wrapper.
+     */
+    public function isIntentApprovedNoticeEnabled(): bool;
+
+    /**
+     * Per-brand COPY override for the buyer-facing "order intent
+     * approved" reassurance notice rendered inline in the checkout
+     * payment tile. Sourced from brand.xml <intent_approved_notice>.
+     * Wording only — it is NOT an off switch; see
+     * isIntentApprovedNoticeEnabled() for that.
+     *
+     *  - `null`  — no override (element absent, empty or whitespace-only):
+     *              platform default translated copy. Never ''.
      *  - non-''  — used verbatim as the company-known copy template
      *              (%1 = brand product name, %2 = buyer company name).
-     *
-     * Callers MUST distinguish null from '' — treating them alike makes
-     * the per-brand off switch unreachable.
      */
     public function getIntentApprovedNotice(): ?string;
 

--- a/Brand/DescriptorBackedBrandRegistry.php
+++ b/Brand/DescriptorBackedBrandRegistry.php
@@ -51,6 +51,11 @@ class DescriptorBackedBrandRegistry implements BrandRegistryInterface
         return $this->activeBrandResolver->resolve()->getSurchargeRoundingSteps();
     }
 
+    public function isIntentApprovedNoticeEnabled(): bool
+    {
+        return $this->activeBrandResolver->resolve()->isIntentApprovedNoticeEnabled();
+    }
+
     public function getIntentApprovedNotice(): ?string
     {
         return $this->activeBrandResolver->resolve()->getIntentApprovedNotice();

--- a/Model/Brand.php
+++ b/Model/Brand.php
@@ -99,6 +99,19 @@ class Brand implements BrandRegistryInterface
     /**
      * @deprecated 2.0.0 See note on getCode().
      */
+    public function isIntentApprovedNoticeEnabled(): bool
+    {
+        throw new \LogicException(
+            'Two\\Gateway\\Model\\Brand is deprecated; consume '
+            . 'BrandRegistryInterface via DescriptorBackedBrandRegistry instead. '
+            . 'The intent-approved notice on/off switch now comes from brand.xml '
+            . '`<intent_approved_notice_enabled>` via ActiveBrandResolver.'
+        );
+    }
+
+    /**
+     * @deprecated 2.0.0 See note on getCode().
+     */
     public function getIntentApprovedNotice(): ?string
     {
         throw new \LogicException(

--- a/Model/Brand/Descriptor.php
+++ b/Model/Brand/Descriptor.php
@@ -44,7 +44,8 @@ final class Descriptor
      * @param string[] $suppressedFields `section_suffix/group/field` paths to hide in the synthesised admin form.
      * @param bool $inlineTermFees Whether to render the per-term merchant fee beside each Payment Terms checkbox in admin.
      * @param float[] $surchargeRoundingSteps Buyer-surcharge rounding steps offered in the admin Rounding Step dropdown, ascending.
-     * @param string|null $intentApprovedNotice Buyer-facing intent-approved notice override; null = brand.xml element absent, '' = suppressed. See getIntentApprovedNotice().
+     * @param string|null $intentApprovedNotice Copy override for the buyer-facing intent-approved notice; null = use the platform default copy. Never ''. See getIntentApprovedNotice().
+     * @param bool $intentApprovedNoticeEnabled Whether the buyer-facing intent-approved notice is rendered at all. Default true. See isIntentApprovedNoticeEnabled().
      */
     public function __construct(
         private readonly string $code,
@@ -70,31 +71,47 @@ final class Descriptor
         private readonly bool $inlineTermFees = true,
         private readonly string $checkoutSubtitle = '',
         private readonly array $surchargeRoundingSteps = [],
-        private readonly ?string $intentApprovedNotice = null
+        private readonly ?string $intentApprovedNotice = null,
+        private readonly bool $intentApprovedNoticeEnabled = true
     ) {
     }
 
     /**
-     * Per-brand override for the buyer-facing "order intent approved"
-     * reassurance notice rendered inline in the checkout payment tile.
+     * Whether the buyer-facing "order intent approved" reassurance notice
+     * is rendered at all, from brand.xml
+     * <intent_approved_notice_enabled>.
      *
-     * Three states, all meaningful:
+     *  - `true`  — notice ON. This is the documented default when the
+     *              brand.xml declares nothing, which is what keeps a
+     *              third-party overlay that says nothing on ON.
+     *  - `false` — notice suppressed ENTIRELY: no element is emitted into
+     *              the DOM, not an empty wrapper.
      *
-     *  - `null`  — brand.xml declares no <intent_approved_notice>. The
-     *              renderers use the platform default translated copy and
-     *              the notice is ON. This is the Two-brand case.
-     *  - `''`    — brand.xml declares an empty <intent_approved_notice>.
-     *              The notice is suppressed ENTIRELY: no element is
-     *              emitted into the DOM, not an empty wrapper.
+     * The switch is independent of the copy override below: a brand can
+     * suppress the notice, keep the default copy, or replace the wording,
+     * and those are three separate decisions.
+     */
+    public function isIntentApprovedNoticeEnabled(): bool
+    {
+        return $this->intentApprovedNoticeEnabled;
+    }
+
+    /**
+     * Per-brand COPY override for the buyer-facing "order intent
+     * approved" reassurance notice rendered inline in the checkout
+     * payment tile. Wording only — it does not turn the notice off; see
+     * isIntentApprovedNoticeEnabled() for that.
+     *
+     *  - `null`  — no override: the renderers use the platform default
+     *              translated copy. This is the Two-brand case, and also
+     *              what an absent, empty or whitespace-only
+     *              <intent_approved_notice> resolves to. Never ''.
      *  - non-''  — used verbatim as the company-known copy template, with
      *              %1 = brand product name and %2 = buyer company name.
      *              The company-unknown variant stays on the platform
      *              default; in practice it is unreachable, because an
      *              order intent is only ever placed once both company
      *              name and company number are known.
-     *
-     * Callers MUST distinguish null from '' — collapsing them makes the
-     * off switch unreachable.
      */
     public function getIntentApprovedNotice(): ?string
     {

--- a/Model/Brand/Loader.php
+++ b/Model/Brand/Loader.php
@@ -176,17 +176,36 @@ class Loader
             }
         }
 
-        // Three-state buyer-facing intent-approved notice. `null` (element
-        // absent) means "use the platform default copy"; '' (element present
-        // but empty) means "suppress the notice entirely". isset() is what
-        // separates the two — SimpleXML reports isset() === true for an
-        // empty element, so a truthiness test would collapse both states
-        // onto the default and make the off switch unreachable. Trimmed, so
-        // a pretty-printed `<intent_approved_notice>\n  </intent_approved_notice>`
-        // counts as the suppressed state rather than a whitespace template.
-        $intentApprovedNotice = null;
-        if (isset($brand->intent_approved_notice)) {
-            $intentApprovedNotice = trim((string)$brand->intent_approved_notice);
+        // On/off switch for the buyer-facing intent-approved notice.
+        // Explicit boolean only: absent is the documented default `true`
+        // (so a third-party overlay that declares nothing keeps the notice
+        // ON), and anything other than the exact strings 'true'/'false' is
+        // an error rather than a silent third behaviour. Validated here as
+        // well as in brand.xsd because nothing validates brand.xsd in
+        // production mode — same reasoning as the rounding-step guard above.
+        $intentApprovedNoticeEnabled = true;
+        if (isset($brand->intent_approved_notice_enabled)) {
+            $raw = trim((string)$brand->intent_approved_notice_enabled);
+            if ($raw !== 'true' && $raw !== 'false') {
+                throw new \DomainException(sprintf(
+                    'brand.xml at %s declares an invalid '
+                    . '<intent_approved_notice_enabled> value "%s"; it must be '
+                    . 'exactly "true" or "false".',
+                    $sourcePath,
+                    $raw
+                ));
+            }
+            $intentApprovedNoticeEnabled = $raw === 'true';
+        }
+
+        // Copy override ONLY — this is no longer an off switch (TWO-25218
+        // superseded the three-state contract). Absent, empty and
+        // whitespace-only all normalise to null, i.e. "use the platform
+        // default copy"; an empty element is inert. Suppression is
+        // <intent_approved_notice_enabled>false</…> above.
+        $intentApprovedNotice = trim((string)($brand->intent_approved_notice ?? ''));
+        if ($intentApprovedNotice === '') {
+            $intentApprovedNotice = null;
         }
 
         $inlineTermFees = true;
@@ -222,7 +241,8 @@ class Loader
             $inlineTermFees,
             (string)($brand->checkout_subtitle ?? ''),
             $roundingSteps,
-            $intentApprovedNotice
+            $intentApprovedNotice,
+            $intentApprovedNoticeEnabled
         );
     }
 }

--- a/Model/Ui/ConfigProvider.php
+++ b/Model/Ui/ConfigProvider.php
@@ -248,18 +248,21 @@ class ConfigProvider implements ConfigProviderInterface
      *                    is resolved)
      *   withoutCompany — defensive fallback
      *
-     * A brand's non-empty <intent_approved_notice> overrides the
-     * company-known variant only; see
-     * Descriptor::getIntentApprovedNotice() for the three-state contract.
+     * Suppression is driven by the brand's
+     * <intent_approved_notice_enabled> switch. The copy override
+     * <intent_approved_notice> is wording only: non-empty replaces the
+     * company-known variant, absent/empty leaves the platform default.
+     * See BrandRegistryInterface for both contracts.
      *
      * @return array{withCompany:string,withoutCompany:string,companyNameToken:string}|null
      */
     private function getOrderIntentApprovedNotice(): ?array
     {
-        $override = $this->brandRegistry->getIntentApprovedNotice();
-        if ($override === '') {
+        if (!$this->brandRegistry->isIntentApprovedNoticeEnabled()) {
             return null;
         }
+
+        $override = $this->brandRegistry->getIntentApprovedNotice();
 
         $productName = $this->brandRegistry->getProductName();
 

--- a/Test/Js/gateway-method-intent-approved-notice.test.js
+++ b/Test/Js/gateway-method-intent-approved-notice.test.js
@@ -100,9 +100,10 @@ describe('gateway_method intent-approved notice', () => {
     });
 
     test('emits nothing at all when the brand suppressed the notice', () => {
-        // ConfigProvider ships null for a brand whose brand.xml declares an
-        // empty <intent_approved_notice>. The observable stays '' so the
-        // template's `ko if` never emits an element.
+        // ConfigProvider ships null for a brand whose brand.xml declares
+        // <intent_approved_notice_enabled>false</intent_approved_notice_enabled>.
+        // The observable stays '' so the template's `ko if` never emits an
+        // element.
         const ctx = makeContext(null);
         ctx.companyName('Acme Widgets AS');
 

--- a/Test/Unit/Model/Brand/LoaderTest.php
+++ b/Test/Unit/Model/Brand/LoaderTest.php
@@ -17,9 +17,13 @@ use Two\Gateway\Model\Brand\Loader;
  *
  *  - <surcharge_rounding_steps> — admin Rounding Step dropdown; absent
  *    and empty both fall back to the parent default set.
- *  - <intent_approved_notice> — buyer-facing intent-approved notice
- *    (TWO-25213); three distinct states, absent (default copy) must not
- *    collapse onto present-and-empty (suppressed).
+ *  - <intent_approved_notice_enabled> — on/off switch for the buyer-facing
+ *    intent-approved notice (TWO-25218); explicit boolean, absent means
+ *    the documented default true, anything else must throw rather than
+ *    become a silent third behaviour.
+ *  - <intent_approved_notice> — copy override for the same notice; empty
+ *    and whitespace-only are INERT (they used to mean "off" under the
+ *    superseded TWO-25213 three-state contract).
  *
  * Loader does no runtime XSD validation, so the parse/validate guards
  * here are the only safety net.
@@ -80,33 +84,110 @@ class LoaderTest extends TestCase
         );
     }
 
-    public function testIntentApprovedNoticeIsNullWhenElementAbsent(): void
+    public function testIntentApprovedNoticeEnabledIsTrueWhenDeclaredTrue(): void
+    {
+        $loader = $this->loaderForBrandBody(
+            '<intent_approved_notice_enabled>true</intent_approved_notice_enabled>'
+        );
+
+        $this->assertTrue(
+            $loader->load()['two_payment']->isIntentApprovedNoticeEnabled()
+        );
+    }
+
+    public function testIntentApprovedNoticeEnabledIsFalseWhenDeclaredFalse(): void
+    {
+        $loader = $this->loaderForBrandBody(
+            '<intent_approved_notice_enabled>false</intent_approved_notice_enabled>'
+        );
+
+        $this->assertFalse(
+            $loader->load()['two_payment']->isIntentApprovedNoticeEnabled()
+        );
+    }
+
+    public function testIntentApprovedNoticeEnabledDefaultsToTrueWhenElementAbsent(): void
     {
         $loader = $this->loaderForBrandBody('');
 
-        // null, not '' — absent means "platform default copy, notice ON".
-        // Collapsing the two makes the per-brand off switch unreachable.
+        // Absent is the documented explicit default true — this is what
+        // keeps a third-party overlay that declares nothing on ON.
+        $this->assertTrue(
+            $loader->load()['two_payment']->isIntentApprovedNoticeEnabled()
+        );
+    }
+
+    public function testIntentApprovedNoticeEnabledIsSurroundingWhitespaceTolerant(): void
+    {
+        $loader = $this->loaderForBrandBody(
+            "<intent_approved_notice_enabled>\n   false\n  </intent_approved_notice_enabled>"
+        );
+
+        // A pretty-printed value is still an explicit decision, not a
+        // malformed one.
+        $this->assertFalse(
+            $loader->load()['two_payment']->isIntentApprovedNoticeEnabled()
+        );
+    }
+
+    /**
+     * Every non-`true`/`false` spelling must be an error, never a silent
+     * third behaviour — including the ones xs:boolean would have accepted
+     * (`1` / `0`) and the empty element that used to mean "off".
+     *
+     * @dataProvider invalidNoticeEnabledProvider
+     */
+    public function testInvalidIntentApprovedNoticeEnabledThrows(string $value): void
+    {
+        $loader = $this->loaderForBrandBody(
+            '<intent_approved_notice_enabled>' . $value . '</intent_approved_notice_enabled>'
+        );
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('invalid <intent_approved_notice_enabled> value');
+        $loader->load();
+    }
+
+    /** @return array<string,array{0:string}> */
+    public static function invalidNoticeEnabledProvider(): array
+    {
+        return [
+            'numeric one' => ['1'],
+            'numeric zero' => ['0'],
+            'yes' => ['yes'],
+            'title case' => ['True'],
+            'upper case' => ['FALSE'],
+            'empty' => [''],
+            'whitespace only' => ["\n   "],
+        ];
+    }
+
+    public function testIntentApprovedNoticeCopyIsNullWhenElementAbsent(): void
+    {
+        $loader = $this->loaderForBrandBody('');
+
         $this->assertNull($loader->load()['two_payment']->getIntentApprovedNotice());
     }
 
-    public function testIntentApprovedNoticeIsEmptyStringWhenElementPresentAndEmpty(): void
+    public function testIntentApprovedNoticeCopyIsNullWhenElementPresentAndEmpty(): void
     {
         $loader = $this->loaderForBrandBody(
             '<intent_approved_notice></intent_approved_notice>'
         );
 
-        // '' is the suppression signal: renderers emit no element at all.
-        $this->assertSame('', $loader->load()['two_payment']->getIntentApprovedNotice());
+        // Empty is INERT, not "off" — it must never surface as '', which is
+        // what the superseded three-state contract used as its off signal.
+        $this->assertNull($loader->load()['two_payment']->getIntentApprovedNotice());
     }
 
-    public function testIntentApprovedNoticeIsEmptyStringWhenElementSelfClosing(): void
+    public function testIntentApprovedNoticeCopyIsNullWhenElementSelfClosing(): void
     {
         $loader = $this->loaderForBrandBody('<intent_approved_notice/>');
 
-        $this->assertSame('', $loader->load()['two_payment']->getIntentApprovedNotice());
+        $this->assertNull($loader->load()['two_payment']->getIntentApprovedNotice());
     }
 
-    public function testIntentApprovedNoticeWhitespaceOnlyCountsAsSuppressed(): void
+    public function testIntentApprovedNoticeCopyIsNullWhenWhitespaceOnly(): void
     {
         $loader = $this->loaderForBrandBody(
             "<intent_approved_notice>\n            </intent_approved_notice>"
@@ -114,10 +195,10 @@ class LoaderTest extends TestCase
 
         // A pretty-printed empty element must not become a whitespace
         // template that renders as a blank notice.
-        $this->assertSame('', $loader->load()['two_payment']->getIntentApprovedNotice());
+        $this->assertNull($loader->load()['two_payment']->getIntentApprovedNotice());
     }
 
-    public function testIntentApprovedNoticeIsUsedVerbatimWhenNonEmpty(): void
+    public function testIntentApprovedNoticeCopyIsUsedVerbatimWhenNonEmpty(): void
     {
         $loader = $this->loaderForBrandBody(
             '<intent_approved_notice>%1 says %2 looks fine.</intent_approved_notice>'
@@ -127,6 +208,22 @@ class LoaderTest extends TestCase
             '%1 says %2 looks fine.',
             $loader->load()['two_payment']->getIntentApprovedNotice()
         );
+    }
+
+    public function testCopyOverrideDoesNotSuppressAndSwitchDoesNotChangeCopy(): void
+    {
+        // The two keys are independent: a brand can suppress the notice
+        // while still declaring copy, and the loader must not let either
+        // decision leak into the other.
+        $loader = $this->loaderForBrandBody(
+            '<intent_approved_notice_enabled>false</intent_approved_notice_enabled>'
+            . '<intent_approved_notice>%1 says %2 looks fine.</intent_approved_notice>'
+        );
+
+        $descriptor = $loader->load()['two_payment'];
+
+        $this->assertFalse($descriptor->isIntentApprovedNoticeEnabled());
+        $this->assertSame('%1 says %2 looks fine.', $descriptor->getIntentApprovedNotice());
     }
 
     /**

--- a/Test/Unit/Model/Ui/ConfigProviderIntentApprovedNoticeTest.php
+++ b/Test/Unit/Model/Ui/ConfigProviderIntentApprovedNoticeTest.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Model\Ui;
+
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Api\BrandRegistryInterface;
+use Two\Gateway\Model\Ui\ConfigProvider;
+
+/**
+ * ConfigProvider's intent-approved-notice payload resolution (TWO-25218).
+ *
+ * The switch — not the copy override — decides whether a payload is
+ * shipped to the storefront renderer at all. `null` is the renderer's
+ * "emit no element" signal, so a regression that keys suppression off the
+ * copy override again would re-introduce the superseded three-state
+ * contract silently.
+ *
+ * ConfigProvider's constructor pulls in the full checkout collaborator
+ * graph and getConfig() reaches most of it; the notice resolution touches
+ * only $brandRegistry. Instantiating without the constructor and injecting
+ * that one collaborator keeps this a unit test rather than a checkout
+ * harness.
+ */
+class ConfigProviderIntentApprovedNoticeTest extends TestCase
+{
+    public function testReturnsNullWhenTheBrandDisabledTheNotice(): void
+    {
+        $payload = $this->resolveFor(false, null);
+
+        $this->assertNull($payload);
+    }
+
+    public function testReturnsNullWhenDisabledEvenWithACopyOverride(): void
+    {
+        // The switch wins. A brand that declares copy and then turns the
+        // notice off must get no payload.
+        $payload = $this->resolveFor(false, 'Custom %1 line for %2.');
+
+        $this->assertNull($payload);
+    }
+
+    public function testReturnsDefaultCopyWhenEnabledWithNoOverride(): void
+    {
+        $payload = $this->resolveFor(true, null);
+
+        $this->assertIsArray($payload);
+        $this->assertSame(
+            'Your invoice with Acme is likely to be accepted for '
+            . ConfigProvider::COMPANY_NAME_TOKEN
+            . ', subject to additional checks.',
+            $payload['withCompany']
+        );
+        $this->assertSame(
+            'Your invoice with Acme is likely to be accepted, subject to additional checks.',
+            $payload['withoutCompany']
+        );
+        $this->assertSame(ConfigProvider::COMPANY_NAME_TOKEN, $payload['companyNameToken']);
+    }
+
+    public function testOverrideReplacesTheCompanyKnownVariantOnly(): void
+    {
+        $payload = $this->resolveFor(true, 'Custom %1 line for %2.');
+
+        $this->assertIsArray($payload);
+        $this->assertSame(
+            'Custom Acme line for ' . ConfigProvider::COMPANY_NAME_TOKEN . '.',
+            $payload['withCompany']
+        );
+        $this->assertSame(
+            'Your invoice with Acme is likely to be accepted, subject to additional checks.',
+            $payload['withoutCompany']
+        );
+    }
+
+    /**
+     * @return array{withCompany:string,withoutCompany:string,companyNameToken:string}|null
+     */
+    private function resolveFor(bool $enabled, ?string $override): ?array
+    {
+        $registry = $this->createMock(BrandRegistryInterface::class);
+        $registry->method('isIntentApprovedNoticeEnabled')->willReturn($enabled);
+        $registry->method('getIntentApprovedNotice')->willReturn($override);
+        $registry->method('getProductName')->willReturn('Acme');
+
+        $reflection = new \ReflectionClass(ConfigProvider::class);
+        $provider = $reflection->newInstanceWithoutConstructor();
+
+        // No setAccessible() call: it has been a no-op since PHP 8.1
+        // (the plugin's floor) and is deprecated from 8.5.
+        $reflection->getProperty('brandRegistry')->setValue($provider, $registry);
+
+        return $reflection->getMethod('getOrderIntentApprovedNotice')->invoke($provider);
+    }
+}

--- a/docs/brand-overlay-guide.md
+++ b/docs/brand-overlay-guide.md
@@ -132,25 +132,81 @@ across modules). Elements may appear in any order (`xs:all`).
 | `extra_http_headers`      | no       | `<header name="…">` list    | Extra headers on API calls.                                                                                             |
 | `suppressed_fields`       | no       | `<field path="…">` list     | Hides admin controls for this brand (below).                                                                            |
 | `inline_term_fees`        | no       | boolean                     | Show per-term merchant fee beside Payment Terms checkboxes in admin (default true).                                     |
-| `intent_approved_notice`  | no       | string                      | Buyer-facing "order intent approved" notice rendered inline in the checkout payment tile. **Three states — see below.** |
+| `intent_approved_notice_enabled` | no | `true` \| `false`      | On/off switch for the buyer-facing "order intent approved" notice. Default `true`. **See below.**                        |
+| `intent_approved_notice`  | no       | string                      | Copy override for that notice — wording only, **not** an off switch. **See below.**                                     |
 
-### `intent_approved_notice` — a three-state switch
+### The intent-approved notice — two keys, one each for on/off and wording
 
-Most optional elements have two states (absent ⇒ default, present ⇒
-override). This one has three, because "no notice at all" is a
-legitimate brand choice and cannot be expressed by omission:
+The notice is a buyer-facing "order intent approved" reassurance line
+rendered inline in the checkout payment tile. It is controlled by **two
+independent keys**: whether it shows, and what it says.
+
+Historically (TWO-25213) there was one key with three states, where
+"present but empty" meant "off". That conflated two unrelated meanings,
+expressed a decision as the absence of content, and made an intentional
+off switch indistinguishable from an unfinished string — any tidy-up that
+deleted the "empty, unused" declaration silently turned the notice back
+on. TWO-25218 split them. **Do not overload one key with both meanings
+again.**
+
+#### `intent_approved_notice_enabled` — the on/off switch
+
+Explicit boolean only:
+
+| brand.xml                                                                | Behaviour                                                                                    |
+| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| `<intent_approved_notice_enabled>true</intent_approved_notice_enabled>`   | Notice **ON**.                                                                               |
+| `<intent_approved_notice_enabled>false</intent_approved_notice_enabled>`  | Notice **suppressed entirely** — no element is emitted into the DOM, not an empty wrapper.   |
+| element absent                                                           | Documented explicit default **`true`** (notice ON).                                          |
+| anything else (`1`, `0`, `yes`, empty, whitespace)                        | **Error.** Never a silent third behaviour.                                                   |
+
+Absent-means-`true` is deliberate: it keeps a third-party overlay that
+declares nothing on ON. Base plugins declare `true` explicitly anyway, so
+the file states its position rather than relying on omission.
+
+The invalid case is caught twice, because `brand.xsd` is not validated at
+runtime (see the validation warning below):
+
+* `brand.xsd` restricts the element to the enumeration `true|false`, so
+  developer-mode config validation fails loudly; and
+* `Model\Brand\Loader` throws a `\DomainException` naming the offending
+  `brand.xml` path, the element and the bad value — the same treatment
+  `<surcharge_rounding_steps>` gets in the same method.
+
+Note `xs:boolean` is deliberately **not** used: it would also accept `1`
+and `0`, and this switch is meant to read as a decision.
+
+#### `intent_approved_notice` — the copy override
 
 | brand.xml                                            | Behaviour                                                                                                              |
 | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| element absent                                       | Platform default translated copy; notice **ON**.                                                                       |
-| `<intent_approved_notice></intent_approved_notice>`  | Notice **suppressed entirely** — no element is emitted into the DOM, not an empty wrapper.                             |
+| element absent                                       | Platform default translated copy.                                                                                      |
+| empty or whitespace-only                             | **Inert** — same as absent. It does **not** mean "off" any more.                                                       |
 | `<intent_approved_notice>…</intent_approved_notice>` | The content is used verbatim as the company-known copy template. `%1` = brand product name, `%2` = buyer company name. |
 
-Whitespace-only content counts as suppressed, so a pretty-printed empty
-element behaves as expected. `Loader` distinguishes absent from
-present-and-empty with `isset()`; `Descriptor::getIntentApprovedNotice()`
-returns `null` / `''` / the template respectively, and callers must not
-collapse the first two — doing so makes the off switch unreachable.
+`Descriptor::getIntentApprovedNotice()` returns `null` for the first two
+rows and the template for the third; it never returns `''`. The switch
+above is what `Model\Ui\ConfigProvider` consults to decide whether to ship
+a payload to the renderer at all.
+
+#### Migration hazard: deploy order
+
+A **new parent** plus a **stale overlay** — one that still carries an
+empty `<intent_approved_notice>` and no
+`<intent_approved_notice_enabled>` — resolves to notice **ON**. That is
+wrong for that brand, but not broken. Making an empty copy element a hard
+error would turn the deploy-order window from "wrong notice" into "broken
+store", which is worse, so empty stays inert and there is deliberately no
+legacy-compat path that resurrects empty-means-off.
+
+The mitigation is **merge order**: `magento-plugin` (parent, owns the
+parsing) → `magento-abn-plugin` (overlay) → `magento-hyva-extension`. Out
+of order there is a window in which Hyvä renders the notice for a brand
+that asked for it off.
+
+Hyvä additionally guards the reverse skew with `method_exists()` against
+an older parent that lacks the registry method — a missing method means
+"no brand opinion", i.e. notice ON.
 
 The company-unknown copy variant always stays on the platform default.
 In practice it is unreachable: an order intent is only ever placed once
@@ -173,7 +229,8 @@ passive). Two consequences:
    parse it produces a silently-absent feature, not a deploy failure.
    Always verify the feature's observable behaviour after deploy.
 2. Where silent mis-parsing would be dangerous, `Loader` carries its own
-   guards (duplicate/empty `code`) that throw `DomainException` at load.
+   guards (duplicate/empty `code`, `<surcharge_rounding_steps>`,
+   `<intent_approved_notice_enabled>`) that throw `DomainException` at load.
    Follow that pattern when you add fields whose zero-value would
    silently disable a constraint.
 

--- a/docs/brand-overlay-guide.md
+++ b/docs/brand-overlay-guide.md
@@ -200,7 +200,7 @@ store", which is worse, so empty stays inert and there is deliberately no
 legacy-compat path that resurrects empty-means-off.
 
 The mitigation is **merge order**: `magento-plugin` (parent, owns the
-parsing) → `magento-abn-plugin` (overlay) → `magento-hyva-extension`. Out
+parsing) → the brand overlay repo → `magento-hyva-extension`. Out
 of order there is a window in which Hyvä renders the notice for a brand
 that asked for it off.
 

--- a/etc/brand.xml
+++ b/etc/brand.xml
@@ -29,6 +29,12 @@
             <step>5.00</step>
             <step>10.00</step>
         </surcharge_rounding_steps>
+        <!--
+            Declared explicitly even though `true` is the documented
+            default: the base plugin states its position rather than
+            relying on the absence of a declaration.
+        -->
+        <intent_approved_notice_enabled>true</intent_approved_notice_enabled>
         <admin_resource>Magento_Sales::config_sales</admin_resource>
         <module_label_chain>
             <module label="Payment Method">Two_Gateway</module>

--- a/etc/brand.xsd
+++ b/etc/brand.xsd
@@ -54,23 +54,45 @@
             -->
             <xs:element name="surcharge_rounding_steps" type="surchargeRoundingStepsType" minOccurs="0"/>
             <!--
-                Buyer-facing "order intent approved" reassurance notice
-                rendered inline inside the checkout payment tile. Three
-                states, all meaningful:
+                On/off switch for the buyer-facing "order intent
+                approved" reassurance notice rendered inline inside the
+                checkout payment tile. Explicit boolean ONLY:
 
-                  absent            ⇒ platform default translated copy,
-                                      notice ON
-                  present, empty    ⇒ notice suppressed entirely; no
-                                      element is emitted into the DOM
-                  present, non-empty⇒ used verbatim as the
-                                      company-known copy template
-                                      (%1 = brand product name,
-                                      %2 = buyer company name)
+                  true    ⇒ notice ON
+                  false   ⇒ notice suppressed entirely; no element is
+                            emitted into the DOM, not an empty wrapper
+                  absent  ⇒ documented explicit default `true`, which is
+                            what keeps a third-party overlay that
+                            declares nothing on ON
+                  anything else ⇒ an error. The enumeration below fails
+                            config validation in developer mode, and
+                            Model\Brand\Loader additionally throws a
+                            \DomainException, because nothing validates
+                            brand.xsd in production mode.
 
-                Because empty is load-bearing, the element must NOT be
-                declared with a minLength restriction, and Loader must
-                use isset() rather than a truthiness test — see
-                Model/Brand/Loader.php.
+                Base plugins declare it explicitly `true`; brand
+                overlays that do not want the notice declare it
+                explicitly `false`.
+            -->
+            <xs:element name="intent_approved_notice_enabled" type="explicitBooleanType" minOccurs="0"/>
+            <!--
+                COPY OVERRIDE ONLY — this element does NOT switch the
+                notice off. That is <intent_approved_notice_enabled>
+                above.
+
+                  absent / empty / whitespace-only
+                          ⇒ INERT: platform default translated copy
+                  non-empty
+                          ⇒ used verbatim as the company-known copy
+                            template (%1 = brand product name,
+                            %2 = buyer company name)
+
+                An empty element used to mean "notice off" (TWO-25213).
+                It no longer does — it is inert (TWO-25218). A stale
+                overlay carrying an empty element against a new parent
+                therefore resolves to notice ON, which is wrong but not
+                broken; the documented merge order (parent first) is the
+                mitigation. Do not resurrect empty-means-off.
             -->
             <xs:element name="intent_approved_notice" type="xs:string" minOccurs="0"/>
             <xs:element name="csp_origins" type="cspOriginsType" minOccurs="0"/>
@@ -102,6 +124,19 @@
         -->
         <xs:attribute name="section_prefix" type="brandCodeType" use="optional"/>
     </xs:complexType>
+
+    <!--
+        A boolean that must be spelled out. Deliberately NOT xs:boolean:
+        xs:boolean also accepts `1` / `0`, and this switch is meant to
+        read as a decision in the brand.xml, not as a flag. Lowercase
+        `true` / `false` only.
+    -->
+    <xs:simpleType name="explicitBooleanType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+        </xs:restriction>
+    </xs:simpleType>
 
     <xs:simpleType name="brandCodeType">
         <xs:restriction base="xs:string">

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -580,8 +580,8 @@ define([
          * @param {object} config the brand's window.checkoutConfig subtree
          */
         initOrderIntentApprovedNotice: function (config) {
-            // `null` means the active brand suppressed the notice (the
-            // three-state brand.xml <intent_approved_notice> switch) — the
+            // `null` means the active brand suppressed the notice
+            // (<intent_approved_notice_enabled>false</…> in brand.xml) — the
             // template then emits no element at all.
             this.orderIntentApprovedNoticeCopy = config.orderIntentApprovedNotice || null;
 

--- a/view/frontend/web/template/payment/gateway_method.html
+++ b/view/frontend/web/template/payment/gateway_method.html
@@ -71,9 +71,10 @@
         <!--
             Persistent inline "order intent approved" notice, inside the
             payment tile next to the term chips. Emitted only when non-empty,
-            so a brand that suppresses the notice (empty
-            <intent_approved_notice> in brand.xml) yields no element at all
-            rather than an empty wrapper. Class name matches the PrestaShop /
+            so a brand that suppresses the notice
+            (<intent_approved_notice_enabled>false</intent_approved_notice_enabled>
+            in brand.xml) yields no element at all rather than an empty
+            wrapper. Class name matches the PrestaShop /
             WooCommerce surfaces so the four platforms stay greppable.
         -->
         <!-- ko if: orderIntentApprovedNotice -->


### PR DESCRIPTION
## TWO-25218 — explicit boolean switch for the order-intent-approved notice

Supersedes the three-state design shipped under TWO-25213 ([#274](https://github.com/two-inc/magento-plugin/pull/274)).

### The design decision

TWO-25213 shipped **one** brand.xml key carrying **three** states: absent = default copy + notice ON, present-and-empty = suppressed, non-empty = copy template. That conflated two unrelated meanings — on/off **and** wording — in one key, and expressed "off" as the *absence of content* rather than as a decision. A reader cannot tell an intentional off switch from an unfinished string, and any tidy-up that deletes an "empty, unused" declaration silently turns the notice back on.

Separated into **two independent keys**: a boolean for on/off, a string for wording. **Do not overload one key with both meanings again.**

### 1. `intent_approved_notice_enabled` — the on/off switch

| value | behaviour |
|---|---|
| `true` | notice ON |
| `false` | notice suppressed entirely — **no element emitted into the DOM**, not an empty wrapper |
| absent | documented explicit default **`true`** (notice ON) |
| anything else (`1`, `0`, `yes`, `True`, `FALSE`, empty, whitespace-only) | **a clear error** — never a silent third behaviour |

Absent-means-`true` is what keeps a third-party overlay that declares nothing on ON. The base plugin declares `true` explicitly anyway, so `etc/brand.xml` states its position rather than relying on omission.

`xs:boolean` is deliberately **not** used: it also accepts `1`/`0`, and this switch is meant to read as a decision. `brand.xsd` gets its own `explicitBooleanType` restricting `xs:string` to the enumeration `true|false`.

**Error handling is doubled up, deliberately:**

* `brand.xsd` restricts the element to `true|false`, so developer mode fails loudly at config validation; **and**
* `Model\Brand\Loader` additionally throws `\DomainException` naming the offending brand.xml path, the element and the bad value — because **nothing validates brand.xsd in production mode**. This mirrors the existing `<surcharge_rounding_steps>` validation in the same method.

### 2. `intent_approved_notice` — copy override ONLY

Keeps its name, loses the switch meaning.

| value | behaviour |
|---|---|
| absent / empty / whitespace-only | **INERT** — platform default translated copy |
| non-empty string | used verbatim as the copy template |

`Descriptor::getIntentApprovedNotice()` now **never returns `''`**. Placeholders unchanged from TWO-25213: `%1` = brand product name, `%2` = buyer company name (substituted client-side via the existing `companyName` token). An override still replaces the company-known variant only.

### Required merge order

**`magento-plugin` → the brand overlay repo → `magento-hyva-extension`.**

**The parent owns the parsing.** Out of order there is a window in which Hyvä renders the notice for a brand that asked for it off. Hyvä's `method_exists()` degradation against an older parent that lacks the new registry method still works and still means "no brand opinion", i.e. notice ON.

### Migration hazard — documented, not "fixed"

New parent + **stale overlay** (still carrying an empty `intent_approved_notice` and no `intent_approved_notice_enabled`) resolves to notice **ON** — wrong for that brand, but not broken. Making an empty copy element a hard error would convert that deploy-order window from "wrong notice" into "broken store", which is worse. So empty stays inert, the merge order above is the mitigation, and there is deliberately **no legacy-compat path** resurrecting empty-means-off. Written up in `docs/brand-overlay-guide.md`.

### Contract exposed to the overlay and Hyvä repos

```php
BrandRegistryInterface::isIntentApprovedNoticeEnabled(): bool   // resolved switch, default true
BrandRegistryInterface::getIntentApprovedNotice(): ?string      // copy override only; null when absent/empty/whitespace
```

Added to `Api/BrandRegistryInterface`, `Brand/DescriptorBackedBrandRegistry`, `Model/Brand/Descriptor`, and as a deprecated throw-stub on `Model/Brand` (mirroring the existing pattern).

`Model\Ui\ConfigProvider::getOrderIntentApprovedNotice()` now returns `null` when the **switch** is false, rather than when the override is `''`. Copy resolution is otherwise unchanged.

### Renderer — no behaviour change

The Luma renderer and KO template were already "null payload ⇒ emit nothing at all". Verified nothing depended on the old `''`-semantics; only the stale three-state comments were rewritten. The PR #274 JS test stays green.

### i18n

**No user-visible string changed.** `i18n/nb_NO.csv`, `nl_NL.csv` and `sv_SE.csv` are untouched — the default copy msgids are byte-identical and the new element is a config switch, not copy. (Magento's CSVs are maintained; WooCommerce's `.pot`/`.po` deliberately are not — that asymmetry is preserved.)

### Gates — run locally the way CI runs them

**PHPUnit** (CI: `phpunit --coverage-clover coverage.xml`, PHPUnit 10.5):
```
PHPUnit 10.5.64 by Sebastian Bergmann and contributors.
Configuration: .../phpunit.xml
Time: 00:00.391, Memory: 30.99 MB
OK, but there were issues!
Tests: 450, Assertions: 766, Deprecations: 2, PHPUnit Deprecations: 2.
```
(The 2 deprecations + 2 PHPUnit deprecations are pre-existing, in `TwoErrorHandlingTest` and friends — `ReflectionProperty::setAccessible()` is deprecated on the local PHP 8.5 but not on any PHP in CI's matrix. The new test deliberately omits `setAccessible()`.)

**Jest** (CI: `npm run test:js`, Node 20):
```
PASS Test/Js/gateway-method-intent-approved-notice.test.js
...
Test Suites: 9 passed, 9 total
Tests:       85 passed, 85 total
```

**Codesniffer** (CI: `michielgerritsen/magento-coding-standard:latest --severity=6`):
```
............................................................ 211 / 211 (100%)
Time: 2.68 secs; Memory: 14MB
```

**PHP lint** (CI: `php -l` over all non-`Test/` PHP): `PHP LINT OK`

**PHPStan + DI compile** (CI matrix leg PHP 8.3 / Magento 2.4.8, in the same `michielgerritsen/magento-project-community-edition` container CI uses):
```
Generated code and dependency injection configuration successfully.
=== PHPSTAN ===
 [OK] No errors
```

**XSD validation** of the shipped brand.xml against the amended schema:
```
$ xmllint --noout --schema etc/brand.xsd etc/brand.xml
etc/brand.xml validates
```

### Mutation checks

Every new test was mutation-checked — production code deliberately broken, the new test confirmed failing, then restored:

| mutation | result |
|---|---|
| Loader: switch default `true` → `false` | 1 failure ✅ |
| Loader: drop the `true`/`false` validation | 7 failures ✅ |
| Loader: invert the switch parse (`=== 'true'` → `!== 'true'`) | 4 failures ✅ |
| Loader: stop normalising empty copy → `null` | 4 failures ✅ |
| Loader: drop `trim()` on the copy | 1 failure ✅ |
| ConfigProvider: ignore the switch entirely | 2 failures ✅ |
| ConfigProvider: invert the switch check | 4 failures ✅ |
| Descriptor: `isIntentApprovedNoticeEnabled()` hardcoded `true` | 3 failures ✅ |

One mutation is **not** caught and that is expected: flipping the `Descriptor` constructor's `$intentApprovedNoticeEnabled` *parameter default* to `false` changes nothing observable, because `Loader` always passes the value explicitly. The default exists for hand-constructed descriptors in overlay code; the getter itself is covered (last row).

### Do not merge yet

Two sibling PRs (overlay + Hyvä) are coded against the contract above and must land **after** this one.

