### PR TITLE
TWO-25228: default every optional checkout field to enabled

### DIFF
--- a/Test/Unit/Config/CheckoutFieldDefaultsTest.php
+++ b/Test/Unit/Config/CheckoutFieldDefaultsTest.php
@@ -1,0 +1,125 @@
+<?php
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Config;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Every optional checkout field ships enabled out of the box.
+ *
+ * These are *declared* defaults in etc/config.xml, which Magento consults
+ * only when no core_config_data row exists for the path and scope. A
+ * merchant who explicitly saved "No" has a row holding `0`, and that row
+ * still wins — so this test pins the out-of-box state without saying
+ * anything about shops that made an explicit choice.
+ *
+ * The values are asserted against the shipped XML rather than a runtime
+ * scope config so the test fails when someone edits config.xml, which is
+ * the change worth catching.
+ */
+class CheckoutFieldDefaultsTest extends TestCase
+{
+    /**
+     * Optional checkout-field toggles, as grouped under "Checkout Fields"
+     * in etc/adminhtml/system.xml.
+     */
+    private const OPTIONAL_FIELD_FLAGS = [
+        'enable_department',
+        'enable_project',
+        'enable_po_number',
+        'enable_order_note',
+        'enable_invoice_emails',
+    ];
+
+    /** @var \SimpleXMLElement */
+    private $twoPaymentDefaults;
+
+    protected function setUp(): void
+    {
+        $path = dirname(__DIR__, 3) . '/etc/config.xml';
+        self::assertFileExists($path, 'etc/config.xml is missing');
+
+        $xml = simplexml_load_file($path);
+        self::assertNotFalse($xml, 'etc/config.xml is not parseable XML');
+
+        $nodes = $xml->xpath('/config/default/payment/two_payment');
+        self::assertIsArray($nodes);
+        self::assertCount(1, $nodes, 'expected exactly one default/payment/two_payment node');
+
+        $this->twoPaymentDefaults = $nodes[0];
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function optionalFieldFlagProvider(): array
+    {
+        $cases = [];
+        foreach (self::OPTIONAL_FIELD_FLAGS as $flag) {
+            $cases[$flag] = [$flag];
+        }
+
+        return $cases;
+    }
+
+    /**
+     * @dataProvider optionalFieldFlagProvider
+     */
+    public function testOptionalCheckoutFieldDefaultsToEnabled(string $flag): void
+    {
+        $node = $this->twoPaymentDefaults->{$flag};
+
+        self::assertTrue(
+            isset($node),
+            sprintf(
+                '%s has no declared default. An unset flag reads as disabled, '
+                . 'so the field would silently vanish from checkout.',
+                $flag
+            )
+        );
+
+        self::assertSame(
+            '1',
+            (string)$node,
+            sprintf('%s must default to 1 so the field renders out of the box', $flag)
+        );
+    }
+
+    /**
+     * Guards the assumption the rest of this test rests on: that these five
+     * flags really are the complete "Checkout Fields" set, so a sixth
+     * optional field added later cannot default to off unnoticed.
+     */
+    public function testFlagListMatchesTheAdminCheckoutFieldsGroup(): void
+    {
+        $path = dirname(__DIR__, 3) . '/etc/adminhtml/system.xml';
+        self::assertFileExists($path, 'etc/adminhtml/system.xml is missing');
+
+        $xml = simplexml_load_file($path);
+        self::assertNotFalse($xml, 'etc/adminhtml/system.xml is not parseable XML');
+
+        $paths = $xml->xpath(
+            '/config/system/section[@id="two_payment"]/group[@id="checkout_fields"]/field/config_path'
+        );
+        self::assertIsArray($paths);
+        self::assertNotEmpty($paths, 'no fields found in the checkout_fields admin group');
+
+        $ids = [];
+        foreach ($paths as $path) {
+            $segments = explode('/', (string)$path);
+            $ids[] = end($segments);
+        }
+        sort($ids);
+
+        $expected = self::OPTIONAL_FIELD_FLAGS;
+        sort($expected);
+
+        self::assertSame(
+            $expected,
+            $ids,
+            'the checkout_fields admin group and OPTIONAL_FIELD_FLAGS have drifted; '
+            . 'add the new toggle to this test and give it a declared default'
+        );
+    }
+}

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -23,16 +23,16 @@
                 <merchant_minimum_order_basis>gross</merchant_minimum_order_basis>
                 <finalize_purchase>1</finalize_purchase>
                 <enable_order_intent>1</enable_order_intent>
-                <enable_invoice_emails>0</enable_invoice_emails>
+                <enable_invoice_emails>1</enable_invoice_emails>
                 <enable_tax_subtotals>1</enable_tax_subtotals>
                 <fulfill_trigger>shipment</fulfill_trigger>
                 <fulfill_order_status>complete</fulfill_order_status>
                 <enable_company_search>1</enable_company_search>
                 <enable_address_search>1</enable_address_search>
                 <enable_department>1</enable_department>
-                <enable_order_note>0</enable_order_note>
+                <enable_order_note>1</enable_order_note>
                 <enable_project>1</enable_project>
-                <enable_po_number>0</enable_po_number>
+                <enable_po_number>1</enable_po_number>
                 <payment_terms_type>standard</payment_terms_type>
                 <payment_terms_duration_days/>
                 <payment_terms>14,30,60,90</payment_terms>


### PR DESCRIPTION
Closes TWO-25228. Magento's share of the cross-platform optional-field alignment.

## What changes

Three declared defaults in `etc/config.xml`:

| Flag | Before | After |
| -- | -- | -- |
| `enable_department` | 1 | 1 (unchanged) |
| `enable_project` | 1 | 1 (unchanged) |
| `enable_po_number` | 0 | **1** |
| `enable_order_note` | 0 | **1** |
| `enable_invoice_emails` | 0 | **1** |

No config key is renamed. All five fields already exist in the payment tile on both Luma (`visible:`) and Hyvä (`x-show:`), each bound directly to its own flag, so nothing needed to change in a template to make them render.

## Explicit merchant choices are preserved — by Magento, not by us

`<default>` values are consulted only when no `core_config_data` row exists for the path and scope. A merchant who explicitly saved **No** in admin has a row holding `0`, and that row still wins over the new declared default. A merchant who never touched the field — or left *Use system value* ticked — has no row and picks up the new default.

So the unset-vs-explicit-`0` distinction is enforced by the platform's own resolution order and needs no data patch. Writing one would in fact be wrong: after the fact it cannot distinguish "merchant chose off" from "never configured", so it would have to guess at exactly the thing the absence of a row already tells us unambiguously.

**Accepted upgrade impact:** shops that never set these flags gain three fields at checkout on upgrade. Magento's bindings have no payment-method-selection gate (unlike WooCommerce's `toggleBusinessFields()`), so the fields appear as soon as the tile renders, not on method selection. This is intended and has been signed off.

