### PR TITLE
docs(TWO-25225): brand-overlay guide describes only the current contract

### DIFF
--- a/docs/brand-overlay-guide.md
+++ b/docs/brand-overlay-guide.md
@@ -122,8 +122,7 @@ across modules). Elements may appear in any order (`xs:all`).
 | `sign_up_url`             | no       | string                      | Merchant signup link in admin.                                                                                          |
 | `documentation_url`       | no       | string                      | Docs link in admin.                                                                                                     |
 | `api_base_url`            | yes      | string                      | Two API base for this brand.                                                                                            |
-| `available_payment_terms` | yes      | `<term>` list               | Day counts offered (positive integers).                                                                                 |
-| `surcharge_fixed_max`     | no       | `amount` + `currency` attrs | Cap on the fixed surcharge component.                                                                                   |
+| `surcharge_rounding_steps` | no      | `<step>` list               | Narrows the admin "Rounding Step" dropdown (major units, each `> 0`). Absent or empty inherits the parent default set. Values are deduped and sorted ascending. |
 | `csp_origins`             | no       | `<origin>` list             | Extra CSP origins.                                                                                                      |
 | `admin_resource`          | yes      | string                      | ACL resource gating the admin section.                                                                                  |
 | `module_label_chain`      | no       | `<module label="…">` list   | Admin Version-panel rows; rows for missing modules silently skip.                                                       |
@@ -139,15 +138,11 @@ across modules). Elements may appear in any order (`xs:all`).
 
 The notice is a buyer-facing "order intent approved" reassurance line
 rendered inline in the checkout payment tile. It is controlled by **two
-independent keys**: whether it shows, and what it says.
-
-Historically (TWO-25213) there was one key with three states, where
-"present but empty" meant "off". That conflated two unrelated meanings,
-expressed a decision as the absence of content, and made an intentional
-off switch indistinguishable from an unfinished string — any tidy-up that
-deleted the "empty, unused" declaration silently turned the notice back
-on. TWO-25218 split them. **Do not overload one key with both meanings
-again.**
+independent keys**: whether it shows, and what it says. **Do not
+overload one key with both meanings** — an off switch expressed as the
+absence of content is indistinguishable from an unfinished string, and
+any tidy-up that deletes the "empty, unused" declaration silently turns
+the notice back on.
 
 #### `intent_approved_notice_enabled` — the on/off switch
 
@@ -181,7 +176,7 @@ and `0`, and this switch is meant to read as a decision.
 | brand.xml                                            | Behaviour                                                                                                              |
 | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | element absent                                       | Platform default translated copy.                                                                                      |
-| empty or whitespace-only                             | **Inert** — same as absent. It does **not** mean "off" any more.                                                       |
+| empty or whitespace-only                             | **Inert** — same as absent. It does **not** mean "off".                                                                |
 | `<intent_approved_notice>…</intent_approved_notice>` | The content is used verbatim as the company-known copy template. `%1` = brand product name, `%2` = buyer company name. |
 
 `Descriptor::getIntentApprovedNotice()` returns `null` for the first two
@@ -189,33 +184,31 @@ rows and the template for the third; it never returns `''`. The switch
 above is what `Model\Ui\ConfigProvider` consults to decide whether to ship
 a payload to the renderer at all.
 
-#### Migration hazard: deploy order
+#### Deploy order
 
-A **new parent** plus a **stale overlay** — one that still carries an
-empty `<intent_approved_notice>` and no
-`<intent_approved_notice_enabled>` — resolves to notice **ON**. That is
-wrong for that brand, but not broken. Making an empty copy element a hard
-error would turn the deploy-order window from "wrong notice" into "broken
-store", which is worse, so empty stays inert and there is deliberately no
-legacy-compat path that resurrects empty-means-off.
+**Merge order is `magento-plugin` (parent, owns the parsing) → the brand
+overlay repo → `magento-hyva-extension`.** Out of order there is a window
+in which Hyvä renders the notice for a brand that asked for it off.
 
