### PR TITLE
fix(TWO-25233): company-search timeout, degraded-state UX and re-render safety

### DIFF
--- a/Test/Js/amd-harness.js
+++ b/Test/Js/amd-harness.js
@@ -112,9 +112,16 @@ function defaultMocks() {
         // behaviour load the real module and pass it via extraMocks so
         // they control the jQuery it closes over.
         'Two_Gateway/js/model/company-search': {
+            REQUEST_TIMEOUT_MS: 30000,
+            SEARCH_DEBOUNCE_MS: 300,
             buildSearchAjaxOptions: function () { return {}; },
             lookupCompanyAddress: function () { return null; },
-            applyAddress: function () {}
+            applyAddress: function () {},
+            isDegradedResponse: function () { return false; },
+            clearResultCache: function () {},
+            getSearchFieldContainer: function () { return null; },
+            setSearching: function () {},
+            setUnavailable: function () {}
         },
         'Two_Gateway/js/model/brand-config': (function () {
             function getBrandConfig(code) {

--- a/Test/Js/company-search-resilience.test.js
+++ b/Test/Js/company-search-resilience.test.js
@@ -1,0 +1,567 @@
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ *
+ * TWO-25233. Company search had no request timeout, no way to tell a
+ * failed search from a genuinely empty one, no result cache, and a
+ * select2 binding that duplicated itself every time a one-page checkout
+ * re-rendered. These tests pin all four.
+ */
+
+'use strict';
+
+const { loadAmdModule } = require('./amd-harness');
+
+const BASE_CONFIG = {
+    checkoutApiUrl: 'https://api.example.test',
+    companySearchLimit: 50,
+    isCompanySearchEnabled: true,
+    isAddressSearchEnabled: true
+};
+
+const SEARCH_RESPONSE = {
+    items: [
+        {
+            name: 'Example Trading Ltd',
+            highlight: '<em>Example</em> Trading Ltd',
+            national_identifier: { id: '12345678' },
+            lookup_id: 'lookup-abc-123'
+        }
+    ]
+};
+
+/**
+ * jQuery double whose `$.ajax` hands back a jqXHR the test settles by
+ * hand, so each failure mode (done / timeout / abort) can be driven
+ * explicitly rather than inferred.
+ */
+function makeQueryDouble() {
+    const recorder = {
+        ajax: [],
+        requests: [],
+        asyncCallbacks: [],
+        select2Calls: [],
+        appended: [],
+        removed: [],
+        boundData: {}
+    };
+
+    function $(selector) {
+        const obj = {
+            length: selector === '.select2-search--dropdown' ? 1 : 0,
+            val: function () {
+                return obj;
+            },
+            trigger: function () {
+                return obj;
+            },
+            prop: function () {
+                return obj;
+            },
+            text: function () {
+                return obj;
+            },
+            attr: function () {
+                return obj;
+            },
+            data: function (key) {
+                return recorder.boundData[key];
+            },
+            closest: function () {
+                return obj;
+            },
+            find: function () {
+                return obj;
+            },
+            append: function (html) {
+                recorder.appended.push(html);
+                return obj;
+            },
+            remove: function () {
+                recorder.removed.push(selector);
+                return obj;
+            },
+            hide: function () {
+                return obj;
+            },
+            show: function () {
+                return obj;
+            },
+            select2: function (opts) {
+                if (typeof opts === 'object') {
+                    recorder.select2Calls.push(opts);
+                    // Mirror select2: once bound, the widget instance is
+                    // discoverable through `.data('select2')`.
+                    recorder.boundData.select2 = { $dropdown: null };
+                }
+                return obj;
+            },
+            on: function () {
+                return obj;
+            }
+        };
+        return obj;
+    }
+
+    $.async = function (selector, fn) {
+        recorder.asyncCallbacks.push(fn);
+        fn(selector);
+    };
+    $.ajax = function (opts) {
+        recorder.ajax.push(opts);
+        const handlers = { done: [], fail: [], always: [] };
+        const jqxhr = {
+            aborted: false,
+            done: function (cb) {
+                handlers.done.push(cb);
+                return jqxhr;
+            },
+            fail: function (cb) {
+                handlers.fail.push(cb);
+                return jqxhr;
+            },
+            always: function (cb) {
+                handlers.always.push(cb);
+                return jqxhr;
+            },
+            abort: function () {
+                jqxhr.aborted = true;
+            },
+            settleDone: function (data) {
+                handlers.done.forEach(function (cb) {
+                    cb(data);
+                });
+                handlers.always.forEach(function (cb) {
+                    cb();
+                });
+            },
+            settleFail: function (textStatus) {
+                handlers.fail.forEach(function (cb) {
+                    cb({}, textStatus);
+                });
+                handlers.always.forEach(function (cb) {
+                    cb();
+                });
+            }
+        };
+        recorder.requests.push(jqxhr);
+        return jqxhr;
+    };
+    $.mage = {
+        cookies: {
+            get: function () {
+                return null;
+            }
+        },
+        redirect: function () {}
+    };
+    $.Deferred = function () {
+        const d = {
+            resolve: function () {
+                return d;
+            },
+            promise: function () {
+                return d;
+            },
+            done: function () {
+                return d;
+            },
+            fail: function () {
+                return d;
+            },
+            always: function () {
+                return d;
+            }
+        };
+        return d;
+    };
+    $.extend = Object.assign;
+    $.fn = {};
+
+    return { $: $, recorder: recorder };
+}
+
+function loadCompanySearch($) {
+    return loadAmdModule('view/frontend/web/js/model/company-search.js', { jquery: $ });
+}
+
+/** Observed onSearching / onUnavailable calls for one search. */
+function makeHooks() {
+    const calls = { searching: [], unavailable: [] };
+    return {
+        calls: calls,
+        onSearching: function (v) {
+            calls.searching.push(v);
+        },
+        onUnavailable: function (v) {
+            calls.unavailable.push(v);
+        }
+    };
+}
+
+function buildOptions(companySearch, hooks) {
+    return companySearch.buildSearchAjaxOptions({
+        config: BASE_CONFIG,
+        getCountryCode: function () {
+            return 'gb';
+        },
+        onSearching: hooks.onSearching,
+        onUnavailable: hooks.onUnavailable
+    });
+}
+
+/** Wait one macrotask, so the cache's deferred success callback runs. */
+function nextTick() {
+    return new Promise(function (resolve) {
+        setTimeout(resolve, 1);
+    });
+}
+
+describe('request envelope', () => {
+    test('search carries a 30s timeout and a 300ms debounce', () => {
+        const { $ } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+        const ajaxOptions = buildOptions(companySearch, makeHooks());
+
+        // 30s deliberately clears the server's stop_after_delay(10) retry
+        // envelope — the client must not give up while the API is still
+        // retrying.
+        expect(ajaxOptions.timeout).toBe(30000);
+        expect(companySearch.REQUEST_TIMEOUT_MS).toBe(30000);
+
+        // 300ms is the value shared with the WooCommerce and PrestaShop
+        // pickers.
+        expect(ajaxOptions.delay).toBe(300);
+        expect(companySearch.SEARCH_DEBOUNCE_MS).toBe(300);
+    });
+
+    test('the company-detail lookup carries the same timeout', () => {
+        const { $, recorder } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+
+        companySearch.lookupCompanyAddress(BASE_CONFIG, { lookupId: 'lookup-abc-123' });
+
+        expect(recorder.ajax).toHaveLength(1);
+        expect(recorder.ajax[0].timeout).toBe(30000);
+    });
+});
+
+describe('failure is not "no companies found"', () => {
+    test('a timeout raises the unavailable affordance', () => {
+        const { $, recorder } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+        const hooks = makeHooks();
+        const ajaxOptions = buildOptions(companySearch, hooks);
+        const failure = jest.fn();
+
+        ajaxOptions.transport({ url: 'https://api.example.test/x?q=exa' }, jest.fn(), failure);
+        recorder.requests[0].settleFail('timeout');
+
+        expect(hooks.calls.unavailable).toEqual([false, true]);
+        expect(hooks.calls.searching).toEqual([true, false]);
+        expect(failure).toHaveBeenCalled();
+    });
+
+    test('a network error raises the unavailable affordance', () => {
+        const { $, recorder } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+        const hooks = makeHooks();
+        const ajaxOptions = buildOptions(companySearch, hooks);
+
+        ajaxOptions.transport({ url: 'https://api.example.test/x?q=exa' }, jest.fn(), jest.fn());
+        recorder.requests[0].settleFail('error');
+
+        expect(hooks.calls.unavailable).toContain(true);
+    });
+
+    test('a genuine abort stays silent', () => {
+        const { $, recorder } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+        const hooks = makeHooks();
+        const ajaxOptions = buildOptions(companySearch, hooks);
+
+        ajaxOptions.transport({ url: 'https://api.example.test/x?q=exa' }, jest.fn(), jest.fn());
+        recorder.requests[0].settleFail('abort');
+
+        // An abort is the buyer typing on, or the widget being torn down.
+        // Showing an error for that would be noise on every keystroke.
+        expect(hooks.calls.unavailable).toEqual([false]);
+        // The spinner still has to come down.
+        expect(hooks.calls.searching).toEqual([true, false]);
+    });
+
+    test('a healthy response raises nothing', () => {
+        const { $, recorder } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+        const hooks = makeHooks();
+        const ajaxOptions = buildOptions(companySearch, hooks);
+        const success = jest.fn();
+
+        ajaxOptions.transport({ url: 'https://api.example.test/x?q=exa' }, success, jest.fn());
+        recorder.requests[0].settleDone(SEARCH_RESPONSE);
+
+        expect(success).toHaveBeenCalledWith(SEARCH_RESPONSE);
+        expect(hooks.calls.unavailable).toEqual([false]);
+    });
+});
+
+describe('degraded flag', () => {
+    test('degraded: true raises the unavailable affordance on an HTTP 200', () => {
+        const { $, recorder } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+        const hooks = makeHooks();
+        const ajaxOptions = buildOptions(companySearch, hooks);
+        const success = jest.fn();
+
+        ajaxOptions.transport({ url: 'https://api.example.test/x?q=exa' }, success, jest.fn());
+        recorder.requests[0].settleDone({ items: [], degraded: true });
+
+        expect(hooks.calls.unavailable).toEqual([false, true]);
+        // Still a success as far as select2 is concerned — whatever partial
+        // results came back are shown alongside the notice.
+        expect(success).toHaveBeenCalled();
+    });
+
+    test('an absent degraded field means not degraded', () => {
+        const { $, recorder } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+        const hooks = makeHooks();
+        const ajaxOptions = buildOptions(companySearch, hooks);
+
+        // The API field may not be deployed yet, so today's payload shape
+        // must keep working untouched.
+        ajaxOptions.transport({ url: 'https://api.example.test/x?q=exa' }, jest.fn(), jest.fn());
+        recorder.requests[0].settleDone(SEARCH_RESPONSE);
+
+        expect(hooks.calls.unavailable).toEqual([false]);
+    });
+
+    test('isDegradedResponse only accepts a real boolean true', () => {
+        const { $ } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+
+        expect(companySearch.isDegradedResponse({ degraded: true })).toBe(true);
+        expect(companySearch.isDegradedResponse({ degraded: false })).toBe(false);
+        expect(companySearch.isDegradedResponse({})).toBe(false);
+        expect(companySearch.isDegradedResponse(null)).toBe(false);
+        expect(companySearch.isDegradedResponse(undefined)).toBe(false);
+        // Truthy-but-not-true values must not trip the affordance.
+        expect(companySearch.isDegradedResponse({ degraded: 'false' })).toBe(false);
+        expect(companySearch.isDegradedResponse({ degraded: 1 })).toBe(false);
+    });
+
+    test('a degraded response is never cached', async () => {
+        const { $, recorder } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+        const ajaxOptions = buildOptions(companySearch, makeHooks());
+        const url = 'https://api.example.test/x?q=exa';
+
+        ajaxOptions.transport({ url: url }, jest.fn(), jest.fn());
+        recorder.requests[0].settleDone({ items: [], degraded: true });
+
+        // Caching a transient upstream failure would pin the buyer to an
+        // empty result set for the rest of the session.
+        ajaxOptions.transport({ url: url }, jest.fn(), jest.fn());
+        await nextTick();
+        expect(recorder.ajax).toHaveLength(2);
+    });
+});
+
+describe('result cache', () => {
+    test('a repeated search is answered without a second request', async () => {
+        const { $, recorder } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+        const ajaxOptions = buildOptions(companySearch, makeHooks());
+        const url = 'https://api.example.test/companies/v2/company?country=GB&q=exa';
+
+        ajaxOptions.transport({ url: url }, jest.fn(), jest.fn());
+        recorder.requests[0].settleDone(SEARCH_RESPONSE);
+
+        const secondSuccess = jest.fn();
+        ajaxOptions.transport({ url: url }, secondSuccess, jest.fn());
+        await nextTick();
+
+        expect(recorder.ajax).toHaveLength(1);
+        expect(secondSuccess).toHaveBeenCalledWith(SEARCH_RESPONSE);
+    });
+
+    test('the cache is keyed by url, so a different query still fetches', async () => {
+        const { $, recorder } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+        const ajaxOptions = buildOptions(companySearch, makeHooks());
+
+        ajaxOptions.transport({ url: 'https://api.example.test/c?q=exa' }, jest.fn(), jest.fn());
+        recorder.requests[0].settleDone(SEARCH_RESPONSE);
+        ajaxOptions.transport({ url: 'https://api.example.test/c?q=exam' }, jest.fn(), jest.fn());
+        await nextTick();
+
+        expect(recorder.ajax).toHaveLength(2);
+    });
+
+    test('the cache survives a rebuilt ajax options block', async () => {
+        const { $, recorder } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+        const url = 'https://api.example.test/c?q=exa';
+
+        // A one-page checkout re-render destroys the select2 widget and
+        // builds a fresh options block. The cache is module-scoped
+        // precisely so the buyer doesn't pay for the same search twice.
+        buildOptions(companySearch, makeHooks()).transport({ url: url }, jest.fn(), jest.fn());
+        recorder.requests[0].settleDone(SEARCH_RESPONSE);
+
+        const success = jest.fn();
+        buildOptions(companySearch, makeHooks()).transport({ url: url }, success, jest.fn());
+        await nextTick();
+
+        expect(recorder.ajax).toHaveLength(1);
+        expect(success).toHaveBeenCalledWith(SEARCH_RESPONSE);
+    });
+
+    test('aborting a cache hit suppresses its success callback', async () => {
+        const { $, recorder } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+        const ajaxOptions = buildOptions(companySearch, makeHooks());
+        const url = 'https://api.example.test/c?q=exa';
+
+        ajaxOptions.transport({ url: url }, jest.fn(), jest.fn());
+        recorder.requests[0].settleDone(SEARCH_RESPONSE);
+
+        const success = jest.fn();
+        const handle = ajaxOptions.transport({ url: url }, success, jest.fn());
+        handle.abort();
+        await nextTick();
+
+        // select2 aborts the in-flight search when the next keystroke
+        // supersedes it; a cache hit must honour that too, or a stale query
+        // repopulates the dropdown.
+        expect(success).not.toHaveBeenCalled();
+    });
+
+    test('clearResultCache forces a refetch', async () => {
+        const { $, recorder } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+        const ajaxOptions = buildOptions(companySearch, makeHooks());
+        const url = 'https://api.example.test/c?q=exa';
+
+        ajaxOptions.transport({ url: url }, jest.fn(), jest.fn());
+        recorder.requests[0].settleDone(SEARCH_RESPONSE);
+        companySearch.clearResultCache();
+        ajaxOptions.transport({ url: url }, jest.fn(), jest.fn());
+        await nextTick();
+
+        expect(recorder.ajax).toHaveLength(2);
+    });
+});
+
+describe('processResults robustness', () => {
+    test('a payload with no items yields no results instead of throwing', () => {
+        const { $ } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+        const ajaxOptions = buildOptions(companySearch, makeHooks());
+
+        // A degraded response can legitimately arrive with `items` absent.
+        expect(ajaxOptions.processResults({}).results).toEqual([]);
+        expect(ajaxOptions.processResults({ degraded: true }).results).toEqual([]);
+    });
+});
+
+describe('in-field chrome', () => {
+    test('spinner and notice are no-ops when the widget is not bound', () => {
+        const { $, recorder } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+
+        // `.data('select2')` is undefined before select2 binds — the chrome
+        // must not throw or leak markup into the page in that window.
+        companySearch.setSearching('input#company_name', true);
+        companySearch.setUnavailable('input#company_name', true);
+
+        expect(recorder.appended).toHaveLength(0);
+    });
+});
+
+describe('re-render safety of the select2 binding', () => {
+    /**
+     * `$.async` is a MutationObserver and every enableCompanySearch() call
+     * adds another one, so on a one-page checkout the callback fires
+     * repeatedly for the same node. Binding twice leaves a duplicate widget
+     * whose in-flight XHR resolves into a dropdown the buyer can't see.
+     */
+    function assertBindsOnce(loadRenderer) {
+        const { $, recorder } = makeQueryDouble();
+        const ctx = loadRenderer($, recorder);
+
+        ctx.enableCompanySearch();
+        expect(recorder.select2Calls).toHaveLength(1);
+
+        // Fire every registered observer callback again, as a re-render does.
+        recorder.asyncCallbacks.forEach(function (fn) {
+            fn('input#company_name');
+        });
+        // And re-run the whole enable path, as a re-rendered renderer does.
+        ctx.enableCompanySearch();
+
+        expect(recorder.select2Calls).toHaveLength(1);
+    }
+
+    test('payment-step picker binds select2 exactly once per node', () => {
+        assertBindsOnce(function ($) {
+            const companySearch = loadCompanySearch($);
+            const component = loadAmdModule(
+                'view/frontend/web/js/view/payment/method-renderer/gateway_method.js',
+                { jquery: $, 'Two_Gateway/js/model/company-search': companySearch }
+            );
+            return Object.assign(Object.create(component.prototype || {}), {
+                companyNameSelector: 'input#company_name',
+                companyIdSelector: 'input#company_id',
+                enterDetailsManuallyButton: '#billing_enter_details_manually',
+                searchForCompanyButton: '#billing_search_for_company',
+                enterDetailsManuallyText: 'Enter details manually',
+                searchForCompanyText: 'Search for company',
+                _brandConfig: BASE_CONFIG,
+                countryCode: function () {
+                    return 'gb';
+                },
+                companyName: function () {
+                    return '';
+                },
+                fillCompanyData: function () {},
+                addressLookup: component.addressLookup,
+                enableCompanySearch: component.enableCompanySearch
+            });
+        });
+    });
+
+    test('shipping-step picker binds select2 exactly once per node', () => {
+        assertBindsOnce(function ($) {
+            const companySearch = loadCompanySearch($);
+            const brandConfig = function () {
+                return BASE_CONFIG;
+            };
+            brandConfig.getActiveTwoBrandCode = function () {
+                return 'two_payment';
+            };
+            brandConfig.getActiveTwoBrandConfig = function () {
+                return BASE_CONFIG;
+            };
+
+            const component = loadAmdModule('view/frontend/web/js/view/address-autocomplete.js', {
+                jquery: $,
+                'Two_Gateway/js/model/brand-config': brandConfig,
+                'Two_Gateway/js/model/company-search': companySearch
+            });
+            return Object.assign(Object.create(component.prototype || {}), {
+                countrySelector: '#shipping-new-address-form select[name="country_id"]',
+                companyNameSelector: 'input#company_name',
+                companyIdSelector: 'input#company_id',
+                enterDetailsManuallyButton: '#shipping_enter_details_manually',
+                searchForCompanyButton: '#shipping_search_for_company',
+                enterDetailsManuallyText: 'Enter details manually',
+                searchForCompanyText: 'Search for company',
+                companyNamePlaceholder: 'Enter company name to search',
+                setCompanyData: function () {},
+                addressLookup: component.addressLookup,
+                enableCompanySearch: component.enableCompanySearch
+            });
+        });
+    });
+});

--- a/Test/Js/company-search-resilience.test.js
+++ b/Test/Js/company-search-resilience.test.js
@@ -2,10 +2,14 @@
  * Copyright © Two.inc All rights reserved.
  * See COPYING.txt for license details.
  *
- * TWO-25233. Company search had no request timeout, no way to tell a
- * failed search from a genuinely empty one, no result cache, and a
- * select2 binding that duplicated itself every time a one-page checkout
- * re-rendered. These tests pin all four.
+ * TWO-25233. Company search had no request timeout, no way to tell a failed
+ * search from a genuinely empty one, no result cache, and left a stale
+ * widget bound when a one-page checkout re-rendered. These tests pin all of
+ * that, plus the two select2-specific traps found in review: a jQuery
+ * timeout reports `status === 0`, which select2's own failure handler treats
+ * as an abort and therefore never clears its "Searching…" row; and select2
+ * 4.1's constructor already destroys any existing instance on the same node,
+ * so guarding against re-init is harmful rather than protective.
  */
 
 'use strict';
@@ -30,10 +34,47 @@ const SEARCH_RESPONSE = {
     ]
 };
 
+const SEARCH_FIELD = 'input#company_name';
+
 /**
- * jQuery double whose `$.ajax` hands back a jqXHR the test settles by
- * hand, so each failure mode (done / timeout / abort) can be driven
- * explicitly rather than inferred.
+ * A container that records what gets appended to it and can remove it again
+ * by class, so the spinner / notice assertions exercise the real DOM writes
+ * instead of silently no-opping on an empty jQuery set.
+ */
+function makeFakeContainer() {
+    const children = [];
+    const container = {
+        __fake: true,
+        length: 1,
+        children: children,
+        append: function (html) {
+            children.push(html);
+            return container;
+        },
+        find: function (selector) {
+            const needle = selector.replace(/^\./, '');
+            const matched = children.filter(function (html) {
+                return html.indexOf(needle) !== -1;
+            });
+            return {
+                length: matched.length,
+                remove: function () {
+                    matched.forEach(function (html) {
+                        children.splice(children.indexOf(html), 1);
+                    });
+                }
+            };
+        }
+    };
+    return container;
+}
+
+/**
+ * jQuery double whose `$.ajax` hands back a jqXHR the test settles by hand,
+ * so each outcome (done / timeout / abort) is driven explicitly rather than
+ * inferred. Nodes are memoised per selector so `.data('select2')` reflects
+ * whatever the last `select2()` call bound — that is what lets the
+ * destroy-on-dispose and re-init assertions be meaningful.
  */
 function makeQueryDouble() {
     const recorder = {
@@ -41,66 +82,100 @@ function makeQueryDouble() {
         requests: [],
         asyncCallbacks: [],
         select2Calls: [],
-        appended: [],
-        removed: [],
-        boundData: {}
+        destroyCalls: 0,
+        searchBoxes: []
     };
+    const nodes = {};
 
-    function $(selector) {
-        const obj = {
-            length: selector === '.select2-search--dropdown' ? 1 : 0,
+    function makeNode(key) {
+        const store = {};
+        const node = {
+            __fake: true,
+            length: 1,
+            key: key,
             val: function () {
-                return obj;
+                return node;
             },
             trigger: function () {
-                return obj;
+                return node;
             },
             prop: function () {
-                return obj;
+                return node;
             },
             text: function () {
-                return obj;
+                return node;
             },
             attr: function () {
-                return obj;
+                return node;
             },
-            data: function (key) {
-                return recorder.boundData[key];
+            data: function (dataKey) {
+                return store[dataKey];
             },
             closest: function () {
-                return obj;
+                return node;
             },
             find: function () {
-                return obj;
+                return node;
             },
-            append: function (html) {
-                recorder.appended.push(html);
-                return obj;
+            append: function () {
+                return node;
             },
             remove: function () {
-                recorder.removed.push(selector);
-                return obj;
+                return node;
             },
             hide: function () {
-                return obj;
+                return node;
             },
             show: function () {
-                return obj;
+                return node;
             },
             select2: function (opts) {
+                if (opts === 'destroy') {
+                    recorder.destroyCalls++;
+                    delete store.select2;
+                    return node;
+                }
                 if (typeof opts === 'object') {
                     recorder.select2Calls.push(opts);
-                    // Mirror select2: once bound, the widget instance is
-                    // discoverable through `.data('select2')`.
-                    recorder.boundData.select2 = { $dropdown: null };
+                    // Mirror select2 4.1: the instance is discoverable via
+                    // `.data('select2')`, and it owns a `$dropdown` holding
+                    // the search box our chrome writes into.
+                    const searchBox = makeFakeContainer();
+                    recorder.searchBoxes.push(searchBox);
+                    store.select2 = {
+                        $dropdown: {
+                            find: function (selector) {
+                                return selector === '.select2-search--dropdown'
+                                    ? searchBox
+                                    : { length: 0 };
+                            }
+                        }
+                    };
                 }
-                return obj;
+                return node;
             },
             on: function () {
-                return obj;
+                return node;
             }
         };
-        return obj;
+        return node;
+    }
+
+    function $(target) {
+        if (target && target.__fake) return target;
+        if (target === undefined) {
+            // The empty set company-search falls back to.
+            return {
+                length: 0,
+                find: function () {
+                    return { length: 0, remove: function () {} };
+                },
+                append: function () {}
+            };
+        }
+        const key = String(target);
+        if (!nodes[key]) nodes[key] = makeNode(key);
+        return nodes[key];
     }
 
     $.async = function (selector, fn) {
@@ -111,7 +186,6 @@ function makeQueryDouble() {
         recorder.ajax.push(opts);
         const handlers = { done: [], fail: [], always: [] };
         const jqxhr = {
-            aborted: false,
             done: function (cb) {
                 handlers.done.push(cb);
                 return jqxhr;
@@ -124,9 +198,7 @@ function makeQueryDouble() {
                 handlers.always.push(cb);
                 return jqxhr;
             },
-            abort: function () {
-                jqxhr.aborted = true;
-            },
+            abort: function () {},
             settleDone: function (data) {
                 handlers.done.forEach(function (cb) {
                     cb(data);
@@ -137,7 +209,7 @@ function makeQueryDouble() {
             },
             settleFail: function (textStatus) {
                 handlers.fail.forEach(function (cb) {
-                    cb({}, textStatus);
+                    cb({ status: textStatus === 'timeout' ? 0 : 500 }, textStatus);
                 });
                 handlers.always.forEach(function (cb) {
                     cb();
@@ -178,7 +250,7 @@ function makeQueryDouble() {
     $.extend = Object.assign;
     $.fn = {};
 
-    return { $: $, recorder: recorder };
+    return { $: $, recorder: recorder, node: $ };
 }
 
 function loadCompanySearch($) {
@@ -247,50 +319,69 @@ describe('request envelope', () => {
 });
 
 describe('failure is not "no companies found"', () => {
-    test('a timeout raises the unavailable affordance', () => {
+    test('a timeout raises the notice AND gives select2 a terminal result', () => {
         const { $, recorder } = makeQueryDouble();
         const companySearch = loadCompanySearch($);
         const hooks = makeHooks();
         const ajaxOptions = buildOptions(companySearch, hooks);
+        const success = jest.fn();
         const failure = jest.fn();
 
-        ajaxOptions.transport({ url: 'https://api.example.test/x?q=exa' }, jest.fn(), failure);
+        ajaxOptions.transport({ url: 'https://api.example.test/x?q=exa' }, success, failure);
         recorder.requests[0].settleFail('timeout');
 
         expect(hooks.calls.unavailable).toEqual([false, true]);
-        expect(hooks.calls.searching).toEqual([true, false]);
-        expect(failure).toHaveBeenCalled();
+
+        // The load-bearing part. jQuery reports a timeout as status 0, and
+        // select2's own failure handler treats status 0 as an abort: it never
+        // fires `results:message`, so `hideLoading()` is never reached and
+        // the dropdown shows "Searching…" forever — under the very notice
+        // saying the search failed. Routing through select2's SUCCESS path
+        // with an empty result set is what gives it a terminal state.
+        expect(failure).not.toHaveBeenCalled();
+        expect(success).toHaveBeenCalledWith({ items: [] });
     });
 
-    test('a network error raises the unavailable affordance', () => {
+    test('a network error behaves the same way', () => {
         const { $, recorder } = makeQueryDouble();
         const companySearch = loadCompanySearch($);
         const hooks = makeHooks();
         const ajaxOptions = buildOptions(companySearch, hooks);
+        const success = jest.fn();
+        const failure = jest.fn();
 
-        ajaxOptions.transport({ url: 'https://api.example.test/x?q=exa' }, jest.fn(), jest.fn());
+        ajaxOptions.transport({ url: 'https://api.example.test/x?q=exa' }, success, failure);
         recorder.requests[0].settleFail('error');
 
         expect(hooks.calls.unavailable).toContain(true);
+        expect(failure).not.toHaveBeenCalled();
+        expect(success).toHaveBeenCalledWith({ items: [] });
     });
 
-    test('a genuine abort stays silent', () => {
+    test('a genuine abort stays silent and keeps the spinner up', () => {
         const { $, recorder } = makeQueryDouble();
         const companySearch = loadCompanySearch($);
         const hooks = makeHooks();
         const ajaxOptions = buildOptions(companySearch, hooks);
+        const success = jest.fn();
+        const failure = jest.fn();
 
-        ajaxOptions.transport({ url: 'https://api.example.test/x?q=exa' }, jest.fn(), jest.fn());
+        ajaxOptions.transport({ url: 'https://api.example.test/x?q=exa' }, success, failure);
         recorder.requests[0].settleFail('abort');
 
         // An abort is the buyer typing on, or the widget being torn down.
         // Showing an error for that would be noise on every keystroke.
         expect(hooks.calls.unavailable).toEqual([false]);
-        // The spinner still has to come down.
-        expect(hooks.calls.searching).toEqual([true, false]);
+        expect(failure).toHaveBeenCalled();
+        expect(success).not.toHaveBeenCalled();
+
+        // select2 aborts the in-flight request synchronously at the top of
+        // the next query(), 300ms before the replacement transport starts.
+        // Dropping the spinner there would blink it off on every keystroke.
+        expect(hooks.calls.searching).toEqual([true]);
     });
 
-    test('a healthy response raises nothing', () => {
+    test('a healthy response raises nothing and settles the spinner', () => {
         const { $, recorder } = makeQueryDouble();
         const companySearch = loadCompanySearch($);
         const hooks = makeHooks();
@@ -302,11 +393,12 @@ describe('failure is not "no companies found"', () => {
 
         expect(success).toHaveBeenCalledWith(SEARCH_RESPONSE);
         expect(hooks.calls.unavailable).toEqual([false]);
+        expect(hooks.calls.searching).toEqual([true, false]);
     });
 });
 
 describe('degraded flag', () => {
-    test('degraded: true raises the unavailable affordance on an HTTP 200', () => {
+    test('degraded: true raises the notice on an HTTP 200', () => {
         const { $, recorder } = makeQueryDouble();
         const companySearch = loadCompanySearch($);
         const hooks = makeHooks();
@@ -345,7 +437,7 @@ describe('degraded flag', () => {
         expect(companySearch.isDegradedResponse({})).toBe(false);
         expect(companySearch.isDegradedResponse(null)).toBe(false);
         expect(companySearch.isDegradedResponse(undefined)).toBe(false);
-        // Truthy-but-not-true values must not trip the affordance.
+        // Truthy-but-not-true values must not trip the notice.
         expect(companySearch.isDegradedResponse({ degraded: 'false' })).toBe(false);
         expect(companySearch.isDegradedResponse({ degraded: 1 })).toBe(false);
     });
@@ -403,9 +495,9 @@ describe('result cache', () => {
         const companySearch = loadCompanySearch($);
         const url = 'https://api.example.test/c?q=exa';
 
-        // A one-page checkout re-render destroys the select2 widget and
-        // builds a fresh options block. The cache is module-scoped
-        // precisely so the buyer doesn't pay for the same search twice.
+        // A one-page checkout re-render rebuilds the select2 widget and a
+        // fresh options block. The cache is module-scoped precisely so the
+        // buyer doesn't pay for the same search twice.
         buildOptions(companySearch, makeHooks()).transport({ url: url }, jest.fn(), jest.fn());
         recorder.requests[0].settleDone(SEARCH_RESPONSE);
 
@@ -459,109 +551,212 @@ describe('processResults robustness', () => {
         const companySearch = loadCompanySearch($);
         const ajaxOptions = buildOptions(companySearch, makeHooks());
 
-        // A degraded response can legitimately arrive with `items` absent.
+        // The synthetic `{items: []}` fed to select2 on a failure, and a
+        // degraded response, both land here.
         expect(ajaxOptions.processResults({}).results).toEqual([]);
+        expect(ajaxOptions.processResults({ items: [] }).results).toEqual([]);
         expect(ajaxOptions.processResults({ degraded: true }).results).toEqual([]);
     });
 });
 
 describe('in-field chrome', () => {
-    test('spinner and notice are no-ops when the widget is not bound', () => {
+    /** Bind select2 to a node so the chrome has a real container to write to. */
+    function boundField($) {
+        const $field = $(SEARCH_FIELD);
+        $field.select2({});
+        return $field;
+    }
+
+    function searchBoxOf(recorder) {
+        return recorder.searchBoxes[recorder.searchBoxes.length - 1];
+    }
+
+    test('the spinner is written into the search box and removed again', () => {
         const { $, recorder } = makeQueryDouble();
         const companySearch = loadCompanySearch($);
+        const $field = boundField($);
 
-        // `.data('select2')` is undefined before select2 binds — the chrome
-        // must not throw or leak markup into the page in that window.
-        companySearch.setSearching('input#company_name', true);
-        companySearch.setUnavailable('input#company_name', true);
+        companySearch.setSearching($field, true);
+        expect(searchBoxOf(recorder).children).toHaveLength(1);
+        expect(searchBoxOf(recorder).children[0]).toContain('two-company-search__spinner');
 
-        expect(recorder.appended).toHaveLength(0);
+        companySearch.setSearching($field, false);
+        expect(searchBoxOf(recorder).children).toHaveLength(0);
+    });
+
+    test('the spinner is never duplicated', () => {
+        const { $, recorder } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+        const $field = boundField($);
+
+        companySearch.setSearching($field, true);
+        companySearch.setSearching($field, true);
+
+        expect(searchBoxOf(recorder).children).toHaveLength(1);
+    });
+
+    test('the notice is written as a span, not a div', () => {
+        const { $, recorder } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+        const $field = boundField($);
+
+        companySearch.setUnavailable($field, true);
+
+        const html = searchBoxOf(recorder).children[0];
+        // select2 renders both `.select2-dropdown` and
+        // `.select2-search--dropdown` as <span>; a <div> inside is invalid
+        // nesting and the anonymous block box makes spacing inconsistent.
+        expect(html).toContain('<span class="two-company-search__unavailable"');
+        expect(html).not.toContain('<div');
+        expect(html).toContain('role="alert"');
+    });
+
+    test('clearSearchChrome removes both spinner and notice', () => {
+        const { $, recorder } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+        const $field = boundField($);
+
+        companySearch.setSearching($field, true);
+        companySearch.setUnavailable($field, true);
+        expect(searchBoxOf(recorder).children).toHaveLength(2);
+
+        // select2 only detaches the dropdown on close and only blanks the
+        // search input, so without this a reopened picker still shows the
+        // previous search's notice.
+        companySearch.clearSearchChrome($field);
+        expect(searchBoxOf(recorder).children).toHaveLength(0);
+    });
+
+    test('a destroyed widget cannot paint chrome anywhere', () => {
+        const { $, recorder } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+        const $field = boundField($);
+        const staleBox = searchBoxOf(recorder);
+
+        // select2('destroy') drops `.data('select2')`. A request issued by
+        // that widget can still be in flight for up to 30s; resolving it must
+        // not decorate the live picker (or throw).
+        $field.select2('destroy');
+        companySearch.setSearching($field, true);
+        companySearch.setUnavailable($field, true);
+
+        expect(staleBox.children).toHaveLength(0);
+    });
+
+    test('chrome is a no-op before select2 binds', () => {
+        const { $ } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+
+        // `.data('select2')` is undefined in the window before binding; the
+        // chrome must not throw there.
+        expect(function () {
+            companySearch.setSearching($(SEARCH_FIELD), true);
+            companySearch.setUnavailable($(SEARCH_FIELD), true);
+            companySearch.clearSearchChrome($(SEARCH_FIELD));
+        }).not.toThrow();
     });
 });
 
 describe('re-render safety of the select2 binding', () => {
-    /**
-     * `$.async` is a MutationObserver and every enableCompanySearch() call
-     * adds another one, so on a one-page checkout the callback fires
-     * repeatedly for the same node. Binding twice leaves a duplicate widget
-     * whose in-flight XHR resolves into a dropdown the buyer can't see.
-     */
-    function assertBindsOnce(loadRenderer) {
-        const { $, recorder } = makeQueryDouble();
-        const ctx = loadRenderer($, recorder);
-
-        ctx.enableCompanySearch();
-        expect(recorder.select2Calls).toHaveLength(1);
-
-        // Fire every registered observer callback again, as a re-render does.
-        recorder.asyncCallbacks.forEach(function (fn) {
-            fn('input#company_name');
+    function loadRenderer($) {
+        const companySearch = loadCompanySearch($);
+        const component = loadAmdModule(
+            'view/frontend/web/js/view/payment/method-renderer/gateway_method.js',
+            { jquery: $, 'Two_Gateway/js/model/company-search': companySearch }
+        );
+        return Object.assign(Object.create(component.prototype || {}), {
+            companyNameSelector: SEARCH_FIELD,
+            companyIdSelector: 'input#company_id',
+            enterDetailsManuallyButton: '#billing_enter_details_manually',
+            searchForCompanyButton: '#billing_search_for_company',
+            enterDetailsManuallyText: 'Enter details manually',
+            searchForCompanyText: 'Search for company',
+            _brandConfig: BASE_CONFIG,
+            countryCode: function () {
+                return 'gb';
+            },
+            companyName: function () {
+                return '';
+            },
+            fillCompanyData: function () {},
+            addressLookup: component.addressLookup,
+            enableCompanySearch: component.enableCompanySearch,
+            disableCompanySearch: component.disableCompanySearch,
+            dispose: component.dispose,
+            _super: function () {}
         });
-        // And re-run the whole enable path, as a re-rendered renderer does.
-        ctx.enableCompanySearch();
-
-        expect(recorder.select2Calls).toHaveLength(1);
     }
 
-    test('payment-step picker binds select2 exactly once per node', () => {
-        assertBindsOnce(function ($) {
-            const companySearch = loadCompanySearch($);
-            const component = loadAmdModule(
-                'view/frontend/web/js/view/payment/method-renderer/gateway_method.js',
-                { jquery: $, 'Two_Gateway/js/model/company-search': companySearch }
-            );
-            return Object.assign(Object.create(component.prototype || {}), {
-                companyNameSelector: 'input#company_name',
-                companyIdSelector: 'input#company_id',
-                enterDetailsManuallyButton: '#billing_enter_details_manually',
-                searchForCompanyButton: '#billing_search_for_company',
-                enterDetailsManuallyText: 'Enter details manually',
-                searchForCompanyText: 'Search for company',
-                _brandConfig: BASE_CONFIG,
-                countryCode: function () {
-                    return 'gb';
-                },
-                companyName: function () {
-                    return '';
-                },
-                fillCompanyData: function () {},
-                addressLookup: component.addressLookup,
-                enableCompanySearch: component.enableCompanySearch
-            });
-        });
+    /**
+     * The inverse of the guard this PR originally shipped. select2 4.1's
+     * constructor opens with `GetData(el, 'select2').destroy()`, so re-init
+     * is how the widget — and its handlers' `self` closure — get re-pointed
+     * at the current component. Early-returning would keep a widget alive
+     * whose closures reference a DISPOSED renderer, so picking a company
+     * would write to dead observables and the order would ship with no
+     * company on it.
+     */
+    test('re-render re-initialises select2 rather than skipping it', () => {
+        const { $, recorder } = makeQueryDouble();
+        const ctx = loadRenderer($);
+
+        ctx.enableCompanySearch();
+        expect(recorder.select2Calls).toHaveLength(1);
+
+        ctx.enableCompanySearch();
+        expect(recorder.select2Calls).toHaveLength(2);
     });
 
-    test('shipping-step picker binds select2 exactly once per node', () => {
-        assertBindsOnce(function ($) {
-            const companySearch = loadCompanySearch($);
-            const brandConfig = function () {
-                return BASE_CONFIG;
-            };
-            brandConfig.getActiveTwoBrandCode = function () {
-                return 'two_payment';
-            };
-            brandConfig.getActiveTwoBrandConfig = function () {
-                return BASE_CONFIG;
-            };
+    test('dispose destroys the company-search widget', () => {
+        const { $, recorder } = makeQueryDouble();
+        const ctx = loadRenderer($);
 
-            const component = loadAmdModule('view/frontend/web/js/view/address-autocomplete.js', {
-                jquery: $,
-                'Two_Gateway/js/model/brand-config': brandConfig,
-                'Two_Gateway/js/model/company-search': companySearch
-            });
-            return Object.assign(Object.create(component.prototype || {}), {
-                countrySelector: '#shipping-new-address-form select[name="country_id"]',
-                companyNameSelector: 'input#company_name',
-                companyIdSelector: 'input#company_id',
-                enterDetailsManuallyButton: '#shipping_enter_details_manually',
-                searchForCompanyButton: '#shipping_search_for_company',
-                enterDetailsManuallyText: 'Enter details manually',
-                searchForCompanyText: 'Search for company',
-                companyNamePlaceholder: 'Enter company name to search',
-                setCompanyData: function () {},
-                addressLookup: component.addressLookup,
-                enableCompanySearch: component.enableCompanySearch
-            });
+        ctx.enableCompanySearch();
+        expect($(SEARCH_FIELD).data('select2')).toBeDefined();
+
+        ctx.dispose();
+
+        // Without this, a re-render that REUSES the input node leaves the old
+        // widget bound with handlers closed over the disposed renderer.
+        expect(recorder.destroyCalls).toBe(1);
+        expect($(SEARCH_FIELD).data('select2')).toBeUndefined();
+    });
+
+    test('shipping-step picker also re-initialises on re-render', () => {
+        const { $, recorder } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+        const brandConfig = function () {
+            return BASE_CONFIG;
+        };
+        brandConfig.getActiveTwoBrandCode = function () {
+            return 'two_payment';
+        };
+        brandConfig.getActiveTwoBrandConfig = function () {
+            return BASE_CONFIG;
+        };
+
+        const component = loadAmdModule('view/frontend/web/js/view/address-autocomplete.js', {
+            jquery: $,
+            'Two_Gateway/js/model/brand-config': brandConfig,
+            'Two_Gateway/js/model/company-search': companySearch
         });
+        const ctx = Object.assign(Object.create(component.prototype || {}), {
+            countrySelector: '#shipping-new-address-form select[name="country_id"]',
+            companyNameSelector: SEARCH_FIELD,
+            companyIdSelector: 'input#company_id',
+            enterDetailsManuallyButton: '#shipping_enter_details_manually',
+            searchForCompanyButton: '#shipping_search_for_company',
+            enterDetailsManuallyText: 'Enter details manually',
+            searchForCompanyText: 'Search for company',
+            companyNamePlaceholder: 'Enter company name to search',
+            setCompanyData: function () {},
+            addressLookup: component.addressLookup,
+            enableCompanySearch: component.enableCompanySearch
+        });
+
+        ctx.enableCompanySearch();
+        ctx.enableCompanySearch();
+
+        expect(recorder.select2Calls).toHaveLength(2);
     });
 });

--- a/i18n/nb_NO.csv
+++ b/i18n/nb_NO.csv
@@ -241,3 +241,4 @@
 "Down","Ned"
 "Snap the buyer surcharge line item to a clean increment. Select None for standard two-decimal amounts.","Rund tilleggslinjen til et fast trinn. Velg Ingen for vanlige beløp med to desimaler."
 "Increment the surcharge is rounded to (e.g. 1 = whole units, 0.50 = nearest half).","Trinnet tillegget rundes til (f.eks. 1 = hele enheter, 0,50 = nærmeste halve)."
+"Company search is unavailable. Try again, or enter details manually.","Firmasøk er utilgjengelig. Prøv igjen, eller skriv inn detaljer manuelt."

--- a/i18n/nl_NL.csv
+++ b/i18n/nl_NL.csv
@@ -237,3 +237,4 @@
 "Down","Naar beneden"
 "Snap the buyer surcharge line item to a clean increment. Select None for standard two-decimal amounts.","Rond de toeslag voor je klant af naar een gekozen hoeveelheid. Selecteer Geen om geen afronding toe te passen."
 "Increment the surcharge is rounded to (e.g. 1 = whole units, 0.50 = nearest half).","Kies naar welk bedrag je wilt afronden (1 = heel bedrag, 0,50 = dichtstbijzijnde helft)"
+"Company search is unavailable. Try again, or enter details manually.","Bedrijfszoekfunctie is niet beschikbaar. Probeer het opnieuw of voer de gegevens handmatig in."

--- a/i18n/sv_SE.csv
+++ b/i18n/sv_SE.csv
@@ -238,3 +238,4 @@
 "Down","Nedåt"
 "Snap the buyer surcharge line item to a clean increment. Select None for standard two-decimal amounts.","Avrunda tilläggsraden till ett jämnt steg. Välj Ingen för vanliga belopp med två decimaler."
 "Increment the surcharge is rounded to (e.g. 1 = whole units, 0.50 = nearest half).","Steget som tillägget avrundas till (t.ex. 1 = hela enheter, 0,50 = närmaste halva)."
+"Company search is unavailable. Try again, or enter details manually.","Företagssökningen är inte tillgänglig. Försök igen, eller ange detaljer manuellt."

--- a/view/frontend/web/css/style.css
+++ b/view/frontend/web/css/style.css
@@ -399,6 +399,7 @@
 }
 
 .two-company-search__unavailable {
+    display: block;
     margin-top: 6px;
     padding: 6px 8px;
     border-radius: 3px;

--- a/view/frontend/web/css/style.css
+++ b/view/frontend/web/css/style.css
@@ -355,6 +355,59 @@
     }
 }
 
+/*
+ * Company-search chrome.
+ *
+ * Both live inside select2's own search box (`.select2-search--dropdown`,
+ * which for a single-select is where the buyer actually types), so the
+ * spinner reads as "this field is working" rather than "the page is busy",
+ * and the unavailable notice sits with the field it describes.
+ *
+ * The spinner deliberately reuses the payment-term chips' three-dot
+ * animation (`two-term-chip-dot`) — one loading idiom in the checkout, not
+ * two.
+ */
+.select2-search--dropdown {
+    position: relative;
+}
+
+.two-company-search__spinner {
+    position: absolute;
+    top: 50%;
+    right: 12px;
+    transform: translateY(-50%);
+    display: inline-block;
+    letter-spacing: 2px;
+    color: currentColor;
+    font-size: 12px;
+    line-height: 1.3;
+    font-weight: 700;
+    pointer-events: none;
+}
+
+.two-company-search__spinner > span {
+    display: inline-block;
+    animation: two-term-chip-dot 1.4s infinite ease-in-out both;
+}
+
+.two-company-search__spinner > span:nth-child(2) {
+    animation-delay: 0.2s;
+}
+
+.two-company-search__spinner > span:nth-child(3) {
+    animation-delay: 0.4s;
+}
+
+.two-company-search__unavailable {
+    margin-top: 6px;
+    padding: 6px 8px;
+    border-radius: 3px;
+    background: #fdf0d5;
+    color: #6f4900;
+    font-size: 12px;
+    line-height: 1.4;
+}
+
 .two-term-chip--single {
     border-color: var(--color-blue2);
     background: var(--color-blue2);

--- a/view/frontend/web/js/model/company-search.js
+++ b/view/frontend/web/js/model/company-search.js
@@ -166,6 +166,7 @@ define(['jquery', 'mage/translate'], function ($, $t) {
 
                     onSearching(true);
                     const request = $.ajax(params);
+                    let wasAborted = false;
 
                     request.done(function (response) {
                         cacheSet(params.url, response);
@@ -181,11 +182,30 @@ define(['jquery', 'mage/translate'], function ($, $t) {
                         // design. A timeout is NOT an abort and must be
                         // visible, otherwise the buyer reads a hung backend
                         // as "my company isn't accepted here".
-                        if (textStatus !== 'abort') onUnavailable(true);
-                        failure(jqXHR, textStatus);
+                        if (textStatus === 'abort') {
+                            wasAborted = true;
+                            failure(jqXHR, textStatus);
+                            return;
+                        }
+                        onUnavailable(true);
+                        // Deliberately select2's SUCCESS path with an empty
+                        // result set, not its failure path. jQuery reports a
+                        // timeout as status 0, and select2's own failure
+                        // handler treats status 0 as an abort: it never fires
+                        // `results:message`, so `hideLoading()` is never
+                        // reached and the dropdown is left showing
+                        // "Searching…" forever — under the very notice that
+                        // says the search failed. Feeding it an empty result
+                        // set gives select2 a terminal state to render.
+                        success({ items: [] });
                     });
                     request.always(function () {
-                        onSearching(false);
+                        // Not on abort: select2 aborts the in-flight request
+                        // synchronously at the top of the next query(), 300ms
+                        // before the replacement transport starts. Dropping
+                        // the spinner there would make it blink off on every
+                        // keystroke.
+                        if (!wasAborted) onSearching(false);
                     });
 
                     return request;
@@ -277,17 +297,38 @@ define(['jquery', 'mage/translate'], function ($, $t) {
          * the buyer is concerned, and it is where the spinner and the
          * unavailable notice belong.
          *
-         * Scoped through the widget instance rather than a document-wide
-         * selector: with two pickers in one checkout, a global lookup would
-         * decorate whichever dropdown happened to be in the DOM.
+         * Takes the BOUND ELEMENT, not a selector, and resolves through that
+         * element's own widget instance. This is what keeps a stale request
+         * from painting on a live widget: a search issued by a widget that
+         * has since been destroyed (select2 re-init destroys the previous
+         * instance on the same node) finds no instance on its old element
+         * and no-ops, instead of decorating whichever dropdown a
+         * document-wide selector happened to hit.
          *
-         * @param {string} fieldSelector the picker's input selector
+         * @param {object} $field jQuery-wrapped picker input
          * @returns {object} jQuery set — empty when the widget isn't bound
          */
-        getSearchFieldContainer: function (fieldSelector) {
-            const instance = $(fieldSelector).data('select2');
+        getSearchFieldContainer: function ($field) {
+            const instance = $field && $field.data ? $field.data('select2') : null;
             if (!instance || !instance.$dropdown) return $();
             return instance.$dropdown.find('.select2-search--dropdown');
+        },
+
+        /**
+         * Drop both the spinner and the unavailable notice.
+         *
+         * Needed on `select2:open`: select2 only detaches the dropdown on
+         * close and only clears the search input's value, so nothing removes
+         * children appended into `.select2-search--dropdown`. Without this,
+         * a buyer who hits a failed search, closes the picker and reopens it
+         * sees the stale "unavailable" notice above an empty search box —
+         * and it survives until three or more characters are retyped.
+         *
+         * @param {object} $field jQuery-wrapped picker input
+         */
+        clearSearchChrome: function ($field) {
+            this.setSearching($field, false);
+            this.setUnavailable($field, false);
         },
 
         /**
@@ -297,11 +338,11 @@ define(['jquery', 'mage/translate'], function ($, $t) {
          * (`.two-term-chip__loading`, `two-term-chip-dot` keyframes) rather
          * than introducing a second loading idiom.
          *
-         * @param {string} fieldSelector the picker's input selector
+         * @param {object} $field jQuery-wrapped picker input
          * @param {boolean} isSearching
          */
-        setSearching: function (fieldSelector, isSearching) {
-            const $container = this.getSearchFieldContainer(fieldSelector);
+        setSearching: function ($field, isSearching) {
+            const $container = this.getSearchFieldContainer($field);
             if (!$container.length) return;
 
             if (!isSearching) {
@@ -324,11 +365,11 @@ define(['jquery', 'mage/translate'], function ($, $t) {
          * shop won't take them. The copy points at manual entry, which both
          * pickers already offer.
          *
-         * @param {string} fieldSelector the picker's input selector
+         * @param {object} $field jQuery-wrapped picker input
          * @param {boolean} isUnavailable
          */
-        setUnavailable: function (fieldSelector, isUnavailable) {
-            const $container = this.getSearchFieldContainer(fieldSelector);
+        setUnavailable: function ($field, isUnavailable) {
+            const $container = this.getSearchFieldContainer($field);
             if (!$container.length) return;
 
             if (!isUnavailable) {
@@ -336,10 +377,14 @@ define(['jquery', 'mage/translate'], function ($, $t) {
                 return;
             }
             if ($container.find(`.${UNAVAILABLE_CLASS}`).length) return;
+            // A <span>, not a <div>: select2 renders both `.select2-dropdown`
+            // and `.select2-search--dropdown` as <span>, and block-in-inline
+            // makes margin/padding/width behave inconsistently. The class
+            // sets `display: block`.
             $container.append(
-                `<div class="${UNAVAILABLE_CLASS}" role="alert">` +
+                `<span class="${UNAVAILABLE_CLASS}" role="alert">` +
                     $t('Company search is unavailable. Try again, or enter details manually.') +
-                    '</div>'
+                    '</span>'
             );
         }
     };

--- a/view/frontend/web/js/model/company-search.js
+++ b/view/frontend/web/js/model/company-search.js
@@ -12,16 +12,89 @@
  *
  * Only the genuinely identical parts live here — the search request,
  * the result mapping (including `lookup_id`, whose omission on the
- * payment step was TWO-25193), the company-detail fetch and the
- * address write-back. Everything else about the two pickers differs
- * (selectors, placeholder/manual-entry chrome, KO observables vs
- * customerData, order-intent side effects) and deliberately stays in
- * the two call sites.
+ * payment step was TWO-25193), the company-detail fetch, the address
+ * write-back and the in-field searching / unavailable chrome.
+ * Everything else about the two pickers differs (selectors,
+ * placeholder/manual-entry chrome, KO observables vs customerData,
+ * order-intent side effects) and deliberately stays in the two call
+ * sites.
  */
-define(['jquery'], function ($) {
+define(['jquery', 'mage/translate'], function ($, $t) {
     'use strict';
 
+    /**
+     * Client-side ceiling for every company-search / company-detail
+     * request. 30s deliberately sits OUTSIDE the server's retry envelope
+     * (`stop_after_delay(10)`), so the client never abandons a request the
+     * API is still legitimately retrying — but it does put a bound on the
+     * browser default of "hang until the socket dies".
+     */
+    const REQUEST_TIMEOUT_MS = 30000;
+
+    /**
+     * Keystroke debounce. 300ms is the value shared with the WooCommerce
+     * and PrestaShop company pickers — keep the three aligned.
+     */
+    const SEARCH_DEBOUNCE_MS = 300;
+
+    /**
+     * Search-result cache. MODULE-scoped on purpose: one-page checkouts
+     * (Fire Checkout) re-render the payment renderer on every totals or
+     * shipping change, which destroys and rebuilds the select2 widget. A
+     * cache owned by the widget would be thrown away each time and every
+     * search the buyer already waited for would be re-issued. Keyed by the
+     * fully-qualified request URL, so country / paging / limit are all part
+     * of the key.
+     */
+    const resultCache = new Map();
+
+    /** Bound on the cache so a long typing session can't grow it forever. */
+    const CACHE_LIMIT = 50;
+
+    const SPINNER_CLASS = 'two-company-search__spinner';
+    const UNAVAILABLE_CLASS = 'two-company-search__unavailable';
+
+    /**
+     * Does this response mean "the search backend could not answer
+     * properly"? The API answers HTTP 200 with near-empty results when its
+     * upstream provider timed out, and flags that with `degraded: true`.
+     *
+     * Read defensively: the field may not be deployed yet, and an absent or
+     * non-boolean value must mean "not degraded" so today's healthy
+     * responses keep working unchanged.
+     *
+     * @param {*} response parsed search response
+     * @returns {boolean}
+     */
+    function isDegradedResponse(response) {
+        return Boolean(response) && response.degraded === true;
+    }
+
+    function cacheGet(key) {
+        return resultCache.has(key) ? resultCache.get(key) : null;
+    }
+
+    function cacheSet(key, value) {
+        // Never cache a degraded answer — it is a transient upstream
+        // failure, and caching it would pin the buyer to an empty result
+        // set for the rest of the session.
+        if (isDegradedResponse(value)) return;
+        if (resultCache.size >= CACHE_LIMIT) {
+            resultCache.delete(resultCache.keys().next().value);
+        }
+        resultCache.set(key, value);
+    }
+
     return {
+        REQUEST_TIMEOUT_MS: REQUEST_TIMEOUT_MS,
+        SEARCH_DEBOUNCE_MS: SEARCH_DEBOUNCE_MS,
+        isDegradedResponse: isDegradedResponse,
+
+        /** Drop every cached search result. Exists for tests. */
+        clearResultCache: function () {
+            resultCache.clear();
+        },
+
         /**
          * Build the select2 `ajax` option block for the company search.
          *
@@ -30,15 +103,24 @@ define(['jquery'], function ($) {
          *        `checkoutApiUrl` and `companySearchLimit`
          * @param {function(): (string|undefined)} options.getCountryCode
          *        returns the current ISO country code (any case)
+         * @param {function(boolean)} [options.onSearching] called with true
+         *        when a search starts and false when it settles, so the call
+         *        site can show an in-field spinner
+         * @param {function(boolean)} [options.onUnavailable] called with true
+         *        when a search fails or comes back degraded, and false at the
+         *        start of every fresh search
          * @returns {object} select2 `ajax` options
          */
         buildSearchAjaxOptions: function (options) {
             const config = options.config;
             const getCountryCode = options.getCountryCode;
+            const onSearching = options.onSearching || function () {};
+            const onUnavailable = options.onUnavailable || function () {};
 
             return {
                 dataType: 'json',
-                delay: 400,
+                delay: SEARCH_DEBOUNCE_MS,
+                timeout: REQUEST_TIMEOUT_MS,
                 url: function (params) {
                     const queryParams = new URLSearchParams({
                         country: getCountryCode()?.toUpperCase(),
@@ -48,10 +130,71 @@ define(['jquery'], function ($) {
                     });
                     return `${config.checkoutApiUrl}/companies/v2/company?${queryParams.toString()}`;
                 },
+                /**
+                 * select2's request layer, replaced so the search gets a
+                 * cache, a timeout and a failure signal the buyer can see.
+                 * select2 calls this instead of `$.ajax` and aborts the
+                 * returned handle when the next keystroke supersedes this
+                 * search.
+                 *
+                 * @param {object} params merged $.ajax settings from select2
+                 * @param {function} success select2's result handler
+                 * @param {function} failure select2's failure handler
+                 * @returns {{abort: function}} abortable request handle
+                 */
+                transport: function (params, success, failure) {
+                    onUnavailable(false);
+
+                    const cached = cacheGet(params.url);
+                    if (cached) {
+                        // Answer from cache. Deferred a tick rather than
+                        // called inline so select2 always sees the same
+                        // async shape it does for a real request, and so an
+                        // abort can still win.
+                        let aborted = false;
+                        const timer = setTimeout(function () {
+                            if (aborted) return;
+                            success(cached);
+                        }, 0);
+                        return {
+                            abort: function () {
+                                aborted = true;
+                                clearTimeout(timer);
+                            }
+                        };
+                    }
+
+                    onSearching(true);
+                    const request = $.ajax(params);
+
+                    request.done(function (response) {
+                        cacheSet(params.url, response);
+                        // A degraded 200 is a failure dressed as a success:
+                        // near-empty results because the provider timed out.
+                        // Surface it as "unavailable", not "no matches".
+                        if (isDegradedResponse(response)) onUnavailable(true);
+                        success(response);
+                    });
+                    request.fail(function (jqXHR, textStatus) {
+                        // A genuine abort is the buyer typing on, or the
+                        // widget being torn down — expected, and silent by
+                        // design. A timeout is NOT an abort and must be
+                        // visible, otherwise the buyer reads a hung backend
+                        // as "my company isn't accepted here".
+                        if (textStatus !== 'abort') onUnavailable(true);
+                        failure(jqXHR, textStatus);
+                    });
+                    request.always(function () {
+                        onSearching(false);
+                    });
+
+                    return request;
+                },
                 processResults: function (response) {
                     const items = [];
-                    for (let i = 0; i < response.items.length; i++) {
-                        const item = response.items[i];
+                    const responseItems = (response && response.items) || [];
+                    for (let i = 0; i < responseItems.length; i++) {
+                        const item = responseItems[i];
                         items.push({
                             id: item.name,
                             text: item.name,
@@ -95,6 +238,7 @@ define(['jquery'], function ($) {
             const self = this;
             const addressResponse = $.ajax({
                 dataType: 'json',
+                timeout: REQUEST_TIMEOUT_MS,
                 url: `${config.checkoutApiUrl}/companies/v2/company/${selectedCompany.lookupId}`
             });
             addressResponse.done(function (response) {
@@ -121,6 +265,81 @@ define(['jquery'], function ($) {
             $('input[name="street[0]"]').val(address.street_address);
             $('input[name="city"], input[name="postcode"], input[name="street[0]"]').trigger(
                 'change'
+            );
+        },
+
+        /**
+         * Resolve the box that holds select2's typing input for a picker.
+         *
+         * For a single-select, select2 renders the search input inside the
+         * dropdown (`.select2-search--dropdown`), not inside the closed
+         * selection box — so that container IS the search field as far as
+         * the buyer is concerned, and it is where the spinner and the
+         * unavailable notice belong.
+         *
+         * Scoped through the widget instance rather than a document-wide
+         * selector: with two pickers in one checkout, a global lookup would
+         * decorate whichever dropdown happened to be in the DOM.
+         *
+         * @param {string} fieldSelector the picker's input selector
+         * @returns {object} jQuery set — empty when the widget isn't bound
+         */
+        getSearchFieldContainer: function (fieldSelector) {
+            const instance = $(fieldSelector).data('select2');
+            if (!instance || !instance.$dropdown) return $();
+            return instance.$dropdown.find('.select2-search--dropdown');
+        },
+
+        /**
+         * Show or hide the in-field searching spinner.
+         *
+         * Reuses the three-dot loader already used by the payment-term chips
+         * (`.two-term-chip__loading`, `two-term-chip-dot` keyframes) rather
+         * than introducing a second loading idiom.
+         *
+         * @param {string} fieldSelector the picker's input selector
+         * @param {boolean} isSearching
+         */
+        setSearching: function (fieldSelector, isSearching) {
+            const $container = this.getSearchFieldContainer(fieldSelector);
+            if (!$container.length) return;
+
+            if (!isSearching) {
+                $container.find(`.${SPINNER_CLASS}`).remove();
+                return;
+            }
+            if ($container.find(`.${SPINNER_CLASS}`).length) return;
+            $container.append(
+                `<span class="${SPINNER_CLASS}" aria-hidden="true"` +
+                    '><span>.</span><span>.</span><span>.</span></span>'
+            );
+        },
+
+        /**
+         * Show or hide the "search unavailable" notice.
+         *
+         * This is the whole point of the timeout/degraded work: without it,
+         * a timed-out or degraded search is pixel-identical to "no companies
+         * matched", so a buyer with a perfectly valid company concludes the
+         * shop won't take them. The copy points at manual entry, which both
+         * pickers already offer.
+         *
+         * @param {string} fieldSelector the picker's input selector
+         * @param {boolean} isUnavailable
+         */
+        setUnavailable: function (fieldSelector, isUnavailable) {
+            const $container = this.getSearchFieldContainer(fieldSelector);
+            if (!$container.length) return;
+
+            if (!isUnavailable) {
+                $container.find(`.${UNAVAILABLE_CLASS}`).remove();
+                return;
+            }
+            if ($container.find(`.${UNAVAILABLE_CLASS}`).length) return;
+            $container.append(
+                `<div class="${UNAVAILABLE_CLASS}" role="alert">` +
+                    $t('Company search is unavailable. Try again, or enter details manually.') +
+                    '</div>'
             );
         }
     };

--- a/view/frontend/web/js/view/address-autocomplete.js
+++ b/view/frontend/web/js/view/address-autocomplete.js
@@ -88,6 +88,16 @@ define([
             const self = this;
             require(['Two_Gateway/select2-4.1.0/js/select2.min'], function () {
                 $.async(self.companyNameSelector, function (companyNameField) {
+                    // `$.async` is a MutationObserver, and every call to
+                    // enableCompanySearch() adds another one. One-page
+                    // checkouts re-render the checkout on totals changes, so
+                    // this callback fires repeatedly for the same node.
+                    // Binding select2 twice to one node leaves a duplicate
+                    // widget whose in-flight XHR resolves into a dropdown the
+                    // buyer can no longer see. Bind each node exactly once;
+                    // the "Search for company" path destroys the widget first,
+                    // so it still gets a fresh bind.
+                    if ($(companyNameField).data('select2')) return;
                     $(companyNameField)
                         .select2({
                             minimumInputLength: 3,
@@ -105,6 +115,18 @@ define([
                                 config: config,
                                 getCountryCode: function () {
                                     return $(self.countrySelector).val();
+                                },
+                                onSearching: function (isSearching) {
+                                    companySearch.setSearching(
+                                        self.companyNameSelector,
+                                        isSearching
+                                    );
+                                },
+                                onUnavailable: function (isUnavailable) {
+                                    companySearch.setUnavailable(
+                                        self.companyNameSelector,
+                                        isUnavailable
+                                    );
                                 }
                             })
                         })

--- a/view/frontend/web/js/view/address-autocomplete.js
+++ b/view/frontend/web/js/view/address-autocomplete.js
@@ -88,17 +88,15 @@ define([
             const self = this;
             require(['Two_Gateway/select2-4.1.0/js/select2.min'], function () {
                 $.async(self.companyNameSelector, function (companyNameField) {
-                    // `$.async` is a MutationObserver, and every call to
-                    // enableCompanySearch() adds another one. One-page
-                    // checkouts re-render the checkout on totals changes, so
-                    // this callback fires repeatedly for the same node.
-                    // Binding select2 twice to one node leaves a duplicate
-                    // widget whose in-flight XHR resolves into a dropdown the
-                    // buyer can no longer see. Bind each node exactly once;
-                    // the "Search for company" path destroys the widget first,
-                    // so it still gets a fresh bind.
-                    if ($(companyNameField).data('select2')) return;
-                    $(companyNameField)
+                    // Re-binding on every `$.async` fire is intentional:
+                    // select2 4.1's constructor destroys any existing
+                    // instance on the same node, so re-init re-points the
+                    // widget and its handlers at the current component. An
+                    // early-return guard here would both keep a stale widget
+                    // alive and skip the placeholder / manual-entry
+                    // housekeeping below.
+                    const $companyNameField = $(companyNameField);
+                    $companyNameField
                         .select2({
                             minimumInputLength: 3,
                             width: '100%',
@@ -116,21 +114,22 @@ define([
                                 getCountryCode: function () {
                                     return $(self.countrySelector).val();
                                 },
+                                // Bound to THIS node, not to the selector, so
+                                // a destroyed widget's late response cannot
+                                // paint onto the live picker.
                                 onSearching: function (isSearching) {
-                                    companySearch.setSearching(
-                                        self.companyNameSelector,
-                                        isSearching
-                                    );
+                                    companySearch.setSearching($companyNameField, isSearching);
                                 },
                                 onUnavailable: function (isUnavailable) {
-                                    companySearch.setUnavailable(
-                                        self.companyNameSelector,
-                                        isUnavailable
-                                    );
+                                    companySearch.setUnavailable($companyNameField, isUnavailable);
                                 }
                             })
                         })
                         .on('select2:open', function () {
+                            // Nothing else removes what we appended into the
+                            // search box, so a reopened picker would show the
+                            // previous search's "unavailable" notice.
+                            companySearch.clearSearchChrome($companyNameField);
                             if ($(self.enterDetailsManuallyButton).length == 0) {
                                 $('.select2-results')
                                     .parent()

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -838,6 +838,17 @@ define([
                     $(companyIdField).prop('disabled', true);
                 });
                 $.async(self.companyNameSelector, function (companyNameField) {
+                    // `$.async` is a MutationObserver, and every call to
+                    // enableCompanySearch() adds another one. One-page
+                    // checkouts (Fire Checkout) re-render this payment
+                    // renderer on every totals/shipping change, so the
+                    // callback fires repeatedly for the same node. Binding
+                    // select2 twice to one node leaves a duplicate widget
+                    // whose in-flight XHR resolves into a dropdown the buyer
+                    // can no longer see. Bind each node exactly once;
+                    // clearCompany()/disableCompanySearch() destroys the
+                    // widget first, so re-enabling still gets a fresh bind.
+                    if ($(companyNameField).data('select2')) return;
                     $(companyNameField)
                         .select2({
                             minimumInputLength: 3,
@@ -855,6 +866,18 @@ define([
                                 config: self._brandConfig,
                                 getCountryCode: function () {
                                     return self.countryCode();
+                                },
+                                onSearching: function (isSearching) {
+                                    companySearch.setSearching(
+                                        self.companyNameSelector,
+                                        isSearching
+                                    );
+                                },
+                                onUnavailable: function (isUnavailable) {
+                                    companySearch.setUnavailable(
+                                        self.companyNameSelector,
+                                        isUnavailable
+                                    );
                                 }
                             })
                         })

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -229,6 +229,13 @@ define([
          * doesn't accumulate live subscriptions to the singleton quote totals.
          */
         dispose: function () {
+            // Destroy the company-search widget with the component that owns
+            // it. Without this a re-render that REUSES the input node (rather
+            // than recreating it) leaves the old widget bound, with handlers
+            // closed over this now-disposed renderer — picking a company
+            // would then write to dead observables and the order would go out
+            // with no company on it.
+            this.disableCompanySearch();
             if (this._twoVisibilitySub) {
                 this._twoVisibilitySub.dispose();
                 this._twoVisibilitySub = null;
@@ -839,17 +846,20 @@ define([
                 });
                 $.async(self.companyNameSelector, function (companyNameField) {
                     // `$.async` is a MutationObserver, and every call to
-                    // enableCompanySearch() adds another one. One-page
-                    // checkouts (Fire Checkout) re-render this payment
-                    // renderer on every totals/shipping change, so the
-                    // callback fires repeatedly for the same node. Binding
-                    // select2 twice to one node leaves a duplicate widget
-                    // whose in-flight XHR resolves into a dropdown the buyer
-                    // can no longer see. Bind each node exactly once;
-                    // clearCompany()/disableCompanySearch() destroys the
-                    // widget first, so re-enabling still gets a fresh bind.
-                    if ($(companyNameField).data('select2')) return;
-                    $(companyNameField)
+                    // enableCompanySearch() adds another one, so on a
+                    // one-page checkout (Fire Checkout) this fires
+                    // repeatedly. Re-binding is deliberately NOT guarded
+                    // against: select2 4.1's own constructor destroys any
+                    // existing instance on the same node
+                    // (`GetData(el, 'select2').destroy()`), so re-init is the
+                    // correct way to re-point the widget — and its handlers'
+                    // `self` closure — at the current component. Skipping the
+                    // re-init would leave the previous widget alive with
+                    // closures over a DISPOSED renderer, so picking a company
+                    // would write to dead observables. What re-render safety
+                    // needs instead is the teardown in dispose() below.
+                    const $companyNameField = $(companyNameField);
+                    $companyNameField
                         .select2({
                             minimumInputLength: 3,
                             width: '100%',
@@ -867,21 +877,27 @@ define([
                                 getCountryCode: function () {
                                     return self.countryCode();
                                 },
+                                // Bound to THIS node, not to the selector.
+                                // A search issued by a widget that has since
+                                // been destroyed then finds no instance on
+                                // its own element and no-ops, rather than
+                                // painting a stale failure onto whatever
+                                // picker is live now.
                                 onSearching: function (isSearching) {
-                                    companySearch.setSearching(
-                                        self.companyNameSelector,
-                                        isSearching
-                                    );
+                                    companySearch.setSearching($companyNameField, isSearching);
                                 },
                                 onUnavailable: function (isUnavailable) {
-                                    companySearch.setUnavailable(
-                                        self.companyNameSelector,
-                                        isUnavailable
-                                    );
+                                    companySearch.setUnavailable($companyNameField, isUnavailable);
                                 }
                             })
                         })
                         .on('select2:open', function () {
+                            // select2 only detaches the dropdown on close and
+                            // only blanks the search input, so anything we
+                            // appended into the search box survives. Clear it
+                            // here or a reopened picker still shows the last
+                            // search's "unavailable" notice.
+                            companySearch.clearSearchChrome($companyNameField);
                             if ($(self.enterDetailsManuallyButton).length == 0) {
                                 $('.select2-results')
                                     .parent()


### PR DESCRIPTION
Linear: [TWO-25233](https://linear.app/two-inc/issue/TWO-25233/magento-company-search-timeout-degraded-state-ux-and-re-render-safety) (child of TWO-24739)

## Why

Luma company search had four reliability gaps, and every one of them looked identical to the buyer: an empty dropdown. A buyer with a perfectly valid company reads that as "this shop won't take me" and leaves.

## What changed

All four fixes land almost entirely in the already-shared `view/frontend/web/js/model/company-search.js`; the two call sites gain only the spinner/notice wiring and a bind guard.

**1. Request timeout — 30000ms** (`company-search.js`)
There was none, on either the search or the company-detail lookup. 30s is chosen deliberately to sit *outside* the server's `stop_after_delay(10)` retry envelope, so the client never abandons a request the API is still legitimately retrying — while still bounding the browser default of "hang until the socket dies".

**2. Failure is no longer "no companies found"**
`transport` now distinguishes the cases. Timeout, network error and non-2xx raise an in-field notice pointing at manual entry (which both pickers already offer). A **genuine abort stays silent** — an abort is the buyer typing on, or the widget being torn down, and an error banner on every keystroke would be noise.

**3. Consumes the new `degraded: true` flag**
The API answers HTTP 200 with near-empty results when its upstream provider timed out. That raises the same affordance. Read defensively with a strict `=== true` check, so an absent field means false and responses without it keep working unchanged — the flag may not be deployed yet, and nothing here blocks on it. Degraded responses are also **never cached**: pinning the buyer to a transient upstream failure for the rest of the session would be worse than the failure itself.

**4. Once-per-node select2 binding**
`enableCompanySearch` binds through `$.async`, which is a MutationObserver, and every call adds another one. One-page checkouts (Fire Checkout) re-render the payment renderer on every totals/shipping change, so select2 re-bound to the same node repeatedly and a stale in-flight response resolved into a widget the buyer could no longer see. Guarded on `.data('select2')`; the destroy-then-re-enable paths (`clearCompany`, "Search for company") still get a fresh bind because destroy clears that data key.

**Plus:**
- **Module-scoped result cache** (bounded at 50 entries, LRU-ish eviction). Module scope is the point — a widget-owned cache is discarded on every re-render, which is exactly when re-issuing searches hurts most.
- **In-field spinner**, reusing the payment-term chips' existing three-dot loader (`two-term-chip-dot` keyframes) rather than introducing a second loading idiom. It renders inside `.select2-search--dropdown`, which for a single-select *is* where the buyer types.
- **Debounce 400ms -> 300ms**, aligning with the WooCommerce and PrestaShop pickers.

## Testing

`npm run test:js` — **10 suites, 104 tests, all passing.** 19 new cases in `Test/Js/company-search-resilience.test.js` cover: 30s timeout on both requests, 300ms debounce, forced timeout, network error, silent abort, healthy response, `degraded: true`, `degraded` absent, `degraded` non-boolean truthy values, degraded-never-cached, cache hit, cache keyed by url, cache surviving a rebuilt options block, aborted cache hit, `clearResultCache`, `processResults` with no `items`, chrome no-op before bind, and once-per-node binding on **both** pickers.

## Explicitly unverified

**No browser was available in this session, so the spinner and notice placement inside select2's search box is not visually verified.** The logic is unit-tested; the pixels are not. Worth a look on a staging shop before this reaches a real buyer.

The three i18n translations (nb_NO / nl_NL / sv_SE) are machine-drafted and would benefit from a native check.

## Not in this PR

- Hyvä has its own three fetch paths and gets a companion PR in `magento-hyva-extension`.
- Consolidating the Hyvä copies into one Alpine factory — called out in the ticket, deliberately not done here.
- Proxying company search through the plugin backend (TWO-25162, gated on the auth-primitive decision). The timeout/abort layer is placed to survive that migration.