### PR TITLE
fix(TWO-25253): guard the optional national_identifier in company search

### DIFF
--- a/Test/Js/company-search-resilience.test.js
+++ b/Test/Js/company-search-resilience.test.js
@@ -694,6 +694,81 @@ describe('processResults robustness', () => {
         expect(ajaxOptions.processResults({ items: [] }).results).toEqual([]);
         expect(ajaxOptions.processResults({ degraded: true }).results).toEqual([]);
     });
+
+    // `national_identifier` is optional in the search response and its `id`
+    // may be null or empty, so every one of these four shapes is reachable.
+    // A throw here would happen inside select2's query pipeline, taking the
+    // whole result list down and leaving the dropdown on "Searching…" — so
+    // the hit renders with whatever it has instead.
+    test.each([
+        [
+            'national_identifier absent',
+            { name: 'Example Trading Ltd', highlight: '<em>Example</em> Trading Ltd' }
+        ],
+        [
+            'national_identifier null',
+            {
+                name: 'Example Trading Ltd',
+                highlight: '<em>Example</em> Trading Ltd',
+                national_identifier: null
+            }
+        ],
+        [
+            'id null',
+            {
+                name: 'Example Trading Ltd',
+                highlight: '<em>Example</em> Trading Ltd',
+                national_identifier: { id: null }
+            }
+        ],
+        [
+            'id empty',
+            {
+                name: 'Example Trading Ltd',
+                highlight: '<em>Example</em> Trading Ltd',
+                national_identifier: { id: '' }
+            }
+        ]
+    ])('%s renders the company without an identifier suffix', (_label, item) => {
+        const { $ } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+        const ajaxOptions = buildOptions(companySearch, makeHooks());
+        const run = function () {
+            return ajaxOptions.processResults({ items: [item] });
+        };
+
+        expect(run).not.toThrow();
+        expect(run().results).toEqual([
+            {
+                id: 'Example Trading Ltd',
+                text: 'Example Trading Ltd',
+                html: '<em>Example</em> Trading Ltd',
+                companyId: '',
+                lookupId: undefined
+            }
+        ]);
+    });
+
+    test('one unusable hit does not take the rest of the result list down', () => {
+        // The point of the guard: one hit with no identifier must not cost
+        // the buyer every other company that matched.
+        const { $ } = makeQueryDouble();
+        const companySearch = loadCompanySearch($);
+        const ajaxOptions = buildOptions(companySearch, makeHooks());
+
+        const out = ajaxOptions.processResults({
+            items: [
+                { name: 'Other Example Ltd', highlight: '<em>Other</em> Example Ltd' },
+                SEARCH_RESPONSE.items[0]
+            ]
+        });
+
+        expect(out.results.map((r) => r.text)).toEqual([
+            'Other Example Ltd',
+            'Example Trading Ltd'
+        ]);
+        expect(out.results.map((r) => r.companyId)).toEqual(['', '12345678']);
+    });
 });
 
 describe('in-field chrome', () => {

--- a/Test/Js/company-search-resilience.test.js
+++ b/Test/Js/company-search-resilience.test.js
@@ -696,14 +696,26 @@ describe('processResults robustness', () => {
     });
 
     // `national_identifier` is optional in the search response and its `id`
-    // may be null or empty, so every one of these four shapes is reachable.
+    // may be null or empty, so every one of these five shapes is reachable.
     // A throw here would happen inside select2's query pipeline, taking the
     // whole result list down and leaving the dropdown on "Searching…" — so
     // the hit renders with whatever it has instead.
+    //
+    // `toEqual` treats `lookupId: undefined` as equal to the key being ABSENT,
+    // so on its own it let an implementation that dropped `lookupId`
+    // altogether pass. `toStrictEqual` is not the fix here — the harness runs
+    // the module inside a `vm` context, so its objects carry that realm's
+    // Object.prototype and every strict compare fails with "serializes to the
+    // same string". The key set is asserted explicitly instead, and the final
+    // row carries a real `lookup_id`: address autofill is the one thing that
+    // still works for an identifier-less hit (lookupCompanyAddress() keys on
+    // `lookupId`, not on the national identifier), so losing it would strip
+    // the remaining value in showing the hit at all.
     test.each([
         [
             'national_identifier absent',
-            { name: 'Example Trading Ltd', highlight: '<em>Example</em> Trading Ltd' }
+            { name: 'Example Trading Ltd', highlight: '<em>Example</em> Trading Ltd' },
+            undefined
         ],
         [
             'national_identifier null',
@@ -711,7 +723,8 @@ describe('processResults robustness', () => {
                 name: 'Example Trading Ltd',
                 highlight: '<em>Example</em> Trading Ltd',
                 national_identifier: null
-            }
+            },
+            undefined
         ],
         [
             'id null',
@@ -719,7 +732,8 @@ describe('processResults robustness', () => {
                 name: 'Example Trading Ltd',
                 highlight: '<em>Example</em> Trading Ltd',
                 national_identifier: { id: null }
-            }
+            },
+            undefined
         ],
         [
             'id empty',
@@ -727,27 +741,50 @@ describe('processResults robustness', () => {
                 name: 'Example Trading Ltd',
                 highlight: '<em>Example</em> Trading Ltd',
                 national_identifier: { id: '' }
-            }
-        ]
-    ])('%s renders the company without an identifier suffix', (_label, item) => {
-        const { $ } = makeQueryDouble();
-        const companySearch = loadCompanySearch($);
-        const ajaxOptions = buildOptions(companySearch, makeHooks());
-        const run = function () {
-            return ajaxOptions.processResults({ items: [item] });
-        };
-
-        expect(run).not.toThrow();
-        expect(run().results).toEqual([
+            },
+            undefined
+        ],
+        [
+            'no identifier but a lookup_id',
             {
-                id: 'Example Trading Ltd',
-                text: 'Example Trading Ltd',
-                html: '<em>Example</em> Trading Ltd',
-                companyId: '',
-                lookupId: undefined
-            }
-        ]);
-    });
+                name: 'Example Trading Ltd',
+                highlight: '<em>Example</em> Trading Ltd',
+                national_identifier: null,
+                lookup_id: 'lookup-abc-123'
+            },
+            'lookup-abc-123'
+        ]
+    ])(
+        '%s renders the company without an identifier suffix',
+        (_label, item, expectedLookupId) => {
+            const { $ } = makeQueryDouble();
+            const companySearch = loadCompanySearch($);
+            const ajaxOptions = buildOptions(companySearch, makeHooks());
+            const run = function () {
+                return ajaxOptions.processResults({ items: [item] });
+            };
+
+            expect(run).not.toThrow();
+            expect(run().results).toEqual([
+                {
+                    id: 'Example Trading Ltd',
+                    text: 'Example Trading Ltd',
+                    html: '<em>Example</em> Trading Ltd',
+                    companyId: '',
+                    lookupId: expectedLookupId
+                }
+            ]);
+            const result = run().results[0];
+            expect(Object.keys(result).sort()).toEqual([
+                'companyId',
+                'html',
+                'id',
+                'lookupId',
+                'text'
+            ]);
+            expect(result.lookupId).toBe(expectedLookupId);
+        }
+    );
 
     test('one unusable hit does not take the rest of the result list down', () => {
         // The point of the guard: one hit with no identifier must not cost

--- a/Test/Js/gateway-method-company-selection.test.js
+++ b/Test/Js/gateway-method-company-selection.test.js
@@ -149,18 +149,30 @@ function loadRenderer() {
 }
 
 const COMPANY_ID_FIELD = 'input#company_id';
+/**
+ * What the two selection paths pass. Only a selection may clear a company that
+ * is already selected; the one-shot `companyData` section read on init may not
+ * (see 'a stale name-only section read does not clobber a live pick').
+ */
+const AS_SELECTION = { authoritative: true };
 const COMPANY_NAME_FIELD = 'input#company_name';
 
 describe('picking a company with no national identifier', () => {
     test('applyCompanyData overwrites a previously selected company id', () => {
         const { renderer, node } = loadRenderer();
 
-        renderer.applyCompanyData({ companyName: 'First Example Ltd', companyId: '12345678' });
+        renderer.applyCompanyData(
+            { companyName: 'First Example Ltd', companyId: '12345678' },
+            AS_SELECTION
+        );
         expect(renderer.companyName()).toBe('First Example Ltd');
         expect(renderer.companyId()).toBe('12345678');
         expect(node(COMPANY_ID_FIELD).val()).toBe('12345678');
 
-        renderer.applyCompanyData({ companyName: 'Second Example Ltd', companyId: '' });
+        renderer.applyCompanyData(
+            { companyName: 'Second Example Ltd', companyId: '' },
+            AS_SELECTION
+        );
 
         // The name moved, so the id MUST have moved with it.
         expect(renderer.companyName()).toBe('Second Example Ltd');
@@ -172,33 +184,63 @@ describe('picking a company with no national identifier', () => {
     test('applyCompanyData re-enables company_id so the buyer can supply it', () => {
         const { renderer, node } = loadRenderer();
 
-        // Company search owns the field until then.
+        // Company search owns the field until then. This assertion is a
+        // precondition, not the property under test — enableCompanySearch()
+        // disables the field itself, so it holds trivially here.
         renderer.enableCompanySearch();
         expect(node(COMPANY_ID_FIELD).prop('disabled')).toBe(true);
 
-        renderer.applyCompanyData({ companyName: 'Second Example Ltd', companyId: '' });
+        renderer.applyCompanyData(
+            { companyName: 'Second Example Ltd', companyId: '' },
+            AS_SELECTION
+        );
 
         expect(node(COMPANY_ID_FIELD).prop('disabled')).toBe(false);
     });
 
-    test('a normal pick leaves company_id disabled', () => {
+    test('a normal pick after an identifier-less one re-disables company_id', () => {
+        // Driven through the real select2:select handler, with NO hand-call of
+        // syncCompanyIdEditable() — production has no such call on this path,
+        // and a test that made one asserted a property the code did not have.
+        // The state being ruled out is a registry organisation number sitting
+        // in an ENABLED field, which the buyer could overwrite by hand.
         const { renderer, node } = loadRenderer();
 
         renderer.enableCompanySearch();
-        renderer.applyCompanyData({ companyName: 'First Example Ltd', companyId: '12345678' });
-        renderer.syncCompanyIdEditable();
+        const select = node(COMPANY_NAME_FIELD).handlers['select2:select'];
 
+        select({
+            params: {
+                data: { id: 'Second Example Ltd', text: 'Second Example Ltd', companyId: '' }
+            }
+        });
+        expect(node(COMPANY_ID_FIELD).prop('disabled')).toBe(false);
+
+        select({
+            params: {
+                data: { id: 'First Example Ltd', text: 'First Example Ltd', companyId: '12345678' }
+            }
+        });
+
+        expect(renderer.companyId()).toBe('12345678');
         expect(node(COMPANY_ID_FIELD).prop('disabled')).toBe(true);
     });
 
     test('a later enableCompanySearch does not re-disable the field', () => {
-        // `$.async` resolves AFTER the synchronous fillCustomerData() that
-        // follows enableCompanySearch() in registeredOrganisationMode(), so an
-        // unconditional disable there stranded the buyer with an empty,
-        // uneditable, required company number.
+        // In the browser the `require()` wrapper puts enableCompanySearch()'s
+        // field handling after the synchronous fillCustomerData() that follows
+        // it in registeredOrganisationMode(). The harness's require() and
+        // $.async doubles are both SYNCHRONOUS, so this test does not model
+        // that ordering — what it pins is narrower and still worth pinning:
+        // enableCompanySearch() derives the disabled state from the selected
+        // company instead of hard-coding `true`, so a revert to the literal
+        // fails here.
         const { renderer, node } = loadRenderer();
 
-        renderer.applyCompanyData({ companyName: 'Second Example Ltd', companyId: '' });
+        renderer.applyCompanyData(
+            { companyName: 'Second Example Ltd', companyId: '' },
+            AS_SELECTION
+        );
         renderer.enableCompanySearch();
 
         expect(node(COMPANY_ID_FIELD).prop('disabled')).toBe(false);
@@ -214,18 +256,36 @@ describe('picking a company with no national identifier', () => {
         expect(typeof select).toBe('function');
 
         select({
-            params: { data: { id: 'First Example Ltd', text: 'First Example Ltd', companyId: '12345678' } }
+            params: {
+                data: { id: 'First Example Ltd', text: 'First Example Ltd', companyId: '12345678' }
+            }
         });
         expect(renderer.companyId()).toBe('12345678');
 
         select({
-            params: { data: { id: 'Second Example Ltd', text: 'Second Example Ltd', companyId: '' } }
+            params: {
+                data: { id: 'Second Example Ltd', text: 'Second Example Ltd', companyId: '' }
+            }
         });
 
         expect(renderer.companyName()).toBe('Second Example Ltd');
         expect(renderer.companyId()).toBe('');
         expect(node(COMPANY_ID_FIELD).val()).toBe('');
         expect(node(COMPANY_ID_FIELD).prop('disabled')).toBe(false);
+    });
+
+    test('a non-string companyId is kept, not treated as identifier-less', () => {
+        // The registry's `national_identifier.id` is not guaranteed to be a
+        // string. A typeof test coerced a numeric one to '' and routed a
+        // company that HAS an identifier down the identifier-less branch,
+        // actively CLEARING it.
+        const { renderer, node } = loadRenderer();
+
+        renderer.applyCompanyData({ companyName: 'First Example Ltd', companyId: 12345678 });
+
+        expect(renderer.companyId()).toBe('12345678');
+        expect(node(COMPANY_ID_FIELD).val()).toBe('12345678');
+        expect(node(COMPANY_ID_FIELD).prop('disabled')).toBe(true);
     });
 
     test('an empty customer-data section on init does not blank live state', () => {
@@ -348,6 +408,139 @@ describe('a company picked on the shipping step reaches the payment step', () =>
         expect(renderer.companyId()).toBe('');
         expect(dom.node(COMPANY_ID_FIELD).prop('disabled')).toBe(false);
     });
+
+    test('a stale name-only section read does not clobber a live pick', () => {
+        // `companyData` is a localStorage customer-data section, so a
+        // `{companyName, companyId: ''}` row outlives page loads and previous
+        // orders — and fillCustomerData() is re-callable (applyPrefetch() →
+        // registeredOrganisationMode()). Treating the one-shot READ as a
+        // selection therefore let a stale row overwrite a live payment-step
+        // pick's name and blank its organisation number. Before the routing
+        // existed this shape was a harmless no-op on the read path; it has to
+        // stay one. Only a change NOTIFICATION on the section is a selection.
+        const { renderer, dom } = loadWithSections({
+            companyName: 'Stale Example Ltd',
+            companyId: ''
+        });
+
+        renderer.applyCompanyData(
+            { companyName: 'Live Example Ltd', companyId: '99999999' },
+            { authoritative: true }
+        );
+
+        renderer.fillCustomerData();
+
+        expect(renderer.companyName()).toBe('Live Example Ltd');
+        expect(renderer.companyId()).toBe('99999999');
+        expect(dom.node(COMPANY_ID_FIELD).val()).toBe('99999999');
+        expect(dom.node(COMPANY_ID_FIELD).prop('disabled')).toBe(true);
+    });
+});
+
+describe('order intent for a company with no registry identifier', () => {
+    /**
+     * `initialize()` never runs under the harness's Component double, so
+     * `isOrderIntentEnabled` is undefined and the intent branch is dead in
+     * every test that does not set it explicitly. Set it, and count the calls.
+     */
+    function loadWithIntent() {
+        const dom = makeDom();
+        const renderer = loadAmdModule(RENDERER, { jquery: dom.$ });
+        renderer.isOrderIntentEnabled = true;
+        const chain = {
+            always: () => chain,
+            done: () => chain,
+            fail: () => chain
+        };
+        renderer.placeOrderIntent = jest.fn(() => chain);
+        return { renderer: renderer, node: dom.node, intent: renderer.placeOrderIntent };
+    }
+
+    test('a normal pick places exactly one intent', () => {
+        const { renderer, node, intent } = loadWithIntent();
+
+        renderer.enableCompanySearch();
+        node(COMPANY_NAME_FIELD).handlers['select2:select']({
+            params: {
+                data: { id: 'First Example Ltd', text: 'First Example Ltd', companyId: '12345678' }
+            }
+        });
+
+        expect(intent).toHaveBeenCalledTimes(1);
+    });
+
+    test('an identifier-less pick places no intent — there is no number yet', () => {
+        const { renderer, node, intent } = loadWithIntent();
+
+        renderer.enableCompanySearch();
+        node(COMPANY_NAME_FIELD).handlers['select2:select']({
+            params: {
+                data: { id: 'Second Example Ltd', text: 'Second Example Ltd', companyId: '' }
+            }
+        });
+
+        expect(intent).not.toHaveBeenCalled();
+    });
+
+    test('the number the buyer types places exactly one intent', () => {
+        // The hole this closes: nothing subscribed to `companyId` to re-fire
+        // the intent, and fillCompanyData() is never reached on this path, so
+        // an identifier-less company's order previously arrived at the API
+        // with no credit check behind it at all.
+        const { renderer, node, intent } = loadWithIntent();
+
+        renderer.enableCompanySearch();
+        node(COMPANY_NAME_FIELD).handlers['select2:select']({
+            params: {
+                data: { id: 'Second Example Ltd', text: 'Second Example Ltd', companyId: '' }
+            }
+        });
+        expect(intent).not.toHaveBeenCalled();
+
+        const commit = node(COMPANY_ID_FIELD).handlers['change'];
+        expect(typeof commit).toBe('function');
+        node(COMPANY_ID_FIELD).val('  99999999  ');
+        commit();
+
+        expect(renderer.companyId()).toBe('99999999');
+        expect(node(COMPANY_ID_FIELD).val()).toBe('99999999');
+        expect(intent).toHaveBeenCalledTimes(1);
+    });
+
+    test('re-committing the same number places no second intent', () => {
+        const { renderer, node, intent } = loadWithIntent();
+
+        renderer.enableCompanySearch();
+        node(COMPANY_NAME_FIELD).handlers['select2:select']({
+            params: {
+                data: { id: 'Second Example Ltd', text: 'Second Example Ltd', companyId: '' }
+            }
+        });
+        const commit = node(COMPANY_ID_FIELD).handlers['change'];
+        node(COMPANY_ID_FIELD).val('99999999');
+        commit();
+        expect(intent).toHaveBeenCalledTimes(1);
+
+        // A blur that commits nothing new, and an emptied field.
+        commit();
+        node(COMPANY_ID_FIELD).val('');
+        commit();
+
+        expect(intent).toHaveBeenCalledTimes(1);
+        expect(renderer.companyId()).toBe('99999999');
+    });
+
+    test('a number typed with no company selected places no intent', () => {
+        const { renderer, node, intent } = loadWithIntent();
+
+        renderer.enableCompanySearch();
+        const commit = node(COMPANY_ID_FIELD).handlers['change'];
+        node(COMPANY_ID_FIELD).val('99999999');
+        commit();
+
+        expect(intent).not.toHaveBeenCalled();
+        expect(renderer.companyId()).toBe('');
+    });
 });
 
 describe('the shipping-step picker agrees with the payment step', () => {
@@ -378,9 +571,16 @@ describe('the shipping-step picker agrees with the payment step', () => {
             companyId: '12345678',
             companyName: 'First Example Ltd'
         });
+        // `toEqual` treats a key holding `undefined` as equal to the key being
+        // absent, so it alone would pass if `companyId` stopped being written.
+        // `toStrictEqual` is not usable here — the harness runs modules in a
+        // `vm` context, so every strict compare fails cross-realm with
+        // "serializes to the same string". Assert the key set instead.
+        expect(Object.keys(sections.companyData).sort()).toEqual(['companyId', 'companyName']);
 
         autocomplete.setCompanyData('', 'Second Example Ltd');
         expect(sections.companyData).toEqual({ companyId: '', companyName: 'Second Example Ltd' });
+        expect(Object.keys(sections.companyData).sort()).toEqual(['companyId', 'companyName']);
         expect(dom.node(autocomplete.companyIdSelector).val()).toBe('');
     });
 });

--- a/Test/Js/gateway-method-company-selection.test.js
+++ b/Test/Js/gateway-method-company-selection.test.js
@@ -1,0 +1,386 @@
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ *
+ * TWO-25253, second half. Guarding `national_identifier` in
+ * `company-search.js` made a new state reachable: a company hit that renders
+ * with an EMPTY `companyId`. These tests cover what the payment step does when
+ * the buyer actually picks one.
+ *
+ * The failure mode being pinned is a mis-submitted order, not a crash.
+ * `fillCompanyData()` early-returns unless BOTH name and id are non-empty, so
+ * picking an identifier-less company after a valid one used to leave the
+ * previous company's organisation number in `companyId()` while select2
+ * displayed the new company's name — `getData()` / `placeOrderIntent()` then
+ * sent company A's number under company B's name. A selection has to be
+ * authoritative.
+ *
+ * Second half of the fix: `company_id` is disabled while company search owns
+ * it, and jQuery Validation's `elements()` skips `:disabled`, so the
+ * template's `required="true"` is NOT enforced on a disabled field. An
+ * identifier-less pick therefore has to RE-ENABLE the field, or the buyer has
+ * neither a way to supply the number nor a validation error telling them to.
+ */
+
+'use strict';
+
+const { loadAmdModule } = require('./amd-harness');
+
+const RENDERER = 'view/frontend/web/js/view/payment/method-renderer/gateway_method.js';
+
+/**
+ * jQuery double that keeps one persistent node per selector, so a write made
+ * through `$(sel).val(...)` is visible to a later `$(sel).val()` read. The
+ * default harness jQuery is inert (every setter returns the same empty object
+ * and records nothing), which would let a broken implementation pass.
+ */
+function makeDom() {
+    const nodes = {};
+
+    function node(selector) {
+        if (nodes[selector]) return nodes[selector];
+        const n = {
+            selector: selector,
+            length: 1,
+            value: '',
+            props: {},
+            textValue: '',
+            handlers: {},
+            appended: [],
+            val: function (next) {
+                if (!arguments.length) return n.value;
+                n.value = next;
+                return n;
+            },
+            prop: function (name, next) {
+                if (arguments.length < 2) return n.props[name];
+                n.props[name] = next;
+                return n;
+            },
+            text: function (next) {
+                if (!arguments.length) return n.textValue;
+                n.textValue = next;
+                return n;
+            },
+            on: function (event, fn) {
+                // Strip the `.twoCompanySearch` namespace so tests can fire by
+                // plain event name.
+                n.handlers[String(event).split('.')[0]] = fn;
+                return n;
+            },
+            off: function () {
+                return n;
+            },
+            closest: function (sel) {
+                return node(selector + ' >closest> ' + sel);
+            },
+            find: function (sel) {
+                return node(selector + ' >find> ' + sel);
+            },
+            append: function (html) {
+                n.appended.push(html);
+                return n;
+            },
+            attr: function () {
+                return n;
+            },
+            data: function () {
+                return null;
+            },
+            hide: function () {
+                return n;
+            },
+            show: function () {
+                return n;
+            },
+            select2: function () {
+                return n;
+            }
+        };
+        nodes[selector] = n;
+        return n;
+    }
+
+    function $(selector) {
+        return node(typeof selector === 'string' ? selector : String(selector));
+    }
+    // `$.async` is a MutationObserver in Magento; the node is already present
+    // here, so resolve immediately with the selector (the renderer re-wraps it
+    // with `$(...)`, which lands on the same node).
+    $.async = function (selector, cb) {
+        cb(selector);
+    };
+    $.each = function (xs, fn) {
+        (xs || []).forEach(function (x, i) {
+            fn(i, x);
+        });
+    };
+    $.ajax = function () {
+        return { done: () => this, fail: () => this, always: () => this };
+    };
+    $.Deferred = function () {
+        const d = {
+            resolve: () => d,
+            reject: () => d,
+            promise: () => d,
+            done: () => d,
+            fail: () => d,
+            always: () => d
+        };
+        return d;
+    };
+    $.mage = { cookies: { get: () => null, set: () => {} }, redirect: () => {} };
+    $.extend = Object.assign;
+    $.fn = {};
+
+    return { $: $, node: node };
+}
+
+/**
+ * Load the renderer against the recording jQuery. `Component.extend(spec)` in
+ * the harness returns an object carrying the spec's own properties, so the
+ * returned value doubles as the `this` the methods run against — including its
+ * own `companyName` / `companyId` observables.
+ */
+function loadRenderer() {
+    const dom = makeDom();
+    const renderer = loadAmdModule(RENDERER, { jquery: dom.$ });
+    return { renderer: renderer, node: dom.node, $: dom.$ };
+}
+
+const COMPANY_ID_FIELD = 'input#company_id';
+const COMPANY_NAME_FIELD = 'input#company_name';
+
+describe('picking a company with no national identifier', () => {
+    test('applyCompanyData overwrites a previously selected company id', () => {
+        const { renderer, node } = loadRenderer();
+
+        renderer.applyCompanyData({ companyName: 'First Example Ltd', companyId: '12345678' });
+        expect(renderer.companyName()).toBe('First Example Ltd');
+        expect(renderer.companyId()).toBe('12345678');
+        expect(node(COMPANY_ID_FIELD).val()).toBe('12345678');
+
+        renderer.applyCompanyData({ companyName: 'Second Example Ltd', companyId: '' });
+
+        // The name moved, so the id MUST have moved with it.
+        expect(renderer.companyName()).toBe('Second Example Ltd');
+        expect(renderer.companyId()).toBe('');
+        expect(node(COMPANY_ID_FIELD).val()).toBe('');
+        expect(node(COMPANY_NAME_FIELD).val()).toBe('Second Example Ltd');
+    });
+
+    test('applyCompanyData re-enables company_id so the buyer can supply it', () => {
+        const { renderer, node } = loadRenderer();
+
+        // Company search owns the field until then.
+        renderer.enableCompanySearch();
+        expect(node(COMPANY_ID_FIELD).prop('disabled')).toBe(true);
+
+        renderer.applyCompanyData({ companyName: 'Second Example Ltd', companyId: '' });
+
+        expect(node(COMPANY_ID_FIELD).prop('disabled')).toBe(false);
+    });
+
+    test('a normal pick leaves company_id disabled', () => {
+        const { renderer, node } = loadRenderer();
+
+        renderer.enableCompanySearch();
+        renderer.applyCompanyData({ companyName: 'First Example Ltd', companyId: '12345678' });
+        renderer.syncCompanyIdEditable();
+
+        expect(node(COMPANY_ID_FIELD).prop('disabled')).toBe(true);
+    });
+
+    test('a later enableCompanySearch does not re-disable the field', () => {
+        // `$.async` resolves AFTER the synchronous fillCustomerData() that
+        // follows enableCompanySearch() in registeredOrganisationMode(), so an
+        // unconditional disable there stranded the buyer with an empty,
+        // uneditable, required company number.
+        const { renderer, node } = loadRenderer();
+
+        renderer.applyCompanyData({ companyName: 'Second Example Ltd', companyId: '' });
+        renderer.enableCompanySearch();
+
+        expect(node(COMPANY_ID_FIELD).prop('disabled')).toBe(false);
+    });
+
+    test('the real select2:select handler routes an empty companyId authoritatively', () => {
+        // Through the actual selection path, not the helper: a regression that
+        // reverted the handler to fillCompanyData() has to fail here.
+        const { renderer, node } = loadRenderer();
+
+        renderer.enableCompanySearch();
+        const select = node(COMPANY_NAME_FIELD).handlers['select2:select'];
+        expect(typeof select).toBe('function');
+
+        select({
+            params: { data: { id: 'First Example Ltd', text: 'First Example Ltd', companyId: '12345678' } }
+        });
+        expect(renderer.companyId()).toBe('12345678');
+
+        select({
+            params: { data: { id: 'Second Example Ltd', text: 'Second Example Ltd', companyId: '' } }
+        });
+
+        expect(renderer.companyName()).toBe('Second Example Ltd');
+        expect(renderer.companyId()).toBe('');
+        expect(node(COMPANY_ID_FIELD).val()).toBe('');
+        expect(node(COMPANY_ID_FIELD).prop('disabled')).toBe(false);
+    });
+
+    test('an empty customer-data section on init does not blank live state', () => {
+        // Why applyCompanyData() routes on "name set, id empty" rather than
+        // just dropping fillCompanyData()'s guard: the guard is load-bearing
+        // for the init call in fillCustomerData(), which passes whatever the
+        // `companyData` section happens to hold.
+        const { renderer, node } = loadRenderer();
+
+        renderer.applyCompanyData({ companyName: 'First Example Ltd', companyId: '12345678' });
+        renderer.applyCompanyData({});
+        renderer.applyCompanyData(undefined);
+        renderer.applyCompanyData({ companyName: '', companyId: '' });
+
+        expect(renderer.companyName()).toBe('First Example Ltd');
+        expect(renderer.companyId()).toBe('12345678');
+        expect(node(COMPANY_ID_FIELD).val()).toBe('12345678');
+    });
+});
+
+describe('a company picked on the shipping step reaches the payment step', () => {
+    /**
+     * Minimal observable with real subscribers, so `fillCustomerData()`'s
+     * `companyData` subscription can be driven the way the shipping-step
+     * picker drives it (`customerData.set('companyData', ...)`).
+     */
+    function observable(initial) {
+        let value = initial;
+        const subs = [];
+        function obs(next) {
+            if (!arguments.length) return value;
+            value = next;
+            subs.forEach((fn) => fn(value));
+            return obs;
+        }
+        obs.subscribe = function (fn) {
+            subs.push(fn);
+            return { dispose: function () {} };
+        };
+        return obs;
+    }
+
+    /**
+     * Load the renderer with a customer-data double whose sections the test
+     * writes, and a quote whose addresses are inert but well-formed enough for
+     * fillCustomerData()'s other subscriptions.
+     */
+    function loadWithSections(initialCompanyData) {
+        const dom = makeDom();
+        const sections = { companyData: observable(initialCompanyData) };
+        const address = { getCacheKey: () => 'k', countryId: 'GB' };
+        const renderer = loadAmdModule(RENDERER, {
+            jquery: dom.$,
+            'Magento_Customer/js/customer-data': {
+                get: function (key) {
+                    if (!sections[key]) sections[key] = observable('');
+                    return sections[key];
+                },
+                set: function (key, value) {
+                    sections[key] = sections[key] || observable('');
+                    sections[key](value);
+                },
+                reload: function () {}
+            },
+            'Magento_Checkout/js/model/quote': {
+                shippingAddress: observable(address),
+                billingAddress: observable(address),
+                getTotals: () => observable({}),
+                getQuoteId: () => null,
+                paymentMethod: observable(null),
+                shippingMethod: observable({ carrier_code: 'freeshipping' }),
+                isVirtual: () => false
+            }
+        });
+        // Normally seeded by initialize(), which the harness's Component
+        // double doesn't run. Pre-seeded for 'gb' so the supported-company-types
+        // lookup resolves from the memo instead of reaching for fetch().
+        renderer.supportedCompanyTypes = { gb: [] };
+        return { renderer: renderer, sections: sections, dom: dom };
+    }
+
+    test('the companyData subscription clears the previous company id', () => {
+        // The shipping-step picker publishes {companyName, companyId: ''} to
+        // the `companyData` customer-data section. Routing that subscription
+        // through fillCompanyData() dropped it on the empty id, leaving the
+        // payment step holding the previously picked company's organisation
+        // number under the newly picked company's name.
+        const { renderer, sections, dom } = loadWithSections({});
+
+        renderer.fillCustomerData();
+        sections.companyData({ companyName: 'First Example Ltd', companyId: '12345678' });
+        expect(renderer.companyId()).toBe('12345678');
+
+        sections.companyData({ companyName: 'Second Example Ltd', companyId: '' });
+
+        expect(renderer.companyName()).toBe('Second Example Ltd');
+        expect(renderer.companyId()).toBe('');
+        expect(dom.node(COMPANY_ID_FIELD).val()).toBe('');
+        expect(dom.node(COMPANY_ID_FIELD).prop('disabled')).toBe(false);
+    });
+
+    test('the section read on init also leaves company_id editable', () => {
+        // Not just the subscription: the payment renderer may initialise AFTER
+        // the shipping-step pick (a fresh renderer, or a re-render), in which
+        // case the name-only company arrives through the one-shot read rather
+        // than through a change notification. Reading it with fillCompanyData()
+        // dropped it and left the buyer facing an empty, disabled, required
+        // company number with no company name to explain it.
+        const { renderer, dom } = loadWithSections({
+            companyName: 'Second Example Ltd',
+            companyId: ''
+        });
+
+        renderer.enableCompanySearch();
+        expect(dom.node(COMPANY_ID_FIELD).prop('disabled')).toBe(true);
+
+        renderer.fillCustomerData();
+
+        expect(renderer.companyName()).toBe('Second Example Ltd');
+        expect(renderer.companyId()).toBe('');
+        expect(dom.node(COMPANY_ID_FIELD).prop('disabled')).toBe(false);
+    });
+});
+
+describe('the shipping-step picker agrees with the payment step', () => {
+    test('setCompanyData writes the empty company id straight through', () => {
+        // The address-step picker is already authoritative — it writes both the
+        // `companyData` customer-data section and the DOM field unconditionally
+        // — and it never disables its own company_id input. This pins that,
+        // because the payment step now trusts the section it publishes.
+        const dom = makeDom();
+        const sections = {};
+        const autocomplete = loadAmdModule('view/frontend/web/js/view/address-autocomplete.js', {
+            jquery: dom.$,
+            'Magento_Customer/js/customer-data': {
+                get: function () {
+                    return function () {
+                        return {};
+                    };
+                },
+                set: function (key, value) {
+                    sections[key] = value;
+                },
+                reload: function () {}
+            }
+        });
+
+        autocomplete.setCompanyData('12345678', 'First Example Ltd');
+        expect(sections.companyData).toEqual({
+            companyId: '12345678',
+            companyName: 'First Example Ltd'
+        });
+
+        autocomplete.setCompanyData('', 'Second Example Ltd');
+        expect(sections.companyData).toEqual({ companyId: '', companyName: 'Second Example Ltd' });
+        expect(dom.node(autocomplete.companyIdSelector).val()).toBe('');
+    });
+});

--- a/view/frontend/web/js/model/company-search.js
+++ b/view/frontend/web/js/model/company-search.js
@@ -320,9 +320,19 @@ define(['jquery', 'mage/translate'], function ($, $t) {
                          * identifier is only the buyer's disambiguator between
                          * two similarly-named companies; dropping the hit
                          * instead would remove a company they can no longer
-                         * select at all. Without one they see the name alone
-                         * and type the organisation number into the (still
-                         * required) company id field themselves.
+                         * select at all. Without one they see the name alone,
+                         * and selecting it is what gives them a route to the
+                         * organisation number: the pickers treat an empty
+                         * `companyId` as authoritative, clear any previously
+                         * selected company's identifier, and (on the payment
+                         * step, where company search disables the field)
+                         * re-enable `company_id` so the buyer can type it.
+                         * See applyCompanyData() /
+                         * selectCompanyWithoutIdentifier() in
+                         * view/payment/method-renderer/gateway_method.js —
+                         * WITHOUT that, an empty `companyId` here silently
+                         * kept the previous company's organisation number and
+                         * submitted it under this company's name.
                          */
                         const identifier =
                             item.national_identifier && item.national_identifier.id

--- a/view/frontend/web/js/model/company-search.js
+++ b/view/frontend/web/js/model/company-search.js
@@ -306,11 +306,33 @@ define(['jquery', 'mage/translate'], function ($, $t) {
                     const responseItems = (response && response.items) || [];
                     for (let i = 0; i < responseItems.length; i++) {
                         const item = responseItems[i];
+                        /*
+                         * `national_identifier` is optional in the search
+                         * response — the company may have none in its home
+                         * registry, and the object itself may be absent, null,
+                         * or carry a null/empty `id`. Reading it unguarded
+                         * threw, and a throw here happens inside select2's
+                         * query pipeline: it takes the WHOLE result list down,
+                         * not just this hit, and leaves the dropdown stuck on
+                         * "Searching…" with no error the buyer can act on.
+                         *
+                         * So render the company with whatever it has. The
+                         * identifier is only the buyer's disambiguator between
+                         * two similarly-named companies; dropping the hit
+                         * instead would remove a company they can no longer
+                         * select at all. Without one they see the name alone
+                         * and type the organisation number into the (still
+                         * required) company id field themselves.
+                         */
+                        const identifier =
+                            item.national_identifier && item.national_identifier.id
+                                ? String(item.national_identifier.id)
+                                : '';
                         items.push({
                             id: item.name,
                             text: item.name,
-                            html: `${item.highlight} (${item.national_identifier.id})`,
-                            companyId: item.national_identifier.id,
+                            html: identifier ? `${item.highlight} (${identifier})` : item.highlight,
+                            companyId: identifier,
                             // Required by lookupCompanyAddress(); dropping it
                             // silently disables address autofill.
                             lookupId: item.lookup_id

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -333,6 +333,74 @@ define([
                     });
             }
         },
+        /**
+         * True when the buyer has to supply the organisation number by hand:
+         * a company is selected, but the registry gave it no national
+         * identifier so there is nothing for the picker to fill in.
+         */
+        needsManualCompanyId: function () {
+            return !!this.companyName() && !this.companyId();
+        },
+        /**
+         * `company_id` is disabled while company search owns it — the
+         * identifier arrives with the picked company, so letting the buyer
+         * edit it would only let them contradict the registry. The one
+         * exception is a company that HAS no identifier: then typing it is
+         * the buyer's only route, and being enabled is also the only state in
+         * which the template's `required="true"` is enforced at all (jQuery
+         * Validation's `elements()` skips `:disabled`, so a disabled empty
+         * field passes validation silently).
+         */
+        syncCompanyIdEditable: function () {
+            $(this.companyIdSelector).prop('disabled', !this.needsManualCompanyId());
+        },
+        /**
+         * Apply a company the buyer (or a customer-data section) selected.
+         *
+         * Routes to fillCompanyData() for the normal case, and to
+         * selectCompanyWithoutIdentifier() when the company has a name but no
+         * identifier — a shape company search can now return, since the
+         * `national_identifier` guard in company-search.js renders those hits
+         * instead of taking the whole result list down.
+         *
+         * The split exists because fillCompanyData() early-returns on an
+         * empty companyId, which is right for its other callers (an empty
+         * customer-data section on init must not blank live state) but wrong
+         * for a selection: a selection is authoritative. Without this, picking
+         * an identifier-less company after a valid one left the PREVIOUS
+         * company's organisation number in `companyId()` while the picker
+         * displayed the new company's name, and getData()/placeOrderIntent()
+         * submitted the two mixed together.
+         */
+        applyCompanyData: function (companyData) {
+            const data = companyData || {};
+            const companyName =
+                typeof data.companyName == 'string' && data.companyName ? data.companyName : '';
+            const companyId = typeof data.companyId == 'string' ? data.companyId : '';
+            if (companyName && !companyId) {
+                this.selectCompanyWithoutIdentifier(companyName);
+                return;
+            }
+            this.fillCompanyData(data);
+        },
+        /**
+         * A selected company whose registry holds no national identifier.
+         * Writes the name, CLEARS any previously selected company's
+         * identifier, and re-enables `company_id` so the buyer can type the
+         * organisation number themselves.
+         *
+         * No order intent is placed: there is no identifier to place one for,
+         * and one will be placed when the buyer supplies it.
+         */
+        selectCompanyWithoutIdentifier: function (companyName) {
+            console.debug({ logger: 'twoPayment.selectCompanyWithoutIdentifier', companyName });
+            this.companyName(companyName);
+            $(this.companyNameSelector).val(companyName);
+            $('#select2-company_name-container')?.text(companyName);
+            this.companyId('');
+            $(this.companyIdSelector).val('');
+            this.syncCompanyIdEditable();
+        },
         fillTelephone: function (telephone) {
             console.debug({ logger: 'twoPayment.fillTelephone', telephone });
             telephone = typeof telephone == 'string' ? telephone : '';
@@ -438,8 +506,13 @@ define([
 
             customerData
                 .get('companyData')
-                .subscribe((companyData) => self.fillCompanyData(companyData));
-            this.fillCompanyData(customerData.get('companyData')());
+                // applyCompanyData(), not fillCompanyData(): the shipping-step
+                // picker writes this section, so an identifier-less company
+                // picked there must land here as "name set, id cleared, field
+                // editable" rather than being dropped by fillCompanyData()'s
+                // empty-id early return.
+                .subscribe((companyData) => self.applyCompanyData(companyData));
+            this.applyCompanyData(customerData.get('companyData')());
 
             customerData
                 .get('shippingTelephone')
@@ -865,7 +938,13 @@ define([
             let self = this;
             require(['Two_Gateway/select2-4.1.0/js/select2.min'], function () {
                 $.async(self.companyIdSelector, function (companyIdField) {
-                    $(companyIdField).prop('disabled', true);
+                    // Not an unconditional disable: this `$.async` callback
+                    // resolves AFTER the synchronous fillCustomerData() that
+                    // follows it in registeredOrganisationMode(), so hard-coding
+                    // `true` here re-disabled the field for an already-selected
+                    // identifier-less company and stranded the buyer with an
+                    // empty, uneditable, required company number.
+                    $(companyIdField).prop('disabled', !self.needsManualCompanyId());
                 });
                 $.async(self.companyNameSelector, function (companyNameField) {
                     // `$.async` is a MutationObserver, and every call to
@@ -981,7 +1060,11 @@ define([
                             const selectedItem = e.params.data;
                             const companyId = selectedItem.companyId;
                             const companyName = selectedItem.text;
-                            self.fillCompanyData({ companyId, companyName });
+                            // applyCompanyData(), not fillCompanyData(): a pick
+                            // is authoritative and must overwrite the previous
+                            // company's identifier even when the new company
+                            // has none of its own.
+                            self.applyCompanyData({ companyId, companyName });
                             // TWO-25193: the payment-step picker used to stop
                             // here, leaving the billing address blank. Gate is
                             // config.isAddressSearchEnabled, applied inside

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -318,20 +318,32 @@ define([
             $('#select2-company_name-container')?.text(companyName);
             this.companyId(companyId);
             $(this.companyIdSelector).val(companyId);
-            if (this.isOrderIntentEnabled) {
-                fullScreenLoader.startLoader();
-                const self = this;
-                this.placeOrderIntent()
-                    .always(function () {
-                        fullScreenLoader.stopLoader();
-                    })
-                    .done(function (response) {
-                        self.processOrderIntentSuccessResponse(response);
-                    })
-                    .fail(function (response) {
-                        self.processOrderIntentErrorResponse(response);
-                    });
-            }
+            this.runOrderIntent();
+        },
+        /**
+         * Place an order intent for the company currently in
+         * companyName/companyId and reflect the answer. No-op when the
+         * merchant has order intents turned off.
+         *
+         * Extracted so there is exactly ONE place the intent is fired from:
+         * fillCompanyData() fires it for a picked company and
+         * applyManualCompanyId() for an organisation number the buyer typed
+         * because the registry had none, and the two must behave identically.
+         */
+        runOrderIntent: function () {
+            if (!this.isOrderIntentEnabled) return;
+            fullScreenLoader.startLoader();
+            const self = this;
+            this.placeOrderIntent()
+                .always(function () {
+                    fullScreenLoader.stopLoader();
+                })
+                .done(function (response) {
+                    self.processOrderIntentSuccessResponse(response);
+                })
+                .fail(function (response) {
+                    self.processOrderIntentErrorResponse(response);
+                });
         },
         /**
          * True when the buyer has to supply the organisation number by hand:
@@ -371,26 +383,56 @@ define([
          * company's organisation number in `companyId()` while the picker
          * displayed the new company's name, and getData()/placeOrderIntent()
          * submitted the two mixed together.
+         *
+         * `options.authoritative` says the name-set/id-empty shape came from
+         * an act of selection — one of the two pickers, or a live change
+         * notification on the `companyData` section, which is the shipping-step
+         * picker writing it. Only those may clear a company that is already
+         * selected. The one-shot section READ on init must not: `companyData`
+         * is a localStorage customer-data section, so it outlives page loads
+         * and previous orders, and a stale `{companyName, companyId: ''}` row
+         * would otherwise overwrite a live payment-step pick's name and blank
+         * its organisation number. Before the routing existed that shape was a
+         * harmless no-op on the read path, and it has to stay one.
+         *
+         * The editable state of `company_id` is derived here, after BOTH
+         * branches, so one place decides it. Deriving it only inside
+         * selectCompanyWithoutIdentifier() left the field enabled after
+         * identifier-less pick → normal pick, which is precisely the state
+         * syncCompanyIdEditable()'s comment says must not exist: the buyer
+         * could hand-overwrite a registry organisation number.
          */
-        applyCompanyData: function (companyData) {
+        applyCompanyData: function (companyData, options) {
             const data = companyData || {};
+            const authoritative = !!(options && options.authoritative);
             const companyName =
                 typeof data.companyName == 'string' && data.companyName ? data.companyName : '';
-            const companyId = typeof data.companyId == 'string' ? data.companyId : '';
+            // String(), not a typeof test: a non-string id (a numeric
+            // `national_identifier.id`, say) coerced to '' would route a
+            // company that HAS an identifier down the identifier-less branch
+            // and actively clear it.
+            const companyId = data.companyId == null ? '' : String(data.companyId);
             if (companyName && !companyId) {
+                if (!authoritative && (this.companyName() || this.companyId())) return;
                 this.selectCompanyWithoutIdentifier(companyName);
-                return;
+            } else {
+                this.fillCompanyData({ companyName: companyName, companyId: companyId });
             }
-            this.fillCompanyData(data);
+            this.syncCompanyIdEditable();
         },
         /**
          * A selected company whose registry holds no national identifier.
-         * Writes the name, CLEARS any previously selected company's
-         * identifier, and re-enables `company_id` so the buyer can type the
-         * organisation number themselves.
+         * Writes the name and CLEARS any previously selected company's
+         * identifier.
          *
-         * No order intent is placed: there is no identifier to place one for,
-         * and one will be placed when the buyer supplies it.
+         * No order intent is placed here: there is no identifier to place one
+         * for. applyManualCompanyId() places it when the buyer supplies the
+         * organisation number by hand, which is the only route by which it
+         * becomes known for such a company.
+         *
+         * `company_id`'s editable state is NOT set here — applyCompanyData()
+         * derives it for this branch and the normal one alike, so a later
+         * normal pick cannot leave the field enabled.
          */
         selectCompanyWithoutIdentifier: function (companyName) {
             console.debug({ logger: 'twoPayment.selectCompanyWithoutIdentifier', companyName });
@@ -399,7 +441,40 @@ define([
             $('#select2-company_name-container')?.text(companyName);
             this.companyId('');
             $(this.companyIdSelector).val('');
-            this.syncCompanyIdEditable();
+        },
+        /**
+         * The buyer typed the organisation number for a company the registry
+         * gave none for (see selectCompanyWithoutIdentifier). Accepting it
+         * here is what makes the order intent possible at all for such a
+         * company — nothing else re-fires it, so without this the order
+         * reached the API with no credit check behind it.
+         *
+         * Fires at most once per number the buyer settles on:
+         *  - bound to `change`, not `input`, so once on commit (blur/Enter),
+         *    not once per keystroke;
+         *  - returns on an empty value, and on a value equal to the one
+         *    already accepted, so a blur that commits nothing new does
+         *    nothing;
+         *  - returns when no company is selected, so it never runs on the
+         *    no-company path;
+         *  - never doubles up with the picker path: fillCompanyData() writes
+         *    this field with `.val()`, which fires no `change` event, and
+         *    places its own intent.
+         *
+         * The field is deliberately not re-disabled once a number is
+         * accepted — the buyer typed it, so they have to be able to correct a
+         * typo, and a correction re-checks. It goes back to disabled when a
+         * company that HAS a registry identifier is picked, which is
+         * applyCompanyData()/syncCompanyIdEditable()'s job.
+         */
+        applyManualCompanyId: function (value) {
+            const companyId = typeof value == 'string' ? value.trim() : '';
+            if (!companyId || companyId === this.companyId()) return;
+            if (!this.companyName()) return;
+            console.debug({ logger: 'twoPayment.applyManualCompanyId', companyId });
+            this.companyId(companyId);
+            $(this.companyIdSelector).val(companyId);
+            this.runOrderIntent();
         },
         fillTelephone: function (telephone) {
             console.debug({ logger: 'twoPayment.fillTelephone', telephone });
@@ -506,12 +581,19 @@ define([
 
             customerData
                 .get('companyData')
-                // applyCompanyData(), not fillCompanyData(): the shipping-step
-                // picker writes this section, so an identifier-less company
-                // picked there must land here as "name set, id cleared, field
-                // editable" rather than being dropped by fillCompanyData()'s
-                // empty-id early return.
-                .subscribe((companyData) => self.applyCompanyData(companyData));
+                // Authoritative: a change NOTIFICATION on this section is the
+                // shipping-step picker writing it, so an identifier-less
+                // company picked there must land here as "name set, id
+                // cleared, field editable" rather than being dropped by
+                // fillCompanyData()'s empty-id early return.
+                .subscribe((companyData) =>
+                    self.applyCompanyData(companyData, { authoritative: true })
+                );
+            // NOT authoritative: this is a one-shot read of a localStorage
+            // section that outlives page loads and previous orders, and
+            // fillCustomerData() is re-callable (registeredOrganisationMode(),
+            // reached from applyPrefetch()). A stale `{companyName,
+            // companyId: ''}` row must not overwrite a live payment-step pick.
             this.applyCompanyData(customerData.get('companyData')());
 
             customerData
@@ -938,13 +1020,31 @@ define([
             let self = this;
             require(['Two_Gateway/select2-4.1.0/js/select2.min'], function () {
                 $.async(self.companyIdSelector, function (companyIdField) {
-                    // Not an unconditional disable: this `$.async` callback
-                    // resolves AFTER the synchronous fillCustomerData() that
-                    // follows it in registeredOrganisationMode(), so hard-coding
-                    // `true` here re-disabled the field for an already-selected
-                    // identifier-less company and stranded the buyer with an
-                    // empty, uneditable, required company number.
-                    $(companyIdField).prop('disabled', !self.needsManualCompanyId());
+                    const $companyIdField = $(companyIdField);
+                    // Not an unconditional disable. What puts this after the
+                    // synchronous fillCustomerData() that follows
+                    // enableCompanySearch() in registeredOrganisationMode() is
+                    // the wrapping `require()`, whose callback cannot run
+                    // before the caller returns — `$.async` itself resolves
+                    // immediately for a node that is already in the DOM, and
+                    // re-resolves on every enableCompanySearch(). Either way
+                    // this body runs with a company possibly already selected,
+                    // so hard-coding `true` re-disabled the field for an
+                    // identifier-less one and stranded the buyer with an empty,
+                    // uneditable, required company number. Derive it.
+                    $companyIdField.prop('disabled', !self.needsManualCompanyId());
+                    // The buyer's typed organisation number is the only route
+                    // to an order intent for a company the registry gave no
+                    // identifier for. `change`, not `input`: once on commit,
+                    // not once per keystroke. `.off()` first for the same
+                    // handler-stacking reason as the company-name field below —
+                    // every enableCompanySearch() adds another observer, and
+                    // our handlers are not in select2's own namespace.
+                    $companyIdField
+                        .off('change' + companySearch.EVENT_NS)
+                        .on('change' + companySearch.EVENT_NS, function () {
+                            self.applyManualCompanyId($companyIdField.val());
+                        });
                 });
                 $.async(self.companyNameSelector, function (companyNameField) {
                     // `$.async` is a MutationObserver, and every call to
@@ -1064,7 +1164,10 @@ define([
                             // is authoritative and must overwrite the previous
                             // company's identifier even when the new company
                             // has none of its own.
-                            self.applyCompanyData({ companyId, companyName });
+                            self.applyCompanyData(
+                                { companyId, companyName },
+                                { authoritative: true }
+                            );
                             // TWO-25193: the payment-step picker used to stop
                             // here, leaving the billing address blank. Gate is
                             // config.isAddressSearchEnabled, applied inside


### PR DESCRIPTION
> [!IMPORTANT]
> **Correction, added after merge.** This PR merged while a review round was still open, and that round found two defects in its last commit (`7f243b5`). Both are fixed in #287.
>
> 1. **The order-intent trigger described below does not work.** The template binds `value: companyId`, so Knockout's `value` binding is already listening on the same `change` event and is registered first (at `applyBindings()`, before `$.async` runs). ko writes `companyId()` first, the handler's `companyId === this.companyId()` dedup is then already true, and it returns. A typed number places **no** intent. It fired only for a value with stray whitespace, because `trim()` made it differ — which is the shape the test used, so the test passed against a no-op. #287 removes the trigger and states the honest behaviour: an identifier-less company is never intent-checked.
> 2. **"four other callers run in modes where company search does not own the field" is false for `updateAddress()`**, which is subscribed inside `fillCustomerData()` and fires on every billing/shipping notification, in registered-organisation mode with the picker live. #287 derives editability from the observables instead, so it cannot desync per caller.
>
> Also inaccurate below: "nobody could type into it" — manual-entry mode leaves `company_id` enabled and typeable.

Linear: [TWO-25253](https://linear.app/two-inc/issue/TWO-25253)

## The defect

`processResults` in `view/frontend/web/js/model/company-search.js` read `item.national_identifier.id` unguarded. That field is **optional** in the search response — a company may have no identifier in its home registry, and internal identifier types are stripped from it — so a perfectly valid hit threw a `TypeError`. This is not a malformed response; the existing guard above it protects against a malformed *body*, not a malformed *hit*.

The throw happens inside select2's query pipeline, so the cost is not one hit. It takes the **whole result list** down and leaves the dropdown stuck on "Searching…" with no error the buyer can act on.

## The fix, part one: render the hit

Render it with whatever it has: name and highlight, the ` (identifier)` suffix only when there is one, empty company id otherwise. Show-over-skip — the identifier is only the buyer's disambiguator between two similarly-named companies, so dropping the hit would remove a company they can no longer select at all.

Covers all four reachable shapes: `national_identifier` absent, `null`, `id: null`, `id: ""`.

## The fix, part two: make picking it authoritative

Self-review caught that part one alone would have shipped a **worse** bug than the crash, so this is not optional polish — it is what makes show-over-skip actually work on this platform.

`fillCompanyData()` early-returns on `if (!companyName || !companyId)`. So picking an identifier-less hit set *neither* observable. If the buyer had already picked a valid company first, `companyId()` / `companyName()` kept the **previous** company's values while select2 displayed the **new** company's name — and `getData()` / `placeOrderIntent()` would submit company A's organisation number under company B's name. Silent wrong data, on a path the guard newly made reachable.

Selecting an identifier-less company now writes the new name, **clears** any previously selected company's identifier, and re-enables the `company_id` input so the buyer can type the organisation number. Re-enabling is also what makes the field's `required` rule apply at all: `enableCompanySearch()` disables the input, and jQuery Validation's `elements()` skips `:disabled`, so `required="true"` was not being enforced.

`fillCompanyData()`'s guard is left alone — it has other callers, including an init read of `customerData` where loosening it would blank state. The no-identifier case is handled at the selection sites instead.

The address-step picker needed no change; it already wrote its fields unconditionally. The gap was the payment step not trusting it, and that cross-step path is now pinned by a test.

## Note on scope

`item.highlight` and `item.lookup_id` are **not** crash paths and are deliberately untouched: template-literal interpolation of `undefined` yields the string `"undefined"`, it does not throw. Only `national_identifier` crashes.

`lookupId` (address autofill) is unaffected by a missing identifier and is now asserted to survive — `lookupCompanyAddress()` gates on `lookupId` alone.

## Parity

Same defect and same first half as the WooCommerce plugin's fix (that repo's PR #393). The second half is Magento-specific: WooCommerce's select handler already wrote `company_id` unconditionally into an editable, server-side-validated field, so it had no stale-company path to close. The `magento-hyva-extension` copy of the same read is fixed separately under the same ticket.

## Verification

`npm run test:js` — **147 passed, 11 suites**.

New suite `Test/Js/gateway-method-company-selection.test.js` (**16 tests**) drives the real `select2:select` handler and the real `company_id` `change` handler with a recording jQuery double, because the shared harness default is inert and would pass almost anything.

Seventeen mutations across two rounds, each caught. Round 1: two (the `companyData` subscription and its init read routing back to `fillCompanyData`) were **green on the first pass** — the cross-step path was unpinned, so two tests were added before those went red. Round 2 found four majors in round 1's own new code, all now pinned: the editable state was derived on one branch only, so identifier-less pick then normal pick left a registry organisation number in an ENABLED field; routing the init read through the selection path let a stale localStorage `{companyName, companyId: ''}` row clobber a live pick; the typed organisation number placed no order intent at all, so an identifier-less company's order reached the API with no credit check; and the test named for the first of those could not fail for it, because it hand-called a function production never calls on that path. Each of the four, and every minor, was reverted individually and confirmed RED. Order-intent behaviour is pinned for the first time — `initialize()` never runs under the harness, so `isOrderIntentEnabled` was `undefined` and the branch was dead in every test.

Mutation-checking the original guard: reverting it turns the shape tests red. Two of the four shapes fail on the throw (`TypeError: Cannot read properties of undefined (reading 'id')`); `id: null` and `id: ""` fail on rendered output instead, because unguarded they produce empty-parens garbage — `"<em>Example</em> Trading Ltd ()"` — rather than throwing. Both are wrong behaviour and both are now pinned.

## Scope grew — read this before approving

This started as a six-line guard and is now a four-figure diff that adds a new order-intent trigger. That was not drift; each step closed a wrong-data path the previous step opened, and the review rounds are in the history. But the last step is a genuine behaviour addition on the payment path and deserves a deliberate yes rather than being waved through with the crash fix:

**Committing a hand-typed organisation number now places an order intent.** Before this PR nothing did, because the field was disabled and nobody could type into it. The alternative was to leave it unchecked and merely document that an identifier-less company is never credit-checked — smaller, but it means an order reaching the API with no check, which is worse than the crash this PR started from. Bound to `change` (not `input`), returns on empty / unchanged / no-company-selected, and cannot double up with the picker path because `fillCompanyData()` writes with `.val()`, which fires no `change`.

One residual is documented rather than fixed: committing an edited number and picking a company in one gesture can place two intents whose responses race. Two rapid picks already had that race; this does not widen it.

If you would rather ship the crash guard alone, the first commit (`aa40318`) stands on its own and the rest can be dropped — but then an identifier-less hit is selectable and submits the previously selected company's organisation number, which is why it was not left there.

## Investigated, deliberately not fixed

`Observer/SalesOrderAddressUpdate.php` dereferences `buyer.company.company_name` and `organization_number` with no `isset`/`??`, which looks like the same class of bug. It is **not reachable**, so it is left alone rather than speculatively guarded: that payload is local state, not an API response. `Service/Order.php` writes both keys unconditionally with `?? ''` defaults, and the observer is gated on `getTwoOrderId()`, whose only writer sits thirteen lines before the payload write in the same method — so the id being set implies the payload was written. The guarded sibling in `Controller/Payment/Confirm.php` does not transfer; its source really is an optional-shaped API response.

One genuine smell found there and left for its own ticket if wanted: the observer can `PUT` empty `companyName` / `companyId` for a buyer with no company. That is a data question, not a crash.