-The mitigation is **merge order**: `magento-plugin` (parent, owns the
-parsing) → the brand overlay repo → `magento-hyva-extension`. Out
-of order there is a window in which Hyvä renders the notice for a brand
-that asked for it off.
+An overlay that declares an empty `<intent_approved_notice>` and no
+`<intent_approved_notice_enabled>` resolves to notice **ON** — wrong for a
+brand that wants it off, but not broken. Empty deliberately stays inert
+rather than being a hard error: that would turn a wrong notice into a
+broken store. Declare the boolean.
 
-Hyvä additionally guards the reverse skew with `method_exists()` against
-an older parent that lacks the registry method — a missing method means
-"no brand opinion", i.e. notice ON.
+Hyvä guards the reverse skew with `method_exists()` against a parent that
+lacks the registry method — a missing method means "no brand opinion",
+i.e. notice ON.
 
 The company-unknown copy variant always stays on the platform default.
 In practice it is unreachable: an order intent is only ever placed once
 the buyer's company name **and** company number are known.
 
-The notice is rendered by both storefront renderers as a persistent
-inline element with class `two-order-intent-message approved`, inside the
-payment-method tile. The same class name is used on the WooCommerce and
-PrestaShop plugins, so the four checkout surfaces stay greppable.
+Both Magento storefront renderers (Luma and Hyvä) emit the notice as a
+persistent inline element with class `two-order-intent-message approved`
+inside the payment-method tile, as does PrestaShop. WooCommerce uses
+`twoinc-intent-approved` instead, so grep for both when sweeping the four
+checkout surfaces.
 
 ### A warning about validation
 
@@ -253,27 +246,28 @@ short-circuits the synthesised section ordering.
 
 ## Worked example: adding a brand-driven field
 
-`surcharge_fixed_max` is the recipe for extending
+`surcharge_rounding_steps` is the reference implementation for extending
 `BrandRegistryInterface` with a new brand-driven value. Six touch
 points, in dependency order:
 
 1. **Schema** — `etc/brand.xsd`: add the element to `brandType`
    (optional, `minOccurs="0"`, so existing brand.xml files stay valid)
-   plus its complexType (attribute-pair idiom:
-   `<surcharge_fixed_max amount="25.0" currency="EUR"/>`).
+   plus its type. Constrain what you can there
+   (`surchargeRoundingStepsType` → `positiveDecimalType`), and document
+   the accepted values in an XSD comment.
 
 2. **Loader** — `Model/Brand/Loader.php` `buildDescriptor()`: parse the
    element, **normalise and validate** — because nothing validates the
-   xsd at runtime, a typo'd amount would otherwise coerce to `0.0` and
-   silently disable whatever the value drives. Throw `DomainException`
-   on malformed input. Pass the value as a constructor argument to
-   `Descriptor`.
+   xsd at runtime, a typo'd value would otherwise coerce to `0.0` and
+   silently disable whatever it drives. Throw `DomainException` naming
+   the brand.xml path, the element and the bad value. Pass the result as
+   a constructor argument to `Descriptor`.
 
 3. **Value object** — `Model/Brand/Descriptor.php`: append a readonly
-   constructor property + getter. Mirror the same getter on the legacy
-   `Model/Brand.php` value object — both implement
-   `BrandRegistryInterface` and must stay in lockstep until the legacy
-   interface is deleted (see the deprecation note in
+   constructor property + getter. Mirror the same getter on the
+   deprecated `Model/Brand.php` value object — both implement
+   `BrandRegistryInterface` and must stay in lockstep while that class
+   exists (see the deprecation note in
    `Brand/DescriptorBackedBrandRegistry.php`).
 
 4. **Interface + adapter** — `Api/BrandRegistryInterface.php`: declare
@@ -294,14 +288,18 @@ warning above), so verify the feature's observable behaviour after
 deploy.
 
 **brand.xml or the API?** Reserve brand.xml for values that are
