### PR TITLE
TWO-25269/revert(surcharge): drop zero-cap fail-closed guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,28 @@ which includes the commands to re-enable PageBuilder for testing
 brand content that relies on it. Same applies to anything
 analytics-driven (e.g. NewRelic dashboards, GA events).
 
+## A surcharge cap of 0 is valid — never guard against it
+
+**A configured surcharge limit of `0` must be relayed to the pricing
+API as `cap => 0.0`. Do not throw, do not omit the key, and do not
+add admin validation rejecting a typed `0`.** A zero cap clamps the
+buyer fee to zero — no surcharge is applied — which is a legitimate
+merchant configuration.
+
+Only an *absent* (null) limit means "no cap"; that omits the `cap`
+key and applies the percentage uncapped. Absent and zero are
+different things and both must pass through faithfully.
+
+TWO-25269 briefly added a guard that threw on a zero cap, on the
+premise that a zero cap read as "no cap" downstream and would relay
+an uncapped percentage. **That premise was false and the guard was
+reverted** — a zero cap clamps the fee to zero, it never uncaps it.
+In `fixed_and_percentage` mode the cap bounds the combined fee, so
+`Limit = 0` suppresses the fixed component too, not just the
+percentage part.
+
+`Test/Unit/Service/Order/SurchargeCalculatorTest.php` pins this.
+
 ## DI registration scope for Structure / Config Reader plugins
 
 **Plugins that target `Magento\Config\Model\Config\Structure\Reader`

--- a/Service/Order/SurchargeCalculator.php
+++ b/Service/Order/SurchargeCalculator.php
@@ -89,10 +89,8 @@ class SurchargeCalculator
      * @param int|null $storeId
      *
      * @return array{amount: float, tax_rate: float, description: string}
