### PR TITLE
TWO-25288 (1/2): make the address-step company number usable

### DIFF
--- a/Plugin/Model/Checkout/LayoutProcessorPlugin.php
+++ b/Plugin/Model/Checkout/LayoutProcessorPlugin.php
@@ -34,6 +34,13 @@ class LayoutProcessorPlugin
         LayoutProcessor $subject,
         array  $jsLayout
     ) {
+        // The field is `visible` now, so a merchant who merely has the module
+        // installed with the payment method switched off would otherwise get a
+        // company-number input on the address step for every buyer. Gated the
+        // same way the payment-method list plugin gates its own append.
+        if (!$this->repository->isActive()) {
+            return $jsLayout;
+        }
         $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']
         ['shippingAddress']['children']['shipping-address-fieldset']['children']['company_id'] = [
             'component' => 'Magento_Ui/js/form/element/abstract',
@@ -43,13 +50,13 @@ class LayoutProcessorPlugin
                 'template' => 'ui/form/field',
                 'elementTmpl' => 'ui/form/element/input',
                 'tooltip' => [
-                    'description' => 'Company Number',
+                    'description' => __('Company Number'),
                 ],
                 'options' => [],
                 'id' => 'company-id'
             ],
             'dataScope' => 'shippingAddress.custom_attributes.company_id',
-            'label' => 'Company Number',
+            'label' => __('Company Number'),
             'provider' => 'checkoutProvider',
             // Rendered, and disabled until the buyer actually has to supply
             // the number by hand. Company search fills it from the registry

--- a/Plugin/Model/Checkout/LayoutProcessorPlugin.php
+++ b/Plugin/Model/Checkout/LayoutProcessorPlugin.php
@@ -43,15 +43,26 @@ class LayoutProcessorPlugin
                 'template' => 'ui/form/field',
                 'elementTmpl' => 'ui/form/element/input',
                 'tooltip' => [
-                    'description' => 'Company Id',
+                    'description' => 'Company Number',
                 ],
                 'options' => [],
                 'id' => 'company-id'
             ],
             'dataScope' => 'shippingAddress.custom_attributes.company_id',
-            'label' => 'Company Id',
+            'label' => 'Company Number',
             'provider' => 'checkoutProvider',
-            'visible' => false,
+            // Rendered, and disabled until the buyer actually has to supply
+            // the number by hand. Company search fills it from the registry
+            // for a picked company, so an editable field would only let the
+            // buyer contradict the registry; the exception is a company the
+            // registry holds no identifier for, where typing it is the only
+            // route. The live derivation of that state — and the publishing of
+            // whatever the buyer types — belongs to
+            // view/frontend/web/js/view/address-autocomplete.js; `disabled`
+            // here is only the initial state for a freshly rendered form with
+            // no company selected yet.
+            'visible' => true,
+            'disabled' => true,
             'validation' => [
                 'required-entry' => false
             ],

