### PR TITLE
TWO-25216: enforce surcharge tax-treatment selection on every admin config save

### DIFF
--- a/Model/Config/Backend/AbstractSurchargeTreatmentGuard.php
+++ b/Model/Config/Backend/AbstractSurchargeTreatmentGuard.php
@@ -37,9 +37,24 @@ use Two\Gateway\Model\Config\Source\SurchargeType as SurchargeTypeSource;
  *
  * Nothing here runs on config page load — this is the save path only, and it
  * throws a LocalizedException, which Magento renders as an admin error
- * message on the section it was saving. The Surcharge Tax Treatment field
+ * message on the section it was saving. The save transaction rolls back as a
+ * whole, so a rejected save writes nothing. The Surcharge Tax Treatment field
  * lives in that same section, so a rejected merchant can always pick a
  * treatment and save again.
+ *
+ * Known write paths this does NOT cover (verified against Magento 2.4.6, not
+ * an oversight — a field backend model is the wrong hook for them):
+ *  - "Use Default" (inherit) at website/store scope. Magento routes inherited
+ *    fields through the delete transaction, so beforeDelete runs, not
+ *    beforeSave. Inheriting the treatment away while the inherited surcharge
+ *    method is enabled is therefore accepted.
+ *  - `bin/magento config:set`. It addresses fields by config path, and
+ *    Magento\Config\Model\Config::setDataByPath() reads that as
+ *    section/group/field — which does not resolve to a system.xml element for
+ *    these fields, so the generic Value backend model is used and no field
+ *    backend model of ours runs at all.
+ *  - Direct core_config_data / config writer writes, which bypass the config
+ *    model entirely by design.
  */
 abstract class AbstractSurchargeTreatmentGuard extends Value
 {
@@ -142,8 +157,9 @@ abstract class AbstractSurchargeTreatmentGuard extends Value
     {
         $path = preg_replace('#/[^/]+$#', '/' . $key, (string)$this->getPath());
         // scope_id, not scope_code: the admin form save sets both, but
-        // CLI config:set (PreparedValueFactory) only sets scope/scope_id,
-        // and ScopeConfigInterface::getValue resolves numeric ids fine.
+        // PreparedValueFactory-driven saves (app:config:import and friends)
+        // only set scope/scope_id, and ScopeConfigInterface::getValue
+        // resolves numeric ids fine.
         return $this->_config->getValue(
             $path,
             $this->getScope() ?: 'default',

--- a/Model/Config/Backend/AbstractSurchargeTreatmentGuard.php
+++ b/Model/Config/Backend/AbstractSurchargeTreatmentGuard.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Model\Config\Backend;
+
+use Magento\Framework\App\Config\Value;
+use Magento\Framework\Exception\LocalizedException;
+use Two\Gateway\Model\Config\Source\SurchargeType as SurchargeTypeSource;
+
+/**
+ * Shared save-time enforcement of the surcharge tax treatment invariant:
+ * while a surcharge method is enabled, a surcharge tax treatment must be
+ * explicitly selected.
+ *
+ * A Magento field backend model is only instantiated when its own field is
+ * part of the save, so a single guard on the treatment selector could never
+ * see a save that only touched the Surcharge Method (or any unrelated field
+ * in the section). Both the Surcharge Method field and the Surcharge Tax
+ * Treatment field therefore extend this class: the admin section save posts
+ * every visible field in the group, so the Surcharge Method guard runs on
+ * every admin save of the payment section — including saves of a shop that
+ * is already sitting in the enabled-with-blank-treatment state.
+ *
+ * "Explicitly selected" deliberately includes the deprecated legacy flat
+ * rate (payment/<code>/surcharge_tax_rate): merchants configured before the
+ * tax-rule selector existed have made a choice, and must not be blocked.
+ * All emptiness checks are null/'' checks, never truthy — a configured rate
+ * of 0 or "0.00" is a real value.
+ *
+ * Sibling config paths are derived from the field's own path so the rule is
+ * brand-aware: synthesized brand forms save under payment/<brand_code>/ and
+ * get identical enforcement.
+ *
+ * Nothing here runs on config page load — this is the save path only, and it
+ * throws a LocalizedException, which Magento renders as an admin error
+ * message on the section it was saving. The Surcharge Tax Treatment field
+ * lives in that same section, so a rejected merchant can always pick a
+ * treatment and save again.
+ */
+abstract class AbstractSurchargeTreatmentGuard extends Value
+{
+    /**
+     * Reject the save when a surcharge is enabled at this scope but no
+     * surcharge tax treatment has been chosen.
+     *
+     * @throws LocalizedException
+     */
+    protected function assertTaxTreatmentSelected(): void
+    {
+        if ($this->isSurchargeEnabled() && !$this->isTaxTreatmentSelected()) {
+            throw new LocalizedException(
+                __(
+                    'Please select a Surcharge Tax Treatment. A surcharge method is enabled '
+                    . '(see the Surcharge Method field), so the Surcharge Tax Treatment field '
+                    . 'must be chosen explicitly before this configuration can be saved.'
+                )
+            );
+        }
+    }
+
+    /**
+     * Whether a surcharge method is enabled for the scope being saved.
+     */
+    protected function isSurchargeEnabled(): bool
+    {
+        $surchargeType = $this->getSurchargeTypeValue();
+        if ($surchargeType === null || $surchargeType === '') {
+            $surchargeType = $this->getScopedSiblingValue('surcharge_type');
+        }
+
+        return $surchargeType !== null
+            && $surchargeType !== ''
+            && $surchargeType !== SurchargeTypeSource::NONE;
+    }
+
+    /**
+     * Whether the merchant has explicitly chosen how the surcharge is taxed.
+     * A pre-existing legacy flat rate counts as a choice.
+     */
+    protected function isTaxTreatmentSelected(): bool
+    {
+        $treatment = $this->getTaxTreatmentValue();
+        if ($treatment !== null && $treatment !== '') {
+            return true;
+        }
+
+        return $this->hasLegacyFlatRate();
+    }
+
+    /**
+     * Surcharge method for this save. Prefers the value posted in the same
+     * request (fieldset data); null/'' means "not part of this save" and the
+     * caller falls back to stored config.
+     */
+    protected function getSurchargeTypeValue(): ?string
+    {
+        $posted = $this->getFieldsetDataValue('surcharge_type');
+
+        return $posted === null ? null : (string)$posted;
+    }
+
+    /**
+     * Surcharge tax treatment for this save. Prefers the value posted in the
+     * same request; falls back to stored config for partial saves. A posted
+     * empty string is a real (blank) submission, not an absent field.
+     */
+    protected function getTaxTreatmentValue(): ?string
+    {
+        $posted = $this->getFieldsetDataValue('surcharge_tax_class');
+        if ($posted !== null) {
+            return (string)$posted;
+        }
+
+        $stored = $this->getScopedSiblingValue('surcharge_tax_class');
+
+        return $stored === null ? null : (string)$stored;
+    }
+
+    /**
+     * Whether the deprecated flat rate genuinely exists at this scope.
+     * Deliberately null/'' checks, never truthy: a configured rate of
+     * 0 or "0.00" is still a real value (classic falsy-zero bug).
+     */
+    protected function hasLegacyFlatRate(): bool
+    {
+        $rate = $this->getScopedSiblingValue('surcharge_tax_rate');
+
+        return $rate !== null && $rate !== '';
+    }
+
+    /**
+     * Read a sibling config key (same payment/<code>/ prefix as this
+     * field) at the scope being saved.
+     *
+     * @return mixed
+     */
+    protected function getScopedSiblingValue(string $key)
+    {
+        $path = preg_replace('#/[^/]+$#', '/' . $key, (string)$this->getPath());
+        // scope_id, not scope_code: the admin form save sets both, but
+        // CLI config:set (PreparedValueFactory) only sets scope/scope_id,
+        // and ScopeConfigInterface::getValue resolves numeric ids fine.
+        return $this->_config->getValue(
+            $path,
+            $this->getScope() ?: 'default',
+            $this->getScopeId()
+        );
+    }
+}

--- a/Model/Config/Backend/SurchargeTaxClass.php
+++ b/Model/Config/Backend/SurchargeTaxClass.php
@@ -26,6 +26,12 @@ use Two\Gateway\Model\Config\Source\SurchargeTaxClass as SurchargeTaxClassSource
  * Custom option is a backward-compat carve-out for pre-existing
  * merchants only, and must not be creatable through a hand-crafted
  * POST. That check belongs to this field alone.
+ *
+ * Real coverage: every admin config-section save, at any scope. NOT
+ * `bin/magento config:set`, NOT "Use Default" / inherit, NOT direct
+ * core_config_data writes — an earlier comment here claimed CLI
+ * coverage and was wrong; {@see AbstractSurchargeTreatmentGuard} has
+ * the verified detail.
  */
 class SurchargeTaxClass extends AbstractSurchargeTreatmentGuard
 {

--- a/Model/Config/Backend/SurchargeTaxClass.php
+++ b/Model/Config/Backend/SurchargeTaxClass.php
@@ -7,10 +7,8 @@ declare(strict_types=1);
 
 namespace Two\Gateway\Model\Config\Backend;
 
-use Magento\Framework\App\Config\Value;
 use Magento\Framework\Exception\LocalizedException;
 use Two\Gateway\Model\Config\Source\SurchargeTaxClass as SurchargeTaxClassSource;
-use Two\Gateway\Model\Config\Source\SurchargeType;
 
 /**
  * Server-side guard for the surcharge tax treatment selector.
@@ -18,21 +16,18 @@ use Two\Gateway\Model\Config\Source\SurchargeType;
  * The selector never auto-defaults (see the source model); this
  * backend model is the enforcement half: while surcharges are enabled
  * the config save is rejected until the merchant has explicitly picked
- * a treatment. Enforced here — not just in admin JS — so CLI
- * `config:set`, API-driven saves and any theme quirk hit the same
- * rule.
+ * a treatment. The shared invariant lives in
+ * {@see AbstractSurchargeTreatmentGuard} so the sibling guard on the
+ * Surcharge Method field enforces exactly the same rule — see that
+ * class for why one guard on this field alone is not enough.
  *
- * It also refuses the deprecated "Custom" treatment when no legacy
- * flat-rate value exists at the scope being saved: the Custom option
- * is a backward-compat carve-out for pre-existing merchants only, and
- * must not be creatable through a hand-crafted POST.
- *
- * Sibling config paths (surcharge_type / surcharge_tax_rate) are
- * derived from this field's own path so the rule is brand-aware —
- * synthesized brand forms save under payment/<brand_code>/ and get the
- * exact same enforcement.
+ * This model additionally refuses the deprecated "Custom" treatment
+ * when no legacy flat-rate value exists at the scope being saved: the
+ * Custom option is a backward-compat carve-out for pre-existing
+ * merchants only, and must not be creatable through a hand-crafted
+ * POST. That check belongs to this field alone.
  */
-class SurchargeTaxClass extends Value
+class SurchargeTaxClass extends AbstractSurchargeTreatmentGuard
 {
     /**
      * @inheritDoc
@@ -43,18 +38,9 @@ class SurchargeTaxClass extends Value
      */
     public function beforeSave()
     {
-        $value = (string)$this->getValue();
+        $this->assertTaxTreatmentSelected();
 
-        if ($value === '' && $this->isSurchargeEnabled()) {
-            throw new LocalizedException(
-                __(
-                    'Please select a surcharge tax treatment. A surcharge method is enabled, '
-                    . 'so the surcharge tax treatment must be chosen explicitly.'
-                )
-            );
-        }
-
-        if ($value === SurchargeTaxClassSource::CUSTOM && !$this->hasLegacyFlatRate()) {
+        if ((string)$this->getValue() === SurchargeTaxClassSource::CUSTOM && !$this->hasLegacyFlatRate()) {
             throw new LocalizedException(
                 __(
                     'The "Custom flat rate" surcharge tax treatment is deprecated and only '
@@ -68,48 +54,12 @@ class SurchargeTaxClass extends Value
     }
 
     /**
-     * Whether a surcharge method is enabled for the scope being saved.
-     * Prefers the value posted in the same save request (fieldset
-     * data); falls back to the stored config for partial saves.
+     * This field IS the treatment: its own submitted value wins outright,
+     * including an explicit blank, which must never fall back to whatever
+     * happens to be stored.
      */
-    private function isSurchargeEnabled(): bool
+    protected function getTaxTreatmentValue(): ?string
     {
-        $surchargeType = $this->getFieldsetDataValue('surcharge_type');
-        if ($surchargeType === null || $surchargeType === '') {
-            $surchargeType = $this->getScopedSiblingValue('surcharge_type');
-        }
-        return $surchargeType !== null
-            && $surchargeType !== ''
-            && $surchargeType !== SurchargeType::NONE;
-    }
-
-    /**
-     * Whether the deprecated flat rate genuinely exists at this scope.
-     * Deliberately null/'' checks, never truthy: a configured rate of
-     * 0 or "0.00" is still a real value (classic falsy-zero bug).
-     */
-    private function hasLegacyFlatRate(): bool
-    {
-        $rate = $this->getScopedSiblingValue('surcharge_tax_rate');
-        return $rate !== null && $rate !== '';
-    }
-
-    /**
-     * Read a sibling config key (same payment/<code>/ prefix as this
-     * field) at the scope being saved.
-     *
-     * @return mixed
-     */
-    private function getScopedSiblingValue(string $key)
-    {
-        $path = preg_replace('#/[^/]+$#', '/' . $key, (string)$this->getPath());
-        // scope_id, not scope_code: the admin form save sets both, but
-        // CLI config:set (PreparedValueFactory) only sets scope/scope_id,
-        // and ScopeConfigInterface::getValue resolves numeric ids fine.
-        return $this->_config->getValue(
-            $path,
-            $this->getScope() ?: 'default',
-            $this->getScopeId()
-        );
+        return (string)$this->getValue();
     }
 }

--- a/Model/Config/Backend/SurchargeType.php
+++ b/Model/Config/Backend/SurchargeType.php
@@ -18,7 +18,9 @@ use Magento\Framework\Exception\LocalizedException;
  * section-save guard: the admin config save posts every visible field
  * in the group, so this model is instantiated on every save of the
  * payment section, which is what catches a shop already sitting in the
- * enabled-with-blank-treatment state (and `config:set` on this path).
+ * enabled-with-blank-treatment state. See
+ * {@see AbstractSurchargeTreatmentGuard} for the write paths that stay
+ * out of reach of a field backend model.
  */
 class SurchargeType extends AbstractSurchargeTreatmentGuard
 {

--- a/Model/Config/Backend/SurchargeType.php
+++ b/Model/Config/Backend/SurchargeType.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Model\Config\Backend;
+
+use Magento\Framework\Exception\LocalizedException;
+
+/**
+ * Server-side guard on the Surcharge Method field.
+ *
+ * Enforces the same invariant as the guard on the treatment selector —
+ * surcharge enabled implies a surcharge tax treatment is explicitly
+ * chosen — from the other side of the pair. This is the effective
+ * section-save guard: the admin config save posts every visible field
+ * in the group, so this model is instantiated on every save of the
+ * payment section, which is what catches a shop already sitting in the
+ * enabled-with-blank-treatment state (and `config:set` on this path).
+ */
+class SurchargeType extends AbstractSurchargeTreatmentGuard
+{
+    /**
+     * @inheritDoc
+     *
+     * @throws LocalizedException when a surcharge method is enabled and
+     *         no surcharge tax treatment is selected.
+     */
+    public function beforeSave()
+    {
+        $this->assertTaxTreatmentSelected();
+
+        return parent::beforeSave();
+    }
+
+    /**
+     * This field IS the surcharge method: its own submitted value wins.
+     */
+    protected function getSurchargeTypeValue(): ?string
+    {
+        return (string)$this->getValue();
+    }
+}

--- a/Test/Unit/Model/Config/Backend/SurchargeTaxClassTest.php
+++ b/Test/Unit/Model/Config/Backend/SurchargeTaxClassTest.php
@@ -60,7 +60,52 @@ class SurchargeTaxClassTest extends TestCase
         ]);
 
         $this->expectException(LocalizedException::class);
-        $this->expectExceptionMessage('select a surcharge tax treatment');
+        $this->expectExceptionMessage('Please select a Surcharge Tax Treatment');
+        $model->beforeSave();
+    }
+
+    public function testEmptyValueWithSurchargeEnabledIsAcceptedWhenLegacyRateExists(): void
+    {
+        // Legacy merchants configured before the selector existed HAVE made a
+        // choice; the guard must not lock them out of the section.
+        $this->stubStoredConfig(['payment/two_payment/surcharge_tax_rate' => '21']);
+        $model = $this->buildModel([
+            'value' => '',
+            'path' => 'payment/two_payment/surcharge_tax_class',
+            'scope' => 'default',
+            'fieldset_data' => ['surcharge_type' => 'percentage'],
+        ]);
+
+        $this->assertSame($model, $model->beforeSave());
+    }
+
+    public function testEmptyValueWithSurchargeEnabledIsAcceptedWhenLegacyRateIsZero(): void
+    {
+        // Falsy-zero guard: a configured rate of "0" is a real value.
+        $this->stubStoredConfig(['payment/two_payment/surcharge_tax_rate' => '0']);
+        $model = $this->buildModel([
+            'value' => '',
+            'path' => 'payment/two_payment/surcharge_tax_class',
+            'scope' => 'default',
+            'fieldset_data' => ['surcharge_type' => 'percentage'],
+        ]);
+
+        $this->assertSame($model, $model->beforeSave());
+    }
+
+    public function testExplicitBlankIsNotSatisfiedByStoredTaxClass(): void
+    {
+        // Clearing the selector must be rejected even though the stored value
+        // is still populated — the field's own submitted value wins.
+        $this->stubStoredConfig(['payment/two_payment/surcharge_tax_class' => '4']);
+        $model = $this->buildModel([
+            'value' => '',
+            'path' => 'payment/two_payment/surcharge_tax_class',
+            'scope' => 'default',
+            'fieldset_data' => ['surcharge_type' => 'percentage'],
+        ]);
+
+        $this->expectException(LocalizedException::class);
         $model->beforeSave();
     }
 

--- a/Test/Unit/Model/Config/Backend/SurchargeTypeTest.php
+++ b/Test/Unit/Model/Config/Backend/SurchargeTypeTest.php
@@ -1,0 +1,263 @@
+<?php
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Model\Config\Backend;
+
+use Magento\Framework\App\Cache\TypeListInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Model\Context;
+use Magento\Framework\Registry;
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Model\Config\Backend\SurchargeType;
+
+/**
+ * Tests the section-save half of the surcharge tax treatment invariant.
+ *
+ * The Surcharge Method field is posted on every admin save of the payment
+ * section, so this guard is what catches a save triggered by any other
+ * field — including a shop already stored in the enabled-with-blank-
+ * treatment state. A pre-existing legacy flat rate counts as an explicit
+ * choice (including a rate of 0).
+ */
+class SurchargeTypeTest extends TestCase
+{
+    /** @var ScopeConfigInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $scopeConfig;
+
+    protected function setUp(): void
+    {
+        $this->scopeConfig = $this->createMock(ScopeConfigInterface::class);
+    }
+
+    private function buildModel(array $data): SurchargeType
+    {
+        return new SurchargeType(
+            $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock(),
+            $this->getMockBuilder(Registry::class)->disableOriginalConstructor()->getMock(),
+            $this->scopeConfig,
+            $this->createMock(TypeListInterface::class),
+            null,
+            null,
+            $data
+        );
+    }
+
+    private function stubStoredConfig(array $map): void
+    {
+        $this->scopeConfig->method('getValue')->willReturnCallback(
+            function ($path) use ($map) {
+                return $map[$path] ?? null;
+            }
+        );
+    }
+
+    public function testEnablingSurchargeWithNoTreatmentAnywhereIsRejected(): void
+    {
+        $this->stubStoredConfig([]);
+        $model = $this->buildModel([
+            'value' => 'percentage',
+            'path' => 'payment/two_payment/surcharge_type',
+            'scope' => 'default',
+            'fieldset_data' => [
+                'surcharge_type' => 'percentage',
+                'surcharge_tax_class' => '',
+            ],
+        ]);
+
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage('Please select a Surcharge Tax Treatment');
+        $model->beforeSave();
+    }
+
+    public function testAlreadyBrokenShopSavingAnUnrelatedFieldIsRejected(): void
+    {
+        // Stored state: surcharge enabled, treatment blank. The merchant edits
+        // some other field in the section; surcharge_type is posted unchanged
+        // and the treatment field is not part of this save at all.
+        $this->stubStoredConfig([
+            'payment/two_payment/surcharge_type' => 'fixed',
+            'payment/two_payment/surcharge_tax_class' => null,
+            'payment/two_payment/surcharge_tax_rate' => null,
+        ]);
+        $model = $this->buildModel([
+            'value' => 'fixed',
+            'path' => 'payment/two_payment/surcharge_type',
+            'scope' => 'default',
+            'fieldset_data' => ['surcharge_type' => 'fixed'],
+        ]);
+
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage('Surcharge Tax Treatment field');
+        $model->beforeSave();
+    }
+
+    public function testLegacyFlatRateCountsAsAnExplicitTreatment(): void
+    {
+        $this->stubStoredConfig(['payment/two_payment/surcharge_tax_rate' => '21']);
+        $model = $this->buildModel([
+            'value' => 'percentage',
+            'path' => 'payment/two_payment/surcharge_type',
+            'scope' => 'default',
+            'fieldset_data' => [
+                'surcharge_type' => 'percentage',
+                'surcharge_tax_class' => '',
+            ],
+        ]);
+
+        $this->assertSame($model, $model->beforeSave());
+    }
+
+    public function testLegacyFlatRateOfZeroCountsAsAnExplicitTreatment(): void
+    {
+        // Falsy-zero guard: a configured rate of "0" is a real value.
+        $this->stubStoredConfig(['payment/two_payment/surcharge_tax_rate' => '0']);
+        $model = $this->buildModel([
+            'value' => 'percentage',
+            'path' => 'payment/two_payment/surcharge_type',
+            'scope' => 'default',
+            'fieldset_data' => [
+                'surcharge_type' => 'percentage',
+                'surcharge_tax_class' => '',
+            ],
+        ]);
+
+        $this->assertSame($model, $model->beforeSave());
+    }
+
+    public function testDisabledSurchargeWithBlankTreatmentIsAccepted(): void
+    {
+        $this->stubStoredConfig([]);
+        $model = $this->buildModel([
+            'value' => 'none',
+            'path' => 'payment/two_payment/surcharge_type',
+            'scope' => 'default',
+            'fieldset_data' => [
+                'surcharge_type' => 'none',
+                'surcharge_tax_class' => '',
+            ],
+        ]);
+
+        $this->assertSame($model, $model->beforeSave());
+    }
+
+    public function testEnablingAndPickingATreatmentInTheSameSaveIsAccepted(): void
+    {
+        // Nothing stored yet — the treatment only exists in the posted data.
+        $this->stubStoredConfig([]);
+        $model = $this->buildModel([
+            'value' => 'percentage',
+            'path' => 'payment/two_payment/surcharge_type',
+            'scope' => 'default',
+            'fieldset_data' => [
+                'surcharge_type' => 'percentage',
+                'surcharge_tax_class' => '4',
+            ],
+        ]);
+
+        $this->assertSame($model, $model->beforeSave());
+    }
+
+    public function testStoredTreatmentSatisfiesTheGuardWhenNotPosted(): void
+    {
+        $this->stubStoredConfig(['payment/two_payment/surcharge_tax_class' => '4']);
+        $model = $this->buildModel([
+            'value' => 'percentage',
+            'path' => 'payment/two_payment/surcharge_type',
+            'scope' => 'default',
+            'fieldset_data' => ['surcharge_type' => 'percentage'],
+        ]);
+
+        $this->assertSame($model, $model->beforeSave());
+    }
+
+    public function testOwnValueWinsOverStoredSurchargeType(): void
+    {
+        // Stored config says enabled; this save switches it off, so the blank
+        // treatment must be accepted.
+        $this->stubStoredConfig(['payment/two_payment/surcharge_type' => 'percentage']);
+        $model = $this->buildModel([
+            'value' => 'none',
+            'path' => 'payment/two_payment/surcharge_type',
+            'scope' => 'default',
+            'fieldset_data' => [
+                'surcharge_type' => 'none',
+                'surcharge_tax_class' => '',
+            ],
+        ]);
+
+        $this->assertSame($model, $model->beforeSave());
+    }
+
+    public function testSystemXmlWiresTheGuardOntoBothFields(): void
+    {
+        // The wiring IS the fix: without the backend_model on surcharge_type
+        // the invariant is only enforced when the treatment field itself is
+        // part of the save.
+        $systemXml = dirname(__DIR__, 5) . '/etc/adminhtml/system.xml';
+        $xml = new \SimpleXMLElement((string)file_get_contents($systemXml));
+
+        $backendModels = [];
+        foreach (['surcharge_type', 'surcharge_tax_class'] as $fieldId) {
+            $nodes = $xml->xpath(sprintf('//field[@id="%s"]/backend_model', $fieldId));
+            $backendModels[$fieldId] = $nodes ? (string)$nodes[0] : null;
+        }
+
+        $this->assertSame(
+            \Two\Gateway\Model\Config\Backend\SurchargeType::class,
+            $backendModels['surcharge_type']
+        );
+        $this->assertSame(
+            \Two\Gateway\Model\Config\Backend\SurchargeTaxClass::class,
+            $backendModels['surcharge_tax_class']
+        );
+    }
+
+    public function testOwnValueEnablesTheGuardWhenNoFieldsetDataIsPresent(): void
+    {
+        // PreparedValueFactory-style saves (app:config:import and friends) set
+        // path/value/scope with no fieldset_data at all. The field's own value
+        // must still drive the check — stored config still says "none".
+        $this->stubStoredConfig([
+            'payment/two_payment/surcharge_type' => 'none',
+            'payment/two_payment/surcharge_tax_class' => '',
+            'payment/two_payment/surcharge_tax_rate' => '',
+        ]);
+        $model = $this->buildModel([
+            'value' => 'percentage',
+            'path' => 'payment/two_payment/surcharge_type',
+            'scope' => 'default',
+        ]);
+
+        $this->expectException(LocalizedException::class);
+        $model->beforeSave();
+    }
+
+    public function testSiblingPathsAreDerivedBrandAware(): void
+    {
+        // Synthesized brand forms save under payment/<brand_code>/ — sibling
+        // lookups must follow the field's own path, not two_payment.
+        $queried = [];
+        $this->scopeConfig->method('getValue')->willReturnCallback(
+            function ($path) use (&$queried) {
+                $queried[] = $path;
+                return null;
+            }
+        );
+        $model = $this->buildModel([
+            'value' => 'percentage',
+            'path' => 'payment/overlay_payment/surcharge_type',
+            'scope' => 'websites',
+            'scope_id' => 2,
+            'fieldset_data' => ['surcharge_type' => 'percentage'],
+        ]);
+
+        try {
+            $model->beforeSave();
+            $this->fail('Expected LocalizedException');
+        } catch (LocalizedException $e) {
+            $this->assertContains('payment/overlay_payment/surcharge_tax_class', $queried);
+            $this->assertContains('payment/overlay_payment/surcharge_tax_rate', $queried);
+        }
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -189,6 +189,12 @@
                     <label>Surcharge Method</label>
                     <comment>Select a method to surcharge your customer.</comment>
                     <source_model>Two\Gateway\Model\Config\Source\SurchargeType</source_model>
+                    <!-- Backend model guards the "surcharge enabled => tax treatment
+                         explicitly selected" invariant from this side of the pair.
+                         Needed because a field backend model only runs when its own
+                         field is in the save: this field is posted on every admin
+                         save of the section, the treatment field is not. -->
+                    <backend_model>Two\Gateway\Model\Config\Backend\SurchargeType</backend_model>
                     <config_path>payment/two_payment/surcharge_type</config_path>
                 </field>
                 <field id="surcharge_differential" translate="label comment" type="select" sortOrder="60" showInDefault="1"


### PR DESCRIPTION
TWO-25216 (child of TWO-24739).

## The bug

`Model/Config/Backend/SurchargeTaxClass.php` enforced "surcharge enabled ⇒ a tax treatment is explicitly selected" — but as a backend model on the `surcharge_tax_class` field. Magento only instantiates a field's backend model when that field is part of the save, so the guard was a *field-transition* guard, not an invariant:

- Enabling the surcharge by saving `surcharge_type` alone never tripped it.
- A shop already stored as enabled-with-blank-treatment was never forced to fix it — it could save that section forever without a prompt.

## The fix

- New `Model/Config/Backend/SurchargeType.php`, wired as the `backend_model` on the Surcharge Method field in `etc/adminhtml/system.xml`. That field is posted on **every** admin save of the payment section, which is what turns the pair of guards into an effective section-save guard.
- The shared invariant moves into `Model/Config/Backend/AbstractSurchargeTreatmentGuard.php` so both guards agree exactly and stay brand-aware (sibling config paths derived from the field's own `getPath()`, so synthesized overlay forms saving under `payment/<code>/` get identical enforcement).
- The Custom-requires-a-pre-existing-legacy-flat-rate check stays on the tax-class field only.

**The checkout-side runtime getter fallbacks are deliberately unchanged.** This is admin save-time enforcement only. Once the admin page forces a selection when the surcharge is first enabled, checkout needs no change — so the runtime resolvers were left exactly as they are, on purpose.

## Behaviour change worth reading twice

Enabled + blank `surcharge_tax_class` + **non-empty legacy** `surcharge_tax_rate` now **passes**, where it previously threw.

A configured legacy flat rate is a real, explicit merchant choice — it is the treatment those merchants are actually running on. Treating it as "unset" is what previously **trapped** them: every save of that section threw, including saves of unrelated fields, with no way to satisfy the guard except abandoning their configured rate. The carve-out is null/`''`-checked, never truthy, so a legacy rate of `0` or `0.00` is a real value and also passes.

A genuinely unselected merchant (both the tax class and the legacy rate blank) is still blocked, on both guards.

## What this does NOT cover

Stated plainly, because the code previously overstated it — the old `SurchargeTaxClass` docblock claimed CLI `config:set` hit this rule. **It never did.** That comment is corrected in this PR.

1. **`bin/magento config:set` bypasses the guard entirely — both fields.** Verified live: `config:set payment/two_payment/surcharge_type percentage` with a blank treatment returns "Value was saved.", and so does `config:set payment/two_payment/surcharge_tax_class custom` with no legacy rate. Cause: `Config::setDataByPath()` splits the *config path* into section/group/field (`payment` / `two_payment` / `surcharge_type`), which does not resolve to the system.xml element (`two_payment` / `payment_terms` / …), so `$field->hasBackendModel()` is false and the generic `Value` model is used. Closing this needs a different hook — a `Config` plugin or an `admin_system_config_changed_section_*` observer — and is out of scope here.
2. **Website/store-scope "Use Default" (inherit) bypasses it.** `Config::_processGroup()` puts inherited fields on the *delete* transaction, so `beforeDelete` runs, not `beforeSave`. Confirmed live. Note also that the delete transaction commits *before* the save transaction, so a mixed save that gets rejected still commits its inherit-deletes.
3. **Direct `core_config_data` / `WriterInterface` writes bypass it**, by design — no config model is involved. The probe script used exactly that to seed the broken state.

Covered: every admin config-section save, whichever field triggered it, at any scope, including a shop already stored in the broken state; plus `PreparedValueFactory`-driven saves that carry path/value/scope.

## Existing merchants are not locked out

- Nothing throws on config page **load** — this is the save path only.
- A rejected save is atomic: the save transaction rolls back as a whole, so nothing is half-applied (verified — after a rejected save, `config:show payment/two_payment/title` is still empty).
- The merchant lands back on the same section, where the Surcharge Tax Treatment dropdown is, and the error message names that field explicitly. They pick a value and save.
- **Honest caveat:** Magento core does not repopulate the rejected POST. `Magento\Config\Controller\Adminhtml\System\Config\Save::execute()` (`app/code/Magento/Config/Controller/Adminhtml/System/Config/Save.php:220-256`) catches `LocalizedException`, adds the message, and calls `_saveState()` — which persists fieldset *collapse* state only, not field values. So an unrelated edit submitted alongside a rejected save is lost and must be re-entered. That is core behaviour, not something introduced here.

## Live end-to-end verification

Real `Config::save()` in a Magento container, with stored config seeded to the broken shape (`surcharge_type=percentage`, `surcharge_tax_class` NULL):

| Scenario | Result |
| --- | --- |
| unrelated field only, treatment not posted | **REJECTED** ← the ticket's core case |
| blank treatment posted | **REJECTED** |
| treatment `2` posted | SAVED |
| website-scope override, blank treatment | **REJECTED** |
| website-scope **inherit** on both | SAVED (documented bypass #2) |
| after a rejected save, `config:show …title` | empty — transaction rolled back, no partial write |

## Gates (run locally the way CI runs them, on the rebased branch)

| Gate | Result |
| --- | --- |
| phpunit (`make test`) | `OK (448 tests, 755 assertions)` |
| phpcs (`magento-coding-standard --severity=6`) | `213 / 213 (100%)`, no violations |
| phpstan (real container, CI command) | `[OK] No errors` |
| `setup:di:compile` (real container, PHP 8.3 / Magento 2.4.8) | `Generated code and dependency injection configuration successfully.` |

## Tests

`Test/Unit/Model/Config/Backend/SurchargeTypeTest.php` (new) and additions to `SurchargeTaxClassTest.php` cover: the already-broken-shop path (`surcharge_type` posted unchanged while the stored treatment is blank), the legacy-flat-rate carve-out including the falsy-zero trap, disabled-plus-blank, enable-and-pick-in-one-save (posted fieldset data beating stored config), explicit-blank-beats-stored, brand-aware sibling-path derivation, and a wiring assertion that `system.xml` declares both backend models — the wiring *is* the fix, so it gets a test.

Every new test was mutation-checked: the production line it covers was broken, the test confirmed failing, then restored. One mutation (dropping the own-value override on the surcharge-type field) initially survived, and a test was added to kill it.

---

<sub>by Claude</sub>
