### PR TITLE
fix(TWO-25233): four defects in the merged company-search hardening

### DIFF
--- a/Test/Js/amd-harness.js
+++ b/Test/Js/amd-harness.js
@@ -119,7 +119,11 @@ function defaultMocks() {
             applyAddress: function () {},
             isDegradedResponse: function () { return false; },
             clearResultCache: function () {},
+            EVENT_NS: '.twoCompanySearch',
+            MIN_INPUT_LENGTH: 3,
             getSearchFieldContainer: function () { return null; },
+            markSearchBinding: function () {},
+            clearSearchChrome: function () {},
             setSearching: function () {},
             setUnavailable: function () {}
         },

--- a/Test/Js/company-search-address-lookup.test.js
+++ b/Test/Js/company-search-address-lookup.test.js
@@ -34,7 +34,14 @@ function makeSpyJQuery(recorder) {
             prop: function () { return obj; },
             text: function () { return obj; },
             attr: function () { return obj; },
-            data: function () { return undefined; },
+            off: function () { return obj; },
+            data: function (key, value) {
+                if (arguments.length > 1) {
+                    recorder.data[key] = value;
+                    return obj;
+                }
+                return recorder.data[key];
+            },
             closest: function () { return obj; },
             find: function () { return obj; },
             append: function () { return obj; },
@@ -47,7 +54,10 @@ function makeSpyJQuery(recorder) {
                 return obj;
             },
             on: function (evt, handler) {
-                recorder.handlers[evt] = handler;
+                // The module namespaces its bindings ('select2:select.twoCompanySearch')
+                // so it can clear only its own handlers on re-init; key on the
+                // bare event name.
+                recorder.handlers[evt.split('.')[0]] = handler;
                 return obj;
             }
         };
@@ -86,6 +96,7 @@ function makeRecorder() {
         written: [],
         triggered: [],
         values: {},
+        data: {},
         handlers: {},
         select2Options: null
     };

--- a/Test/Js/company-search-resilience.test.js
+++ b/Test/Js/company-search-resilience.test.js
@@ -209,6 +209,10 @@ function makeQueryDouble() {
         return node;
     }
 