--- a/Test/Js/address-company-id.test.js
+++ b/Test/Js/address-company-id.test.js
@@ -1,0 +1,349 @@
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ *
+ * TWO-25288, first half. The address step gains a usable company-number
+ * field, so that it can become the single company surface on Luma. What is
+ * pinned here:
+ *
+ *  - the field is editable exactly when a company is in play with no registry
+ *    identifier behind it (the derivation the payment tile already applies to
+ *    its own copy of the field), and
+ *  - whatever the buyer types into it reaches the payment step through the ONE
+ *    writer of the `companyData` customer-data section, because the payment
+ *    step reads a change notification on that section as an act of selection.
+ *
+ * LIMITATIONS OF THE DOUBLES BELOW — read before trusting a pass here.
+ *
+ *  1. `node.on()` keeps ONE handler per event name and `off()` is a no-op, so
+ *     nothing here can speak to handler ordering or coexistence.
+ *  2. The AMD harness's sandbox `document` has no `querySelector`, so the
+ *     `select2:open` handler (which calls it) cannot be driven. The
+ *     "Enter details manually" affordance is therefore exercised through
+ *     `setCompanyData()` — what that handler calls — and not through the click
+ *     itself. A regression that unwired the click would NOT fail here.
+ *  3. The shared harness mocks `Two_Gateway/js/model/company-search` to a set
+ *     of no-ops (`buildSearchAjaxOptions` returns `{}`, `lookupCompanyAddress`
+ *     returns null). Nothing in this file covers real search behaviour, and a
+ *     test that loaded the module and asserted on search results would be
+ *     asserting against those stubs.
+ */
+
+'use strict';
+
+const { loadAmdModule } = require('./amd-harness');
+
+const MODULE = 'view/frontend/web/js/view/address-autocomplete.js';
+
+const NAME_FIELD = '#shipping-new-address-form input[name="company"]';
+const ID_FIELD = '#shipping-new-address-form input[name="custom_attributes[company_id]"]';
+const COUNTRY_FIELD = '#shipping-new-address-form select[name="country_id"]';
+
+/**
+ * jQuery double with one persistent node per selector, so a write made through
+ * `$(sel).val(...)` is visible to a later `$(sel).val()` read. The default
+ * harness jQuery is inert — every setter returns the same empty object and
+ * records nothing — which would let a broken implementation pass.
+ */
+function makeDom() {
+    const nodes = {};
+
+    function node(selector) {
+        if (nodes[selector]) return nodes[selector];
+        const n = {
+            selector: selector,
+            length: 1,
+            value: '',
+            props: {},
+            textValue: '',
+            dataValues: {},
+            handlers: {},
+            appended: [],
+            val: function (next) {
+                if (!arguments.length) return n.value;
+                n.value = next;
+                return n;
+            },
+            prop: function (name, next) {
+                if (arguments.length < 2) return n.props[name];
+                n.props[name] = next;
+                return n;
+            },
+            text: function (next) {
+                if (!arguments.length) return n.textValue;
+                n.textValue = next;
+                return n;
+            },
+            data: function (key, next) {
+                if (arguments.length < 2) return n.dataValues[key];
+                n.dataValues[key] = next;
+                return n;
+            },
+            // ONE handler per event name; `off()` does nothing. See limitation
+            // 1 in the file header.
+            on: function (event, fn) {
+                n.handlers[String(event).split('.')[0]] = fn;
+                return n;
+            },
+            off: function () {
+                return n;
+            },
+            closest: function (sel) {
+                return node(selector + ' >closest> ' + sel);
+            },
+            find: function (sel) {
+                return node(selector + ' >find> ' + sel);
+            },
+            append: function (html) {
+                n.appended.push(html);
+                return n;
+            },
+            attr: function () {
+                return n;
+            },
+            show: function () {
+                return n;
+            },
+            hide: function () {
+                return n;
+            },
+            select2: function () {
+                return n;
+            }
+        };
+        nodes[selector] = n;
+        return n;
+    }
+
+    function $(selector) {
+        return node(typeof selector === 'string' ? selector : String(selector));
+    }
+    // `$.async` is a MutationObserver in Magento; the nodes are already present
+    // here, so resolve immediately with the selector — the module re-wraps it
+    // with `$(...)`, which lands on the same node.
+    $.async = function (selector, cb) {
+        cb(selector);
+    };
+    $.extend = Object.assign;
+    $.fn = {};
+
+    return { $: $, node: node };
+}
+
+/**
+ * Customer-data double whose `companyData` section records every write, so the
+ * "one writer, and it carries the right payload" claims are checkable.
+ */
+function makeCustomerData() {
+    const writes = [];
+    const sections = {};
+
+    function observable(initial) {
+        let value = initial;
+        function obs(next) {
+            if (!arguments.length) return value;
+            value = next;
+            return obs;
+        }
+        obs.subscribe = function () {
+            return { dispose: function () {} };
+        };
+        return obs;
+    }
+
+    return {
+        writes: writes,
+        api: {
+            get: function (key) {
+                if (!sections[key]) sections[key] = observable(undefined);
+                return sections[key];
+            },
+            set: function (key, value) {
+                writes.push({ key: key, value: value });
+                if (!sections[key]) sections[key] = observable(undefined);
+                sections[key](value);
+            },
+            reload: function () {}
+        }
+    };
+}
+
+function load(options) {
+    const opts = options || {};
+    const dom = makeDom();
+    const cd = makeCustomerData();
+    // Country has to read as a string: toggleCompanyVisibility() lowercases it.
+    dom.node(COUNTRY_FIELD).val(opts.country || 'GB');
+    if (opts.prefillName) dom.node(NAME_FIELD).val(opts.prefillName);
+    if (opts.prefillId) dom.node(ID_FIELD).val(opts.prefillId);
+
+    const component = loadAmdModule(MODULE, {
+        jquery: dom.$,
+        'Magento_Customer/js/customer-data': cd.api,
+        'Two_Gateway/js/model/brand-config': {
+            // Company search off by default: enableCompanySearch() then
+            // early-returns and these tests stay about the company-number
+            // field. The select2 paths need a `document.querySelector` the
+            // harness sandbox does not have (limitation 2).
+            getActiveTwoBrandConfig: function () {
+                return { isCompanySearchEnabled: !!opts.searchEnabled };
+            }
+        }
+    });
+    return { component: component, node: dom.node, writes: cd.writes };
+}
+
+/**
+ * Run the component's real `initialize()`. The harness's Component double
+ * returns the spec rather than constructing an instance, so `initialize()` is
+ * NOT called by loading the module — but running it is what proves the
+ * company-number wiring is actually reached on render rather than only when a
+ * test calls it by hand.
+ */
+function initialise(component) {
+    component._super = function () {};
+    component.initialize();
+    return component;
+}
+
+/** Make the double report select2 as bound to the company-name input. */
+function activateSearch(node) {
+    node(NAME_FIELD).data('select2', {});
+}
+
+describe('address-step company-number field editability', () => {
+    test('a registry pick leaves the field disabled', () => {
+        const { component, node } = load();
+        activateSearch(node);
+
+        component.setCompanyData('12345678', 'First Example Ltd');
+
+        expect(node(ID_FIELD).val()).toBe('12345678');
+        expect(node(ID_FIELD).prop('disabled')).toBe(true);
+    });
+
+    test('a pick with no registry identifier enables the field', () => {
+        const { component, node } = load();
+        activateSearch(node);
+
+        component.setCompanyData('', 'Second Example Ltd');
+
+        expect(node(ID_FIELD).prop('disabled')).toBe(false);
+    });
+
+    test('a registry pick after an identifier-less one re-disables the field', () => {
+        const { component, node } = load();
+        activateSearch(node);
+
+        component.setCompanyData('', 'Second Example Ltd');
+        expect(node(ID_FIELD).prop('disabled')).toBe(false);
+
+        component.setCompanyData('12345678', 'First Example Ltd');
+        expect(node(ID_FIELD).prop('disabled')).toBe(true);
+    });
+
+    test('a manually typed company name enables the field', () => {
+        // "Enter details manually" calls setCompanyData() with no arguments and
+        // destroys the picker; the buyer then types the name into a plain text
+        // input. Without the re-derivation on that input the buyer is left with
+        // a company and no way to supply its number.
+        const { component, node } = load();
+        component.enableManualCompanyId();
+
+        component.setCompanyData();
+        expect(node(ID_FIELD).prop('disabled')).toBe(true);
+
+        node(NAME_FIELD).val('Hand Typed Ltd');
+        node(NAME_FIELD).handlers['input']();
+
+        expect(node(ID_FIELD).prop('disabled')).toBe(false);
+    });
+
+    test('typing into the company-number field does not disable it', () => {
+        // The derivation reads this very field, so re-deriving on its own
+        // events would disable it the instant the buyer finished typing.
+        const { component, node } = load();
+        component.enableManualCompanyId();
+
+        component.setCompanyData('', 'Second Example Ltd');
+        expect(node(ID_FIELD).prop('disabled')).toBe(false);
+
+        node(ID_FIELD).val('87654321');
+        node(ID_FIELD).handlers['change']();
+
+        expect(node(ID_FIELD).prop('disabled')).toBe(false);
+    });
+
+    test('a form rendered with a company already on it derives on resolve', () => {
+        const { component, node } = load({ prefillName: 'Saved Ltd', prefillId: '12345678' });
+        initialise(component);
+
+        expect(node(ID_FIELD).prop('disabled')).toBe(true);
+    });
+
+    test('a form rendered with a company name but no number derives editable', () => {
+        const { component, node } = load({ prefillName: 'Saved Ltd' });
+        initialise(component);
+
+        expect(node(ID_FIELD).prop('disabled')).toBe(false);
+    });
+});
+
+describe('what the buyer types reaches the payment step', () => {
+    test('the company-number field publishes to companyData', () => {
+        const { component, node, writes } = load();
+        component.enableManualCompanyId();
+
+        component.setCompanyData('', 'Second Example Ltd');
+        activateSearch(node);
+        node(ID_FIELD).val('87654321');
+        node(ID_FIELD).handlers['change']();
+
+        const last = writes[writes.length - 1];
+        expect(last.key).toBe('companyData');
+        expect(last.value).toEqual({ companyId: '87654321', companyName: 'Second Example Ltd' });
+    });
+
+    test('a manually typed name and number publish together', () => {
+        const { component, node, writes } = load();
+        component.enableManualCompanyId();
+
+        component.setCompanyData();
+        node(NAME_FIELD).val('Hand Typed Ltd');
+        node(NAME_FIELD).handlers['input']();
+        node(ID_FIELD).val('87654321');
+        node(ID_FIELD).handlers['change']();
+
+        const last = writes[writes.length - 1];
+        expect(last.value).toEqual({ companyId: '87654321', companyName: 'Hand Typed Ltd' });
+    });
+
+    test('every companyData write goes through publishCompanyData', () => {
+        // The payment step reads a change notification on this section as an
+        // act of selection, which is only sound while the section has one
+        // writer. Pinned by neutering the one writer and requiring that NO
+        // write survives.
+        const { component, node, writes } = load();
+        component.enableManualCompanyId();
+        component.publishCompanyData = function () {};
+
+        component.setCompanyData('12345678', 'First Example Ltd');
+        component.setCompanyData();
+        node(ID_FIELD).val('87654321');
+        node(ID_FIELD).handlers['change']();
+
+        expect(writes.filter((w) => w.key === 'companyData')).toEqual([]);
+    });
+
+    test('the company-number field is not bound per keystroke', () => {
+        // An order intent fires as soon as the payment step holds both a name
+        // and a number, so a keyup/input publish would fire one credit-check
+        // request per character.
+        const { component, node } = load();
+        component.enableManualCompanyId();
+
+        expect(typeof node(ID_FIELD).handlers['change']).toBe('function');
+        expect(node(ID_FIELD).handlers['keyup']).toBeUndefined();
+        expect(node(ID_FIELD).handlers['input']).toBeUndefined();
+    });
+});

