### PR TITLE
fix(admin): drop redundant surcharge tax treatment comment

### DIFF
--- a/etc/adminhtml/brand_form_template.xml
+++ b/etc/adminhtml/brand_form_template.xml
@@ -278,11 +278,10 @@
                     <comment><![CDATA[Description shown to the buyer for the surcharge line item. Use <strong>%1</strong> to insert the selected number of days (e.g. "Payment terms fee - %1 days"). If you leave the default, the word <em>days</em> is translated per locale.]]></comment>
                     <config_path>payment/{{code}}/surcharge_line_description</config_path>
                 </field>
-                <field id="surcharge_tax_class" translate="label comment" type="select" sortOrder="80"
+                <field id="surcharge_tax_class" translate="label" type="select" sortOrder="80"
                        showInDefault="1" showInWebsite="1" showInStore="1"
                        brand_code="{{code}}">
                     <label>Surcharge Tax Treatment</label>
-                    <comment><![CDATA[Product Tax Class applied to the surcharge. When a class is selected, surcharge tax is resolved through Magento's Tax Rules (destination-aware, supports combined rates such as US state + local); <strong>None</strong> means the surcharge is never taxed. This selection is never made automatically: while a surcharge method is enabled, the configuration cannot be saved until a treatment is chosen.]]></comment>
                     <source_model>Two\Gateway\Model\Config\Source\SurchargeTaxClass</source_model>
                     <backend_model>Two\Gateway\Model\Config\Backend\SurchargeTaxClass</backend_model>
                     <config_path>payment/{{code}}/surcharge_tax_class</config_path>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -210,10 +210,9 @@
                     <config_path>payment/two_payment/surcharge_line_description</config_path>
                 </field>
 
-                <field id="surcharge_tax_class" translate="label comment" type="select" sortOrder="80"
+                <field id="surcharge_tax_class" translate="label" type="select" sortOrder="80"
                        showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Surcharge Tax Treatment</label>
-                    <comment><![CDATA[Product Tax Class applied to the surcharge. When a class is selected, surcharge tax is resolved through Magento's Tax Rules (destination-aware, supports combined rates such as US state + local); <strong>None</strong> means the surcharge is never taxed. This selection is never made automatically: while a surcharge method is enabled, the configuration cannot be saved until a treatment is chosen.]]></comment>
                     <source_model>Two\Gateway\Model\Config\Source\SurchargeTaxClass</source_model>
                     <backend_model>Two\Gateway\Model\Config\Backend\SurchargeTaxClass</backend_model>
                     <config_path>payment/two_payment/surcharge_tax_class</config_path>


### PR DESCRIPTION
ABN-476 follow-up.

## Change

Removes the help comment under the **Surcharge Tax Treatment** selector in the admin Configuration surface. It restated what the selector's own options already convey.

Exact string removed:

> Product Tax Class applied to the surcharge. When a class is selected, surcharge tax is resolved through Magento's Tax Rules (destination-aware, supports combined rates such as US state + local); \<strong\>None\</strong\> means the surcharge is never taxed. This selection is never made automatically: while a surcharge method is enabled, the configuration cannot be saved until a treatment is chosen.

Removed from two places:

- `etc/adminhtml/system.xml` — the live admin field.
- `etc/adminhtml/brand_form_template.xml` — a tokenised clone of that file, substituted per registered brand by `SynthesiseBrandAdminForm`. Leaving the comment there would keep it on every synthesised admin surface.

The field's `translate` attribute drops `comment` in both files, since there is no longer a comment to translate.

## i18n

The string was **not** present in any catalogue — `i18n/nb_NO.csv`, `i18n/nl_NL.csv` and `i18n/sv_SE.csv` were all checked and none contained it, so no catalogue changes were needed. No test or PHP source referenced the string either.