-     * @throws LocalizedException when no FX rate is resolvable for the pair, when a
-     *         configured surcharge cap resolves to zero in the order currency (sending
-     *         it would relay an UNCAPPED percentage), or when the API response is
-     *         malformed or quotes a currency other than the order's
+     * @throws LocalizedException when no FX rate is resolvable for the pair, or when
+     *         the API response is malformed or quotes a currency other than the order's
      */
     public function calculate(
         float $grossAmount,
@@ -200,16 +198,14 @@ class SurchargeCalculator
      *  - fixed types supply `surcharge` (FX-converted to order currency)
      *  - a non-null limit supplies `cap` (FX-converted to order currency);
      *    an ABSENT limit is a legitimate "no cap" configuration and sends an
-     *    uncapped percentage, while a limit that IS set but evaluates to zero
-     *    fails closed (see below)
+     *    uncapped percentage
      *  - a rounding basis + step supplies `rounding` (percentage modes only)
      *  - differential mode supplies `reference_terms` so the API computes
      *    the threshold itself — no delta math in the plugin
      *  - `surcharge_basis` is sent explicitly for clarity
      *
      * @return array<string, mixed>
-     * @throws LocalizedException when the FX rate is missing, or when a
-     *         configured cap evaluates to zero
+     * @throws LocalizedException when the FX rate is missing
      */
     private function buildBuyerFeeShare(
         string $surchargeType,
@@ -246,43 +242,25 @@ class SurchargeCalculator
         // a stored limit left over from a previous surcharge type must not leak into
         // a fixed-only request and clamp the fee.
         //
-        // A cap that IS configured but evaluates to zero must never be sent:
-        // downstream, `cap => 0.0` is indistinguishable from NO cap at all, so
-        // the pricing API would apply the percentage UNCAPPED — the exact
-        // opposite of the merchant's intent, and an overcharge to the buyer.
-        // Fail closed instead. A limit of exactly 0 survives the admin grid
-        // (Model\Config\Backend\SurchargeGrid::validateValue only rejects
-        // negatives, and only the empty string deletes the row), so this is
-        // reachable from the UI, not just from a legacy DB write.
+        // Distinguish ABSENT from ZERO, and send both through faithfully:
+        //  - an ABSENT limit (null) is a legitimate "no cap" configuration: omit
+        //    `cap` entirely and the percentage is applied uncapped;
+        //  - a limit of exactly 0 caps the fee at nothing, i.e. no surcharge is
+        //    applied, and `cap => 0.0` is how the API is told that.
         //
-        // An ABSENT limit (null) is NOT an error: "no cap" is a legitimate
-        // configuration and must keep sending an uncapped percentage.
+        // TWO-25269 briefly threw here on a zero cap, on the premise that
+        // `cap => 0.0` read as "no cap" downstream and would relay an uncapped
+        // percentage. That premise was false: a zero cap clamps the fee to
+        // zero, it never uncaps it. Do not reintroduce the guard, and do not
+        // add admin validation rejecting a typed 0 — 0 is a valid setting.
         if ($hasPercentage && $config['limit'] !== null) {
-            $cap = $this->convertAmount(
+            $payload['cap'] = $this->convertAmount(
                 (float)$config['limit'],
                 $fixedCurrency,
                 $orderCurrency,
                 $storeId,
                 $selectedTermDays
             );
-            if ($cap <= 0.0) {
-                $this->logRepository->addErrorLog('Surcharge cap is configured but resolves to zero', [
-                    'selected_term' => $selectedTermDays,
-                    'configured_limit' => (float)$config['limit'],
-                    'from_currency' => $fixedCurrency,
-                    'to_currency' => $orderCurrency,
-                    'converted_cap' => $cap,
-                    'store_id' => $storeId,
-                ]);
-                throw new LocalizedException(
-                    __(
-                        'The configured surcharge cap resolves to zero in %1 and cannot be applied. '
-                        . 'Please try another payment method or contact support.',
-                        $orderCurrency
-                    )
-                );
-            }
-            $payload['cap'] = $cap;
         }
 
         // `rounding` snaps the final buyer line item to a clean increment, computed
@@ -351,15 +329,24 @@ class SurchargeCalculator
     /**
      * Convert an amount between currencies if needed.
      *
-     * The result is deliberately NOT rounded — the pricing API is the only
-     * place surcharge figures get rounded (via the `rounding` block and its
-     * own money precision), so no FX conversion here can collapse a non-zero
-     * configured amount to zero. Combined with CurrencyRatesProvider returning
-     * null rather than a zero/negative rate, a zero `cap` can only ever come
-     * from a zero configured limit, never from the conversion itself.
+     * The result is returned unrounded (`$amount * $rate`); no rounding is
+     * applied here. Since CurrencyRatesProvider returns null rather than a
+     * zero or negative rate, the conversion cannot turn a non-zero configured
+     * amount into zero.
+     *
+     * KNOWN PRE-EXISTING GAP (not introduced by, and not fixed by, the
+     * TWO-25269 revert): the unrounded result is sent as-is, but the API
+     * rejects monetary values finer than two decimal places rather than
+     * rounding them. A conversion landing on >2dp (e.g. 349 * 0.0872) is
+     * therefore refused upstream and surfaces to the buyer as the generic
+     * "temporarily unavailable" error. Both `cap` and `surcharge` need
+     * rounding to 2dp at this boundary. When that fix lands it must round a
+     * cap AWAY from zero (or special-case zero), because a `cap` of 0.0 is
+     * meaningful — it suppresses the surcharge — so a 0.004 cap must not be
+     * rounded down into it.
      *
      * @param int|null $selectedTermDays term the conversion is being made for,
-     *                                   for the fail-closed diagnostic log only
+     *                                   for the diagnostic log only
      * @throws LocalizedException when no FX rate is resolvable for the pair
      */
     private function convertAmount(

--- a/Test/Unit/Model/Config/RepositoryPaymentTermsTest.php
+++ b/Test/Unit/Model/Config/RepositoryPaymentTermsTest.php
@@ -424,13 +424,17 @@ class RepositoryPaymentTermsTest extends TestCase
         $this->assertEquals(25.50, $config['limit']);
     }
 
-    public function testGetSurchargeConfigDefaultsToZero(): void
+    public function testGetSurchargeConfigDefaultsAmountsToZeroAndLimitToNull(): void
     {
         $this->stubConfig([]);
         $config = $this->repository->getSurchargeConfig(60);
         $this->assertEquals(0, $config['percentage']);
         $this->assertEquals(0, $config['fixed']);
-        $this->assertEquals(0.0, $config['limit']);
+        // `limit` defaults to NULL, not 0.0 — the two are not interchangeable:
+        // null means "no cap" (uncapped percentage) while 0.0 is a real cap of
+        // zero that suppresses the surcharge. The previous assertEquals(0.0, ...)
+        // passed only because PHP's loose comparison treats null == 0.0.
+        $this->assertNull($config['limit']);
     }
 
     // ── getPaymentTermsType (retained) ──────────────────────────────

--- a/Test/Unit/Service/Order/SurchargeCalculatorTest.php
+++ b/Test/Unit/Service/Order/SurchargeCalculatorTest.php
@@ -727,55 +727,105 @@ class SurchargeCalculatorTest extends TestCase
         $this->calculator->calculate(1000.0, 45, 'NO', 'GBP');
     }
 
-    // ── Zero cap fails closed (a zero cap reads as NO cap downstream) ──
+    // ── A configured limit of 0 is a real cap of zero, sent as `cap => 0.0` ──
 
-    public function testThrowsWhenConfiguredCapIsZero(): void
+    public function testConfiguredCapOfZeroIsSentAsZeroCap(): void
     {
-        // `cap => 0.0` is indistinguishable from an absent cap downstream, so
-        // sending it would apply the percentage UNCAPPED — an overcharge and the
-        // opposite of the merchant's configuration. A limit of exactly 0 reaches
-        // here from the admin grid (validateValue only rejects negatives).
-        $this->stubCommonConfig(SurchargeType::FIXED_AND_PERCENTAGE);
-        $this->stubSurchargeConfig(50, 5, 0.0);
-        $this->stubFixedCurrency('NOK');
-
-        $this->adapter->expects($this->never())->method('execute');
-
-        $this->expectException(\Magento\Framework\Exception\LocalizedException::class);
-        $this->expectExceptionMessage('surcharge cap resolves to zero in NOK');
-
-        $this->calculator->calculate(1000.0, 60, 'NO', 'NOK');
-    }
-
-    public function testZeroCapFailClosedIsLoggedWithCurrencyPairAndTerm(): void
-    {
+        // A limit of exactly 0 caps the fee at nothing, i.e. charges no
+        // surcharge, and `cap => 0.0` is how the API is told that — 0 clamps
+        // rather than uncaps. TWO-25269 briefly threw a LocalizedException here
+        // on the false premise that a zero cap would relay an uncapped
+        // percentage; that guard is gone and must not come back. This test is
+        // its headstone.
         $this->stubCommonConfig(SurchargeType::PERCENTAGE);
         $this->stubSurchargeConfig(50, 0, 0.0);
         $this->stubFixedCurrency('NOK');
 
-        $this->log->expects($this->once())
-            ->method('addErrorLog')
-            ->with(
-                'Surcharge cap is configured but resolves to zero',
-                $this->callback(function ($context) {
-                    return $context['from_currency'] === 'NOK'
-                        && $context['to_currency'] === 'SEK'
-                        && $context['selected_term'] === 90
-                        && $context['configured_limit'] === 0.0
-                        && $context['converted_cap'] === 0.0;
-                })
-            );
+        $this->log->expects($this->never())->method('addErrorLog');
 
-        $this->expectException(\Magento\Framework\Exception\LocalizedException::class);
+        $this->adapter->expects($this->once())
+            ->method('execute')
+            ->with(
+                '/v1/pricing/order/fee',
+                $this->callback(function ($payload) {
+                    $share = $payload['buyer_fee_share'];
+                    return array_key_exists('cap', $share)
+                        && $share['cap'] === 0.0
+                        && $share['percentage'] === 50.0;
+                })
+            )
+            ->willReturn(['buyer_fee_share' => 0.0]);
+
+        $result = $this->calculator->calculate(1000.0, 60, 'NO', 'NOK');
+
+        $this->assertEquals(0.0, $result['amount']);
+    }
+
+    public function testZeroCapNeedsNoFxRateEvenAcrossCurrencies(): void
+    {
+        // Pins convertAmount()'s `$amount === 0.0` early return: a zero limit
+        // must reach the API as `cap => 0.0` on a cross-currency order with NO
+        // rate available for the pair. Without that early return this mock's
+        // getRate() returns null and checkout hard-fails, so a percentage-only
+        // merchant with limit 0 and an unrated pair would break. PERCENTAGE
+        // (not mixed) so nothing else needs a rate either.
+        $this->stubCommonConfig(SurchargeType::PERCENTAGE);
+        $this->stubSurchargeConfig(50, 0, 0.0);
+        $this->stubFixedCurrency('NOK');
+        $this->ratesProvider->method('getRate')->willReturn(null);
+
+        $this->log->expects($this->never())->method('addErrorLog');
+
+        $this->adapter->expects($this->once())
+            ->method('execute')
+            ->with(
+                '/v1/pricing/order/fee',
+                $this->callback(function ($payload) {
+                    return $payload['buyer_fee_share']['cap'] === 0.0;
+                })
+            )
+            ->willReturn(['buyer_fee_share' => 0.0]);
 
         $this->calculator->calculate(1000.0, 90, 'NO', 'SEK');
     }
 
-    public function testZeroLimitInFixedOnlyModeDoesNotFailClosed(): void
+    public function testZeroCapIsSentAlongsideTheConvertedFixedSurcharge(): void
     {
-        // The zero-cap guard sits behind the same $hasPercentage gate as `cap`
-        // itself: a stale zero limit left over from a previous surcharge type
-        // must not break a fixed-only fee, which has no cap to send.
+        // Payload-level guard for the mixed type: `cap => 0.0` is sent verbatim
+        // and does NOT disturb the FX-converted `surcharge`.
+        //
+        // API-side (not pinnable from here — the adapter is mocked): the cap
+        // clamps the SUM of the fixed passthrough and the percentage
+        // contribution, so a limit of 0 zeroes the configured Fixed fee too,
+        // not just the percentage part. Easy to misread as "Limit only bounds
+        // the %", and reachable straight from the admin grid.
+        $this->stubCommonConfig(SurchargeType::FIXED_AND_PERCENTAGE);
+        $this->stubSurchargeConfig(50, 5, 0.0);
+        $this->stubFixedCurrency('NOK');
+        $this->stubFxRate('NOK', 1.1);
+
+        $this->log->expects($this->never())->method('addErrorLog');
+
+        $this->adapter->expects($this->once())
+            ->method('execute')
+            ->with(
+                '/v1/pricing/order/fee',
+                $this->callback(function ($payload) {
+                    $share = $payload['buyer_fee_share'];
+                    return $share['cap'] === 0.0
+                        && abs($share['surcharge'] - 5.5) < 0.0001;
+                })
+            )
+            ->willReturn(['buyer_fee_share' => 0.0]);
+
+        $this->calculator->calculate(1000.0, 90, 'NO', 'SEK');
+    }
+
+    public function testZeroLimitInFixedOnlyModeSendsNoCap(): void
+    {
+        // `cap` sits behind a $hasPercentage gate: a stale zero limit left over
+        // from a previous surcharge type must not leak into a fixed-only fee,
+        // which is constant and has nothing to clamp.
         $this->stubCommonConfig(SurchargeType::FIXED);
         $this->stubSurchargeConfig(0, 10, 0.0);
         $this->stubFixedCurrency('NOK');
@@ -801,10 +851,9 @@ class SurchargeCalculatorTest extends TestCase
 
     public function testAbsentLimitSendsUncappedPercentageSurcharge(): void
     {
-        // REGRESSION GUARD. "No cap defined" is a valid, common configuration.
-        // The zero-cap guard above must never be widened to treat a null limit
-        // as a failure — an uncapped percentage surcharge has to keep being
-        // charged normally, with no `cap` key and no error.
+        // REGRESSION GUARD. "No cap defined" is a valid, common configuration
+        // and is distinct from a cap of 0: an absent limit must send no `cap`
+        // key at all so the percentage is applied uncapped, with no error.
         $this->stubCommonConfig(SurchargeType::PERCENTAGE);
         $this->stubSurchargeConfig(50, 0, null);
         $this->stubFixedCurrency('NOK');
@@ -830,8 +879,8 @@ class SurchargeCalculatorTest extends TestCase
 
     public function testAbsentLimitSendsUncappedFixedAndPercentageSurcharge(): void
     {
-        // Same guard for the mixed type, where a `surcharge` FX conversion also
-        // runs — an absent cap must not disturb it.
+        // Same for the mixed type, where a `surcharge` FX conversion also runs
+        // — an absent cap must not disturb it.
         $this->stubCommonConfig(SurchargeType::FIXED_AND_PERCENTAGE);
         $this->stubSurchargeConfig(50, 5, null);
         $this->stubFixedCurrency('NOK');
@@ -859,11 +908,15 @@ class SurchargeCalculatorTest extends TestCase
 
     public function testNonZeroCapNeverCollapsesToZeroThroughFxConversion(): void
     {
-        // convertAmount() does NO rounding (`$amount * $rate`) and
+        // convertAmount() applies no rounding (`$amount * $rate`) and
         // CurrencyRatesProvider returns null rather than a zero/negative rate,
         // so a tiny cap under a tiny rate stays non-zero and is sent as-is.
-        // The "converted cap rounds to 0.00" hazard other platforms guard
-        // against therefore cannot arise on Magento.
+        //
+        // This pins the plugin's current unrounded pass-through ONLY. The value
+        // asserted below (0.000001) exceeds the pricing API's two-decimal money
+        // precision and would in fact be rejected upstream — see the
+        // KNOWN PRE-EXISTING GAP note on convertAmount(). Do not read this test
+        // as evidence that the API accepts sub-cent figures; it does not.
         $this->stubCommonConfig(SurchargeType::PERCENTAGE);
         $this->stubSurchargeConfig(50, 0, 0.01);
         $this->stubFixedCurrency('NOK');


### PR DESCRIPTION
## What

Reverts the zero-cap fail-closed guard added by #291. TWO-25269.

## Why

The guard's premise was **false**. It threw a `LocalizedException` whenever a configured surcharge limit resolved to zero, on the belief that a zero cap read as "no cap" downstream and would therefore relay an **uncapped** percentage — an overcharge to the buyer.

The pricing API does not behave that way. A zero cap **clamps** the buyer fee to zero; it never uncaps it, so no overcharge was possible. Only an *absent* limit means "no cap". A zero cap is a legitimate merchant configuration meaning "apply no surcharge", and the plugin now relays it unchanged.

Verified against the API's current behaviour rather than assumed.

## Reverted

- the `$cap <= 0.0` block: its `addErrorLog('Surcharge cap is configured but resolves to zero', ...)` and its `LocalizedException`. `$payload['cap']` is now assigned unconditionally for a non-null configured limit.
- the comment prose asserting the uncapped/overcharge premise.
- the `@throws LocalizedException` docblock additions covering the zero-cap case, on both `calculate()` and `buildBuyerFeeShare()`.
- the clause "while a limit that IS set but evaluates to zero fails closed". The statement that an **absent** limit is a legitimate "no cap" sending an uncapped percentage is retained — that part is true.

## Kept — deliberately not over-reverted

- the no-FX-rate fail-closed behaviour in `convertAmount()`: `addErrorLog('Surcharge FX conversion failed: no rate available', ...)` plus its `LocalizedException`. The "fail-closed path previously threw with nothing logged" fix was real and unrelated to the cap premise.
- `addErrorLog('Pricing API response missing buyer_fee_share', ...)` and `addErrorLog('Pricing API returned a mismatched currency', ...)`.
- the `?int $selectedTermDays = null` parameter threaded into `convertAmount()` and its use in the no-rate log context.

## No admin validation reinstated

A typed `0` limit must save and be relayed as `cap => 0.0` — that is the desired outcome, not an error. #291 did not modify `Model/Config/Backend/SurchargeGrid::validateValue` (it only referenced it in a comment), so there was nothing to revert there; confirmed with `git show 7939779 -m --first-parent --stat`, which touches exactly two files. No i18n catalogue row was added by #291 either, so none is removed. A blank Limit cell already deletes the config row, so absent and zero stay distinguishable at the storage layer.

## Downstream safety

The newly-reachable zero-surcharge path lands on handling that already exists: `Model/Total/Surcharge.php` short-circuits on `$netAmount <= 0`, clearing the session and total, and `fetch()` returns `[]` so no line renders and no tax passes. That path was already reachable before this PR (a percentage of 0, a fully-discounted cart, the API returning 0), so this makes the collector consistent rather than opening new behaviour.

## Tests

Removed the two tests asserting the zero-cap `LocalizedException`. Added coverage that a configured limit of 0 yields `cap => 0.0` with no exception and no error log, that it needs no FX rate on a cross-currency order, and that it rides alongside a converted fixed fee. Every no-rate, missing-`buyer_fee_share` and mismatched-currency test is retained. `RepositoryPaymentTermsTest` now asserts `limit` defaults to `null` rather than `0.0` — the old assertion passed only via PHP's loose `null == 0.0`, and absent vs zero now mean opposite things on the wire.

```
OK (481 tests, 883 assertions)
```

## Out of scope — pre-existing unrounded-amount gap

`convertAmount()` returns `$amount * $rate` unrounded, and both `$payload['surcharge']` and `$payload['cap']` pass through it. The API rejects monetary values finer than two decimal places rather than rounding them, so a cross-currency conversion landing on >2dp is refused upstream and surfaces to the buyer as the generic "temporarily unavailable" error. **Pre-existing, not introduced by #291, and deliberately not fixed here** — no rounding behaviour changes in this PR. Recorded in a docblock note, including the constraint any future fix must respect: round a cap *away* from zero, since a cap of `0.0` is now meaningful.

Two further items were found during review and are deliberately left for separate tickets: `getSurchargeConfig` maps `''` and non-numeric values to `0.0` rather than `null` (so such a value now silently zeroes the surcharge — not reachable from the admin grid, only from scripted config imports or legacy rows), and the admin "Limit" column does not say that `Limit = 0` in `fixed_and_percentage` mode suppresses the fixed component too.

## Docs

`AGENTS.md` records that the guard was reverted and why, so it does not get reintroduced.