### PR TITLE
fix(firecheckout): beat Fire Checkout's field specificity for the term chips

### DIFF
--- a/view/frontend/web/css/style.css
+++ b/view/frontend/web/css/style.css
@@ -393,17 +393,24 @@
 /*
  * Theme specific css for fire checkout on the payment term chips.
  *
- * Fire Checkout lays every `.field` inside its one-page checkout form out as a
- * label/control row rather than the stacked block layout Luma and Hyva use, so
- * the chip container is pulled up onto the same line as the "Selected payment
- * terms" label. Making the field itself a column flex container puts the
- * container back below the label, and — because float is ignored on a flex
- * item — it neutralises the row layout whether Fire achieves it by floating
- * the label or by flexing the field. No `!important` needed: this changes the
- * `.field` wrapper's own formatting context rather than fighting Fire's rules
- * on the label.
+ * Fire Checkout's own stylesheet (Swissup_Firecheckout/css/firecheckout-light.css)
+ * lays out every field inside the payment tile as a label/control row:
+ *
+ *   .firecheckout .payment-method-content div.field       { display: inline-block; width: 100% }
+ *   .firecheckout .payment-method-content div.field > .label { float: left; width: auto }
+ *
+ * The floated label leaves the chip container beside it rather than under it.
+ * Making the field a column flex container puts the container back below the
+ * label, and float has no effect on a flex item so the label unfloats too.
+ *
+ * The selector has to carry `.payment-method-content div.field` as well: Fire's
+ * rule scores 0-3-1, so the shorter `.firecheckout .two-term-chips` (0-2-0) that
+ * this replaces lost on specificity and never applied. Adding the chip class on
+ * top of Fire's own selector scores 0-4-1 and wins without `!important`.
+ *
+ * Everything here stays inside `.firecheckout`, so Luma and Hyva are untouched.
  */
-.firecheckout .two-term-chips {
+.firecheckout .payment-method-content div.field.two-term-chips {
     display: flex;
     flex-direction: column;
 }


### PR DESCRIPTION
## Problem

PR #280 added `.firecheckout .two-term-chips { display: flex; flex-direction: column }` to stack the payment-term chips below their "Selected payment terms" label on the Fire Checkout store view. It shipped, deployed, and did nothing — the chips are still beside the label.

## Diagnosis (in a real browser, on the Fire store view)

`body` genuinely carries the class, so the selector matched the right page:

```
firecheckout checkout-index-index fc-form-compact fc-theme-light fc-form-hide-labels
firecheckout-col3-set fc-onestep firecheckout-layout-empty firecheckout-index-index
page-layout-firecheckout_empty fc-step-payment fc-step-shipping equal-billing-shipping
```

But the computed `display` on `.two-term-chips` was `inline-block`, not `flex`. The winning rules both live in `Swissup_Firecheckout/css/firecheckout-light.css`:

```css
.firecheckout .payment-method-content div.field       { display: inline-block; float: none; width: 100% }
.firecheckout .payment-method-content div.field > .label { float: left; width: auto }
```

Fire's field rule scores **0-3-1**; PR #280's rule scores **0-2-0**. It lost on specificity outright — and Fire's stylesheet also loads *after* `Two_Gateway/css/style.css`, so it would have lost on source order too even at a tie. The layout is float-based, not flex or grid: the floated label leaves the block-level chip container sitting alongside it in the remaining ~160px.

## Fix

Re-scope the same two declarations onto Fire's own selector plus the chip class, which scores **0-4-1** and wins with no `!important`:

```css
.firecheckout .payment-method-content div.field.two-term-chips {
    display: flex;
    flex-direction: column;
}
```

`float` has no effect on a flex item, so this also unfloats the label — one rule covers both of Fire's declarations. The shared chip CSS (`.two-term-chips`, `.two-term-chips__container`) is untouched, and the new selector is still fully inside `.firecheckout`.

## Verification

Measured on the Fire store view with the rule injected live, Two payment block expanded:

| | field display | container top | label bottom | container width | chips below label |
|---|---|---|---|---|---|
| before | `inline-block` | 335px | 351px | 160px | no |
| after | `flex` | 360px | 351px | 318px | yes |

Screenshots before/after confirm the chips move from a narrow column to the label's right into a full-width row underneath it.

Luma and Hyva checkout were loaded with the same rule injected and showed **identical** geometry before and after — as expected, since nothing outside `.firecheckout` is selected.