### PR TITLE
docs(e2e): replace cross-repo source reference with behaviour description

### DIFF
--- a/e2e/tests/_helpers.ts
+++ b/e2e/tests/_helpers.ts
@@ -2,7 +2,8 @@ import { expect, Page } from '@playwright/test';
 
 // GB skip-verification test buyer (auto-approved, no SCA) — the staging store is
 // GBP, so a GB buyer keeps the order coherent and passes the order-intent.
-// Source: two-inc/e2e-tests e2e_tests/config.py GBSettings.TEST_BUYER_COMPANY_SKIP_VERIFICATION.
+// Value mirrors the shared GB skip-verification buyer used by the internal e2e
+// suite; override with COMPANY_QUERY if that fixture changes.
 export const COMPANY_QUERY = process.env.COMPANY_QUERY || 'RESTAURANT 53 LTD';
 export const COUNTRY = process.env.COUNTRY || 'GB';
 export const PRODUCT = process.env.PRODUCT || '/default/push-it-messenger-bag.html';


### PR DESCRIPTION
## What

One comment in `e2e/tests/_helpers.ts` explained a test fixture value by pointing at an internal repository's internals. Replaced with a description of what the value is and how to override it.

## Why

This is a public repository. Comments here should describe behaviour in our own words, not reproduce another repository's internal identifiers or paths.

## Risk

Comment text only — nothing reads it, and the constant keeps its `process.env` override. No behaviour change.

Item #30.17. A companion PR does the same on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