-intrinsically brand-static (URLs, labels, payment terms, CSP origins).
-A value the platform owns and may change per merchant — the minimum
-order value is the canonical case — belongs in the Two API instead:
-the gate reads `GET /v1/merchant`'s `min_order_amount/currency/basis`
-via `Service/Order/MinimumOrderProvider` (TWO-24775), so the storefront
-and checkout-api can never disagree on the threshold. The brand.xml
-`<minimum_order>` element that originally shipped with TWO-24743 was
-removed in favour of that lookup.
+intrinsically brand-static: URLs, labels, CSP origins, admin-form shape.
+
+Anything the platform owns and may change per merchant comes from
+`GET /v1/merchant`, never brand.xml, so the storefront and checkout-api
+can never disagree:
+
+-   minimum order value — `min_order_amount/currency/basis`, read via
+    `Service/Order/MinimumOrderProvider` and enforced by
+    `Service/Order/MinimumOrderGate`;
+-   offerable payment terms — `available_terms`, read via
+    `Service/Merchant/SettingsProvider`;
+-   buyer-surcharge cap — `surcharge_limit`, same provider.
 
 ## Local development
 

--- a/docs/brand-overlay-guide.md
+++ b/docs/brand-overlay-guide.md
@@ -109,30 +109,30 @@ across modules). Elements may appear in any order (`xs:all`).
 
 **Elements**
 
-| Element                   | Required | Type                        | Controls                                                                                                                |
-| ------------------------- | -------- | --------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `provider`                | yes      | string                      | Short provider name (admin/UI copy).                                                                                    |
-| `provider_full_name`      | no       | string                      | Legal entity name.                                                                                                      |
-| `product_name`            | yes      | string                      | Customer-facing product name (checkout, emails, admin).                                                                 |
-| `tab_label`               | yes      | string                      | Admin Configuration tab label.                                                                                          |
-| `tab_css_class`           | no       | string                      | CSS class on the admin tab.                                                                                             |
-| `checkout_subtitle`       | no       | string                      | Subtitle under the method title at checkout.                                                                            |
-| `checkout_url_template`   | yes      | string                      | Hosted-checkout URL template (`https://%s.…`).                                                                          |
-| `brand_tag`               | no       | string                      | Checkout-page URL query param (`?brand=<tag>`). **Never sent in order bodies.**                                         |
-| `sign_up_url`             | no       | string                      | Merchant signup link in admin.                                                                                          |
-| `documentation_url`       | no       | string                      | Docs link in admin.                                                                                                     |
-| `api_base_url`            | yes      | string                      | Two API base for this brand.                                                                                            |
-| `surcharge_rounding_steps` | no      | `<step>` list               | Narrows the admin "Rounding Step" dropdown (major units, each `> 0`). Absent or empty inherits the parent default set. Values are deduped and sorted ascending. |
-| `csp_origins`             | no       | `<origin>` list             | Extra CSP origins.                                                                                                      |
-| `admin_resource`          | yes      | string                      | ACL resource gating the admin section.                                                                                  |
-| `module_label_chain`      | no       | `<module label="…">` list   | Admin Version-panel rows; rows for missing modules silently skip.                                                       |
-| `allowed_currencies`      | no       | `<currency>` list           | Currency allow-list.                                                                                                    |
-| `allowed_countries`       | no       | `<country>` list            | Country allow-list.                                                                                                     |
-| `extra_http_headers`      | no       | `<header name="…">` list    | Extra headers on API calls.                                                                                             |
-| `suppressed_fields`       | no       | `<field path="…">` list     | Hides admin controls for this brand (below).                                                                            |
-| `inline_term_fees`        | no       | boolean                     | Show per-term merchant fee beside Payment Terms checkboxes in admin (default true).                                     |
-| `intent_approved_notice_enabled` | no | `true` \| `false`      | On/off switch for the buyer-facing "order intent approved" notice. Default `true`. **See below.**                        |
-| `intent_approved_notice`  | no       | string                      | Copy override for that notice — wording only, **not** an off switch. **See below.**                                     |
+| Element                          | Required | Type                      | Controls                                                                                                                                                        |
+| -------------------------------- | -------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `provider`                       | yes      | string                    | Short provider name (admin/UI copy).                                                                                                                            |
+| `provider_full_name`             | no       | string                    | Legal entity name.                                                                                                                                              |
+| `product_name`                   | yes      | string                    | Customer-facing product name (checkout, emails, admin).                                                                                                         |
+| `tab_label`                      | yes      | string                    | Admin Configuration tab label.                                                                                                                                  |
+| `tab_css_class`                  | no       | string                    | CSS class on the admin tab.                                                                                                                                     |
+| `checkout_subtitle`              | no       | string                    | Subtitle under the method title at checkout.                                                                                                                    |
+| `checkout_url_template`          | yes      | string                    | Hosted-checkout URL template (`https://%s.…`).                                                                                                                  |
+| `brand_tag`                      | no       | string                    | Checkout-page URL query param (`?brand=<tag>`). **Never sent in order bodies.**                                                                                 |
+| `sign_up_url`                    | no       | string                    | Merchant signup link in admin.                                                                                                                                  |
+| `documentation_url`              | no       | string                    | Docs link in admin.                                                                                                                                             |
+| `api_base_url`                   | yes      | string                    | Two API base for this brand.                                                                                                                                    |
+| `surcharge_rounding_steps`       | no       | `<step>` list             | Narrows the admin "Rounding Step" dropdown (major units, each `> 0`). Absent or empty inherits the parent default set. Values are deduped and sorted ascending. |
+| `csp_origins`                    | no       | `<origin>` list           | Extra CSP origins.                                                                                                                                              |
+| `admin_resource`                 | yes      | string                    | ACL resource gating the admin section.                                                                                                                          |
+| `module_label_chain`             | no       | `<module label="…">` list | Admin Version-panel rows; rows for missing modules silently skip.                                                                                               |
+| `allowed_currencies`             | no       | `<currency>` list         | Currency allow-list.                                                                                                                                            |
+| `allowed_countries`              | no       | `<country>` list          | Country allow-list.                                                                                                                                             |
+| `extra_http_headers`             | no       | `<header name="…">` list  | Extra headers on API calls.                                                                                                                                     |
+| `suppressed_fields`              | no       | `<field path="…">` list   | Hides admin controls for this brand (below).                                                                                                                    |
+| `inline_term_fees`               | no       | boolean                   | Show per-term merchant fee beside Payment Terms checkboxes in admin (default true).                                                                             |
+| `intent_approved_notice_enabled` | no       | `true` \| `false`         | On/off switch for the buyer-facing "order intent approved" notice. Default `true`. **See below.**                                                               |
+| `intent_approved_notice`         | no       | string                    | Copy override for that notice — wording only, **not** an off switch. **See below.**                                                                             |
 
 ### The intent-approved notice — two keys, one each for on/off and wording
 
