### PR TITLE
TWO-25230/ci: bump the version on staging too, take the level from the convention

### DIFF
--- a/.github/scripts/decide-bump-level.sh
+++ b/.github/scripts/decide-bump-level.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+#
+# Decide the semantic-version bump level for a version-bump / release run.
+#
+# Convention:
+#   patch  — change landing anywhere other than `main` (i.e. `staging`)
+#   minor  — change landing on `main`
+#   major  — escape hatch. Two independent signals, the higher wins:
+#
+#     Declared  a root `.next-major` file whose first whitespace-delimited
+#               token is the target major, with a short human reason on the
+#               same line. Human-editable and reviewable in the PR that
+#               decides it, so a *planned* major with no single breaking
+#               commit still lands as a major:
+#
+#                   3  # overlay migration, 3.0.0 release
+#
+#     Discovered  a `!` on a conventional-commit type (`feat!:`,
+#                 `TWO-1/fix(scope)!:`) or a `BREAKING CHANGE:` footer in the
+#                 commits under consideration. Covers a break that actually
+#                 happened.
+#
+#   target = max(declared, current_major + (breaking ? 1 : 0))
+#   target > current_major  ->  major, new version is exactly <target>.0.0
+#   otherwise               ->  the branch rule above
+#
+# `.next-major` is deliberately NEVER cleared by CI. The `target >
+# current_major` condition disarms it on its own once the major has shipped,
+# and leaving the file in place keeps the declared intent reviewable. The one
+# thing this scheme can still get wrong is a declaration that has fallen
+# BEHIND the current major, so that is a hard failure (see below) rather than
+# a silent no-op.
+#
+# Usage:  decide-bump-level.sh <branch> [<git-rev-range>]
+#
+# With no range, it is derived as "everything not already accounted for" — see
+# the anchor list below. Deriving it carefully matters: a naive
+# `<last-tag>..HEAD` would re-discover the same breaking commit on every single
+# staging PR and major-bump over and over, because `staging` is only tagged
+# when it reaches `main`.
+#
+# Writes `level=`, `set_version=` and `reason=` to stdout as `key=value`
+# lines, and appends the same to $GITHUB_OUTPUT when running under Actions.
+# The full decision — including the declared reason string — is logged on
+# every run, so a stale `.next-major` is visible without digging.
+set -euo pipefail
+
+branch="${1:?usage: decide-bump-level.sh <branch> [<git-rev-range>]}"
+range="${2:-}"
+
+repo_root=$(git rev-parse --show-toplevel)
+toml="${repo_root}/bumpver.toml"
+[ -f "$toml" ] || { echo "::error::no bumpver.toml at ${toml}" >&2; exit 1; }
+
+current=$(sed -n 's/^[[:space:]]*current_version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$toml" | head -1)
+[ -n "$current" ] || { echo "::error::could not read current_version from ${toml}" >&2; exit 1; }
+current_major=${current%%.*}
+case "$current_major" in
+    '' | *[!0-9]*) echo "::error::unparseable current_version '${current}' in ${toml}" >&2; exit 1 ;;
+esac
+
+# --- derive the range, if not given ------------------------------------------
+#
+# The base is the closest-to-HEAD of three anchors, each meaning "everything
+# before this is already accounted for":
+#
+#   1. the last version-bump commit — the normal steady-state anchor;
+#   2. the newest semver tag reachable from HEAD — covers a release cut
+#      without a bump commit on this branch;
+#   3. the commit that first added THIS script — the activation floor.
+#
+# (3) is what stops the very first run from re-discovering years of already
+# shipped `feat!:` commits and jumping several majors. Without it, four of the
+# six plugin repos would have gone straight to 3.0.0 the moment this landed.
+# It costs nothing afterwards: once a bump commit exists it is always closer
+# to HEAD, so (1) takes over and (3) never binds again.
+if [ -z "$range" ]; then
+    # Subject prefix of a bump commit, taken from bumpver's own configured
+    # commit_message so the two can't drift — the capitalisation of "bump"
+    # is not consistent across repos, so it must not be hardcoded here.
+    bump_msg=$(sed -n 's/^[[:space:]]*commit_message[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$toml" | head -1)
+    bump_prefix=${bump_msg%%\{*}
+    bump_prefix=${bump_prefix%% }
+    [ -n "$bump_prefix" ] || bump_prefix="chore: Bump version"
+
+    self_rel=".github/scripts/decide-bump-level.sh"
+
+    candidates=""
+    add_candidate() {
+        [ -n "$1" ] || return 1
+        # Only anchors on this history are usable as a range base.
+        git merge-base --is-ancestor "$1" HEAD 2>/dev/null || return 1
+        candidates="${candidates}${1}
+"
+    }
+
+    add_candidate "$(git log -1 --format='%H' --fixed-strings --grep="$bump_prefix" HEAD || true)" || true
+    # Version-sorted, so the first tag that is actually reachable is the newest.
+    for t in $(git tag --list --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' || true); do
+        if add_candidate "$(git rev-parse -q --verify "refs/tags/${t}^{commit}" || true)"; then
+            break
+        fi
+    done
+    add_candidate "$(git -C "$repo_root" log --diff-filter=A --format='%H' -1 -- "$self_rel" || true)" || true
+
+    # Closest to HEAD wins — fewest commits between it and HEAD.
+    base=""
+    best=""
+    while IFS= read -r c; do
+        [ -n "$c" ] || continue
+        n=$(git rev-list --count "${c}..HEAD")
+        if [ -z "$best" ] || [ "$n" -lt "$best" ]; then
+            best="$n"
+            base="$c"
+        fi
+    done <<EOF
+${candidates}
+EOF
+
+    if [ -n "$base" ]; then
+        range="${base}..HEAD"
+    else
+        range="HEAD"
+    fi
+fi
+
+# --- signal 1: declared major -------------------------------------------------
+declared=0
+declared_reason=""
+next_major_file="${repo_root}/.next-major"
+if [ -f "$next_major_file" ]; then
+    raw=$(head -1 "$next_major_file")
+    declared=$(printf '%s' "$raw" | awk '{print $1}')
+    declared_reason=$(printf '%s' "$raw" | sed 's/^[^[:space:]]*[[:space:]]*//; s/^#[[:space:]]*//')
+    case "$declared" in
+        '' | *[!0-9]*)
+            echo "::error::.next-major must start with the target major version as a bare integer; got '${raw}'" >&2
+            exit 1
+            ;;
+    esac
+    # The failure mode this scheme can still get wrong: a declaration left
+    # behind by a major that has already shipped some other way. Silently
+    # ignoring it would let it rot; regressing to it would be worse. Fail.
+    if [ "$declared" -lt "$current_major" ]; then
+        echo "::error::.next-major declares major ${declared} but the current version is ${current} (major ${current_major}). A declaration below the current major is always stale — delete or raise it." >&2
+        exit 1
+    fi
+fi
+
+# --- signal 2: discovered breaking change ------------------------------------
+breaking=0
+breaking_reason=""
+subject_re='^([A-Z]+-[0-9]+/)?[a-z]+(\([^)]+\))?!:'
+footer_re='^BREAKING[ -]CHANGE:'
+
+while IFS= read -r subject; do
+    if printf '%s' "$subject" | grep -qE "$subject_re"; then
+        breaking=1
+        breaking_reason="$subject"
+        break
+    fi
+done < <(git log "$range" --no-merges --format='%s')
+
+if [ "$breaking" -eq 0 ]; then
+    footer=$(git log "$range" --no-merges --format='%B' | grep -m1 -E "$footer_re" || true)
+    if [ -n "$footer" ]; then
+        breaking=1
+        breaking_reason="$footer"
+    fi
+fi
+
+# --- combine ------------------------------------------------------------------
+discovered=$current_major
+[ "$breaking" -eq 1 ] && discovered=$((current_major + 1))
+
+target=$declared
+[ "$discovered" -gt "$target" ] && target=$discovered
+
+set_version=""
+if [ "$target" -gt "$current_major" ]; then
+    level=major
+    # `--set-version` rather than `--major`: a declaration may skip more than
+    # one major (current 2, declared 4), which `bumpver --major` cannot express.
+    set_version="${target}.0.0"
+    if [ "$declared" -ge "$target" ]; then
+        why="declared .next-major=${declared}"
+        [ -n "$declared_reason" ] && why="${why} (${declared_reason})"
+    else
+        why="discovered breaking change: ${breaking_reason}"
+    fi
+elif [ "$branch" = "main" ]; then
+    level=minor
+    why="branch rule: main -> minor"
+else
+    level=patch
+    why="branch rule: ${branch} -> patch"
+fi
+
+reason=$(printf '%s' "$why" | tr '\n' ' ')
+
+# Always log the whole decision, not just the outcome — a stale declaration or
+# an unexpected breaking commit is only visible if the inputs are printed too.
+{
+    echo "----- bump level decision -----"
+    echo "branch          : ${branch}"
+    echo "range           : ${range}"
+    echo "current version : ${current} (major ${current_major})"
+    if [ -f "$next_major_file" ]; then
+        echo "declared major  : ${declared}${declared_reason:+  — ${declared_reason}}"
+    else
+        echo "declared major  : (no .next-major)"
+    fi
+    echo "breaking commit : ${breaking_reason:-none}"
+    echo "target major    : ${target}"
+    echo "level           : ${level}${set_version:+  -> ${set_version}}"
+    echo "reason          : ${reason}"
+    echo "-------------------------------"
+} >&2
+
+echo "level=${level}"
+echo "set_version=${set_version}"
+echo "reason=${reason}"
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+        echo "level=${level}"
+        echo "set_version=${set_version}"
+        echo "reason=${reason}"
+    } >> "$GITHUB_OUTPUT"
+fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,37 @@
 name: Release
 
-# Triggered after CI completes on main, not on the raw push.
-# Release only fires when CI's conclusion is 'success' (gated below),
-# so a broken commit landing on main can't produce a tagged
-# Release page.
+# Triggered after CI completes on `main` or `staging`, not on the raw
+# push. Release only fires when CI's conclusion is 'success' (gated
+# below), so a broken commit landing on either branch can't produce a
+# version bump or a tagged Release page.
+#
+# Two outcomes from one job, keyed on which branch CI ran for:
+#
+#   staging — version-bump commit ONLY. No tag, no GitHub Release.
+#             The bump keeps the in-flight version moving so a staging
+#             install is always distinguishable from the last release.
+#   main    — version-bump commit + tag + GitHub Release, exactly the
+#             mechanics this workflow has always had.
+#
+# The bump LEVEL comes from `.github/scripts/decide-bump-level.sh`
+# (shared byte-identically across the Magento plugin repos): patch on
+# `staging`, minor on `main`, with a major escape hatch via a root
+# `.next-major` file or a `!` / `BREAKING CHANGE:` commit. The script
+# owns that decision — this workflow only consumes it.
 on:
   workflow_run:
     workflows: [CI]
     types: [completed]
-    branches: [main]
+    branches: [main, staging]
 
 permissions:
   contents: write
 
+# Per-branch concurrency group: a `main` release and a `staging` bump
+# are independent pieces of work and must not serialise behind each
+# other.
 concurrency:
-  group: release-main
+  group: release-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: false
 
 jobs:
@@ -24,14 +41,19 @@ jobs:
     # 1. CI must have succeeded on the same SHA. workflow_run fires
     #    on every CI completion (success/failure/cancelled); this
     #    `if:` filters to the green case.
-    # 2. Skip ourselves: bumpver's commit lands on main and triggers
-    #    another CI run; once that CI finishes, the release.yml
+    # 2. Skip ourselves: bumpver's commit lands on the branch and
+    #    triggers another CI run; once that CI finishes, the release.yml
     #    workflow_run fires again. Skip when the head commit message
-    #    is already a `chore: Bump version` commit.
+    #    is already a `chore: Bump version` commit. The prefix must
+    #    match bumpver.toml's `commit_message` exactly.
     #    (HEAD-already-tagged check below is the second guard.)
     if: |
       github.event.workflow_run.conclusion == 'success' &&
       !startsWith(github.event.workflow_run.head_commit.message, 'chore: Bump version')
+    env:
+      # The branch CI ran for — `main` or `staging`. Every step that
+      # needs to know which of the two behaviours applies reads this.
+      BRANCH: ${{ github.event.workflow_run.head_branch }}
     steps:
       - name: Mint GitHub App token
         id: app-token
@@ -43,24 +65,27 @@ jobs:
       - uses: actions/checkout@v7
         with:
           # Check out the branch (not the SHA) so HEAD lands on
-          # `main` rather than detached — bumpver's commit then
-          # advances the branch, and the later `git push origin
-          # main` actually pushes the bump.
-          ref: main
+          # `main` / `staging` rather than detached — bumpver's commit
+          # then advances the branch, and the later `git push origin
+          # "$BRANCH"` actually pushes the bump.
+          ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Should we release?
+      - name: Should we bump?
         # Two reasons to skip:
         # 1. Branch drift — workflow_run fires after CI completes,
-        #    but another commit could land on main in the small
-        #    window before release runs. If branch HEAD no longer
-        #    matches the SHA CI signed off on, the next CI cycle
-        #    will retry against the new tip.
-        # 2. Already tagged — re-runs on the same commit (or on
-        #    the bumpver commit itself) shouldn't produce a
-        #    duplicate release. Match bare numeric tags
-        #    (1.14.1 etc.) — the repo's established convention.
+        #    but another commit could land in the small window before
+        #    this job runs. If branch HEAD no longer matches the SHA
+        #    CI signed off on, the next CI cycle will retry against
+        #    the new tip.
+        # 2. Already tagged — re-runs on the same commit (or on the
+        #    bumpver commit itself) shouldn't produce a duplicate
+        #    release. Match bare numeric tags (1.14.1 etc.) — the
+        #    repo's established convention. This is also what makes
+        #    the merge-back safe: when a `main` release fast-forwards
+        #    into `staging`, staging's new tip already carries that
+        #    release's tag, so this correctly bumps nothing.
         id: gate
         env:
           PASSED_SHA: ${{ github.event.workflow_run.head_sha }}
@@ -68,7 +93,7 @@ jobs:
           set -euo pipefail
           actual=$(git rev-parse HEAD)
           if [ "$actual" != "$PASSED_SHA" ]; then
-            echo "::warning::main moved from ${PASSED_SHA} to ${actual} between CI and release. Skipping."
+            echo "::warning::${BRANCH} moved from ${PASSED_SHA} to ${actual} between CI and release. Skipping."
             echo "skip=1" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -96,18 +121,34 @@ jobs:
           git config user.name "two-inc-app[bot]"
           git config user.email "${{ vars.TWO_INC_APP_ID }}+two-inc-app[bot]@users.noreply.github.com"
 
-      - name: Decide bump level + build release notes
-        # Single pass over `<previous-numeric-tag>..HEAD`:
-        # - Buckets each non-merge commit into Breaking / Features /
-        #   Fixes / Internals / Other based on its conventional-commit
-        #   type, with optional Linear ticket prefix (e.g. CET-123/feat:).
-        # - Writes the bucketed list to release-notes.md so the GitHub
-        #   Release page reflects exactly what triggered the bump level
-        #   (any Breaking entries → major; any Features → minor; else
-        #   patch). Reading the notes makes the bump-level decision
-        #   visible without having to look at the workflow log.
+      - name: Decide bump level
+        # The branch decides: `staging` -> patch, `main` -> minor, with
+        # a major escape hatch the script owns (root `.next-major` file,
+        # or a `!` / `BREAKING CHANGE:` commit). Outputs `level`,
+        # `set_version` (non-empty only for a major) and `reason`, and
+        # logs the whole decision — inputs included — to the step log.
+        #
+        # The script derives its OWN commit range and is deliberately
+        # not given one. Its range is anchored on the last bump commit
+        # rather than the last tag, because `staging` is only tagged
+        # once it reaches `main`; a tag-anchored range would
+        # re-discover the same breaking commit on every staging bump.
+        # That makes it a DIFFERENT range from the previous-tag range
+        # the release notes below use, and the two must stay separate.
         if: steps.gate.outputs.skip == '0'
         id: bump
+        run: .github/scripts/decide-bump-level.sh "$BRANCH"
+
+      - name: Build release notes
+        # `main` only — `staging` cuts no GitHub Release, so it needs
+        # no notes. Single pass over `<previous-numeric-tag>..HEAD`,
+        # bucketing each non-merge commit into Breaking / Features /
+        # Fixes / Internals / Other by conventional-commit type, with
+        # optional Linear ticket prefix (e.g. CET-123/feat:). This is
+        # presentation only: the bump level no longer comes from which
+        # buckets are non-empty, it comes from the script above.
+        if: steps.gate.outputs.skip == '0' && env.BRANCH == 'main'
+        id: notes
         run: |
           set -euo pipefail
           prev=$(git tag --list --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
@@ -139,17 +180,6 @@ jobs:
             fi
           done < <(git log "$range" --no-merges --format='%h%x09%s')
 
-          # Bump level is the highest-severity bucket that's non-empty.
-          if [ -s /tmp/breaking ]; then
-            level=major
-          elif [ -s /tmp/features ]; then
-            level=minor
-          else
-            level=patch
-          fi
-          echo "level=$level" >> "$GITHUB_OUTPUT"
-          echo "Selected bump level: $level (range: $range)"
-
           # Render notes — only print sections that have entries.
           {
             [ -s /tmp/breaking ]  && { echo "## ⚠️ Breaking changes";  cat /tmp/breaking;  echo; }
@@ -176,7 +206,17 @@ jobs:
         if: steps.gate.outputs.skip == '0'
         env:
           LEVEL: ${{ steps.bump.outputs.level }}
-        run: bumpver update "--${LEVEL}" --no-tag-commit --no-push
+          SET_VERSION: ${{ steps.bump.outputs.set_version }}
+        run: |
+          set -euo pipefail
+          if [ -n "$SET_VERSION" ]; then
+            # `--set-version` rather than `--major`: a declared
+            # `.next-major` may skip more than one major (current 2,
+            # declared 4), which `bumpver --major` cannot express.
+            bumpver update --set-version "$SET_VERSION" --no-tag-commit --no-push
+          else
+            bumpver update "--${LEVEL}" --no-tag-commit --no-push
+          fi
 
       - name: Read new version
         if: steps.gate.outputs.skip == '0'
@@ -184,45 +224,56 @@ jobs:
         run: |
           new=$(bumpver show --environ | grep '^CURRENT_VERSION=' | cut -d= -f2)
           echo "new=$new" >> "$GITHUB_OUTPUT"
-          echo "Released $new"
+          echo "New version on ${BRANCH}: $new"
 
       - name: Append full-diff link to release notes
         # Now that the new version is known we can render a proper
         # <prev>..<new> link instead of leaving the right-hand side
         # blank (the prior shape rendered as "<prefix>-1.13.2..").
-        if: steps.gate.outputs.skip == '0'
+        # `main` only — the notes only exist there.
+        if: steps.gate.outputs.skip == '0' && env.BRANCH == 'main'
         env:
-          PREV: ${{ steps.bump.outputs.prev }}
+          PREV: ${{ steps.notes.outputs.prev }}
           NEW: ${{ steps.ver.outputs.new }}
         run: |
           if [ -n "$PREV" ]; then
             echo "**Full diff:** [\`${PREV}..${NEW}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/compare/${PREV}...${NEW})" >> release-notes.md
           fi
 
-      - name: Tag + push
+      - name: Push version bump
+        # Both branches: the bump commit is the entire deliverable on
+        # `staging`, and the first half of it on `main`.
         if: steps.gate.outputs.skip == '0'
+        run: |
+          set -euo pipefail
+          # checkout@v7 already wrote the App token into the remote
+          # URL, so this push fires downstream workflows as the App
+          # identity (not GITHUB_TOKEN).
+          git push origin "$BRANCH"
+
+      - name: Tag + push tag
+        # `main` only. `staging` gets a version-bump commit and nothing
+        # else — no tag, therefore no GitHub Release either.
+        if: steps.gate.outputs.skip == '0' && env.BRANCH == 'main'
         env:
           NEW: ${{ steps.ver.outputs.new }}
         run: |
           set -euo pipefail
           git tag -a "${NEW}" -m "Release v${NEW}"
-          # checkout@v5 already wrote the App token into the remote
-          # URL, so this push fires downstream workflows as the App
-          # identity (not GITHUB_TOKEN).
-          git push origin main
           git push origin "${NEW}"
 
       - name: Create GitHub Release
-        if: steps.gate.outputs.skip == '0'
+        # `main` only, for the same reason as the tag above.
+        if: steps.gate.outputs.skip == '0' && env.BRANCH == 'main'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           NEW: ${{ steps.ver.outputs.new }}
         run: |
           # Publishing the artifact is out of scope here — this just
           # cuts the tag and Release page. --notes-file points at the
-          # bucketed changelog rendered in the bump-level step, so the
-          # Release page mirrors exactly what triggered the bump
-          # (Breaking → major, Features → minor, else patch).
+          # bucketed changelog rendered in the release-notes step; the
+          # bump level itself is decided by
+          # .github/scripts/decide-bump-level.sh and logged there.
           gh release create "${NEW}" \
             --target main \
             --title "${NEW}" \

--- a/README.md
+++ b/README.md
@@ -199,25 +199,45 @@ make test-e2e TWO_API_KEY=<your-key>
 
 ## Releases
 
-Releases are cut automatically once CI passes on `main`.
+Version bumps happen automatically once CI passes on `staging` or `main`. Only `main` cuts a tag and a GitHub Release.
 
-### Tagging (automatic, gated on CI)
+### The version-bump convention
 
-`.github/workflows/release.yml` is triggered by the `CI` workflow completing on `main`. When CI's conclusion is `success`, it:
+The bump level is decided by the branch, not by the commits:
 
-1. Skips itself if the head commit is already a `chore: Bump version` commit, or if the SHA already carries a numeric tag.
-2. Reads conventional-commit types in `<previous-tag>..HEAD` to pick the bump level:
-   - `BREAKING CHANGE:` / `<type>!:` → **major**
-   - `feat:` → **minor**
-   - everything else → **patch**
+| Merge lands on | Bump | Also produces |
+|---|---|---|
+| `staging` | **patch** | nothing else — bump commit only |
+| `main` | **minor** | tag `X.Y.Z` + GitHub Release |
 
-   Linear ticket prefixes are supported (e.g. `INF-123/feat:`).
-3. Runs `bumpver update --<level> --no-tag-commit --no-push` to rewrite `composer.json`, `etc/config.xml`, and `bumpver.toml`.
-4. Tags `X.Y.Z` (bare numeric, matching the established tag convention), pushes the bump commit and tag under the org GitHub App identity, and creates a GitHub Release with a bucketed changelog (Breaking / Features / Fixes / Internals / Other) — so reading the Release page reveals at a glance why the bump was a major / minor / patch.
+A **major** is an explicit escape hatch, and overrides the branch rule on either branch. Two independent signals, the higher wins:
 
-`.github/workflows/merge-back.yml` keeps `develop` fast-forwarded to match `main` after each release. `.github/workflows/auto-pr.yml` keeps a rolling sync PR open from `develop` to `main` with a preview of the next release notes — the same bucketing the actual Release page uses.
+- **Declared** — a root `.next-major` file whose first whitespace-delimited token is the target major, with a short human reason on the same line:
 
-To trigger a release, merge the rolling sync PR into `main`. CI runs on the merged commit; once green, `release.yml` fires.
+  ```
+  3  # overlay migration, 3.0.0 release
+  ```
+
+  Reviewable in the PR that decides it, so a *planned* major with no single breaking commit still lands as a major. The file is never cleared by CI: it disarms itself once the current major reaches the declared one. A declaration that has fallen *below* the current major is a hard CI failure — delete or raise it.
+
+- **Discovered** — a `!` on a conventional-commit type (`feat!:`, `TWO-1/fix(scope)!:`) or a `BREAKING CHANGE:` footer in the commits under consideration.
+
+The new version for a major is exactly `<target>.0.0`, so a declaration may skip more than one major.
+
+`.github/scripts/decide-bump-level.sh` owns this decision and is shared byte-identically across the Magento plugin repos. It logs the full decision — inputs included — to the workflow log on every run.
+
+### Bumping and tagging (automatic, gated on CI)
+
+`.github/workflows/release.yml` is triggered by the `CI` workflow completing on `main` or `staging`. When CI's conclusion is `success`, it:
+
+1. Skips itself if the head commit is already a `chore: Bump version` commit, if the branch tip drifted from the SHA CI signed off on, or if the SHA already carries a numeric tag. (That last check is what makes the merge-back a no-op: after a `main` release fast-forwards into `staging`, staging's tip already carries the tag.)
+2. Calls `.github/scripts/decide-bump-level.sh "$BRANCH"` for the level.
+3. Runs `bumpver update --<level> --no-tag-commit --no-push` (or `--set-version <N>.0.0` for a major) to rewrite `composer.json`, `etc/config.xml`, and `bumpver.toml`, and pushes the bump commit under the org GitHub App identity.
+4. **`main` only:** tags `X.Y.Z` (bare numeric, matching the established tag convention), pushes the tag, and creates a GitHub Release with a bucketed changelog (Breaking / Features / Fixes / Internals / Other). The buckets are presentation only now — the level comes from step 2.
+
+`.github/workflows/merge-back.yml` keeps `staging` fast-forwarded to match `main` after each release (falling back to a sync PR if the two have diverged).
+
+To trigger a release, merge `staging` into `main`. CI runs on the merged commit; once green, `release.yml` fires.
 
 ## Links
 


### PR DESCRIPTION
## What changed

`release.yml` now fires on **`staging`** as well as `main`, and takes its bump level from a
shared script instead of its own inline conventional-commit bucketing.

| CI ran green on | Bump      | Also produces |
| --------------- | --------- | ------------- |
| `staging`       | **patch** | nothing else — bump commit only |
| `main`          | **minor** | tag + GitHub Release — exactly the mechanics it always had |

The behaviour change is `staging`: these repos did not bump on it **at all**, so the
declared version sat still while `staging` ran a hundred-plus commits ahead of it.

Existing tag / push / Release mechanics on `main` are untouched — they are now simply
gated on `env.BRANCH == 'main'`. `staging` gets a version-bump commit and nothing else.

## The major escape hatch

`.github/scripts/decide-bump-level.sh` (new, **byte-identical in all six Two plugin
repos** — verified by sha256). Dependency-free shell. Emits `level=` / `set_version=` /
`reason=`, and logs its full input set on every run, so a stale declaration is visible
without digging.

Two independent signals, higher wins:

- **Declared** — a root `.next-major` file whose first token is the target major, with a
  short reason on the same line (`3  # <why>`). Covers a *planned* major that no single
  commit happens to mark, and is reviewable in the PR that decides it. Deliberately
  **never cleared** — the `target > current_major` condition disarms it by itself.
- **Discovered** — a `!` on a conventional-commit type or a `BREAKING CHANGE:` footer.

`target = max(declared, current_major + (breaking ? 1 : 0))`. A `.next-major` naming a
major **below** the current version is a **hard job failure**, not a silent no-op — that is
the one failure mode this scheme can still get wrong, so it fails loudly. The bump uses
`--set-version <target>.0.0` rather than `--major`, because a declaration may skip more
than one major and `--major` cannot express that.

## Two details worth a reviewer's eye

**1. Two different commit ranges, deliberately not unified.** The release notes keep their
`<previous-tag>..HEAD` range. The *level* decision uses a range the script derives itself,
anchored on the last **bump commit** rather than the last tag. That matters because
`staging` is only tagged once it reaches `main` — a tag-anchored range would re-discover
the same breaking commit on every single staging bump and major-bump repeatedly.

**2. The activation floor.** The script's range base is the closest-to-HEAD of three
anchors: last bump commit, newest reachable semver tag, and **the commit that first added
the script itself**. That third anchor is why the first run doesn't re-discover already
shipped `feat!:` commits and jump majors — without it, four of the six plugin repos would
have gone straight to `3.0.0` the moment this landed. It stops binding as soon as a real
bump commit exists.

The `HEAD already tagged` gate is left unconditional, which is also what keeps the
merge-back safe: when a `main` release fast-forwards into `staging`, staging's new tip
already carries that release's tag, so this correctly bumps nothing.

## Verification

Real local output, no paraphrase. Level selection:

```
staging  -> level=patch  reason=branch rule: staging -> patch
main     -> level=minor  reason=branch rule: main -> minor
.next-major containing "4" -> level=major  set_version=4.0.0
```

The stale-declaration guard bites:

```
$ printf '1  # stale\n' > .next-major
$ .github/scripts/decide-bump-level.sh staging; echo "exit=$?"
::error::.next-major declares major 1 but the current version is 2.1.2 (major 2).
A declaration below the current major is always stale — delete or raise it.
exit=1
```

`bumpver update --dry` at each level, showing the real file edits:

```
--patch              -> 2.1.3   (bumpver.toml + composer.json + etc/config.xml)
--minor              -> 2.2.0   (same three files)
--set-version 4.0.0  -> 4.0.0   (same three files)
```

No `.next-major` is seeded or committed in this repo — the temporary ones above were
deleted, and the tree is clean. **No tag was created and no release was cut while
testing** (`--dry` throughout).

---
Refs [TWO-25230](https://linear.app/two-inc/issue/TWO-25230) (parent TWO-24739).
Raised by Claude.