--- a/Test/Js/address-company-id.test.js
+++ b/Test/Js/address-company-id.test.js
@@ -27,6 +27,10 @@
  *     returns null). Nothing in this file covers real search behaviour, and a
  *     test that loaded the module and asserted on search results would be
  *     asserting against those stubs.
+ *  4. The harness's `uiRegistry.get()` returns undefined, so every assertion
+ *     below observes the DOM half of `setCompanyIdDisabled()`. The UI-component
+ *     half — the authoritative one, see that method's comment — is not
+ *     exercised here.
  */
 
 'use strict';
@@ -254,6 +258,29 @@ describe('address-step company-number field editability', () => {
         expect(node(ID_FIELD).prop('disabled')).toBe(true);
 
         node(NAME_FIELD).val('Hand Typed Ltd');
+        node(NAME_FIELD).handlers['input']();
+
+        expect(node(ID_FIELD).prop('disabled')).toBe(false);
+    });
+
+    test('editing the company name again does not disable a typed-in number', () => {
+        // Manual mode, and the buyer goes back to correct the company name
+        // after typing its number. The name handler must not re-derive from the
+        // number field's value: the number is non-empty by then, so the full
+        // derivation reads "no manual entry needed" and would lock the buyer
+        // out of the number they just typed, with nothing clearing it.
+        const { component, node } = load();
+        component.enableManualCompanyId();
+
+        component.setCompanyData();
+        node(NAME_FIELD).val('Hand Typed Ltd');
+        node(NAME_FIELD).handlers['input']();
+        expect(node(ID_FIELD).prop('disabled')).toBe(false);
+
+        node(ID_FIELD).val('87654321');
+        node(ID_FIELD).handlers['change']();
+
+        node(NAME_FIELD).val('Hand Typed Limited');
         node(NAME_FIELD).handlers['input']();
 
         expect(node(ID_FIELD).prop('disabled')).toBe(false);

--- a/Test/Unit/Plugin/Model/Checkout/LayoutProcessorPluginTest.php
+++ b/Test/Unit/Plugin/Model/Checkout/LayoutProcessorPluginTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Plugin\Model\Checkout;
+
+use Magento\Checkout\Block\Checkout\LayoutProcessor;
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Model\Config\Repository;
+use Two\Gateway\Plugin\Model\Checkout\LayoutProcessorPlugin;
+
+/**
+ * TWO-25288. The address step's company-number field is the company-number
+ * surface the buyer actually uses, so it has to render — it spent its life
+ * declared invisible while the payment tile carried a second copy.
+ *
+ * `disabled` is asserted too: the field must arrive locked. Company search
+ * fills it from the registry for a picked company, and the storefront JS
+ * unlocks it only for a company the registry holds no identifier for. A field
+ * that arrived unlocked would let the buyer contradict the registry.
+ */
+class LayoutProcessorPluginTest extends TestCase
+{
+    /**
+     * @return array<string,mixed>
+     */
+    private function companyIdField(): array
+    {
+        $plugin = new LayoutProcessorPlugin($this->createMock(Repository::class));
+        $jsLayout = $plugin->afterProcess($this->createMock(LayoutProcessor::class), []);
+
+        return $jsLayout['components']['checkout']['children']['steps']['children']
+            ['shipping-step']['children']['shippingAddress']['children']
+            ['shipping-address-fieldset']['children']['company_id'];
+    }
+
+    public function testCompanyNumberFieldIsRendered(): void
+    {
+        $this->assertTrue($this->companyIdField()['visible']);
+    }
+
+    public function testCompanyNumberFieldArrivesDisabled(): void
+    {
+        $this->assertTrue($this->companyIdField()['disabled']);
+    }
+
+    public function testCompanyNumberFieldIsLabelledForTheBuyer(): void
+    {
+        $field = $this->companyIdField();
+
+        // Matches the label the payment tile used, and an existing translated
+        // string in every shipped i18n CSV.
+        $this->assertSame('Company Number', $field['label']);
+        $this->assertSame('Company Number', $field['config']['tooltip']['description']);
+    }
+
+    public function testCompanyNumberFieldKeepsItsAddressDataScope(): void
+    {
+        // The organisation number the Two API receives comes from the payment
+        // scope, but this field is also the writer of the address attribute the
+        // payment step reads back off the quote. A drifted dataScope silently
+        // stops that.
+        $field = $this->companyIdField();
+
+        $this->assertSame('shippingAddress.custom_attributes.company_id', $field['dataScope']);
+        $this->assertSame('shippingAddress.custom_attributes', $field['config']['customScope']);
+    }
+}

--- a/Test/Unit/Plugin/Model/Checkout/LayoutProcessorPluginTest.php
+++ b/Test/Unit/Plugin/Model/Checkout/LayoutProcessorPluginTest.php
@@ -25,16 +25,118 @@ use Two\Gateway\Plugin\Model\Checkout\LayoutProcessorPlugin;
 class LayoutProcessorPluginTest extends TestCase
 {
     /**
+     * A `jsLayout` shaped like the real one: the shipping-address fieldset
+     * already exists and already carries a field. Seeding it is what makes the
+     * assertions mean something — `afterProcess()` writes through a chain of
+     * array keys, so handing it `[]` autovivifies whatever path the plugin
+     * happens to use and every read below would only re-read what was just
+     * written. Reading out of the PRE-EXISTING fieldset makes a drifted path
+     * fail.
+     *
+     * @return array<string,mixed>
+     */
+    private function seededLayout(): array
+    {
+        return [
+            'components' => [
+                'checkout' => [
+                    'children' => [
+                        'steps' => [
+                            'children' => [
+                                'shipping-step' => [
+                                    'children' => [
+                                        'shippingAddress' => [
+                                            'children' => [
+                                                'shipping-address-fieldset' => [
+                                                    'children' => [
+                                                        'company' => ['label' => 'Company'],
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    private function plugin(bool $isActive): LayoutProcessorPlugin
+    {
+        $repository = $this->createMock(Repository::class);
+        $repository->method('isActive')->willReturn($isActive);
+
+        return new LayoutProcessorPlugin($repository);
+    }
+
+    /**
+     * The pre-existing fieldset's children, after the plugin has run.
+     *
+     * @param array<string,mixed> $jsLayout
+     * @return array<string,mixed>
+     */
+    private function fieldset(array $jsLayout): array
+    {
+        return $jsLayout['components']['checkout']['children']['steps']['children']
+            ['shipping-step']['children']['shippingAddress']['children']
+            ['shipping-address-fieldset']['children'];
+    }
+
+    /**
      * @return array<string,mixed>
      */
     private function companyIdField(): array
     {
-        $plugin = new LayoutProcessorPlugin($this->createMock(Repository::class));
-        $jsLayout = $plugin->afterProcess($this->createMock(LayoutProcessor::class), []);
+        $jsLayout = $this->plugin(true)->afterProcess(
+            $this->createMock(LayoutProcessor::class),
+            $this->seededLayout()
+        );
 
-        return $jsLayout['components']['checkout']['children']['steps']['children']
-            ['shipping-step']['children']['shippingAddress']['children']
-            ['shipping-address-fieldset']['children']['company_id'];
+        $fieldset = $this->fieldset($jsLayout);
+        $this->assertArrayHasKey(
+            'company_id',
+            $fieldset,
+            'company_id was not inserted into the existing shipping-address fieldset'
+        );
+
+        return $fieldset['company_id'];
+    }
+
+    public function testFieldIsInsertedIntoTheExistingShippingAddressFieldset(): void
+    {
+        $jsLayout = $this->plugin(true)->afterProcess(
+            $this->createMock(LayoutProcessor::class),
+            $this->seededLayout()
+        );
+
+        $fieldset = $this->fieldset($jsLayout);
+
+        // The seeded sibling still there alongside the new node is what pins
+        // the insertion to the real fieldset rather than a path the plugin
+        // conjured on its way through.
+        $this->assertSame(['company', 'company_id'], array_keys($fieldset));
+        $this->assertSame(['label' => 'Company'], $fieldset['company']);
+    }
+
+    /**
+     * The field renders for every buyer on the address step, so it must not
+     * appear on a store that merely has the module installed with the payment
+     * method switched off.
+     */
+    public function testNothingIsAddedWhenThePaymentMethodIsInactive(): void
+    {
+        $seeded = $this->seededLayout();
+
+        $jsLayout = $this->plugin(false)->afterProcess(
+            $this->createMock(LayoutProcessor::class),
+            $seeded
+        );
+
+        $this->assertSame($seeded, $jsLayout);
+        $this->assertArrayNotHasKey('company_id', $this->fieldset($jsLayout));
     }
 
     public function testCompanyNumberFieldIsRendered(): void
@@ -52,9 +154,11 @@ class LayoutProcessorPluginTest extends TestCase
         $field = $this->companyIdField();
 
         // Matches the label the payment tile used, and an existing translated
-        // string in every shipped i18n CSV.
-        $this->assertSame('Company Number', $field['label']);
-        $this->assertSame('Company Number', $field['config']['tooltip']['description']);
+        // string in every shipped i18n CSV. Compared as a cast string so the
+        // assertion holds for the Phrase `__()` returns and does NOT cement the
+        // untranslated form.
+        $this->assertSame('Company Number', (string)$field['label']);
+        $this->assertSame('Company Number', (string)$field['config']['tooltip']['description']);
     }
 
     public function testCompanyNumberFieldKeepsItsAddressDataScope(): void

--- a/view/frontend/web/js/view/address-autocomplete.js
+++ b/view/frontend/web/js/view/address-autocomplete.js
@@ -32,6 +32,12 @@ define([
     // isn't present.
     const config = brandConfig.getActiveTwoBrandConfig();
 
+    // Our own event namespace, separate from company-search's. The picker
+    // teardown paths clear `companySearch.EVENT_NS` off the company-name input
+    // and select2's own destroy() clears `.select2`; the company-number
+    // handlers below have to survive both.
+    const EVENT_NS = '.twoAddressCompanyId';
+
     return Component.extend({
         countrySelector: '#shipping-new-address-form select[name="country_id"]',
         companyNameSelector: '#shipping-new-address-form input[name="company"]',
@@ -54,6 +60,7 @@ define([
                 });
             });
             this.enableCompanySearch();
+            this.enableManualCompanyId();
             const setTwoTelephone = (e) => customerData.set('shippingTelephone', e.target.value);
             $.async(self.shippingTelephoneSelector, function (telephoneSelector) {
                 $(telephoneSelector).on('change keyup', setTwoTelephone);
@@ -70,12 +77,112 @@ define([
                 return (style || '') + 'width: 100% !important;';
             });
         },
+        /**
+         * THE single writer of the `companyData` customer-data section.
+         *
+         * Its own method so that every path which has to publish — a registry
+         * pick, "Enter details manually", and the company-number field the
+         * buyer types into — shares one call site. The payment step treats a
+         * change NOTIFICATION on this section as an act of selection, and that
+         * reading is only sound while the section has exactly one writer.
+         */
+        publishCompanyData: function (companyId, companyName) {
+            customerData.set('companyData', { companyId: companyId, companyName: companyName });
+        },
         setCompanyData: function (companyId = '', companyName = '') {
             console.debug({ logger: 'addressAutocomplete.setCompanyData', companyId, companyName });
-            customerData.set('companyData', { companyId, companyName });
+            this.publishCompanyData(companyId, companyName);
             $('.select2-selection__rendered').text(companyName);
             $(this.companyNameSelector).val(companyName);
             $(this.companyIdSelector).val(companyId);
+            this.syncCompanyIdEditable();
+        },
+        /**
+         * True while select2 owns the company-name input. The widget replaces
+         * the input's own value with its internal item id, so the company NAME
+         * can only be read off the input once it is a plain text field again.
+         */
+        isCompanySearchActive: function () {
+            const $field = $(this.companyNameSelector);
+            return !!($field.length && $field.data('select2'));
+        },
+        /**
+         * The company name currently in play. Prefers the published section
+         * while the picker owns the input (see isCompanySearchActive), and the
+         * input's own value once the buyer has switched to manual entry — the
+         * one state in which the buyer's typing is the only record of it.
+         */
+        currentCompanyName: function () {
+            const published = (customerData.get('companyData')() || {}).companyName || '';
+            if (this.isCompanySearchActive()) {
+                return published;
+            }
+            return $(this.companyNameSelector).val() || published;
+        },
+        /**
+         * The buyer has to supply the company number by hand exactly when a
+         * company is in play but no registry identifier came with it. Same
+         * derivation the payment tile applies to its own company-number field.
+         */
+        needsManualCompanyId: function () {
+            return !!this.currentCompanyName() && !$(this.companyIdSelector).val();
+        },
+        /**
+         * Company search owns `company_id` while it can fill it: the number
+         * arrives with the picked company, so an editable field would only let
+         * the buyer contradict the registry. Being enabled is also the state in
+         * which a `required` rule would be enforced at all — jQuery
+         * Validation's `elements()` skips `:disabled`.
+         *
+         * Deliberately NOT called from the company-number field's own change
+         * handler. The derivation reads that field's value, so re-deriving on
+         * the buyer's own input would disable the field the instant they
+         * finished typing into it.
+         */
+        syncCompanyIdEditable: function () {
+            $(this.companyIdSelector).prop('disabled', !this.needsManualCompanyId());
+        },
+        /**
+         * Make the company-number field usable: publish what the buyer types
+         * into it, and re-derive its editable state when a manually-typed
+         * company name appears.
+         *
+         * `change`, never `keyup`: the payment step fires an order intent as
+         * soon as it holds both a company name and a number, so publishing per
+         * keystroke would fire one credit-check request per character. The
+         * telephone handler above can afford `keyup` because nothing downstream
+         * of it calls out.
+         */
+        enableManualCompanyId: function () {
+            const self = this;
+            $.async(this.companyIdSelector, function (companyIdField) {
+                $(companyIdField)
+                    .off('change' + EVENT_NS)
+                    .on('change' + EVENT_NS, function () {
+                        self.publishCompanyData(
+                            $(self.companyIdSelector).val() || '',
+                            self.currentCompanyName()
+                        );
+                    });
+                // A form rendered with an address already on it (returning
+                // customer, or a reload mid-checkout) never passes through
+                // setCompanyData(), so derive once on resolve.
+                self.syncCompanyIdEditable();
+            });
+            $.async(this.companyNameSelector, function (companyNameField) {
+                // Only meaningful after "Enter details manually" has destroyed
+                // the widget: until then the input's value is select2's own
+                // item id, and picks arrive through setCompanyData(). Re-derives
+                // editability only — the manually typed NAME reaches the payment
+                // step through the quote's billing address, and publishing it
+                // from here on every keystroke would fire order intents.
+                $(companyNameField)
+                    .off('input' + EVENT_NS)
+                    .on('input' + EVENT_NS, function () {
+                        if (self.isCompanySearchActive()) return;
+                        self.syncCompanyIdEditable();
+                    });
+            });
         },
         setAddressData: function (address) {
             companySearch.applyAddress(address);

--- a/view/frontend/web/js/view/address-autocomplete.js
+++ b/view/frontend/web/js/view/address-autocomplete.js
@@ -98,19 +98,22 @@ define([
             this.syncCompanyIdEditable();
         },
         /**
-         * True while select2 owns the company-name input. The widget replaces
-         * the input's own value with its internal item id, so the company NAME
-         * can only be read off the input once it is a plain text field again.
+         * True while select2 owns the company-name input, i.e. while the buyer
+         * cannot type into it and every company that comes into play arrives
+         * through setCompanyData().
          */
         isCompanySearchActive: function () {
             const $field = $(this.companyNameSelector);
             return !!($field.length && $field.data('select2'));
         },
         /**
-         * The company name currently in play. Prefers the published section
-         * while the picker owns the input (see isCompanySearchActive), and the
-         * input's own value once the buyer has switched to manual entry — the
-         * one state in which the buyer's typing is the only record of it.
+         * The company name currently in play. While the picker owns the input,
+         * the published section is preferred: setCompanyData() writes the name
+         * to both, so the two agree and the section is the one the picker's own
+         * chrome cannot get in front of. Once the buyer has switched to manual
+         * entry the input wins — that is the one state in which their typing is
+         * the sole record of the name, because nothing publishes it per
+         * keystroke.
          */
         currentCompanyName: function () {
             const published = (customerData.get('companyData')() || {}).companyName || '';
@@ -128,24 +131,66 @@ define([
             return !!this.currentCompanyName() && !$(this.companyIdSelector).val();
         },
         /**
+         * uiRegistry name of the layout node the company-number input belongs
+         * to — the `company_id` child of the shipping-address fieldset declared
+         * in Plugin/Model/Checkout/LayoutProcessorPlugin.php. uiRegistry names
+         * are the layout's own `children` path with the `children` links
+         * dropped.
+         */
+        companyIdComponent:
+            'checkout.steps.shipping-step.shippingAddress.shipping-address-fieldset.company_id',
+        /**
+         * Set the company-number field's disabled state through the UI
+         * component, not only the DOM.
+         *
+         * The layout declares `disabled` as a component property and
+         * `ui/form/element/input` binds it inside a compound `attr: {...}`
+         * binding alongside `error`, `required` and friends. Knockout
+         * re-evaluates that whole binding when ANY observable it reads changes,
+         * so a raw `prop('disabled', …)` write survives only until the next
+         * such re-evaluation, which then reinstates the component's stale
+         * value. The component is therefore the authoritative one.
+         *
+         * The DOM write is kept as well, and deliberately: `uiRegistry.get()`
+         * yields nothing if this runs before the component registers, and the
+         * derivation below reads the field's own value off the DOM, so the two
+         * have to be written together to stay consistent within a tick.
+         */
+        setCompanyIdDisabled: function (isDisabled) {
+            const component = uiRegistry.get(this.companyIdComponent);
+            if (component && typeof component.disabled === 'function') {
+                component.disabled(isDisabled);
+            }
+            $(this.companyIdSelector).prop('disabled', isDisabled);
+        },
+        /**
          * Company search owns `company_id` while it can fill it: the number
          * arrives with the picked company, so an editable field would only let
-         * the buyer contradict the registry. Being enabled is also the state in
-         * which a `required` rule would be enforced at all — jQuery
-         * Validation's `elements()` skips `:disabled`.
+         * the buyer contradict the registry.
          *
          * Deliberately NOT called from the company-number field's own change
-         * handler. The derivation reads that field's value, so re-deriving on
-         * the buyer's own input would disable the field the instant they
-         * finished typing into it.
+         * handler, nor from the company-name one. The derivation reads the
+         * number field's value, so re-deriving after the buyer has typed into
+         * it would disable the field they are still using. Only the paths that
+         * learn a number from the registry — setCompanyData(), and the one-shot
+         * derivation on a pre-filled form — may disable.
          */
         syncCompanyIdEditable: function () {
-            $(this.companyIdSelector).prop('disabled', !this.needsManualCompanyId());
+            this.setCompanyIdDisabled(!this.needsManualCompanyId());
+        },
+        /**
+         * Enable-only half of the derivation, for events that can reveal a
+         * company with no number behind it but can never establish that a
+         * number came from the registry.
+         */
+        enableCompanyIdIfNeeded: function () {
+            if (this.needsManualCompanyId()) {
+                this.setCompanyIdDisabled(false);
+            }
         },
         /**
          * Make the company-number field usable: publish what the buyer types
-         * into it, and re-derive its editable state when a manually-typed
-         * company name appears.
+         * into it, and enable it once a manually-typed company name appears.
          *
          * `change`, never `keyup`: the payment step fires an order intent as
          * soon as it holds both a company name and a number, so publishing per
@@ -171,16 +216,19 @@ define([
             });
             $.async(this.companyNameSelector, function (companyNameField) {
                 // Only meaningful after "Enter details manually" has destroyed
-                // the widget: until then the input's value is select2's own
-                // item id, and picks arrive through setCompanyData(). Re-derives
-                // editability only — the manually typed NAME reaches the payment
-                // step through the quote's billing address, and publishing it
-                // from here on every keystroke would fire order intents.
+                // the widget: until then the buyer cannot type here at all and
+                // picks arrive through setCompanyData(). ENABLES only — the
+                // buyer may come back to edit the name after typing a number,
+                // and the full derivation reads that number, so re-deriving
+                // here would disable the field and lock them out of what they
+                // just typed. Nothing published either: the manually typed NAME
+                // reaches the payment step through the quote's billing address,
+                // and publishing per keystroke would fire order intents.
                 $(companyNameField)
                     .off('input' + EVENT_NS)
                     .on('input' + EVENT_NS, function () {
                         if (self.isCompanySearchActive()) return;
-                        self.syncCompanyIdEditable();
+                        self.enableCompanyIdIfNeeded();
                     });
             });
         },

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -433,17 +433,19 @@ define([
          * Writes the name and CLEARS any previously selected company's
          * identifier.
          *
-         * No order intent is placed here, and — stating the current behaviour
-         * plainly rather than promising a fix this change does not make — none
-         * is placed later either. An identifier-less company is never
-         * intent-checked: the buyer can type the organisation number into the
-         * re-enabled `company_id` field and the order goes out with it, but no
-         * credit check runs for it. Firing an intent on hand-typed input is
-         * its own ticket; the obvious `change`-handler version of it does not
-         * work, because the template binds `value: companyId` and ko's `value`
-         * binding is registered at applyBindings() on the SAME `change` event,
-         * so ko has already written `companyId()` by the time any later
-         * handler runs.
+         * No order intent is placed here. Whether one is placed later depends
+         * on WHICH company-number field the buyer then types into:
+         *
+         *  - the address step's field publishes what it is given to the
+         *    `companyData` customer-data section, which arrives back here as an
+         *    authoritative notification and reaches fillCompanyData() — so that
+         *    route does get intent-checked;
+         *  - this tile's own field does not. It binds `value: companyId`
+         *    directly, and ko's `value` binding is registered at
+         *    applyBindings() on the same `change` event, so ko has already
+         *    written `companyId()` before any later handler could see the edit
+         *    and fire an intent from it. Stating the current behaviour plainly
+         *    rather than promising a fix this change does not make.
          *
          * `company_id`'s editable state is NOT set here — it is derived from
          * the companyName/companyId observables (see enableCompanySearch()),
@@ -579,7 +581,9 @@ define([
                 //
                 // "A notification IS the shipping-step picker" holds only
                 // because `companyData` has exactly one writer
-                // (address-autocomplete.js's setCompanyData()) and the repo
+                // (address-autocomplete.js's publishCompanyData(), the sole
+                // call site of `customerData.set('companyData', …)`) and the
+                // repo
                 // ships no `sections.xml`, so the server never invalidates and
                 // repopulates the section either. Add a second writer, or a
                 // `sections.xml` entry, and this authoritative subscription


### PR DESCRIPTION
## TWO-25288 (1 of 2) — make the address step capable

Magento is the only one of the four checkout surfaces with **two** buyer-facing
company fields: one on the address step and one in the payment tile. The goal is
one field, on the address step. This PR is the purely-additive half — it gives
the address step the capabilities the tile's copy has. **Nothing is removed and
the payment tile behaves exactly as before.** Removing the tile's copy is the
stacked follow-up.

### Why re-plumbing rather than deletion

The organisation number that reaches the Two API has exactly **one** source and
**zero** fallbacks — the payment scope's additional data:

```php
'company' => [
    'organization_number' => $additionalData['companyId'] ?? '',
```

The company *name* on that same structure falls back to the billing address's
`getCompany()`; the number does not. Nothing under `Service/`, `Gateway/` or
`Model/` reads the address `company_id` attribute — that attribute is only
*written*, from the API's response, after the fact. So deleting the tile's inputs
without first plumbing the value would ship orders with an empty organisation
number.

### What this PR adds

**Layout** (`Plugin/Model/Checkout/LayoutProcessorPlugin.php`)

The address-step `company_id` field existed but was declared `'visible' => false`.
It now renders, and arrives `'disabled' => true`. Company search fills it from
the registry for a picked company, so an editable field would only let the buyer
contradict the registry. Label and tooltip move from "Company Id" to
"Company Number" — matching the tile's label, and a string already translated in
all three shipped i18n CSVs, so **no CSV was touched**.

**Storefront JS** (`view/frontend/web/js/view/address-autocomplete.js`)

- `needsManualCompanyId()` / `syncCompanyIdEditable()` are ports of the tile's
  derivation: editable exactly when a company is in play with no registry
  identifier behind it.
- `enableManualCompanyId()` publishes what the buyer types so it reaches the
  payment step.
- `publishCompanyData()` is now the **sole** call site of
  `customerData.set('companyData', …)`. The payment step reads a change
  notification on that section as an act of selection, and that reading is only
  sound while the section has exactly one writer, so the split is load-bearing
  rather than tidying.

Two decisions worth a reviewer's attention, both documented in code:

1. **The derivation is not re-run from the company-number field's own change
   handler.** It reads that field's value, so re-deriving on the buyer's own
   input would disable the field the instant they finished typing into it.
2. **The publish is bound to `change`, never `keyup`.** The payment step fires an
   order intent as soon as it holds both a company name and a number, so a
   per-keystroke publish would fire one credit-check request per character.

**Docs.** Two comment blocks in the payment renderer became false and were
rewritten in this PR: the one asserting that a hand-typed organisation number is
never intent-checked (now true only of the tile's own field, not of the address
step's), and the one naming the single writer of the `companyData` section.

### Sole trader — reported, not built

The brief asked for a sole-trader surface on the address step, or evidence that
it is infeasible. **It is infeasible on the address step, and it is also
unnecessary.**

Infeasible: the sole-trader flow needs a *saved* billing address to autofill the
signup popup, the buyer's email, the brand's checkout config, and a
`window.postMessage` listener owned by the payment renderer. At the address step
the address is mid-entry and the billing address is still null.

Unnecessary: the mode selector stays in the tile, and the synthetic company id it
mints is written to the tile's observables, not to its DOM inputs — so it
survives the inputs being removed. PR 2 keeps the selector and adds a read-only
echo of the resolved company, so the buyer still sees which company is being
credit-checked without a second editable *field*.

### Tests — verified by mutation

`Test/Js/address-company-id.test.js` (11 tests) and
`Test/Unit/Plugin/Model/Checkout/LayoutProcessorPluginTest.php` (4 tests).

Every behavioural claim was verified by breaking the code, confirming RED, and
restoring. Fourteen mutations, all RED: dropping the derivation call; forcing
`needsManualCompanyId()` to each constant; unwiring the publish; unwiring the
name-field re-derivation; rebinding the publish to `keyup`; making the name
always come from the published section; dropping the `initialize()` wiring;
writing the wrong section key; re-deriving from the number field's own handler;
and each of `visible`, `disabled`, the label and the dataScope on the PHP side.

Full runs, collected == executed:

```
Test Suites: 12 passed, 12 total
Tests:       157 passed, 157 total
```

```
Tests: 485, Assertions: 889, Deprecations: 2, PHPUnit Deprecations: 2.
```

(The two deprecations are pre-existing — the same counts appear with this PR's
PHP test file removed.)

### Harness caveat, per the brief

The shared AMD harness stubs `Two_Gateway/js/model/company-search` to a set of
no-ops and its default jQuery double is inert (every node reports `length: 0`),
so **no suite in this repo covers surface-to-markup binding**. The new suite
brings its own recording jQuery double, and its header states three specific
limitations: one handler per event name, no `document.querySelector` in the
sandbox (so the "Enter details manually" *click* is not driven — the method it
calls is), and the company-search stub.

### Not done here

`clearCompany()` writing the DOM only and never the observables, and the
document-wide `.select2-selection__rendered` selectors, are both real and both
belong to PR 2 — this PR removes nothing, and neither is a defect until the tile
inputs are gone.

Clearing the stored company id when the company *name* changes is TWO-25262 and
is deliberately **not** implemented here. Nothing added here clears the id on a
name change.

---
Raised by Claude.
