### PR TITLE
fix(TWO-25253): drop the inert intent-on-typed-number trigger, derive editability from the observables

### DIFF
--- a/Test/Js/company-search-address-lookup.test.js
+++ b/Test/Js/company-search-address-lookup.test.js
@@ -241,7 +241,11 @@ describe('payment-step company picker (gateway_method.js)', () => {
             searchForCompanyText: 'Search for company',
             _brandConfig: config,
             countryCode: function () { return 'gb'; },
-            companyName: function () { return ''; },
+            // Carries `subscribe` because enableCompanySearch() derives
+            // company_id's editable state from this observable.
+            companyName: Object.assign(function () { return ''; }, {
+                subscribe: function () { return { dispose: function () {} }; }
+            }),
             fillCompanyData: function (data) { filled.push(data); },
             addressLookup: component.addressLookup,
             enableCompanySearch: component.enableCompanySearch

--- a/Test/Js/company-search-resilience.test.js
+++ b/Test/Js/company-search-resilience.test.js
@@ -1071,9 +1071,18 @@ describe('re-render safety of the select2 binding', () => {
             countryCode: function () {
                 return 'gb';
             },
-            companyName: function () {
-                return '';
-            },
+            // Carries `subscribe` because enableCompanySearch() derives
+            // company_id's editable state from this observable.
+            companyName: Object.assign(
+                function () {
+                    return '';
+                },
+                {
+                    subscribe: function () {
+                        return { dispose: function () {} };
+                    }
+                }
+            ),
             fillCompanyData: function () {},
             addressLookup: component.addressLookup,
             enableCompanySearch: component.enableCompanySearch,

--- a/Test/Js/gateway-method-company-selection.test.js
+++ b/Test/Js/gateway-method-company-selection.test.js
@@ -20,6 +20,22 @@
  * template's `required="true"` is NOT enforced on a disabled field. An
  * identifier-less pick therefore has to RE-ENABLE the field, or the buyer has
  * neither a way to supply the number nor a validation error telling them to.
+ *
+ * LIMITATION OF THE jQuery DOUBLE BELOW — read before trusting a passing test
+ * here. `node.on()` stores ONE handler per event name and `node.off()` is a
+ * no-op, so two handlers bound to the same event on the same node are
+ * unmodellable and the LAST bind silently wins. Nothing in this file can
+ * therefore say anything about handler ORDERING or handler COEXISTENCE.
+ *
+ * That is not academic: it is exactly how a `change` handler on `input#company_id`
+ * got here looking correct. In the browser the template binds `value: companyId`,
+ * so ko's `value` binding is already listening on that same `change` event and
+ * was registered first (at applyBindings, before `$.async` runs) — ko writes
+ * `companyId()` before any later handler sees the event, which made the later
+ * handler's "did the value change?" check trivially false. The double could not
+ * express the ko handler at all, so the test passed against a no-op. If a
+ * question depends on more than one listener for an event, make the double
+ * faithful (a real handler list plus a working `off()`) first.
  */
 
 'use strict';
@@ -62,6 +78,10 @@ function makeDom() {
                 n.textValue = next;
                 return n;
             },
+            // ONE handler per event name, and `off()` does nothing. See the
+            // "LIMITATION OF THE jQuery DOUBLE" note at the top of this file
+            // before writing anything that depends on handler ordering or on
+            // two handlers sharing an event.
             on: function (event, fn) {
                 // Strip the `.twoCompanySearch` namespace so tests can fire by
                 // plain event name.
@@ -400,6 +420,9 @@ describe('a company picked on the shipping step reaches the payment step', () =>
         });
 
         renderer.enableCompanySearch();
+        // Precondition, not the property under test — enableCompanySearch()
+        // disables the field itself with nothing selected, so this holds
+        // trivially (same as at 'applyCompanyData re-enables company_id').
         expect(dom.node(COMPANY_ID_FIELD).prop('disabled')).toBe(true);
 
         renderer.fillCustomerData();
@@ -482,11 +505,17 @@ describe('order intent for a company with no registry identifier', () => {
         expect(intent).not.toHaveBeenCalled();
     });
 
-    test('the number the buyer types places exactly one intent', () => {
-        // The hole this closes: nothing subscribed to `companyId` to re-fire
-        // the intent, and fillCompanyData() is never reached on this path, so
-        // an identifier-less company's order previously arrived at the API
-        // with no credit check behind it at all.
+    test('a hand-typed organisation number is never intent-checked', () => {
+        // Current, deliberate behaviour, stated so nobody reads the absence of
+        // a test as an oversight: nothing re-fires the intent once an
+        // identifier-less company is picked. The buyer can type the number and
+        // the order goes out carrying it, with no credit check behind it.
+        //
+        // The `change`-handler version of this does NOT work — see the
+        // "LIMITATION OF THE jQuery DOUBLE" note at the top of this file — and
+        // is split to its own ticket. Asserting on the renderer's own API here
+        // rather than through the DOM, because the double cannot model the ko
+        // `value` binding that shares the event.
         const { renderer, node, intent } = loadWithIntent();
 
         renderer.enableCompanySearch();
@@ -497,49 +526,93 @@ describe('order intent for a company with no registry identifier', () => {
         });
         expect(intent).not.toHaveBeenCalled();
 
-        const commit = node(COMPANY_ID_FIELD).handlers['change'];
-        expect(typeof commit).toBe('function');
-        node(COMPANY_ID_FIELD).val('  99999999  ');
-        commit();
+        // No handler is bound to the field's `change` at all any more.
+        expect(node(COMPANY_ID_FIELD).handlers['change']).toBeUndefined();
 
-        expect(renderer.companyId()).toBe('99999999');
-        expect(node(COMPANY_ID_FIELD).val()).toBe('99999999');
-        expect(intent).toHaveBeenCalledTimes(1);
-    });
-
-    test('re-committing the same number places no second intent', () => {
-        const { renderer, node, intent } = loadWithIntent();
-
-        renderer.enableCompanySearch();
-        node(COMPANY_NAME_FIELD).handlers['select2:select']({
-            params: {
-                data: { id: 'Second Example Ltd', text: 'Second Example Ltd', companyId: '' }
-            }
-        });
-        const commit = node(COMPANY_ID_FIELD).handlers['change'];
-        node(COMPANY_ID_FIELD).val('99999999');
-        commit();
-        expect(intent).toHaveBeenCalledTimes(1);
-
-        // A blur that commits nothing new, and an emptied field.
-        commit();
-        node(COMPANY_ID_FIELD).val('');
-        commit();
-
-        expect(intent).toHaveBeenCalledTimes(1);
-        expect(renderer.companyId()).toBe('99999999');
-    });
-
-    test('a number typed with no company selected places no intent', () => {
-        const { renderer, node, intent } = loadWithIntent();
-
-        renderer.enableCompanySearch();
-        const commit = node(COMPANY_ID_FIELD).handlers['change'];
-        node(COMPANY_ID_FIELD).val('99999999');
-        commit();
+        // What ko's `value` binding does when the buyer commits a number.
+        renderer.companyId('99999999');
 
         expect(intent).not.toHaveBeenCalled();
-        expect(renderer.companyId()).toBe('');
+    });
+});
+
+describe('company_id editability is derived, not set per caller', () => {
+    /**
+     * Same sections harness as above, so updateAddress() can be driven the way
+     * fillCustomerData() drives it — through a billing-address notification.
+     */
+    function observable(initial) {
+        let value = initial;
+        const subs = [];
+        function obs(next) {
+            if (!arguments.length) return value;
+            value = next;
+            subs.forEach((fn) => fn(value));
+            return obs;
+        }
+        obs.subscribe = function (fn) {
+            subs.push(fn);
+            return { dispose: function () {} };
+        };
+        return obs;
+    }
+
+    test('an address notify carrying company_id cannot leave a registry number in an enabled field', () => {
+        // The desync 7f243b5 argued could not happen. Its reasoning was that
+        // fillCompanyData()'s other callers "run in modes where company search
+        // does not own the field" — false for updateAddress(), which is
+        // subscribed inside fillCustomerData() and fires on every
+        // billing/shipping notification, i.e. in registered-organisation mode
+        // with the picker live. So: pick an identifier-less company (field
+        // enabled), then let one address notification arrive carrying a
+        // `company_id` custom attribute. Before the derived subscription the
+        // registry number landed in a still-ENABLED field — MAJOR 1's exact
+        // state, which the buyer can hand-overwrite.
+        const dom = makeDom();
+        const address = { getCacheKey: () => 'k', countryId: 'GB' };
+        const billingAddress = observable(address);
+        const renderer = loadAmdModule(RENDERER, {
+            jquery: dom.$,
+            'Magento_Customer/js/customer-data': {
+                get: function () {
+                    return observable('');
+                },
+                set: function () {},
+                reload: function () {}
+            },
+            'Magento_Checkout/js/model/quote': {
+                shippingAddress: observable(address),
+                billingAddress: billingAddress,
+                getTotals: () => observable({}),
+                getQuoteId: () => null,
+                paymentMethod: observable(null),
+                shippingMethod: observable({ carrier_code: 'freeshipping' }),
+                isVirtual: () => false
+            }
+        });
+        renderer.supportedCompanyTypes = { gb: [] };
+
+        renderer.enableCompanySearch();
+        renderer.fillCustomerData();
+
+        renderer.applyCompanyData(
+            { companyName: 'Second Example Ltd', companyId: '' },
+            AS_SELECTION
+        );
+        expect(dom.node(COMPANY_ID_FIELD).prop('disabled')).toBe(false);
+
+        // One billing-address notification, carrying a company_id attribute.
+        billingAddress({
+            getCacheKey: () => 'k2',
+            countryId: 'GB',
+            company: 'First Example Ltd',
+            customAttributes: [{ attribute_code: 'company_id', value: '12345678' }]
+        });
+
+        // Whatever the notification does to the selection, it must not leave a
+        // registry organisation number sitting in a hand-editable field.
+        expect(dom.node(COMPANY_ID_FIELD).prop('disabled')).toBe(true);
+        expect(renderer.companyId()).toBe('12345678');
     });
 });
 

--- a/Test/Js/gateway-method-company-selection.test.js
+++ b/Test/Js/gateway-method-company-selection.test.js
@@ -599,6 +599,10 @@ describe('company_id editability is derived, not set per caller', () => {
             { companyName: 'Second Example Ltd', companyId: '' },
             AS_SELECTION
         );
+        // Precondition, not the property under test: this is backed by
+        // applyCompanyData()'s own syncCompanyIdEditable() call, not by the
+        // subscription, so it survives all four mutations. The assertion after
+        // the notification below is the load-bearing one.
         expect(dom.node(COMPANY_ID_FIELD).prop('disabled')).toBe(false);
 
         // One billing-address notification, carrying a company_id attribute.

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -393,11 +393,22 @@ define([
          * harmless no-op on the read path, and it has to stay one.
          *
          * The editable state of `company_id` is re-derived here, after BOTH
-         * branches. Belt-and-braces only: the authoritative derivation is the
-         * companyName/companyId subscription in enableCompanySearch(), which
-         * catches every writer including the ones that never come through a
-         * selection path. This call covers the case where a pick writes values
-         * identical to the current ones, which ko does not notify for.
+         * branches. The authoritative derivation is the companyName/companyId
+         * subscription in enableCompanySearch(), which catches every writer OF
+         * THE OBSERVABLES, including the ones that never come through a
+         * selection path. This call is not merely belt-and-braces; it is
+         * load-bearing for two cases the subscription cannot cover:
+         *
+         *  - a pick that writes values identical to the current ones, which ko
+         *    does not notify for;
+         *  - the window before `$.async('input#company_id')` has resolved. On
+         *    init, registeredOrganisationMode() calls enableCompanySearch() and
+         *    then fillCustomerData(), whose companyData notification fires
+         *    synchronously — possibly before the field node exists and
+         *    therefore before the subscription has been created at all.
+         *
+         * A writer that touches only the DOM field and never the observables is
+         * outside both mechanisms by construction — see clearCompany().
          */
         applyCompanyData: function (companyData, options) {
             const data = companyData || {};
@@ -1036,6 +1047,16 @@ define([
                     // Bound once per component: enableCompanySearch() re-runs
                     // on every re-render (see the $.async note below) and each
                     // run would otherwise stack another subscription.
+                    //
+                    // Once per COMPONENT, not once per page: `companyName` and
+                    // `companyId` are module-level observables shared by every
+                    // renderer instance (see the note where they are declared),
+                    // so N live brand renderers mean N subscriptions on one
+                    // observable, each writing the same document-wide
+                    // `input#company_id`. Harmless rather than wasteful-and-
+                    // wrong: syncCompanyIdEditable() is idempotent and derives
+                    // from those same shared observables, so every subscriber
+                    // computes the identical answer. dispose() clears them.
                     if (!self._companyIdEditableSubs) {
                         const sync = function () {
                             self.syncCompanyIdEditable();
@@ -1231,6 +1252,16 @@ define([
                 });
             });
         },
+        /**
+         * PRE-EXISTING, flagged rather than changed: this writes the DOM fields
+         * only and never clears `companyName()` / `companyId()`. No notification
+         * therefore reaches the editability subscription, so after "Enter
+         * details manually" the field reads empty and enabled while the
+         * observables still hold the previously selected company's registry
+         * number. The derivation cannot desync per CALLER any more, but it can
+         * still be bypassed by a writer that skips the observables entirely.
+         * Out of scope here; noted so it is not mistaken for new behaviour.
+         */
         clearCompany: function (disableCompanyId = false) {
             const companyIdSelector = $(this.companyIdSelector);
             companyIdSelector.val('');

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -263,6 +263,15 @@ define([
                 this._twoVisibilitySub.dispose();
                 this._twoVisibilitySub = null;
             }
+            // The company_id editable-state derivation (enableCompanySearch()).
+            // Closed over this renderer, so a re-render would otherwise leave
+            // it writing the field on behalf of a disposed component.
+            if (this._companyIdEditableSubs) {
+                this._companyIdEditableSubs.forEach(function (sub) {
+                    sub.dispose();
+                });
+                this._companyIdEditableSubs = null;
+            }
             if (this.isTwoVisible && this.isTwoVisible.dispose) {
                 this.isTwoVisible.dispose();
             }
@@ -318,32 +327,20 @@ define([
             $('#select2-company_name-container')?.text(companyName);
             this.companyId(companyId);
             $(this.companyIdSelector).val(companyId);
-            this.runOrderIntent();
-        },
-        /**
-         * Place an order intent for the company currently in
-         * companyName/companyId and reflect the answer. No-op when the
-         * merchant has order intents turned off.
-         *
-         * Extracted so there is exactly ONE place the intent is fired from:
-         * fillCompanyData() fires it for a picked company and
-         * applyManualCompanyId() for an organisation number the buyer typed
-         * because the registry had none, and the two must behave identically.
-         */
-        runOrderIntent: function () {
-            if (!this.isOrderIntentEnabled) return;
-            fullScreenLoader.startLoader();
-            const self = this;
-            this.placeOrderIntent()
-                .always(function () {
-                    fullScreenLoader.stopLoader();
-                })
-                .done(function (response) {
-                    self.processOrderIntentSuccessResponse(response);
-                })
-                .fail(function (response) {
-                    self.processOrderIntentErrorResponse(response);
-                });
+            if (this.isOrderIntentEnabled) {
+                fullScreenLoader.startLoader();
+                const self = this;
+                this.placeOrderIntent()
+                    .always(function () {
+                        fullScreenLoader.stopLoader();
+                    })
+                    .done(function (response) {
+                        self.processOrderIntentSuccessResponse(response);
+                    })
+                    .fail(function (response) {
+                        self.processOrderIntentErrorResponse(response);
+                    });
+            }
         },
         /**
          * True when the buyer has to supply the organisation number by hand:
@@ -395,12 +392,12 @@ define([
          * its organisation number. Before the routing existed that shape was a
          * harmless no-op on the read path, and it has to stay one.
          *
-         * The editable state of `company_id` is derived here, after BOTH
-         * branches, so one place decides it. Deriving it only inside
-         * selectCompanyWithoutIdentifier() left the field enabled after
-         * identifier-less pick → normal pick, which is precisely the state
-         * syncCompanyIdEditable()'s comment says must not exist: the buyer
-         * could hand-overwrite a registry organisation number.
+         * The editable state of `company_id` is re-derived here, after BOTH
+         * branches. Belt-and-braces only: the authoritative derivation is the
+         * companyName/companyId subscription in enableCompanySearch(), which
+         * catches every writer including the ones that never come through a
+         * selection path. This call covers the case where a pick writes values
+         * identical to the current ones, which ko does not notify for.
          */
         applyCompanyData: function (companyData, options) {
             const data = companyData || {};
@@ -425,14 +422,21 @@ define([
          * Writes the name and CLEARS any previously selected company's
          * identifier.
          *
-         * No order intent is placed here: there is no identifier to place one
-         * for. applyManualCompanyId() places it when the buyer supplies the
-         * organisation number by hand, which is the only route by which it
-         * becomes known for such a company.
+         * No order intent is placed here, and — stating the current behaviour
+         * plainly rather than promising a fix this change does not make — none
+         * is placed later either. An identifier-less company is never
+         * intent-checked: the buyer can type the organisation number into the
+         * re-enabled `company_id` field and the order goes out with it, but no
+         * credit check runs for it. Firing an intent on hand-typed input is
+         * its own ticket; the obvious `change`-handler version of it does not
+         * work, because the template binds `value: companyId` and ko's `value`
+         * binding is registered at applyBindings() on the SAME `change` event,
+         * so ko has already written `companyId()` by the time any later
+         * handler runs.
          *
-         * `company_id`'s editable state is NOT set here — applyCompanyData()
-         * derives it for this branch and the normal one alike, so a later
-         * normal pick cannot leave the field enabled.
+         * `company_id`'s editable state is NOT set here — it is derived from
+         * the companyName/companyId observables (see enableCompanySearch()),
+         * so a later normal pick cannot leave the field enabled.
          */
         selectCompanyWithoutIdentifier: function (companyName) {
             console.debug({ logger: 'twoPayment.selectCompanyWithoutIdentifier', companyName });
@@ -441,40 +445,6 @@ define([
             $('#select2-company_name-container')?.text(companyName);
             this.companyId('');
             $(this.companyIdSelector).val('');
-        },
-        /**
-         * The buyer typed the organisation number for a company the registry
-         * gave none for (see selectCompanyWithoutIdentifier). Accepting it
-         * here is what makes the order intent possible at all for such a
-         * company — nothing else re-fires it, so without this the order
-         * reached the API with no credit check behind it.
-         *
-         * Fires at most once per number the buyer settles on:
-         *  - bound to `change`, not `input`, so once on commit (blur/Enter),
-         *    not once per keystroke;
-         *  - returns on an empty value, and on a value equal to the one
-         *    already accepted, so a blur that commits nothing new does
-         *    nothing;
-         *  - returns when no company is selected, so it never runs on the
-         *    no-company path;
-         *  - never doubles up with the picker path: fillCompanyData() writes
-         *    this field with `.val()`, which fires no `change` event, and
-         *    places its own intent.
-         *
-         * The field is deliberately not re-disabled once a number is
-         * accepted — the buyer typed it, so they have to be able to correct a
-         * typo, and a correction re-checks. It goes back to disabled when a
-         * company that HAS a registry identifier is picked, which is
-         * applyCompanyData()/syncCompanyIdEditable()'s job.
-         */
-        applyManualCompanyId: function (value) {
-            const companyId = typeof value == 'string' ? value.trim() : '';
-            if (!companyId || companyId === this.companyId()) return;
-            if (!this.companyName()) return;
-            console.debug({ logger: 'twoPayment.applyManualCompanyId', companyId });
-            this.companyId(companyId);
-            $(this.companyIdSelector).val(companyId);
-            this.runOrderIntent();
         },
         fillTelephone: function (telephone) {
             console.debug({ logger: 'twoPayment.fillTelephone', telephone });
@@ -576,6 +546,15 @@ define([
             console.debug({ logger: 'twoPayment.updateBillingAddress', billingAddress });
             this.updateAddress(billingAddress);
         },
+        /**
+         * PRE-EXISTING, not introduced here, flagged so it is not mistaken for
+         * new: none of the subscriptions below are disposed, and
+         * fillCustomerData() is re-callable (registeredOrganisationMode(),
+         * reached from applyPrefetch()). N calls therefore leave N stacked
+         * subscriptions on each section, so one notification runs
+         * applyCompanyData() N times. Idempotent today, so it is waste rather
+         * than a bug — out of scope for this change.
+         */
         fillCustomerData: function () {
             const self = this;
 
@@ -586,6 +565,16 @@ define([
                 // company picked there must land here as "name set, id
                 // cleared, field editable" rather than being dropped by
                 // fillCompanyData()'s empty-id early return.
+                //
+                // "A notification IS the shipping-step picker" holds only
+                // because `companyData` has exactly one writer
+                // (address-autocomplete.js's setCompanyData()) and the repo
+                // ships no `sections.xml`, so the server never invalidates and
+                // repopulates the section either. Add a second writer, or a
+                // `sections.xml` entry, and this authoritative subscription
+                // becomes a path by which a non-selection can clobber a live
+                // payment-step pick — the exact thing the non-authoritative
+                // one-shot read below exists to prevent.
                 .subscribe((companyData) =>
                     self.applyCompanyData(companyData, { authoritative: true })
                 );
@@ -1033,18 +1022,29 @@ define([
                     // identifier-less one and stranded the buyer with an empty,
                     // uneditable, required company number. Derive it.
                     $companyIdField.prop('disabled', !self.needsManualCompanyId());
-                    // The buyer's typed organisation number is the only route
-                    // to an order intent for a company the registry gave no
-                    // identifier for. `change`, not `input`: once on commit,
-                    // not once per keystroke. `.off()` first for the same
-                    // handler-stacking reason as the company-name field below —
-                    // every enableCompanySearch() adds another observer, and
-                    // our handlers are not in select2's own namespace.
-                    $companyIdField
-                        .off('change' + companySearch.EVENT_NS)
-                        .on('change' + companySearch.EVENT_NS, function () {
-                            self.applyManualCompanyId($companyIdField.val());
-                        });
+                    // From here on the editable state is DERIVED from the two
+                    // observables, so it cannot desync per writer. Calling
+                    // syncCompanyIdEditable() from the selection paths alone
+                    // was not enough: updateAddress() is subscribed inside
+                    // fillCustomerData() and fires on every billing/shipping
+                    // notify — in registered-organisation mode, while the
+                    // picker owns the field — so an address attribute carrying
+                    // `company_id` reached fillCompanyData() and wrote a
+                    // registry organisation number into a field a previous
+                    // identifier-less pick had left ENABLED, i.e. hand-editable.
+                    //
+                    // Bound once per component: enableCompanySearch() re-runs
+                    // on every re-render (see the $.async note below) and each
+                    // run would otherwise stack another subscription.
+                    if (!self._companyIdEditableSubs) {
+                        const sync = function () {
+                            self.syncCompanyIdEditable();
+                        };
+                        self._companyIdEditableSubs = [
+                            self.companyName.subscribe(sync),
+                            self.companyId.subscribe(sync)
+                        ];
+                    }
                 });
                 $.async(self.companyNameSelector, function (companyNameField) {
                     // `$.async` is a MutationObserver, and every call to


### PR DESCRIPTION
Linear: [TWO-25253](https://linear.app/two-inc/issue/TWO-25253)

Follow-up to #286 (merged). Two defects in that PR's own last commit, `7f243b5`, found by the review round that was still running when it merged.

## 1. The order-intent trigger it added does not work

`7f243b5` added a `change` handler on `input#company_id` so that a hand-typed organisation number would place an order intent. **It is inert in production**, and this PR removes it.

Why: the template binds `value: companyId` (`view/frontend/web/template/payment/gateway_method.html:198`). Knockout's `value` binding listens on the **same** `change` event and is registered at `applyBindings()` — before the `$.async` body runs. So ko writes `companyId()` first, and by the time the handler ran, its `companyId === this.companyId()` dedup was already true and it returned.

It fired only when the typed value carried stray whitespace, because `trim()` then made it differ. That is exactly the shape the test used (`'  99999999  '`), so **the test passed against a no-op**. A plain number would have caught it.

The honest behaviour, now stated in the code where the promise was: an identifier-less company is never intent-checked. The buyer types the organisation number into the re-enabled field and the order goes out carrying it with no credit check behind it. That is the smaller option, and visible rather than silent.

Split to its own ticket along with the **pre-existing** stale-response race on the intent path — `placeOrderIntent()` carries no request token, and `processOrderIntentSuccessResponse()` builds its notice from the *current* `companyName()`, so two intents in flight can paint company A's answer under company B's name. Removing this trigger removes a second concurrent intent source rather than adding one.

## 2. Its editability justification was false for one caller

`7f243b5` kept `syncCompanyIdEditable()` out of `fillCompanyData()` on the grounds that its four other callers "run in modes where company search does not own the field". **False for `updateAddress()`**, which is subscribed inside `fillCustomerData()` and fires on every billing/shipping notification — in registered-organisation mode, with the picker live.

So an identifier-less pick followed by any address notification carrying a `company_id` custom attribute wrote a registry organisation number into a still-**enabled**, hand-overwritable field: the exact state that commit's own first fix was about. The other three callers do hold, but per-caller reasoning was the defect.

Editability is now derived from the `companyName`/`companyId` observables — subscribed once in `enableCompanySearch()`, disposed in `dispose()` — so it cannot desync per caller.

## Also in here

- `runOrderIntent()` inlined back into `fillCompanyData()`: one caller left after the removal, so the extraction earned nothing and this restores the pre-PR shape.
- Two pre-existing issues **flagged in comments, not fixed** (out of scope): `fillCustomerData()` re-subscribes on every call with no dispose and is re-callable via `applyPrefetch()`, so N stacked subscriptions mean N `applyCompanyData()` per notification; and the "a `companyData` notification *is* the shipping-step picker" assumption holds only because that section has exactly one writer and the repo has no `sections.xml` entry.

## Verification

`npm run test:js` — **146 passed, 11 suites**. `Test/Js/gateway-method-company-selection.test.js` is now 15 tests.

Four mutations, each RED:

| Mutation | Result |
|---|---|
| remove the derived `companyName`/`companyId` subscribe | `an address notify carrying company_id cannot leave a registry number in an enabled field` |
| re-add a `change` handler on `input#company_id` | `a hand-typed organisation number is never intent-checked` |
| kill the intent in `fillCompanyData()` | `a normal pick places exactly one intent` |
| add an intent to `selectCompanyWithoutIdentifier()` | 2 tests, incl. `an identifier-less pick places no intent` |

**Two assertions started green and are labelled as documentation rather than detection**, not left looking load-bearing: `companyId()` after the address notify (`fillCompanyData()` writes it regardless) and `companyId('99999999')` placing no intent (nothing subscribes intent to that observable, so it is green by construction and only guards a future naive subscribe). The load-bearing assertions in those same tests — `prop('disabled')` and `handlers['change'] === undefined` — both go red under the first two mutations.

A limitation of the test double is now documented loudly at the top of the file: its `on()` keeps one handler per event name and its `off()` is a no-op, so two handlers on one event are unmodellable and nothing in it can speak to handler ordering. **That is precisely how the Knockout blocker got through review.** Making the double faithful is deferred to the follow-up ticket, since the second handler is gone and nothing in-repo now needs handler coexistence.