+    function asyncKey(selector) {
+        return selector + '::matched';
+    }
+
     function $(target) {
         if (target && target.__fake) return target;
         if (target === undefined) {
@@ -226,9 +230,17 @@ function makeQueryDouble() {
         return nodes[key];
     }
 
+    // `$.async` hands the callback the matched ELEMENT. Modelled as a node
+    // distinct from `$(selector)` on purpose: that is what makes a
+    // document-wide `$(companyNameSelector).select2('destroy')` provably miss
+    // the widget the component actually bound (the multi-brand hazard), rather
+    // than accidentally hitting the same memoised node.
     $.async = function (selector, fn) {
         recorder.asyncCallbacks.push(fn);
-        fn(selector);
+        fn(asyncKey(selector));
+    };
+    $.asyncNode = function (selector) {
+        return $(asyncKey(selector));
     };
     $.ajax = function (opts) {
         recorder.ajax.push(opts);
@@ -247,6 +259,11 @@ function makeQueryDouble() {
                 return jqxhr;
             },
             aborted: false,
+            // jQuery sets status 0 for BOTH a timeout and an abort. Present
+            // here on purpose: it is what makes `'status' in handle` a real
+            // assertion rather than a tautology, since returning this jqXHR
+            // straight through would satisfy select2's cancellation check.
+            status: 0,
             abort: function () {
                 jqxhr.aborted = true;
             },
@@ -322,9 +339,10 @@ function makeHooks() {
     };
 }
 
-function buildOptions(companySearch, hooks) {
+function buildOptions(companySearch, hooks, token) {
     return companySearch.buildSearchAjaxOptions({
         config: BASE_CONFIG,
+        token: token || {},
         getCountryCode: function () {
             return 'gb';
         },
@@ -827,6 +845,59 @@ describe('in-field chrome', () => {
         expect(searchBoxOf(recorder).children).toHaveLength(0);
     });
 
+    test('dropping below the minimum input length CANCELS the request', () => {
+        const { $, recorder } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+        const $field = $(SEARCH_FIELD);
+        const token = {};
+
+        $field.select2({});
+        companySearch.markSearchBinding($field, token);
+
+        companySearch
+            .buildSearchAjaxOptions({
+                config: BASE_CONFIG,
+                token: token,
+                getCountryCode: function () {
+                    return 'gb';
+                }
+            })
+            .transport({ url: 'https://api.example.test/c?q=exa' }, jest.fn(), jest.fn());
+
+        // select2's minimumInputLength decorator returns BEFORE delegating to
+        // the ajax adapter, and `_request.abort()` lives inside that adapter —
+        // so select2 never cancels here. Left running, the request resolves
+        // 30s later and repaints results for an abandoned term.
+        const searchField = recorder.searchFields[recorder.searchFields.length - 1];
+        searchField.value = 'ex';
+        searchField.__handlers['input' + companySearch.EVENT_NS].call(searchField);
+
+        expect(recorder.requests[0].aborted).toBe(true);
+    });
+
+    test('abortActiveRequest reports whether there was anything to cancel', () => {
+        const { $, recorder } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+        const token = {};
+
+        expect(companySearch.abortActiveRequest(token)).toBe(false);
+
+        companySearch
+            .buildSearchAjaxOptions({
+                config: BASE_CONFIG,
+                token: token,
+                getCountryCode: function () {
+                    return 'gb';
+                }
+            })
+            .transport({ url: 'https://api.example.test/c?q=exa' }, jest.fn(), jest.fn());
+
+        expect(companySearch.abortActiveRequest(token)).toBe(true);
+        expect(recorder.requests[0].aborted).toBe(true);
+        // Deregistered, so a second call is a no-op rather than a double abort.
+        expect(companySearch.abortActiveRequest(token)).toBe(false);
+    });
+
     test('chrome is a no-op before select2 binds', () => {
         const { $ } = makeQueryDouble();
         const companySearch = loadCompanySearch($);
@@ -897,14 +968,14 @@ describe('re-render safety of the select2 binding', () => {
         const ctx = loadRenderer($);
 
         ctx.enableCompanySearch();
-        expect($(SEARCH_FIELD).data('select2')).toBeDefined();
+        expect($.asyncNode(SEARCH_FIELD).data('select2')).toBeDefined();
 
         ctx.dispose();
 
         // Without this, a re-render that REUSES the input node leaves the old
         // widget bound with handlers closed over the disposed renderer.
         expect(recorder.destroyCalls).toBe(1);
-        expect($(SEARCH_FIELD).data('select2')).toBeUndefined();
+        expect($.asyncNode(SEARCH_FIELD).data('select2')).toBeUndefined();
     });
 
     /**
@@ -919,14 +990,17 @@ describe('re-render safety of the select2 binding', () => {
         const ctx = loadRenderer($);
 
         ctx.enableCompanySearch();
-        // A sibling renderer's widget, bound to a different node.
-        const $sibling = $('input#company_name_sibling');
+        // Another node that the component's own selector ALSO matches — the
+        // duplicate `#company_name` a second Two-family brand renders. A
+        // document-wide destroy would take this one out.
+        const $sibling = $(SEARCH_FIELD);
         $sibling.select2({});
 
         ctx.dispose();
 
         expect(recorder.destroyCalls).toBe(1);
         expect($sibling.data('select2')).toBeDefined();
+        expect($.asyncNode(SEARCH_FIELD).data('select2')).toBeUndefined();
     });
 
     test('dispose is safe when no widget was ever bound', () => {
@@ -948,7 +1022,7 @@ describe('re-render safety of the select2 binding', () => {
     test('re-render does not stack duplicate select2 handlers', () => {
         const { $ } = makeQueryDouble();
         const ctx = loadRenderer($);
-        const $field = $(SEARCH_FIELD);
+        const $field = $.asyncNode(SEARCH_FIELD);
 
         ctx.enableCompanySearch();
         expect($field.handlersFor('select2:select')).toHaveLength(1);
@@ -960,10 +1034,52 @@ describe('re-render safety of the select2 binding', () => {
         expect($field.handlersFor('select2:open')).toHaveLength(1);
     });
 
+    /**
+     * Covers the CALL SITES, not the model. An earlier revision threaded the
+     * bind token only into `clearSearchChrome` — which runs on `select2:open`
+     * and is by definition the live widget — while the two hooks that can
+     * actually paint from a stale widget passed none. Because the guard then
+     * failed open on a missing token, every model-level token test still
+     * passed and the bug shipped. This drives the real hooks.
+     */
+    test('a stale widget\'s hooks cannot paint after a re-render', () => {
+        const { $, recorder } = makeQueryDouble();
+        const ctx = loadRenderer($);
+
+        ctx.enableCompanySearch();
+        const staleOptions = recorder.select2Calls[0].ajax;
+
+        // Re-render: same node, fresh widget, fresh box.
+        ctx.enableCompanySearch();
+        const liveBox = recorder.searchBoxes[recorder.searchBoxes.length - 1];
+
+        // The stale widget's request finally times out.
+        staleOptions.transport({ url: 'https://api.example.test/x?q=exa' }, jest.fn(), jest.fn());
+        recorder.requests[recorder.requests.length - 1].settleFail('timeout');
+
+        expect(liveBox.children).toHaveLength(0);
+    });
+
+    test('the live widget\'s hooks DO paint', () => {
+        const { $, recorder } = makeQueryDouble();
+        const ctx = loadRenderer($);
+
+        ctx.enableCompanySearch();
+        const liveOptions = recorder.select2Calls[0].ajax;
+        const liveBox = recorder.searchBoxes[recorder.searchBoxes.length - 1];
+
+        liveOptions.transport({ url: 'https://api.example.test/x?q=exa' }, jest.fn(), jest.fn());
+        recorder.requests[recorder.requests.length - 1].settleFail('timeout');
+
+        // Guards against "fails closed" degenerating into "never works".
+        expect(liveBox.children).toHaveLength(1);
+        expect(liveBox.children[0]).toContain('two-company-search__unavailable');
+    });
+
     test('shipping-step picker does not stack handlers either', () => {
         const { $ } = makeQueryDouble();
         const ctx = loadShippingComponent($);
-        const $field = $(SEARCH_FIELD);
+        const $field = $.asyncNode(SEARCH_FIELD);
 
         ctx.enableCompanySearch();
         ctx.enableCompanySearch();

--- a/Test/Js/company-search-resilience.test.js
+++ b/Test/Js/company-search-resilience.test.js
@@ -166,6 +166,11 @@ function makeQueryDouble() {
                     };
                     recorder.searchFields.push(searchField);
                     store.select2 = {
+                        // select2's ajax data adapter holds the debounced
+                        // query in `_queryTimeout`; the below-minimum handler
+                        // has to clear it as well as abort the in-flight
+                        // request.
+                        dataAdapter: { _queryTimeout: null },
                         $dropdown: {
                             find: function (selector) {
                                 if (selector === '.select2-search--dropdown') return searchBox;
@@ -845,6 +850,30 @@ describe('in-field chrome', () => {
         expect(searchBoxOf(recorder).children).toHaveLength(0);
     });
 
+    test('dropping below the minimum input length clears the PENDING query', () => {
+        const { $, recorder } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+        const $field = $(SEARCH_FIELD);
+        const token = {};
+
+        $field.select2({});
+        companySearch.markSearchBinding($field, token);
+
+        // select2 armed its 300ms debounce but has not fired the request yet.
+        // Its minimumInputLength decorator short-circuits query() before
+        // reaching the adapter, so select2 never clears this timer either:
+        // backspacing from 4 chars to 2 inside 300ms would otherwise fire a
+        // search for the abandoned term.
+        const dataAdapter = $field.data('select2').dataAdapter;
+        dataAdapter._queryTimeout = setTimeout(function () {}, 10000);
+
+        const searchField = recorder.searchFields[recorder.searchFields.length - 1];
+        searchField.value = 'ex';
+        searchField.__handlers['input' + companySearch.EVENT_NS].call(searchField);
+
+        expect(dataAdapter._queryTimeout).toBeNull();
+    });
+
     test('dropping below the minimum input length CANCELS the request', () => {
         const { $, recorder } = makeQueryDouble();
         const companySearch = loadCompanySearch($);
@@ -1042,7 +1071,7 @@ describe('re-render safety of the select2 binding', () => {
      * failed open on a missing token, every model-level token test still
      * passed and the bug shipped. This drives the real hooks.
      */
-    test('a stale widget\'s hooks cannot paint after a re-render', () => {
+    test("a stale widget's hooks cannot paint after a re-render", () => {
         const { $, recorder } = makeQueryDouble();
         const ctx = loadRenderer($);
 
@@ -1060,7 +1089,7 @@ describe('re-render safety of the select2 binding', () => {
         expect(liveBox.children).toHaveLength(0);
     });
 
-    test('the live widget\'s hooks DO paint', () => {
+    test("the live widget's hooks DO paint", () => {
         const { $, recorder } = makeQueryDouble();
         const ctx = loadRenderer($);
 

--- a/Test/Js/company-search-resilience.test.js
+++ b/Test/Js/company-search-resilience.test.js
@@ -83,12 +83,14 @@ function makeQueryDouble() {
         asyncCallbacks: [],
         select2Calls: [],
         destroyCalls: 0,
-        searchBoxes: []
+        searchBoxes: [],
+        searchFields: []
     };
     const nodes = {};
 
     function makeNode(key) {
         const store = {};
+        const handlers = [];
         const node = {
             __fake: true,
             length: 1,
@@ -108,7 +110,11 @@ function makeQueryDouble() {
             attr: function () {
                 return node;
             },
-            data: function (dataKey) {
+            data: function (dataKey, value) {
+                if (arguments.length > 1) {
+                    store[dataKey] = value;
+                    return node;
+                }
                 return store[dataKey];
             },
             closest: function () {
@@ -133,6 +139,11 @@ function makeQueryDouble() {
                 if (opts === 'destroy') {
                     recorder.destroyCalls++;
                     delete store.select2;
+                    // Mirrors select2 4.1: destroy() does
+                    // `$element.off('.select2')` and nothing more, so handlers
+                    // in any OTHER namespace survive. That is exactly why the
+                    // module has to clear its own namespace before re-binding.
+                    node.off('.select2');
                     return node;
                 }
                 if (typeof opts === 'object') {
@@ -142,20 +153,57 @@ function makeQueryDouble() {
                     // the search box our chrome writes into.
                     const searchBox = makeFakeContainer();
                     recorder.searchBoxes.push(searchBox);
+                    const searchField = {
+                        value: '',
+                        __handlers: {},
+                        off: function () {
+                            return searchField;
+                        },
+                        on: function (spec, handler) {
+                            searchField.__handlers[spec] = handler;
+                            return searchField;
+                        }
+                    };
+                    recorder.searchFields.push(searchField);
                     store.select2 = {
                         $dropdown: {
                             find: function (selector) {
-                                return selector === '.select2-search--dropdown'
-                                    ? searchBox
-                                    : { length: 0 };
+                                if (selector === '.select2-search--dropdown') return searchBox;
+                                if (selector === '.select2-search__field') return searchField;
+                                return { length: 0 };
                             }
                         }
                     };
                 }
                 return node;
             },
-            on: function () {
+            on: function (spec, handler) {
+                // Record per event name AND namespace, so the tests can prove
+                // handlers are not stacking across re-binds.
+                handlers.push({ spec: spec, handler: handler });
                 return node;
+            },
+            off: function (spec) {
+                if (spec === undefined) {
+                    handlers.length = 0;
+                    return node;
+                }
+                const remaining = handlers.filter(function (h) {
+                    // A bare namespace ('.twoCompanySearch') removes every
+                    // handler bound in it; jQuery semantics.
+                    if (spec.charAt(0) === '.') return h.spec.indexOf(spec) === -1;
+                    return h.spec !== spec;
+                });
+                handlers.length = 0;
+                remaining.forEach(function (h) {
+                    handlers.push(h);
+                });
+                return node;
+            },
+            handlersFor: function (eventName) {
+                return handlers.filter(function (h) {
+                    return h.spec.split('.')[0] === eventName;
+                });
             }
         };
         return node;
@@ -198,7 +246,10 @@ function makeQueryDouble() {
                 handlers.always.push(cb);
                 return jqxhr;
             },
-            abort: function () {},
+            aborted: false,
+            abort: function () {
+                jqxhr.aborted = true;
+            },
             settleDone: function (data) {
                 handlers.done.forEach(function (cb) {
                     cb(data);
@@ -319,7 +370,18 @@ describe('request envelope', () => {
 });
 
 describe('failure is not "no companies found"', () => {
-    test('a timeout raises the notice AND gives select2 a terminal result', () => {
+    /**
+     * The crux of the whole ticket. select2's ajax adapter builds its failure
+     * closure as `'status' in e && (0 === e.status || '0' === e.status) ||
+     * trigger('results:message', {message: 'errorLoading'})`, where `e` is
+     * the value the TRANSPORT RETURNED — not the jqXHR. jQuery reports both a
+     * user abort AND a timeout as `status === 0`, so handing back the raw
+     * jqXHR makes the two indistinguishable: select2 swallows the timeout,
+     * never fires `results:message`, never reaches `hideLoading()`, and
+     * leaves "Searching…" in the dropdown forever. Owning the handle is what
+     * lets `status = 0` mean "abort" and only that.
+     */
+    test('a timeout reaches select2 as a real failure, not a cancellation', () => {
         const { $, recorder } = makeQueryDouble();
         const companySearch = loadCompanySearch($);
         const hooks = makeHooks();
@@ -327,19 +389,21 @@ describe('failure is not "no companies found"', () => {
         const success = jest.fn();
         const failure = jest.fn();
 
-        ajaxOptions.transport({ url: 'https://api.example.test/x?q=exa' }, success, failure);
+        const handle = ajaxOptions.transport(
+            { url: 'https://api.example.test/x?q=exa' },
+            success,
+            failure
+        );
         recorder.requests[0].settleFail('timeout');
 
         expect(hooks.calls.unavailable).toEqual([false, true]);
+        expect(failure).toHaveBeenCalled();
+        expect(success).not.toHaveBeenCalled();
 
-        // The load-bearing part. jQuery reports a timeout as status 0, and
-        // select2's own failure handler treats status 0 as an abort: it never
-        // fires `results:message`, so `hideLoading()` is never reached and
-        // the dropdown shows "Searching…" forever — under the very notice
-        // saying the search failed. Routing through select2's SUCCESS path
-        // with an empty result set is what gives it a terminal state.
-        expect(failure).not.toHaveBeenCalled();
-        expect(success).toHaveBeenCalledWith({ items: [] });
+        // No `status` key on the handle => select2 fires `errorLoading`, and
+        // displayMessage() calls hideLoading(). A `status` of 0 here would
+        // reinstate the stuck-spinner bug.
+        expect('status' in handle).toBe(false);
     });
 
     test('a network error behaves the same way', () => {
@@ -347,18 +411,21 @@ describe('failure is not "no companies found"', () => {
         const companySearch = loadCompanySearch($);
         const hooks = makeHooks();
         const ajaxOptions = buildOptions(companySearch, hooks);
-        const success = jest.fn();
         const failure = jest.fn();
 
-        ajaxOptions.transport({ url: 'https://api.example.test/x?q=exa' }, success, failure);
+        const handle = ajaxOptions.transport(
+            { url: 'https://api.example.test/x?q=exa' },
+            jest.fn(),
+            failure
+        );
         recorder.requests[0].settleFail('error');
 
         expect(hooks.calls.unavailable).toContain(true);
-        expect(failure).not.toHaveBeenCalled();
-        expect(success).toHaveBeenCalledWith({ items: [] });
+        expect(failure).toHaveBeenCalled();
+        expect('status' in handle).toBe(false);
     });
 
-    test('a genuine abort stays silent and keeps the spinner up', () => {
+    test('a genuine abort is marked status 0 so select2 stays silent', () => {
         const { $, recorder } = makeQueryDouble();
         const companySearch = loadCompanySearch($);
         const hooks = makeHooks();
@@ -366,7 +433,11 @@ describe('failure is not "no companies found"', () => {
         const success = jest.fn();
         const failure = jest.fn();
 
-        ajaxOptions.transport({ url: 'https://api.example.test/x?q=exa' }, success, failure);
+        const handle = ajaxOptions.transport(
+            { url: 'https://api.example.test/x?q=exa' },
+            success,
+            failure
+        );
         recorder.requests[0].settleFail('abort');
 
         // An abort is the buyer typing on, or the widget being torn down.
@@ -374,11 +445,30 @@ describe('failure is not "no companies found"', () => {
         expect(hooks.calls.unavailable).toEqual([false]);
         expect(failure).toHaveBeenCalled();
         expect(success).not.toHaveBeenCalled();
+        expect(handle.status).toBe(0);
 
         // select2 aborts the in-flight request synchronously at the top of
         // the next query(), 300ms before the replacement transport starts.
         // Dropping the spinner there would blink it off on every keystroke.
         expect(hooks.calls.searching).toEqual([true]);
+    });
+
+    test('the handle aborts the underlying request', () => {
+        const { $, recorder } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+        const ajaxOptions = buildOptions(companySearch, makeHooks());
+
+        const handle = ajaxOptions.transport(
+            { url: 'https://api.example.test/x?q=exa' },
+            jest.fn(),
+            jest.fn()
+        );
+        handle.abort();
+
+        // select2 calls `this._request.abort()` at the top of the next
+        // query(); the wrapper must forward that or every keystroke leaks a
+        // request.
+        expect(recorder.requests[0].aborted).toBe(true);
     });
 
     test('a healthy response raises nothing and settles the spinner', () => {
@@ -529,6 +619,30 @@ describe('result cache', () => {
         expect(success).not.toHaveBeenCalled();
     });
 
+    test('a cache hit takes down a spinner an abort left up', async () => {
+        const { $, recorder } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+        const hooks = makeHooks();
+        const ajaxOptions = buildOptions(companySearch, hooks);
+        const url = 'https://api.example.test/c?q=exa';
+
+        ajaxOptions.transport({ url: url }, jest.fn(), jest.fn());
+        recorder.requests[0].settleDone(SEARCH_RESPONSE);
+
+        // Type on (spinner up), then backspace back to the cached term. The
+        // abort deliberately keeps the spinner, so the cache hit is the only
+        // thing that can take it down — otherwise the dots spin forever over
+        // a fully populated dropdown.
+        ajaxOptions.transport({ url: url + 'm' }, jest.fn(), jest.fn());
+        recorder.requests[1].settleFail('abort');
+        expect(hooks.calls.searching[hooks.calls.searching.length - 1]).toBe(true);
+
+        ajaxOptions.transport({ url: url }, jest.fn(), jest.fn());
+        await nextTick();
+
+        expect(hooks.calls.searching[hooks.calls.searching.length - 1]).toBe(false);
+    });
+
     test('clearResultCache forces a refetch', async () => {
         const { $, recorder } = makeQueryDouble();
         const companySearch = loadCompanySearch($);
@@ -643,6 +757,76 @@ describe('in-field chrome', () => {
         expect(staleBox.children).toHaveLength(0);
     });
 
+    test('a stale bind token cannot paint on the widget that replaced it', () => {
+        const { $, recorder } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+        const $field = $(SEARCH_FIELD);
+
+        const staleToken = {};
+        $field.select2({});
+        companySearch.markSearchBinding($field, staleToken);
+
+        // Re-render: select2 re-inits on the SAME node, so `data('select2')`
+        // now resolves to the NEW instance. The old widget's request can still
+        // be in flight for up to 30s; resolving it must not paint here.
+        const liveToken = {};
+        $field.select2({});
+        companySearch.markSearchBinding($field, liveToken);
+        const liveBox = searchBoxOf(recorder);
+
+        companySearch.setUnavailable($field, true, staleToken);
+        expect(liveBox.children).toHaveLength(0);
+
+        // And the live token still works.
+        companySearch.setUnavailable($field, true, liveToken);
+        expect(liveBox.children).toHaveLength(1);
+    });
+
+    test('a stale token cannot strip the live spinner', () => {
+        const { $, recorder } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+        const $field = $(SEARCH_FIELD);
+
+        const staleToken = {};
+        $field.select2({});
+        companySearch.markSearchBinding($field, staleToken);
+
+        const liveToken = {};
+        $field.select2({});
+        companySearch.markSearchBinding($field, liveToken);
+        const liveBox = searchBoxOf(recorder);
+
+        companySearch.setSearching($field, true, liveToken);
+        expect(liveBox.children).toHaveLength(1);
+
+        // The stale widget's `always` handler fires onSearching(false).
+        companySearch.setSearching($field, false, staleToken);
+        expect(liveBox.children).toHaveLength(1);
+    });
+
+    test('dropping below the minimum input length clears the chrome', () => {
+        const { $, recorder } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+        const $field = $(SEARCH_FIELD);
+        const token = {};
+
+        $field.select2({});
+        companySearch.markSearchBinding($field, token);
+
+        companySearch.setSearching($field, true, token);
+        companySearch.setUnavailable($field, true, token);
+        expect(searchBoxOf(recorder).children).toHaveLength(2);
+
+        // Below `minimumInputLength` select2 short-circuits query() in its
+        // decorator and never calls the data adapter, so no transport runs and
+        // nothing else would ever take the spinner down.
+        const searchField = recorder.searchFields[recorder.searchFields.length - 1];
+        searchField.value = 'ex';
+        searchField.__handlers['input' + companySearch.EVENT_NS].call(searchField);
+
+        expect(searchBoxOf(recorder).children).toHaveLength(0);
+    });
+
     test('chrome is a no-op before select2 binds', () => {
         const { $ } = makeQueryDouble();
         const companySearch = loadCompanySearch($);
@@ -682,6 +866,7 @@ describe('re-render safety of the select2 binding', () => {
             addressLookup: component.addressLookup,
             enableCompanySearch: component.enableCompanySearch,
             disableCompanySearch: component.disableCompanySearch,
+            destroyCompanySearchWidget: component.destroyCompanySearchWidget,
             dispose: component.dispose,
             _super: function () {}
         });
@@ -722,8 +907,72 @@ describe('re-render safety of the select2 binding', () => {
         expect($(SEARCH_FIELD).data('select2')).toBeUndefined();
     });
 
-    test('shipping-step picker also re-initialises on re-render', () => {
+    /**
+     * The renderer is pushed once per Two-family brand, so a checkout offering
+     * two of them has two `#company_name` inputs. dispose() must tear down the
+     * node THIS component bound, not everything a document-wide selector
+     * matches — otherwise disposing one renderer silently turns the other
+     * brand's picker into a plain text input.
+     */
+    test('dispose only destroys the node this component bound', () => {
         const { $, recorder } = makeQueryDouble();
+        const ctx = loadRenderer($);
+
+        ctx.enableCompanySearch();
+        // A sibling renderer's widget, bound to a different node.
+        const $sibling = $('input#company_name_sibling');
+        $sibling.select2({});
+
+        ctx.dispose();
+
+        expect(recorder.destroyCalls).toBe(1);
+        expect($sibling.data('select2')).toBeDefined();
+    });
+
+    test('dispose is safe when no widget was ever bound', () => {
+        const { $ } = makeQueryDouble();
+        const ctx = loadRenderer($);
+
+        expect(function () {
+            ctx.dispose();
+        }).not.toThrow();
+    });
+
+    /**
+     * select2's destroy() only does `$element.off('.select2')`, so handlers we
+     * bind outside that namespace survive every re-init. Left unchecked they
+     * stack one copy per re-render, and a single company pick then fires N
+     * `select2:select` handlers — N address lookups, N-1 of them closed over
+     * disposed renderers, which is the dead-observable bug all over again.
+     */
+    test('re-render does not stack duplicate select2 handlers', () => {
+        const { $ } = makeQueryDouble();
+        const ctx = loadRenderer($);
+        const $field = $(SEARCH_FIELD);
+
+        ctx.enableCompanySearch();
+        expect($field.handlersFor('select2:select')).toHaveLength(1);
+
+        ctx.enableCompanySearch();
+        ctx.enableCompanySearch();
+
+        expect($field.handlersFor('select2:select')).toHaveLength(1);
+        expect($field.handlersFor('select2:open')).toHaveLength(1);
+    });
+
+    test('shipping-step picker does not stack handlers either', () => {
+        const { $ } = makeQueryDouble();
+        const ctx = loadShippingComponent($);
+        const $field = $(SEARCH_FIELD);
+
+        ctx.enableCompanySearch();
+        ctx.enableCompanySearch();
+
+        expect($field.handlersFor('select2:select')).toHaveLength(1);
+        expect($field.handlersFor('select2:open')).toHaveLength(1);
+    });
+
+    function loadShippingComponent($) {
         const companySearch = loadCompanySearch($);
         const brandConfig = function () {
             return BASE_CONFIG;
@@ -740,7 +989,7 @@ describe('re-render safety of the select2 binding', () => {
             'Two_Gateway/js/model/brand-config': brandConfig,
             'Two_Gateway/js/model/company-search': companySearch
         });
-        const ctx = Object.assign(Object.create(component.prototype || {}), {
+        return Object.assign(Object.create(component.prototype || {}), {
             countrySelector: '#shipping-new-address-form select[name="country_id"]',
             companyNameSelector: SEARCH_FIELD,
             companyIdSelector: 'input#company_id',
@@ -753,6 +1002,11 @@ describe('re-render safety of the select2 binding', () => {
             addressLookup: component.addressLookup,
             enableCompanySearch: component.enableCompanySearch
         });
+    }
+
+    test('shipping-step picker also re-initialises on re-render', () => {
+        const { $, recorder } = makeQueryDouble();
+        const ctx = loadShippingComponent($);
 
         ctx.enableCompanySearch();
         ctx.enableCompanySearch();

--- a/Test/Js/company-search-resilience.test.js
+++ b/Test/Js/company-search-resilience.test.js
@@ -1032,6 +1032,25 @@ describe('re-render safety of the select2 binding', () => {
         expect($.asyncNode(SEARCH_FIELD).data('select2')).toBeUndefined();
     });
 
+    /**
+     * The re-enable link is only visible on paths that have already destroyed
+     * the widget (manual entry → clearCompany → destroy), so resolving it from
+     * `_$companyNameField` found nothing and left the link up in sole-trader
+     * mode. It must resolve from the cached container instead.
+     */
+    test('the re-enable link stays resolvable after the widget is destroyed', () => {
+        const { $ } = makeQueryDouble();
+        const ctx = loadRenderer($);
+
+        ctx.enableCompanySearch();
+        expect(ctx.searchForCompanyLink().length).toBe(1);
+
+        ctx.destroyCompanySearchWidget();
+
+        expect(ctx._$companyNameField).toBeNull();
+        expect(ctx.searchForCompanyLink().length).toBe(1);
+    });
+
     test('dispose is safe when no widget was ever bound', () => {
         const { $ } = makeQueryDouble();
         const ctx = loadRenderer($);

--- a/view/frontend/web/js/model/company-search.js
+++ b/view/frontend/web/js/model/company-search.js
@@ -52,6 +52,20 @@ define(['jquery', 'mage/translate'], function ($, $t) {
     const CACHE_LIMIT = 50;
 
     /**
+     * The in-flight request per bind token.
+     *
+     * Needed because select2 does NOT abort when the buyer drops below
+     * `minimumInputLength`: its decorator's `query()` returns after firing
+     * `results:message` WITHOUT delegating to the ajax adapter, and
+     * `_request.abort()` lives inside that adapter. So the request stays on
+     * the wire; 30s later it resolves and repaints results — or the
+     * "unavailable" notice — for a term the buyer already abandoned.
+     *
+     * A WeakMap so a discarded bind token takes its entry with it.
+     */
+    const activeRequests = new WeakMap();
+
+    /**
      * Mirrors the `minimumInputLength: 3` both call sites pass to select2.
      * Below it select2's decorator short-circuits `query()` and never reaches
      * the data adapter, so no transport runs — which the chrome has to know
@@ -103,6 +117,20 @@ define(['jquery', 'mage/translate'], function ($, $t) {
         EVENT_NS: EVENT_NS,
         isDegradedResponse: isDegradedResponse,
 
+        /**
+         * Cancel the in-flight search for a bind, if any.
+         *
+         * @param {object} token identity stamped by markSearchBinding()
+         * @returns {boolean} true when a request was actually aborted
+         */
+        abortActiveRequest: function (token) {
+            const handle = activeRequests.get(token);
+            if (!handle) return false;
+            activeRequests.delete(token);
+            handle.abort();
+            return true;
+        },
+
         /** Drop every cached search result. Exists for tests. */
         clearResultCache: function () {
             resultCache.clear();
@@ -129,6 +157,7 @@ define(['jquery', 'mage/translate'], function ($, $t) {
             const getCountryCode = options.getCountryCode;
             const onSearching = options.onSearching || function () {};
             const onUnavailable = options.onUnavailable || function () {};
+            const token = options.token;
 
             return {
                 dataType: 'json',
@@ -239,7 +268,11 @@ define(['jquery', 'mage/translate'], function ($, $t) {
                         onUnavailable(true);
                         failure();
                     });
+                    activeRequests.set(token, handle);
                     request.always(function () {
+                        if (activeRequests.get(token) === handle) {
+                            activeRequests.delete(token);
+                        }
                         // Not on abort: select2 aborts the in-flight request
                         // synchronously at the top of the next query(), 300ms
                         // before the replacement transport starts. Dropping
@@ -353,7 +386,11 @@ define(['jquery', 'mage/translate'], function ($, $t) {
          */
         getSearchFieldContainer: function ($field, token) {
             if (!$field || !$field.data) return $();
-            if (token && $field.data('twoSearchBind') !== token) return $();
+            // Fails CLOSED on a missing token. An earlier revision guarded
+            // with `if (token && ...)`, which meant any caller that forgot to
+            // pass one silently bypassed the staleness check — which is
+            // exactly how two call sites shipped with the guard inert.
+            if ($field.data('twoSearchBind') !== token) return $();
             const instance = $field.data('select2');
             if (!instance || !instance.$dropdown) return $();
             return instance.$dropdown.find('.select2-search--dropdown');
@@ -374,20 +411,21 @@ define(['jquery', 'mage/translate'], function ($, $t) {
             const instance = $field.data('select2');
             if (!instance || !instance.$dropdown) return;
 
-            // Below `minimumInputLength` select2 short-circuits query() in its
-            // decorator and never calls the data adapter, so no transport runs
-            // and nothing clears the spinner. Type three characters, then
-            // delete one while the request is in flight: the request aborts
-            // (spinner deliberately kept), no replacement runs, and the dots
-            // spin under "Please enter 3 or more characters" until the picker
-            // is closed and reopened.
+            // Below `minimumInputLength` select2's decorator returns after
+            // firing `results:message` WITHOUT delegating to the ajax adapter,
+            // and `_request.abort()` lives inside that adapter. So dropping
+            // from three characters to two neither runs a new transport nor
+            // cancels the running one: nothing clears the spinner, and 30s
+            // later the abandoned request repaints results or the
+            // "unavailable" notice under "Please enter 3 or more characters".
+            // Cancel it ourselves, then clear the chrome.
             instance.$dropdown
                 .find('.select2-search__field')
                 .off('input' + EVENT_NS)
                 .on('input' + EVENT_NS, function () {
-                    if (this.value.length < MIN_INPUT_LENGTH) {
-                        self.clearSearchChrome($field, token);
-                    }
+                    if (this.value.length >= MIN_INPUT_LENGTH) return;
+                    self.abortActiveRequest(token);
+                    self.clearSearchChrome($field, token);
                 });
         },
 

--- a/view/frontend/web/js/model/company-search.js
+++ b/view/frontend/web/js/model/company-search.js
@@ -124,7 +124,7 @@ define(['jquery', 'mage/translate'], function ($, $t) {
          * @returns {boolean} true when a request was actually aborted
          */
         abortActiveRequest: function (token) {
-            const handle = token ? activeRequests.get(token) : null;
+            const handle = token && typeof token === 'object' ? activeRequests.get(token) : null;
             if (!handle) return false;
             activeRequests.delete(token);
             handle.abort();
@@ -271,8 +271,9 @@ define(['jquery', 'mage/translate'], function ($, $t) {
                     // Guarded: WeakMap.set throws on a non-object key, and a
                     // crash here would take the whole picker down. Degrades to
                     // "no cancel-on-short-input" and says so, rather than
-                    // failing the buyer's search.
-                    if (token) {
+                    // failing the buyer's search. Checks the TYPE, not just
+                    // truthiness — a string token is truthy and still throws.
+                    if (token && typeof token === 'object') {
                         activeRequests.set(token, handle);
                     } else {
                         console.error(

--- a/view/frontend/web/js/model/company-search.js
+++ b/view/frontend/web/js/model/company-search.js
@@ -124,7 +124,7 @@ define(['jquery', 'mage/translate'], function ($, $t) {
          * @returns {boolean} true when a request was actually aborted
          */
         abortActiveRequest: function (token) {
-            const handle = activeRequests.get(token);
+            const handle = token ? activeRequests.get(token) : null;
             if (!handle) return false;
             activeRequests.delete(token);
             handle.abort();
@@ -268,9 +268,19 @@ define(['jquery', 'mage/translate'], function ($, $t) {
                         onUnavailable(true);
                         failure();
                     });
-                    activeRequests.set(token, handle);
+                    // Guarded: WeakMap.set throws on a non-object key, and a
+                    // crash here would take the whole picker down. Degrades to
+                    // "no cancel-on-short-input" and says so, rather than
+                    // failing the buyer's search.
+                    if (token) {
+                        activeRequests.set(token, handle);
+                    } else {
+                        console.error(
+                            'companySearch: buildSearchAjaxOptions called without a bind token'
+                        );
+                    }
                     request.always(function () {
-                        if (activeRequests.get(token) === handle) {
+                        if (token && activeRequests.get(token) === handle) {
                             activeRequests.delete(token);
                         }
                         // Not on abort: select2 aborts the in-flight request
@@ -424,6 +434,22 @@ define(['jquery', 'mage/translate'], function ($, $t) {
                 .off('input' + EVENT_NS)
                 .on('input' + EVENT_NS, function () {
                     if (this.value.length >= MIN_INPUT_LENGTH) return;
+                    // Two things to cancel, not one. Besides a request already
+                    // on the wire, select2's ajax adapter may be sitting on a
+                    // DEBOUNCED one (`_queryTimeout`, our 300ms `delay`) that
+                    // it has not fired yet — and because the
+                    // minimumInputLength decorator short-circuits `query()`
+                    // before reaching that adapter, it never clears the timer
+                    // either. Backspacing from 4 characters to 2 inside 300ms
+                    // (trivial on key-repeat) would otherwise fire a fresh
+                    // search for the abandoned term, bringing the spinner back
+                    // up under "Please enter 3 or more characters".
+                    const instance = $field.data('select2');
+                    const dataAdapter = instance && instance.dataAdapter;
+                    if (dataAdapter && dataAdapter._queryTimeout) {
+                        clearTimeout(dataAdapter._queryTimeout);
+                        dataAdapter._queryTimeout = null;
+                    }
                     self.abortActiveRequest(token);
                     self.clearSearchChrome($field, token);
                 });

--- a/view/frontend/web/js/model/company-search.js
+++ b/view/frontend/web/js/model/company-search.js
@@ -51,6 +51,17 @@ define(['jquery', 'mage/translate'], function ($, $t) {
     /** Bound on the cache so a long typing session can't grow it forever. */
     const CACHE_LIMIT = 50;
 
+    /**
+     * Mirrors the `minimumInputLength: 3` both call sites pass to select2.
+     * Below it select2's decorator short-circuits `query()` and never reaches
+     * the data adapter, so no transport runs — which the chrome has to know
+     * about, or nothing ever takes the spinner down.
+     */
+    const MIN_INPUT_LENGTH = 3;
+
+    /** jQuery event namespace for everything this module binds. */
+    const EVENT_NS = '.twoCompanySearch';
+
     const SPINNER_CLASS = 'two-company-search__spinner';
     const UNAVAILABLE_CLASS = 'two-company-search__unavailable';
 
@@ -88,6 +99,8 @@ define(['jquery', 'mage/translate'], function ($, $t) {
     return {
         REQUEST_TIMEOUT_MS: REQUEST_TIMEOUT_MS,
         SEARCH_DEBOUNCE_MS: SEARCH_DEBOUNCE_MS,
+        MIN_INPUT_LENGTH: MIN_INPUT_LENGTH,
+        EVENT_NS: EVENT_NS,
         isDegradedResponse: isDegradedResponse,
 
         /** Drop every cached search result. Exists for tests. */
@@ -154,6 +167,13 @@ define(['jquery', 'mage/translate'], function ($, $t) {
                         let aborted = false;
                         const timer = setTimeout(function () {
                             if (aborted) return;
+                            // The spinner survives an abort (see below), so a
+                            // cache hit that follows one has to be what takes
+                            // it down. Otherwise: type `abc`, type `abcd`
+                            // (spinner up), backspace to `abc` — the abort
+                            // keeps the spinner, the cache answers, and the
+                            // dots spin forever over a full dropdown.
+                            onSearching(false);
                             success(cached);
                         }, 0);
                         return {
@@ -167,6 +187,34 @@ define(['jquery', 'mage/translate'], function ($, $t) {
                     onSearching(true);
                     const request = $.ajax(params);
                     let wasAborted = false;
+
+                    /**
+                     * Our own request handle, deliberately NOT the jqXHR.
+                     *
+                     * select2's ajax adapter builds its failure closure as
+                     * `function () { 'status' in e && (0 === e.status || '0'
+                     * === e.status) || trigger('results:message', {message:
+                     * 'errorLoading'}) }` where `e` is the value the
+                     * TRANSPORT RETURNED — not the jqXHR it was handed. And
+                     * jQuery reports BOTH a user abort and a timeout as
+                     * `status === 0`, so returning the raw jqXHR makes the two
+                     * indistinguishable: select2 silently swallows a timeout,
+                     * never fires `results:message`, never reaches
+                     * `hideLoading()`, and leaves "Searching…" in the dropdown
+                     * forever — directly under our notice saying the search
+                     * failed.
+                     *
+                     * Owning the handle lets us set `status = 0` for a real
+                     * abort only. A genuine failure leaves `status` absent, so
+                     * select2 renders `errorLoading` — and `displayMessage()`
+                     * calls `hideLoading()`, which is the terminal state we
+                     * actually want.
+                     */
+                    const handle = {
+                        abort: function () {
+                            request.abort();
+                        }
+                    };
 
                     request.done(function (response) {
                         cacheSet(params.url, response);
@@ -184,20 +232,12 @@ define(['jquery', 'mage/translate'], function ($, $t) {
                         // as "my company isn't accepted here".
                         if (textStatus === 'abort') {
                             wasAborted = true;
-                            failure(jqXHR, textStatus);
+                            handle.status = 0;
+                            failure();
                             return;
                         }
                         onUnavailable(true);
-                        // Deliberately select2's SUCCESS path with an empty
-                        // result set, not its failure path. jQuery reports a
-                        // timeout as status 0, and select2's own failure
-                        // handler treats status 0 as an abort: it never fires
-                        // `results:message`, so `hideLoading()` is never
-                        // reached and the dropdown is left showing
-                        // "Searching…" forever — under the very notice that
-                        // says the search failed. Feeding it an empty result
-                        // set gives select2 a terminal state to render.
-                        success({ items: [] });
+                        failure();
                     });
                     request.always(function () {
                         // Not on abort: select2 aborts the in-flight request
@@ -208,7 +248,7 @@ define(['jquery', 'mage/translate'], function ($, $t) {
                         if (!wasAborted) onSearching(false);
                     });
 
-                    return request;
+                    return handle;
                 },
                 processResults: function (response) {
                     const items = [];
@@ -297,21 +337,58 @@ define(['jquery', 'mage/translate'], function ($, $t) {
          * the buyer is concerned, and it is where the spinner and the
          * unavailable notice belong.
          *
-         * Takes the BOUND ELEMENT, not a selector, and resolves through that
-         * element's own widget instance. This is what keeps a stale request
-         * from painting on a live widget: a search issued by a widget that
-         * has since been destroyed (select2 re-init destroys the previous
-         * instance on the same node) finds no instance on its old element
-         * and no-ops, instead of decorating whichever dropdown a
-         * document-wide selector happened to hit.
+         * Takes the BOUND ELEMENT plus the token stamped on it at bind time.
+         *
+         * The element alone is not enough. Both call sites re-init select2 on
+         * the SAME node across a re-render, so `$field.data('select2')` always
+         * resolves to the current instance — a request issued by the previous
+         * widget, still in flight for up to 30s, would paint its failure onto
+         * the live picker and its `onSearching(false)` would strip the live
+         * spinner. The token is re-stamped on every bind, so a stale closure's
+         * token no longer matches and it no-ops.
          *
          * @param {object} $field jQuery-wrapped picker input
-         * @returns {object} jQuery set — empty when the widget isn't bound
+         * @param {object} token identity stamped by markSearchBinding()
+         * @returns {object} jQuery set — empty when stale or not bound
          */
-        getSearchFieldContainer: function ($field) {
-            const instance = $field && $field.data ? $field.data('select2') : null;
+        getSearchFieldContainer: function ($field, token) {
+            if (!$field || !$field.data) return $();
+            if (token && $field.data('twoSearchBind') !== token) return $();
+            const instance = $field.data('select2');
             if (!instance || !instance.$dropdown) return $();
             return instance.$dropdown.find('.select2-search--dropdown');
+        },
+
+        /**
+         * Stamp a bind identity on the picker and wire the chrome resets that
+         * select2 gives us no other hook for. Call once, immediately after
+         * `.select2({...})`.
+         *
+         * @param {object} $field jQuery-wrapped picker input
+         * @param {object} token identity for this bind
+         */
+        markSearchBinding: function ($field, token) {
+            const self = this;
+            $field.data('twoSearchBind', token);
+
+            const instance = $field.data('select2');
+            if (!instance || !instance.$dropdown) return;
+
+            // Below `minimumInputLength` select2 short-circuits query() in its
+            // decorator and never calls the data adapter, so no transport runs
+            // and nothing clears the spinner. Type three characters, then
+            // delete one while the request is in flight: the request aborts
+            // (spinner deliberately kept), no replacement runs, and the dots
+            // spin under "Please enter 3 or more characters" until the picker
+            // is closed and reopened.
+            instance.$dropdown
+                .find('.select2-search__field')
+                .off('input' + EVENT_NS)
+                .on('input' + EVENT_NS, function () {
+                    if (this.value.length < MIN_INPUT_LENGTH) {
+                        self.clearSearchChrome($field, token);
+                    }
+                });
         },
 
         /**
@@ -325,10 +402,11 @@ define(['jquery', 'mage/translate'], function ($, $t) {
          * and it survives until three or more characters are retyped.
          *
          * @param {object} $field jQuery-wrapped picker input
+         * @param {object} token identity stamped by markSearchBinding()
          */
-        clearSearchChrome: function ($field) {
-            this.setSearching($field, false);
-            this.setUnavailable($field, false);
+        clearSearchChrome: function ($field, token) {
+            this.setSearching($field, false, token);
+            this.setUnavailable($field, false, token);
         },
 
         /**
@@ -340,9 +418,10 @@ define(['jquery', 'mage/translate'], function ($, $t) {
          *
          * @param {object} $field jQuery-wrapped picker input
          * @param {boolean} isSearching
+         * @param {object} token identity stamped by markSearchBinding()
          */
-        setSearching: function ($field, isSearching) {
-            const $container = this.getSearchFieldContainer($field);
+        setSearching: function ($field, isSearching, token) {
+            const $container = this.getSearchFieldContainer($field, token);
             if (!$container.length) return;
 
             if (!isSearching) {
@@ -367,9 +446,10 @@ define(['jquery', 'mage/translate'], function ($, $t) {
          *
          * @param {object} $field jQuery-wrapped picker input
          * @param {boolean} isUnavailable
+         * @param {object} token identity stamped by markSearchBinding()
          */
-        setUnavailable: function ($field, isUnavailable) {
-            const $container = this.getSearchFieldContainer($field);
+        setUnavailable: function ($field, isUnavailable, token) {
+            const $container = this.getSearchFieldContainer($field, token);
             if (!$container.length) return;
 
             if (!isUnavailable) {

--- a/view/frontend/web/js/view/address-autocomplete.js
+++ b/view/frontend/web/js/view/address-autocomplete.js
@@ -119,6 +119,7 @@ define([
                             },
                             ajax: companySearch.buildSearchAjaxOptions({
                                 config: config,
+                                token: bindToken,
                                 getCountryCode: function () {
                                     return $(self.countrySelector).val();
                                 },
@@ -126,10 +127,18 @@ define([
                                 // a destroyed widget's late response cannot
                                 // paint onto the live picker.
                                 onSearching: function (isSearching) {
-                                    companySearch.setSearching($companyNameField, isSearching);
+                                    companySearch.setSearching(
+                                        $companyNameField,
+                                        isSearching,
+                                        bindToken
+                                    );
                                 },
                                 onUnavailable: function (isUnavailable) {
-                                    companySearch.setUnavailable($companyNameField, isUnavailable);
+                                    companySearch.setUnavailable(
+                                        $companyNameField,
+                                        isUnavailable,
+                                        bindToken
+                                    );
                                 }
                             })
                         })
@@ -146,14 +155,23 @@ define([
                                             `<span>${self.enterDetailsManuallyText}</span>` +
                                             '</div>'
                                     );
-                                $(self.enterDetailsManuallyButton).on('click', function (e) {
+                            }
+                            // Re-bound unconditionally, OUTSIDE the append
+                            // guard: the div survives a re-render, so the
+                            // guard was false and this handler kept closing
+                            // over the first, stale component.
+                            $(self.enterDetailsManuallyButton)
+                                .off('click' + companySearch.EVENT_NS)
+                                .on('click' + companySearch.EVENT_NS, function () {
                                     self.setCompanyData();
-                                    $(self.companyNameSelector).select2('destroy');
-                                    $(self.companyNameSelector).attr('type', 'text');
-                                    $(self.companyNameSelector).val('');
+                                    // Scoped to the node this bind owns, not
+                                    // the document-wide selector.
+                                    $companyNameField.off(companySearch.EVENT_NS);
+                                    $companyNameField.select2('destroy');
+                                    $companyNameField.attr('type', 'text');
+                                    $companyNameField.val('');
                                     $(self.searchForCompanyButton).show();
                                 });
-                            }
                             document.querySelector('.select2-search__field').focus();
                         })
                         .on('select2:select' + companySearch.EVENT_NS, function (e) {
@@ -186,11 +204,16 @@ define([
                                     `<span>${self.searchForCompanyText}</span>` +
                                     '</div>'
                             );
-                        $(self.searchForCompanyButton).on('click', function (e) {
+                    }
+                    // Re-bound unconditionally: the div survives a re-render,
+                    // so the append guard above was false and this handler kept
+                    // closing over the first, stale component.
+                    $(self.searchForCompanyButton)
+                        .off('click' + companySearch.EVENT_NS)
+                        .on('click' + companySearch.EVENT_NS, function () {
                             self.enableCompanySearch();
                             $(self.searchForCompanyButton).hide();
                         });
-                    }
                     $(self.searchForCompanyButton).hide();
                 });
             });

--- a/view/frontend/web/js/view/address-autocomplete.js
+++ b/view/frontend/web/js/view/address-autocomplete.js
@@ -96,6 +96,14 @@ define([
                     // alive and skip the placeholder / manual-entry
                     // housekeeping below.
                     const $companyNameField = $(companyNameField);
+                    // Identity for this bind, so a previous widget's late
+                    // response cannot paint chrome on its replacement.
+                    const bindToken = {};
+                    // select2's destroy() only clears its own `.select2`
+                    // namespace, so our handlers would stack one copy per
+                    // re-render and a single pick would fire N address
+                    // lookups. Clear ours before re-binding.
+                    $companyNameField.off(companySearch.EVENT_NS);
                     $companyNameField
                         .select2({
                             minimumInputLength: 3,
@@ -125,11 +133,11 @@ define([
                                 }
                             })
                         })
-                        .on('select2:open', function () {
+                        .on('select2:open' + companySearch.EVENT_NS, function () {
                             // Nothing else removes what we appended into the
                             // search box, so a reopened picker would show the
                             // previous search's "unavailable" notice.
-                            companySearch.clearSearchChrome($companyNameField);
+                            companySearch.clearSearchChrome($companyNameField, bindToken);
                             if ($(self.enterDetailsManuallyButton).length == 0) {
                                 $('.select2-results')
                                     .parent()
@@ -148,7 +156,7 @@ define([
                             }
                             document.querySelector('.select2-search__field').focus();
                         })
-                        .on('select2:select', function (e) {
+                        .on('select2:select' + companySearch.EVENT_NS, function (e) {
                             const selectedItem = e.params.data;
                             $('.select2-selection__rendered').text(selectedItem.id);
                             self.setCompanyData(selectedItem.companyId, selectedItem.text);
@@ -158,6 +166,7 @@ define([
                             // payment-step picker.
                             self.addressLookup(selectedItem);
                         });
+                    companySearch.markSearchBinding($companyNameField, bindToken);
                     // Set initial placeholder text for the company search
                     if (!$(self.companyNameSelector).val()) {
                         $(self.companyNameSelector)

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -70,7 +70,16 @@ define([
         enterDetailsManuallyText: $t('Enter details manually'),
         enterDetailsManuallyButton: '#billing_enter_details_manually',
         searchForCompanyText: $t('Search for company'),
-        searchForCompanyButton: '#billing_search_for_company',
+        // No `searchForCompanyButton` id selector here on purpose. The append
+        // guard is per-field, so this renderer — pushed once per Two-family
+        // brand — would otherwise mint duplicate ids and a document-wide
+        // lookup would hand brand A's link to brand B. Use
+        // searchForCompanyLink() instead.
+        searchForCompanyLink: function () {
+            const $field = this._$companyNameField;
+            if (!$field || !$field.closest) return $();
+            return $field.closest('.field').find('.search_for_company');
+        },
         delegationToken: '',
         autofillToken: '',
         companyName: ko.observable(''),
@@ -980,7 +989,7 @@ define([
                     const $field = $companyNameField.closest('.field');
                     if ($field.find('.search_for_company').length == 0) {
                         $field.append(
-                            `<div id="billing_search_for_company" class="search_for_company" title="${self.searchForCompanyText}">` +
+                            `<div class="search_for_company" title="${self.searchForCompanyText}">` +
                                 `<span>${self.searchForCompanyText}</span>` +
                                 '</div>'
                         );
@@ -1131,8 +1140,11 @@ define([
         // the email-driven prefetch and the chip-click handler.
         enterSoleTraderUi() {
             this.showSoleTrader(true);
+            // Resolve the link BEFORE clearCompany(), which tears the widget
+            // down and nulls _$companyNameField.
+            const $searchForCompany = this.searchForCompanyLink();
             this.clearCompany(true);
-            $(this.searchForCompanyButton).hide();
+            $searchForCompany.hide();
         },
 
         // Sole-trader chip click. Resolves against the prefetched autofill

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -76,9 +76,16 @@ define([
         // lookup would hand brand A's link to brand B. Use
         // searchForCompanyLink() instead.
         searchForCompanyLink: function () {
-            const $field = this._$companyNameField;
-            if (!$field || !$field.closest) return $();
-            return $field.closest('.field').find('.search_for_company');
+            // Resolved from the cached CONTAINER, not from
+            // `_$companyNameField`: the paths where this link is visible are
+            // exactly the paths that have already destroyed the widget and
+            // nulled that node ("Enter details manually" → clearCompany() →
+            // destroyCompanySearchWidget()). Keying on the node meant
+            // enterSoleTraderUi() silently hid nothing and the link stayed up
+            // in sole-trader mode.
+            const $container = this._$companyFieldContainer;
+            if (!$container || !$container.find) return $();
+            return $container.find('.search_for_company');
         },
         delegationToken: '',
         autofillToken: '',
@@ -879,6 +886,9 @@ define([
                     // THIS widget rather than whatever a document-wide
                     // selector happens to match.
                     self._$companyNameField = $companyNameField;
+                    // Survives the widget teardown on purpose — see
+                    // searchForCompanyLink().
+                    self._$companyFieldContainer = $companyNameField.closest('.field');
                     // Identity for this bind. Re-stamped below, so a previous
                     // widget's still-in-flight response can't paint chrome on
                     // the widget that replaced it.
@@ -1047,6 +1057,9 @@ define([
          */
         destroyCompanySearchWidget: function () {
             const $field = this._$companyNameField;
+            // `_$companyFieldContainer` is deliberately NOT cleared here: the
+            // re-enable link lives in that container and has to stay
+            // resolvable after the widget is gone.
             this._$companyNameField = null;
             if (!$field || !$field.data || !$field.data('select2')) return;
             $field.off(companySearch.EVENT_NS);

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -948,7 +948,13 @@ define([
                                 .off('click' + companySearch.EVENT_NS)
                                 .on('click' + companySearch.EVENT_NS, function () {
                                     self.clearCompany();
-                                    $(self.searchForCompanyButton).show();
+                                    // Resolved here rather than closed over,
+                                    // and scoped to this bind's container for
+                                    // the same duplicate-id reason as below.
+                                    $companyNameField
+                                        .closest('.field')
+                                        .find('.search_for_company')
+                                        .show();
                                 });
                             document.querySelector('.select2-search__field').focus();
                         })
@@ -966,23 +972,30 @@ define([
                         });
                     companySearch.markSearchBinding($companyNameField, bindToken);
                     $('#select2-company_name-container').text(self.companyName());
-                    if ($(self.searchForCompanyButton).length == 0) {
-                        $(self.companyNameSelector)
-                            .closest('.field')
-                            .append(
-                                `<div id="billing_search_for_company" class="search_for_company" title="${self.searchForCompanyText}">` +
-                                    `<span>${self.searchForCompanyText}</span>` +
-                                    '</div>'
-                            );
+                    // Scoped to the container of the node THIS bind owns.
+                    // With two Two-family renderers there is one
+                    // `#billing_search_for_company` id in the page, so a
+                    // document-wide lookup would hand the link in brand A's
+                    // field to whichever component bound last.
+                    const $field = $companyNameField.closest('.field');
+                    if ($field.find('.search_for_company').length == 0) {
+                        $field.append(
+                            `<div id="billing_search_for_company" class="search_for_company" title="${self.searchForCompanyText}">` +
+                                `<span>${self.searchForCompanyText}</span>` +
+                                '</div>'
+                        );
                     }
-                    // Same reasoning as the manual-entry link above.
-                    $(self.searchForCompanyButton)
+                    // Re-bound unconditionally (the div survives a re-render,
+                    // so an append guard would leave this closed over a stale
+                    // component) and scoped to this bind's own container.
+                    const $searchForCompany = $field.find('.search_for_company');
+                    $searchForCompany
                         .off('click' + companySearch.EVENT_NS)
                         .on('click' + companySearch.EVENT_NS, function () {
                             self.enableCompanySearch();
-                            $(self.searchForCompanyButton).hide();
+                            $searchForCompany.hide();
                         });
-                    $(self.searchForCompanyButton).hide();
+                    $searchForCompany.hide();
                 });
             });
         },

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -896,6 +896,7 @@ define([
                             },
                             ajax: companySearch.buildSearchAjaxOptions({
                                 config: self._brandConfig,
+                                token: bindToken,
                                 getCountryCode: function () {
                                     return self.countryCode();
                                 },
@@ -906,10 +907,18 @@ define([
                                 // painting a stale failure onto whatever
                                 // picker is live now.
                                 onSearching: function (isSearching) {
-                                    companySearch.setSearching($companyNameField, isSearching);
+                                    companySearch.setSearching(
+                                        $companyNameField,
+                                        isSearching,
+                                        bindToken
+                                    );
                                 },
                                 onUnavailable: function (isUnavailable) {
-                                    companySearch.setUnavailable($companyNameField, isUnavailable);
+                                    companySearch.setUnavailable(
+                                        $companyNameField,
+                                        isUnavailable,
+                                        bindToken
+                                    );
                                 }
                             })
                         })
@@ -928,11 +937,19 @@ define([
                                             `<span>${self.enterDetailsManuallyText}</span>` +
                                             '</div>'
                                     );
-                                $(self.enterDetailsManuallyButton).on('click', function (e) {
+                            }
+                            // Re-bound unconditionally, OUTSIDE the append
+                            // guard: the div survives a re-render, so the
+                            // guard was false and this handler kept closing
+                            // over the FIRST, now-disposed renderer —
+                            // clearCompany() then ran against dead
+                            // observables.
+                            $(self.enterDetailsManuallyButton)
+                                .off('click' + companySearch.EVENT_NS)
+                                .on('click' + companySearch.EVENT_NS, function () {
                                     self.clearCompany();
                                     $(self.searchForCompanyButton).show();
                                 });
-                            }
                             document.querySelector('.select2-search__field').focus();
                         })
                         .on('select2:select' + companySearch.EVENT_NS, function (e) {
@@ -957,11 +974,14 @@ define([
                                     `<span>${self.searchForCompanyText}</span>` +
                                     '</div>'
                             );
-                        $(self.searchForCompanyButton).on('click', function (e) {
+                    }
+                    // Same reasoning as the manual-entry link above.
+                    $(self.searchForCompanyButton)
+                        .off('click' + companySearch.EVENT_NS)
+                        .on('click' + companySearch.EVENT_NS, function () {
                             self.enableCompanySearch();
                             $(self.searchForCompanyButton).hide();
                         });
-                    }
                     $(self.searchForCompanyButton).hide();
                 });
             });
@@ -1011,12 +1031,15 @@ define([
             $field.select2('destroy');
             $field.attr('type', 'text');
         },
+        /**
+         * Kept for its callers; delegates to the scoped teardown. The previous
+         * document-wide `$(this.companyNameSelector).select2('destroy')` had
+         * the same multi-brand hazard as dispose() did — the renderer is
+         * pushed once per Two-family brand, so it could destroy a sibling
+         * brand's live widget.
+         */
         disableCompanySearch: function () {
-            const companyNameSelector = $(this.companyNameSelector);
-            if (companyNameSelector.data('select2')) {
-                companyNameSelector.select2('destroy');
-                companyNameSelector.attr('type', 'text');
-            }
+            this.destroyCompanySearchWidget();
         },
         getTokens() {
             const URL = url.build('rest/V1/two/get-tokens');

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -235,7 +235,14 @@ define([
             // closed over this now-disposed renderer — picking a company
             // would then write to dead observables and the order would go out
             // with no company on it.
-            this.disableCompanySearch();
+            //
+            // Scoped to the node THIS component bound, not to
+            // `companyNameSelector`: the renderer is pushed once per
+            // Two-family brand, so a checkout offering two of them has two
+            // `#company_name` inputs and the document-wide destroy in
+            // disableCompanySearch() would tear down the sibling's live
+            // widget and leave it a plain text input.
+            this.destroyCompanySearchWidget();
             if (this._twoVisibilitySub) {
                 this._twoVisibilitySub.dispose();
                 this._twoVisibilitySub = null;
@@ -859,6 +866,21 @@ define([
                     // would write to dead observables. What re-render safety
                     // needs instead is the teardown in dispose() below.
                     const $companyNameField = $(companyNameField);
+                    // Remember the node we bound, so dispose() can destroy
+                    // THIS widget rather than whatever a document-wide
+                    // selector happens to match.
+                    self._$companyNameField = $companyNameField;
+                    // Identity for this bind. Re-stamped below, so a previous
+                    // widget's still-in-flight response can't paint chrome on
+                    // the widget that replaced it.
+                    const bindToken = {};
+                    // select2's destroy() only does `$element.off('.select2')`
+                    // — our own handlers are not in that namespace and would
+                    // survive every re-init, stacking one more copy per
+                    // re-render. N stacked `select2:select` handlers means one
+                    // company pick fires N address lookups, N-1 of them closed
+                    // over disposed renderers. Clear ours first.
+                    $companyNameField.off(companySearch.EVENT_NS);
                     $companyNameField
                         .select2({
                             minimumInputLength: 3,
@@ -891,13 +913,13 @@ define([
                                 }
                             })
                         })
-                        .on('select2:open', function () {
+                        .on('select2:open' + companySearch.EVENT_NS, function () {
                             // select2 only detaches the dropdown on close and
                             // only blanks the search input, so anything we
                             // appended into the search box survives. Clear it
                             // here or a reopened picker still shows the last
                             // search's "unavailable" notice.
-                            companySearch.clearSearchChrome($companyNameField);
+                            companySearch.clearSearchChrome($companyNameField, bindToken);
                             if ($(self.enterDetailsManuallyButton).length == 0) {
                                 $('.select2-results')
                                     .parent()
@@ -913,7 +935,7 @@ define([
                             }
                             document.querySelector('.select2-search__field').focus();
                         })
-                        .on('select2:select', function (e) {
+                        .on('select2:select' + companySearch.EVENT_NS, function (e) {
                             const selectedItem = e.params.data;
                             const companyId = selectedItem.companyId;
                             const companyName = selectedItem.text;
@@ -925,6 +947,7 @@ define([
                             // picker uses.
                             self.addressLookup(selectedItem);
                         });
+                    companySearch.markSearchBinding($companyNameField, bindToken);
                     $('#select2-company_name-container').text(self.companyName());
                     if ($(self.searchForCompanyButton).length == 0) {
                         $(self.companyNameSelector)
@@ -976,6 +999,17 @@ define([
             companyIdSelector.prop('disabled', disableCompanyId);
             $(this.companyNameSelector).val('');
             this.disableCompanySearch();
+        },
+        /**
+         * Destroy only the widget this component bound. Safe to call twice.
+         */
+        destroyCompanySearchWidget: function () {
+            const $field = this._$companyNameField;
+            this._$companyNameField = null;
+            if (!$field || !$field.data || !$field.data('select2')) return;
+            $field.off(companySearch.EVENT_NS);
+            $field.select2('destroy');
+            $field.attr('type', 'text');
         },
         disableCompanySearch: function () {
             const companyNameSelector = $(this.companyNameSelector);


### PR DESCRIPTION
Linear: [TWO-25233](https://linear.app/two-inc/issue/TWO-25233/magento-company-search-timeout-degraded-state-ux-and-re-render-safety)
Follow-up to #282, which was merged to `staging` before self-review round 2 finished. **Everything below is a live defect on `staging` right now.**

## 1. `dispose()` destroyed the wrong widget — MAJOR

It called `disableCompanySearch()`, which resolves `companyNameSelector` document-wide. The renderer is pushed once per Two-family brand, so a checkout offering two of them has two `#company_name` inputs. Disposing one renderer destroyed the **sibling brand's live widget** and left it a plain text input with no re-init path. `dispose()` now tears down only the node the component actually bound (`_$companyNameField`).

## 2. Event handlers stacked on every re-render — MAJOR

Round 1 removed the bind guard, correctly: select2 4.1's constructor opens with `GetData(el, 'select2').destroy()`, so re-init is how the widget gets re-pointed at the current component. What that reasoning missed is that `destroy()` only does **`$element.off('.select2')`** — our un-namespaced `select2:open` / `select2:select` handlers survive every re-init and stack one copy per re-render.

After N re-renders, one company pick fired N `select2:select` handlers: N address lookups, N−1 of them closed over **disposed** renderers. That is precisely the dead-observable bug `dispose()` was added to prevent, reintroduced through a different door. Handlers are now bound in a `.twoCompanySearch` namespace and cleared before each re-bind.

## 3. A stale widget could still paint on the live one — MAJOR

Round 1 keyed the chrome on the bound element instead of a document selector. Not sufficient: both call sites re-init select2 on the **same node**, so `.data('select2')` always resolves to the *current* instance. A request from the previous widget — in flight for up to 30s — painted its failure notice onto the live picker, and its `always` handler stripped the live spinner. Each bind now stamps a token (`markSearchBinding`) that the chrome must match, and the tests assert isolation in both directions.

## 4. Two spinner leaks — MAJOR

- **Cache hit after an abort.** The abort path deliberately keeps the spinner up (otherwise it blinks off on every keystroke). The cached branch never cleared it, so: type `abc`, type `abcd`, backspace to `abc` → the dots spin forever over a fully populated dropdown.
- **Dropping below `minimumInputLength`.** select2 short-circuits `query()` in its decorator without reaching the data adapter, so no transport runs and nothing took the spinner down. It span under "Please enter 3 or more characters" until the picker was closed and reopened.

## Plus: the timeout fix was still wrong, and now it is right

This is worth reading, because it is the crux of the whole ticket and the same trap the WooCommerce work hit independently.

select2's ajax adapter builds its failure closure as:

```js
var e = i.transport(i, successCb, function () {
    "status" in e && (0 === e.status || "0" === e.status)
        || s.trigger("results:message", { message: "errorLoading" })
});
```

`e` is the value the **transport returned** — not the jqXHR it was handed. And jQuery reports **both a user abort and a timeout as `status === 0`**. So with the default transport a timeout is indistinguishable from "the buyer kept typing": select2 silently swallows it, never fires `results:message`, never reaches `hideLoading()`, and leaves "Searching…" in the dropdown forever.

Round 1 worked around this by routing failures through select2's *success* path with `{items: []}`. That cleared the loading row, but made select2 render **"No results found" directly underneath our notice saying the search had failed** — two contradictory statements.

The correct fix, verified against `select2.min.js` in this repo: the transport returns **its own handle** and sets `status = 0` for a real abort only. A genuine failure leaves `status` absent, so select2 fires `errorLoading`, and `displayMessage()` calls `this.clear(); this.hideLoading();` — a real terminal state, with a message that agrees with ours.

## Testing

`npm run test:js` — **10 suites, 119 tests, all passing** (was 110).

The test double now models select2's destroy-clears-only-its-own-namespace behaviour, so the handler-stacking regression is genuinely caught rather than assumed. New cases: the returned handle's `status` contract on timeout / error / abort, `handle.abort()` forwarding, stale-token isolation in both directions (can't paint, can't strip), the short-input chrome reset, the cache-hit spinner clear, scoped dispose with a sibling widget present, and dispose being safe with nothing bound.

Two pre-existing test doubles needed `off()` and a `data()` setter to keep working against the namespaced bindings; no assertions were weakened.

## Still visually unverified

**No browser in this session.** The spinner position, the notice, and select2's `errorLoading` message rendering alongside our own notice are all reasoned about from the select2 source, not seen. Worth a look on a staging shop.