### PR TITLE
TWO-25243 docs: explain company-search result-cache staleness

### DIFF
--- a/view/frontend/web/js/model/company-search.js
+++ b/view/frontend/web/js/model/company-search.js
@@ -45,6 +45,13 @@ define(['jquery', 'mage/translate'], function ($, $t) {
      * search the buyer already waited for would be re-issued. Keyed by the
      * fully-qualified request URL, so country / paging / limit are all part
      * of the key.
+     *
+     * Entries never expire within the page's lifetime, so a company
+     * registered mid-session stays absent from an already-searched term
+     * until the buyer reloads. That is deliberate, not a bug: buyers search
+     * for their own company, which is already registered, so a TTL or
+     * cache-busting would spend API calls on a case that essentially never
+     * happens.
      */
     const resultCache = new Map();
 


### PR DESCRIPTION
Comment-only. No behaviour change.

The module-scoped company-search result cache never expires within a page lifetime, so a company registered mid-session will not appear in an already-searched term until the page is reloaded. That is intentional — buyers search for their own, already-registered company, so a TTL or cache-busting would spend API calls on a case that essentially never happens. Also notes that the key is the full request URL, so country/limit/query changes already miss correctly and the key should not be "fixed".

Part of the parity epic; companion PRs add the equivalent note to PrestaShop. WooCommerce has no company-search result cache, so nothing to document there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)