@@ -148,12 +148,12 @@ the notice back on.
 
 Explicit boolean only:
 
-| brand.xml                                                                | Behaviour                                                                                    |
-| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
-| `<intent_approved_notice_enabled>true</intent_approved_notice_enabled>`   | Notice **ON**.                                                                               |
-| `<intent_approved_notice_enabled>false</intent_approved_notice_enabled>`  | Notice **suppressed entirely** — no element is emitted into the DOM, not an empty wrapper.   |
-| element absent                                                           | Documented explicit default **`true`** (notice ON).                                          |
-| anything else (`1`, `0`, `yes`, empty, whitespace)                        | **Error.** Never a silent third behaviour.                                                   |
+| brand.xml                                                                | Behaviour                                                                                  |
+| ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| `<intent_approved_notice_enabled>true</intent_approved_notice_enabled>`  | Notice **ON**.                                                                             |
+| `<intent_approved_notice_enabled>false</intent_approved_notice_enabled>` | Notice **suppressed entirely** — no element is emitted into the DOM, not an empty wrapper. |
+| element absent                                                           | Documented explicit default **`true`** (notice ON).                                        |
+| anything else (`1`, `0`, `yes`, empty, whitespace)                       | **Error.** Never a silent third behaviour.                                                 |
 
 Absent-means-`true` is deliberate: it keeps a third-party overlay that
 declares nothing on ON. Base plugins declare `true` explicitly anyway, so
@@ -162,11 +162,11 @@ the file states its position rather than relying on omission.
 The invalid case is caught twice, because `brand.xsd` is not validated at
 runtime (see the validation warning below):
 