Side effect: closes the `enable_po_number` drift between our two internal staging shops for the unset case.

## Order note stays in the tile — deliberate, with reasoning

The cross-platform rule is that the order note belongs with the primary address field. On Magento that is **already where it is**: the billing address form — the primary address for this payment method — renders *inside* the Two payment tile.

- `view/frontend/layout/checkout_index_index.xml` places `two_payment` under `billing-step > payment > renders` with `isBillingAddressRequired = true`
- `view/frontend/web/template/payment/gateway_method.html` renders `<div class="payment-method-billing-address">` with the billing form region as a child of the tile template
- `Plugin/Magento/Checkout/Block/LayoutProcessor/SynthesiseBrandRenderers.php` sets `isBillingAddressRequired => true` for synthesised brand renderers too

The only other address form on the page is the **shipping** address step. Moving the order note there would move it *away* from the primary address, not toward it — and would drop the field entirely on virtual and downloadable carts, which have no shipping step at all. It would also need a new `customer_address` EAV attribute plus data patch, a `LayoutProcessorPlugin` injection, new read logic in `updateAddress()`, a greenfield Hyvä Checkout `EntityFormModifier` that *adds* a field (the existing one only reorders), and cross-step plumbing to carry the value into the Magewire tile state.

Reading this as parity rather than an exception: the tile is where Magento renders the primary address.

## Test

`Test/Unit/Config/CheckoutFieldDefaultsTest.php` asserts the declared defaults against the shipped XML, and cross-checks the flag list against the admin *Checkout Fields* group so a sixth optional field cannot be added later and silently default to off.

Mutation-checked — each mutant killed:
- `enable_po_number` back to `0` → fails
- `enable_order_note` node deleted entirely → fails ("has no declared default")
- a sixth admin toggle added with no default → fails ("have drifted")

## Gates

- `phpunit` — **470 passed**, 823 assertions (464 pre-existing + 6 new)
- `phpcs` via `michielgerritsen/magento-coding-standard:latest --severity=6` — **clean**, 215 files
- `php -l` sweep as CI runs it — clean
- `phpstan` / `setup:di:compile` — not run locally (need a full Magento install). Both are unaffected by reasoning I'd rather state than hide: the diff adds no class, constructor or DI wiring, and `phpstan.neon` excludes `Test/*`, so the new file is outside its analysis set. CI runs both on this PR regardless.
- `npm run test:js` — not run; no JS or Knockout template was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)