### PR TITLE
fix(checkout): name the PO field "Purchase order number" in the tile (TWO-25271)

### DIFF
--- a/i18n/nb_NO.csv
+++ b/i18n/nb_NO.csv
@@ -73,6 +73,7 @@
 "Order Note","Bestillingsmerknad"
 "Order edit request was accepted by %1","Bestillingsredigeringsforespørsel ble akseptert av %1"
 "PO Number","PO-nummer"
+"Purchase order number","Innkjøpsordrenummer"
 "Payment","Betaling"
 "Payment Method","Betalingsmetode"
 "Phone Number","Telefonnummer"

--- a/i18n/nl_NL.csv
+++ b/i18n/nl_NL.csv
@@ -74,6 +74,7 @@
 "Order Note","Bestelnotitie"
 "Order edit request was accepted by %1","Bestellingswijzigingsverzoek is geaccepteerd door %1"
 "PO Number","PO-nummer"
+"Purchase order number","Inkoopordernummer"
 "Payment","Betaling"
 "Payment Method","Betaalmethode"
 "Phone Number","Telefoonnummer"

--- a/i18n/sv_SE.csv
+++ b/i18n/sv_SE.csv
@@ -73,6 +73,7 @@
 "Order Note","Beställningsanmärkning"
 "Order edit request was accepted by %1","Begäran om beställningsredigering accepterades av %1"
 "PO Number","PO-nummer"
+"Purchase order number","Inköpsordernummer"
 "Payment","Betalning"
 "Payment Method","Betalningsmetod"
 "Phone Number","Telefonnummer"

--- a/view/frontend/web/template/payment/gateway_method.html
+++ b/view/frontend/web/template/payment/gateway_method.html
@@ -225,7 +225,7 @@
                 </div>
                 <div class="field field-text" data-bind="visible: isPONumberFieldEnabled">
                     <label for="two_po_number" class="label">
-                        <span><!-- ko i18n: 'PO Number'--><!-- /ko --></span>
+                        <span><!-- ko i18n: 'Purchase order number'--><!-- /ko --></span>
                     </label>
                     <div class="control">
                         <input
@@ -233,7 +233,7 @@
                             id="two_po_number"
                             name="payment[poNumber]"
                             data-bind='
-                            attr: {title: $t("PO Number")},
+                            attr: {title: $t("Purchase order number")},
                             value: poNumber'
                             class="input-text"
                         />


### PR DESCRIPTION
## What

Magento's checkout tile was the **only surface anywhere** still saying "PO Number". Everything else already agrees:

| plugin | checkout | admin |
|---|---|---|
| magento | **`PO Number`** | `Show Purchase order number field` |
| woocommerce | `Purchase order number` | `Show Purchase order number field` |
| prestashop | `Purchase order number` | `Show Purchase order number field` |

So the one changes to match the five. No admin label is touched; `woocommerce-plugin` and `prestashop-plugin` need nothing.

Both sites in `view/frontend/web/template/payment/gateway_method.html` updated — the label's `ko i18n` binding (`:228`) and the input's `$t()` title attribute (`:236`).

## Translations

There was **no** existing standalone `Purchase order number` msgid — only the longer `Show Purchase order number field` admin key — so a new entry was needed in each catalogue. Added rather than left English, and cross-checked against independent sources rather than transliterated from the admin toggle:

| locale | msgstr |
|---|---|
| `nb_NO` | Innkjøpsordrenummer |
| `nl_NL` | Inkoopordernummer |
| `sv_SE` | Inköpsordernummer |

## The `PO Number` msgid is deliberately kept

It looks orphaned in this repo after this change. It is not.

`magento-hyva-extension` calls `__("PO Number")` in its own `gateway_method.phtml` and **ships no `i18n` files of its own**, so it resolves that string against *this* module's catalogues. Deleting the row would silently drop Hyvä's translated label to English in all three locales.

**Consequence worth flagging:** until `magento-hyva-extension` is updated too, Luma / Amasty / Fire will say "Purchase order number" while Hyvä still says "PO Number". That companion change belongs in that repo, not here.

## Checks

PHPUnit 473 tests / 863 assertions, Jest 146 — green. Repo-wide sweep confirms no remaining `PO Number` outside the intentionally-kept catalogue rows.

Linear: TWO-25271