-* `brand.xsd` restricts the element to the enumeration `true|false`, so
-  developer-mode config validation fails loudly; and
-* `Model\Brand\Loader` throws a `\DomainException` naming the offending
-  `brand.xml` path, the element and the bad value — the same treatment
-  `<surcharge_rounding_steps>` gets in the same method.
+-   `brand.xsd` restricts the element to the enumeration `true|false`, so
+    developer-mode config validation fails loudly; and
+-   `Model\Brand\Loader` throws a `\DomainException` naming the offending
+    `brand.xml` path, the element and the bad value — the same treatment
+    `<surcharge_rounding_steps>` gets in the same method.
 
 Note `xs:boolean` is deliberately **not** used: it would also accept `1`
 and `0`, and this switch is meant to read as a decision.

--- a/docs/brand-overlay-guide.md
+++ b/docs/brand-overlay-guide.md
@@ -210,6 +210,14 @@ inside the payment-method tile, as does PrestaShop. WooCommerce uses
 `twoinc-intent-approved` instead, so grep for both when sweeping the four
 checkout surfaces.
 
+The two keys carry the same names and the same semantics on WooCommerce
+and PrestaShop, where they are real PHP booleans rather than an XSD
+enumeration. **The failure mode differs:** an invalid value throws here
+and is a logged error plus the default `true` there, because those
+resolvers run while rendering a buyer-facing checkout, where a white
+screen is worse than a notice that stays on. Don't assume Magento's
+throw when working across platforms.
+
 ### A warning about validation
 
 `brand.xsd` is enforced by CI/IDE tooling only — **nothing validates


### PR DESCRIPTION
Docs-only. No code change.

Doug's standing instruction: plugin docs must be **concise** and express **only how to work the current version** — no history, no migration narrative, no "historically there was X".

## Cut

- **The TWO-25213 → TWO-25218 before/after narrative** for the intent-approved-notice keys (~10 lines). The rule it was there to justify — two keys, one for on/off and one for wording, never one key with both meanings — stays, stated as a rule. How we got there does not.
- **`available_payment_terms` and `surcharge_fixed_max`** from the `brand.xml` schema table. `Model\Brand\Loader::buildDescriptor()` parses neither, `Descriptor` exposes a getter for neither, and no `brand.xml` in either repo declares them. `available_payment_terms` was additionally documented as **required**, which would have sent someone adding a dead element to a new overlay.
- **The `<minimum_order>` removal story** (which element shipped under which ticket and what replaced it) → replaced by the current rule plus the three values that actually come from `GET /v1/merchant`.
- Ticket IDs used purely as provenance for current behaviour.

## Fixed

- **`surcharge_rounding_steps` was missing from the schema table** entirely, despite being the one narrowing element a brand overlay is most likely to want.
- **The "adding a brand-driven field" worked example was built on the dead `surcharge_fixed_max`** — rebuilt on `surcharge_rounding_steps`, which is the live reference implementation for the same six touch points.
- **False cross-platform claim.** The guide said WooCommerce and PrestaShop share the `two-order-intent-message` class. PrestaShop does; WooCommerce renders `twoinc-intent-approved`. Both are now named, so a sweep of the four checkout surfaces actually finds all four.

## Deliberately kept

- The **merge-order warning** (`magento-plugin` → brand overlay → `magento-hyva-extension`), promoted from a subsection titled "Migration hazard" to plain "Deploy order". The parent owns the parsing; this is a live constraint, not history.
- **Empty-means-inert and why it is not a hard error.** Reads as history but is a live "do not change this" — making an empty copy element throw would turn a wrong notice into a broken store.
- The **Hyvä `method_exists()` reverse-skew guard**, the **runtime-validation warning** (nothing validates `brand.xsd` at runtime), and the **`Model/Brand.php` lockstep requirement** — all describe code that exists today.

## Related, not changed here

`etc/brand.xsd` still carries `available_payment_terms` and `surcharge_fixed_max` as `minOccurs="0"` with a comment keeping them "during the transition", plus the same TWO-25213 narrative in its `<intent_approved_notice>` comment. No `brand.xml` declares either element, so both could go — but that is a code change, out of scope for a docs sweep.

Linear: TWO-25225 (parent TWO-24739)

🤖 Generated with [Claude Code](https://claude.com/claude-code)