### PR TITLE
fix(firecheckout): stack term chips below their label

### DIFF
--- a/view/frontend/web/css/style.css
+++ b/view/frontend/web/css/style.css
@@ -391,6 +391,24 @@
 }
 
 /*
+ * Theme specific css for fire checkout on the payment term chips.
+ *
+ * Fire Checkout lays every `.field` inside its one-page checkout form out as a
+ * label/control row rather than the stacked block layout Luma and Hyva use, so
+ * the chip container is pulled up onto the same line as the "Selected payment
+ * terms" label. Making the field itself a column flex container puts the
+ * container back below the label, and — because float is ignored on a flex
+ * item — it neutralises the row layout whether Fire achieves it by floating
+ * the label or by flexing the field. No `!important` needed: this changes the
+ * `.field` wrapper's own formatting context rather than fighting Fire's rules
+ * on the label.
+ */
+.firecheckout .two-term-chips {
+    display: flex;
+    flex-direction: column;
+}
+
+/*
  * Persistent "order intent approved" notice, rendered inline inside the
  * payment tile (see view/frontend/web/template/payment/gateway_method.html).
  * Replaces the transient checkout message-region treatment, which checkout


### PR DESCRIPTION
## Problem

In Fire Checkout only, `.two-term-chips__container` renders on the **same line** as the "Selected payment terms" label. It should sit below it. Luma and Hyva render correctly.

## Cause

Fire Checkout lays out every `.field` inside its one-page checkout form as a label/control row, rather than the stacked block layout Luma and Hyva use. Our markup (`view/frontend/web/template/payment/gateway_method.html:25-29`) is a bare `<div class="field two-term-chips">` holding a `<label class="label">` followed by the chip container, with no `.control` wrapper — so Fire's row layout pulls the container up alongside the label.

## Fix

One rule, scoped to the `.firecheckout` body class:

```css
.firecheckout .two-term-chips {
    display: flex;
    flex-direction: column;
}
```

- Column flex restores the stacked order.
- Because `float` is ignored on flex items, this neutralises the row layout whether Fire builds it by floating the label or by flexing the field — it does not depend on which mechanism is in play.
- No `!important`: this changes the wrapper's own formatting context instead of fighting Fire's rules on the label, so there is no specificity race.

## Scope / regression risk

There is one shared `view/frontend/web/css/style.css` for all three checkouts, so the fix is gated on the `.firecheckout` body class — the same convention the existing `select2` overrides in that file use (added in CET-450). Luma and Hyva never match the selector and are untouched.

## Verification

**Not visually verified** — no browser available in this session. Please confirm on a Fire Checkout shop: select Two as the payment method with multiple payment terms available, and check the term chips now render on the line below the "Selected payment terms" label, wrapping normally. Worth a quick spot-check on Luma and Hyva to confirm no movement there.

---
Raised by Claude.