### PR TITLE
TWO-25269/fix(surcharge): fail closed on zero cap, log FX failures

### DIFF
--- a/Service/Order/SurchargeCalculator.php
+++ b/Service/Order/SurchargeCalculator.php
@@ -89,7 +89,10 @@ class SurchargeCalculator
      * @param int|null $storeId
      *
      * @return array{amount: float, tax_rate: float, description: string}
-     * @throws LocalizedException when FX rate is missing or API response is malformed
+     * @throws LocalizedException when no FX rate is resolvable for the pair, when a
+     *         configured surcharge cap resolves to zero in the order currency (sending
+     *         it would relay an UNCAPPED percentage), or when the API response is
+     *         malformed or quotes a currency other than the order's
      */
     public function calculate(
         float $grossAmount,

--- a/Service/Order/SurchargeCalculator.php
+++ b/Service/Order/SurchargeCalculator.php
@@ -142,6 +142,10 @@ class SurchargeCalculator
         }
 
         if (!isset($response['buyer_fee_share'])) {
+            $this->logRepository->addErrorLog('Pricing API response missing buyer_fee_share', [
+                'selected_term' => $selectedTermDays,
+                'order_currency' => $orderCurrency,
+            ]);
             throw new LocalizedException(
                 __('Pricing API response missing required field: buyer_fee_share')
             );
@@ -154,6 +158,11 @@ class SurchargeCalculator
         // applied to the order without FX, which is the API's job not ours.
         $respCurrency = isset($response['currency']) ? (string)$response['currency'] : $orderCurrency;
         if ($respCurrency !== $orderCurrency) {
+            $this->logRepository->addErrorLog('Pricing API returned a mismatched currency', [
+                'selected_term' => $selectedTermDays,
+                'response_currency' => $respCurrency,
+                'order_currency' => $orderCurrency,
+            ]);
             throw new LocalizedException(
                 __(
                     'Pricing API returned currency %1 but order currency is %2.',
@@ -186,14 +195,18 @@ class SurchargeCalculator
      * Maps merchant config to the API schema:
      *  - percentage types supply `percentage`
      *  - fixed types supply `surcharge` (FX-converted to order currency)
-     *  - limit > 0 supplies `cap` (FX-converted to order currency)
+     *  - a non-null limit supplies `cap` (FX-converted to order currency);
+     *    an ABSENT limit is a legitimate "no cap" configuration and sends an
+     *    uncapped percentage, while a limit that IS set but evaluates to zero
+     *    fails closed (see below)
      *  - a rounding basis + step supplies `rounding` (percentage modes only)
      *  - differential mode supplies `reference_terms` so the API computes
      *    the threshold itself — no delta math in the plugin
      *  - `surcharge_basis` is sent explicitly for clarity
      *
      * @return array<string, mixed>
-     * @throws LocalizedException when FX rate is missing
+     * @throws LocalizedException when the FX rate is missing, or when a
+     *         configured cap evaluates to zero
      */
     private function buildBuyerFeeShare(
         string $surchargeType,
@@ -219,7 +232,8 @@ class SurchargeCalculator
                 (float)$config['fixed'],
                 $fixedCurrency,
                 $orderCurrency,
-                $storeId
+                $storeId,
+                $selectedTermDays
             );
         }
 
@@ -228,13 +242,44 @@ class SurchargeCalculator
         // types only (a fixed-only fee is constant — there is nothing to clamp), so
         // a stored limit left over from a previous surcharge type must not leak into
         // a fixed-only request and clamp the fee.
+        //
+        // A cap that IS configured but evaluates to zero must never be sent:
+        // downstream, `cap => 0.0` is indistinguishable from NO cap at all, so
+        // the pricing API would apply the percentage UNCAPPED — the exact
+        // opposite of the merchant's intent, and an overcharge to the buyer.
+        // Fail closed instead. A limit of exactly 0 survives the admin grid
+        // (Model\Config\Backend\SurchargeGrid::validateValue only rejects
+        // negatives, and only the empty string deletes the row), so this is
+        // reachable from the UI, not just from a legacy DB write.
+        //
+        // An ABSENT limit (null) is NOT an error: "no cap" is a legitimate
+        // configuration and must keep sending an uncapped percentage.
         if ($hasPercentage && $config['limit'] !== null) {
-            $payload['cap'] = $this->convertAmount(
+            $cap = $this->convertAmount(
                 (float)$config['limit'],
                 $fixedCurrency,
                 $orderCurrency,
-                $storeId
+                $storeId,
+                $selectedTermDays
             );
+            if ($cap <= 0.0) {
+                $this->logRepository->addErrorLog('Surcharge cap is configured but resolves to zero', [
+                    'selected_term' => $selectedTermDays,
+                    'configured_limit' => (float)$config['limit'],
+                    'from_currency' => $fixedCurrency,
+                    'to_currency' => $orderCurrency,
+                    'converted_cap' => $cap,
+                    'store_id' => $storeId,
+                ]);
+                throw new LocalizedException(
+                    __(
+                        'The configured surcharge cap resolves to zero in %1 and cannot be applied. '
+                        . 'Please try another payment method or contact support.',
+                        $orderCurrency
+                    )
+                );
+            }
+            $payload['cap'] = $cap;
         }
 
         // `rounding` snaps the final buyer line item to a clean increment, computed
@@ -303,13 +348,23 @@ class SurchargeCalculator
     /**
      * Convert an amount between currencies if needed.
      *
+     * The result is deliberately NOT rounded — the pricing API is the only
+     * place surcharge figures get rounded (via the `rounding` block and its
+     * own money precision), so no FX conversion here can collapse a non-zero
+     * configured amount to zero. Combined with CurrencyRatesProvider returning
+     * null rather than a zero/negative rate, a zero `cap` can only ever come
+     * from a zero configured limit, never from the conversion itself.
+     *
+     * @param int|null $selectedTermDays term the conversion is being made for,
+     *                                   for the fail-closed diagnostic log only
      * @throws LocalizedException when no FX rate is resolvable for the pair
      */
     private function convertAmount(
         float $amount,
         string $fromCurrency,
         string $toCurrency,
-        ?int $storeId = null
+        ?int $storeId = null,
+        ?int $selectedTermDays = null
     ): float {
         if ($amount === 0.0 || $fromCurrency === '' || $fromCurrency === $toCurrency) {
             return $amount;
@@ -317,6 +372,16 @@ class SurchargeCalculator
 
         $rate = $this->ratesProvider->getRate($fromCurrency, $toCurrency, $storeId);
         if ($rate === null) {
+            // Fail closed — but never silently. Without this the buyer sees a
+            // checkout error while ops and the merchant see nothing at all, so
+            // a missing rate for a pair looks like an unexplained drop-off.
+            $this->logRepository->addErrorLog('Surcharge FX conversion failed: no rate available', [
+                'from_currency' => $fromCurrency,
+                'to_currency' => $toCurrency,
+                'selected_term' => $selectedTermDays,
+                'amount' => $amount,
+                'store_id' => $storeId,
+            ]);
             throw new LocalizedException(
                 __(
                     'Cannot convert surcharge from %1 to %2: no exchange rate is currently available.',

--- a/Test/Unit/Service/Order/SurchargeCalculatorTest.php
+++ b/Test/Unit/Service/Order/SurchargeCalculatorTest.php
@@ -26,6 +26,9 @@ class SurchargeCalculatorTest extends TestCase
     /** @var CurrencyRatesProviderInterface|\PHPUnit\Framework\MockObject\MockObject */
     private $ratesProvider;
 
+    /** @var LogRepository|\PHPUnit\Framework\MockObject\MockObject */
+    private $log;
+
     /** @var SurchargeCalculator */
     private $calculator;
 
@@ -43,10 +46,15 @@ class SurchargeCalculatorTest extends TestCase
             ->onlyMethods(['execute'])
             ->getMock();
 
-        $log = $this->createMock(LogRepository::class);
+        $this->log = $this->createMock(LogRepository::class);
         $this->ratesProvider = $this->createMock(CurrencyRatesProviderInterface::class);
 
-        $this->calculator = new SurchargeCalculator($this->config, $this->adapter, $log, $this->ratesProvider);
+        $this->calculator = new SurchargeCalculator(
+            $this->config,
+            $this->adapter,
+            $this->log,
+            $this->ratesProvider
+        );
     }
 
     private function stubCommonConfig(string $type, bool $differential = false): void
@@ -691,6 +699,189 @@ class SurchargeCalculatorTest extends TestCase
         $this->expectExceptionMessage('Cannot convert surcharge from NOK to GBP');
 
         $this->calculator->calculate(1000.0, 30, 'NO', 'GBP');
+    }
+
+    public function testFailClosedFxErrorIsLoggedWithCurrencyPairAndTerm(): void
+    {
+        // The buyer sees a checkout error either way; without this log ops and
+        // the merchant see nothing at all and a bad currency pair reads as an
+        // unexplained drop-off.
+        $this->stubCommonConfig(SurchargeType::FIXED);
+        $this->stubSurchargeConfig(0, 10);
+        $this->stubFixedCurrency('NOK');
+        $this->ratesProvider->method('getRate')->willReturn(null);
+
+        $this->log->expects($this->once())
+            ->method('addErrorLog')
+            ->with(
+                'Surcharge FX conversion failed: no rate available',
+                $this->callback(function ($context) {
+                    return $context['from_currency'] === 'NOK'
+                        && $context['to_currency'] === 'GBP'
+                        && $context['selected_term'] === 45;
+                })
+            );
+
+        $this->expectException(\Magento\Framework\Exception\LocalizedException::class);
+
+        $this->calculator->calculate(1000.0, 45, 'NO', 'GBP');
+    }
+
+    // ── Zero cap fails closed (a zero cap reads as NO cap downstream) ──
+
+    public function testThrowsWhenConfiguredCapIsZero(): void
+    {
+        // `cap => 0.0` is indistinguishable from an absent cap downstream, so
+        // sending it would apply the percentage UNCAPPED — an overcharge and the
+        // opposite of the merchant's configuration. A limit of exactly 0 reaches
+        // here from the admin grid (validateValue only rejects negatives).
+        $this->stubCommonConfig(SurchargeType::FIXED_AND_PERCENTAGE);
+        $this->stubSurchargeConfig(50, 5, 0.0);
+        $this->stubFixedCurrency('NOK');
+
+        $this->adapter->expects($this->never())->method('execute');
+
+        $this->expectException(\Magento\Framework\Exception\LocalizedException::class);
+        $this->expectExceptionMessage('surcharge cap resolves to zero in NOK');
+
+        $this->calculator->calculate(1000.0, 60, 'NO', 'NOK');
+    }
+
+    public function testZeroCapFailClosedIsLoggedWithCurrencyPairAndTerm(): void
+    {
+        $this->stubCommonConfig(SurchargeType::PERCENTAGE);
+        $this->stubSurchargeConfig(50, 0, 0.0);
+        $this->stubFixedCurrency('NOK');
+
+        $this->log->expects($this->once())
+            ->method('addErrorLog')
+            ->with(
+                'Surcharge cap is configured but resolves to zero',
+                $this->callback(function ($context) {
+                    return $context['from_currency'] === 'NOK'
+                        && $context['to_currency'] === 'SEK'
+                        && $context['selected_term'] === 90
+                        && $context['configured_limit'] === 0.0
+                        && $context['converted_cap'] === 0.0;
+                })
+            );
+
+        $this->expectException(\Magento\Framework\Exception\LocalizedException::class);
+
+        $this->calculator->calculate(1000.0, 90, 'NO', 'SEK');
+    }
+
+    public function testZeroLimitInFixedOnlyModeDoesNotFailClosed(): void
+    {
+        // The zero-cap guard sits behind the same $hasPercentage gate as `cap`
+        // itself: a stale zero limit left over from a previous surcharge type
+        // must not break a fixed-only fee, which has no cap to send.
+        $this->stubCommonConfig(SurchargeType::FIXED);
+        $this->stubSurchargeConfig(0, 10, 0.0);
+        $this->stubFixedCurrency('NOK');
+
+        $this->log->expects($this->never())->method('addErrorLog');
+
+        $this->adapter->expects($this->once())
+            ->method('execute')
+            ->with(
+                '/v1/pricing/order/fee',
+                $this->callback(function ($payload) {
+                    return !array_key_exists('cap', $payload['buyer_fee_share']);
+                })
+            )
+            ->willReturn(['buyer_fee_share' => 10.0]);
+
+        $result = $this->calculator->calculate(1000.0, 60, 'NO', 'NOK');
+
+        $this->assertEquals(10.0, $result['amount']);
+    }
+
+    // ── An ABSENT cap is legitimate: uncapped percentage must still charge ──
+
+    public function testAbsentLimitSendsUncappedPercentageSurcharge(): void
+    {
+        // REGRESSION GUARD. "No cap defined" is a valid, common configuration.
+        // The zero-cap guard above must never be widened to treat a null limit
+        // as a failure — an uncapped percentage surcharge has to keep being
+        // charged normally, with no `cap` key and no error.
+        $this->stubCommonConfig(SurchargeType::PERCENTAGE);
+        $this->stubSurchargeConfig(50, 0, null);
+        $this->stubFixedCurrency('NOK');
+
+        $this->log->expects($this->never())->method('addErrorLog');
+
+        $this->adapter->expects($this->once())
+            ->method('execute')
+            ->with(
+                '/v1/pricing/order/fee',
+                $this->callback(function ($payload) {
+                    $share = $payload['buyer_fee_share'];
+                    return !array_key_exists('cap', $share)
+                        && $share['percentage'] === 50.0;
+                })
+            )
+            ->willReturn(['buyer_fee_share' => 25.0]);
+
+        $result = $this->calculator->calculate(1000.0, 60, 'NO', 'NOK');
+
+        $this->assertEquals(25.0, $result['amount']);
+    }
+
+    public function testAbsentLimitSendsUncappedFixedAndPercentageSurcharge(): void
+    {
+        // Same guard for the mixed type, where a `surcharge` FX conversion also
+        // runs — an absent cap must not disturb it.
+        $this->stubCommonConfig(SurchargeType::FIXED_AND_PERCENTAGE);
+        $this->stubSurchargeConfig(50, 5, null);
+        $this->stubFixedCurrency('NOK');
+        $this->stubFxRate('NOK', 1.1);
+
+        $this->log->expects($this->never())->method('addErrorLog');
+
+        $this->adapter->expects($this->once())
+            ->method('execute')
+            ->with(
+                '/v1/pricing/order/fee',
+                $this->callback(function ($payload) {
+                    $share = $payload['buyer_fee_share'];
+                    return !array_key_exists('cap', $share)
+                        && $share['percentage'] === 50.0
+                        && abs($share['surcharge'] - 5.5) < 0.0001;
+                })
+            )
+            ->willReturn(['buyer_fee_share' => 30.0]);
+
+        $result = $this->calculator->calculate(1000.0, 60, 'NO', 'SEK');
+
+        $this->assertEquals(30.0, $result['amount']);
+    }
+
+    public function testNonZeroCapNeverCollapsesToZeroThroughFxConversion(): void
+    {
+        // convertAmount() does NO rounding (`$amount * $rate`) and
+        // CurrencyRatesProvider returns null rather than a zero/negative rate,
+        // so a tiny cap under a tiny rate stays non-zero and is sent as-is.
+        // The "converted cap rounds to 0.00" hazard other platforms guard
+        // against therefore cannot arise on Magento.
+        $this->stubCommonConfig(SurchargeType::PERCENTAGE);
+        $this->stubSurchargeConfig(50, 0, 0.01);
+        $this->stubFixedCurrency('NOK');
+        $this->stubFxRate('NOK', 0.0001);
+
+        $this->log->expects($this->never())->method('addErrorLog');
+
+        $this->adapter->expects($this->once())
+            ->method('execute')
+            ->with(
+                '/v1/pricing/order/fee',
+                $this->callback(function ($payload) {
+                    return abs($payload['buyer_fee_share']['cap'] - 0.000001) < 1.0e-12;
+                })
+            )
+            ->willReturn(['buyer_fee_share' => 0.000001]);
+
+        $this->calculator->calculate(1000.0, 60, 'NO', 'SEK');
     }
 
     public function testConversionForwardsStoreScopeToRateLookup(): void


### PR DESCRIPTION
## TWO-25269 — FX fail-closed consistency gaps

Magento is the FX fail-closed reference implementation; this closes the two remaining consistency gaps in it. Sibling changes are landing on the other platforms.

### 1. A configured surcharge cap of zero was sent as `cap => 0.0` (overcharge)

`buildBuyerFeeShare()` gated the cap on `$config['limit'] !== null`, while its own docblock claimed *"limit > 0 supplies `cap`"*. Those are not the same, and the gap is reachable **from the admin UI**, not just from a legacy DB write:

- `Model\Config\Backend\SurchargeGrid::validateValue()` rejects only `$value < 0`.
- Only the **empty string** deletes the config row; a literal `"0"` is saved.
- `Model\Config\Repository::getSurchargeConfig()` then yields `'limit' => 0.0`, which is `!== null`.

Downstream, a zero cap is indistinguishable from **no** cap, so the request applied the percentage **uncapped** — the opposite of what the merchant configured, and an overcharge to the buyer. Now fails closed with a `LocalizedException`, matching the file's existing style.

**An absent cap is unchanged and still charges.** `limit === null` is a legitimate "no cap" configuration and must keep sending a non-zero, uncapped percentage surcharge. Three explicit regression tests pin this so the guard cannot be widened later:

- `testAbsentLimitSendsUncappedPercentageSurcharge`
- `testAbsentLimitSendsUncappedFixedAndPercentageSurcharge`
- `testZeroLimitInFixedOnlyModeDoesNotFailClosed` (the guard sits behind the same `$hasPercentage` gate as the cap itself, so a stale zero limit cannot break a fixed-only fee)

### 2. The fail-closed paths had no ops- or merchant-visible signal

When `convertAmount()` threw on a missing FX rate the buyer saw a checkout error while the logs said nothing — a bad currency pair read as an unexplained drop-off. Silent failure is exactly what this work is eliminating.

Every fail-closed throw in `SurchargeCalculator` now emits `LogRepository::addErrorLog()` with the **currency pair** and the **selected term**:

| Throw site | Log message |
|---|---|
| missing FX rate | `Surcharge FX conversion failed: no rate available` |
| configured cap resolves to zero | `Surcharge cap is configured but resolves to zero` |
| response missing `buyer_fee_share` | `Pricing API response missing buyer_fee_share` |
| response currency mismatch | `Pricing API returned a mismatched currency` |

`LogRepository` was already imported and already wired into the constructor, so no constructor change was needed — the `Two.php` / `GenericPaymentMethod` DI-mirror hazard does not apply here.

### The "converted cap rounds to 0.00" hazard cannot arise on Magento

Documented in the `convertAmount()` docblock rather than guarded against, because it is structurally impossible:

- `convertAmount()` returns `$amount * $rate` with **no rounding** — the pricing API is the only place surcharge figures get rounded.
- `CurrencyRatesProvider::getRate()` returns `null` rather than a zero or negative rate (`if ($fromInEur <= 0 || $toInEur <= 0) return null;`).

So FX can never collapse a non-zero configured cap to zero. `testNonZeroCapNeverCollapsesToZeroThroughFxConversion` pins it: a 0.01 cap at a 0.0001 rate is sent as `0.000001`, not zero.

### Deliberately NOT changed — the mechanism divergence

The other platforms are moving to **withhold the payment method** on a fail-closed surcharge error, so the buyer picks another method. Magento instead hard-errors in the total collector (`Model\Total\Surcharge::collect()` rethrows the `LocalizedException`), so the buyer hits a wall. That divergence is left in place here — see the review notes below for why harmonising is a separate piece of work.

### Verification

All run locally against this branch. Full output in the review notes.

- PHPUnit 10.5.64 / PHP 8.5.8 — **477/477 pass** (7 new tests)
- Codesniffer `--severity=6` (the CI docker image) — **clean, 215/215**
- PHPStan (in the Magento 2.4.7 / PHP 8.2 CI container) — **`[OK] No errors`**
- `setup:di:compile` (same container) — **`Generated code and dependency injection configuration successfully.`**
- `php -l` on both changed files — clean

### Docs

No doc describes the changed behaviour (`docs/brand-overlay-guide.md` mentions `surcharge_limit` only as a merchant-record field; there is no `CHANGELOG.md` and no `.ai/` directory). The misleading `limit > 0` docblock is corrected in-place, and the zero-cap rationale plus the no-rounding invariant are documented as in-code comments.
