### PR TITLE
fix(TWO-25288): server-side guard for empty company number

### DIFF
--- a/Model/Two.php
+++ b/Model/Two.php
@@ -248,10 +248,10 @@ class Two extends AbstractMethod
     {
         $order = $payment->getOrder();
         $this->assertOrderMeetsMinimum($order);
+        $additionalInformation = $payment->getAdditionalInformation();
+        $this->assertOrganizationNumberPresent($additionalInformation);
         $this->urlCookie->delete();
         $orderReference = (string)rand();
-
-        $additionalInformation = $payment->getAdditionalInformation();
 
         $payload = $this->compositeOrder->execute(
             $order,
@@ -967,6 +967,37 @@ class Two extends AbstractMethod
             if ($orderValue + 0.0001 < $display['amount']) {
                 throw new LocalizedException($this->minimumOrderMessage($display, $order));
             }
+        }
+    }
+
+    /**
+     * Server-side floor for the buyer's company number.
+     *
+     * Until now the only thing stopping a placement with an empty company
+     * number was a client-side validator on the checkout field, so any
+     * checkout that does not render that field — or any client that skips
+     * it — reached the API with an empty value and was refused only after
+     * placement had begun. This guard declines before the order request is
+     * built, on the one path every storefront's placement runs through, so
+     * no checkout variant can diverge from another.
+     *
+     * Whitespace counts as empty: a space-only value is not a company
+     * number and would be refused downstream just the same.
+     *
+     * @param array $additionalInformation payment additional information as
+     *     submitted by the checkout
+     * @throws LocalizedException when no company number was supplied
+     */
+    private function assertOrganizationNumberPresent(array $additionalInformation): void
+    {
+        $companyId = $additionalInformation['companyId'] ?? '';
+
+        if (!is_scalar($companyId) || trim((string)$companyId) === '') {
+            $message = __(
+                'Invoice purchase with %1 requires a company number. Please add your company details and try again.',
+                $this->brandRegistry->getProductName()
+            );
+            throw new LocalizedException($message);
         }
     }
 

--- a/Model/Two.php
+++ b/Model/Two.php
@@ -982,7 +982,10 @@ class Two extends AbstractMethod
      * no checkout variant can diverge from another.
      *
      * Whitespace counts as empty: a space-only value is not a company
-     * number and would be refused downstream just the same.
+     * number, so it is refused. The trim serves that decision only — the
+     * guard normalises nothing. A padded but non-empty number clears the
+     * guard and is sent downstream exactly as the checkout submitted it,
+     * padding included.
      *
      * @param array $additionalInformation payment additional information as
      *     submitted by the checkout

--- a/Test/Unit/Model/TwoOrganizationNumberGuardTest.php
+++ b/Test/Unit/Model/TwoOrganizationNumberGuardTest.php
@@ -121,12 +121,12 @@ class TwoOrganizationNumberGuardTest extends TestCase
         $this->assertNotFalse($guardAt, 'authorize() must call the company-number guard.');
         $this->assertSame(
             1,
-            preg_match('/assertOrganizationNumberPresent\(([^)]*)\)/', $source, $call),
+            preg_match_all('/assertOrganizationNumberPresent\(([^)]*)\)/', $source, $calls),
             'authorize() must call the company-number guard exactly once, with a simple argument.'
         );
         $this->assertSame(
             '$additionalInformation',
-            $call[1],
+            $calls[1][0],
             'The guard must be handed the checkout payload authorize() composes the order'
             . ' request from, not some other value.'
         );

--- a/Test/Unit/Model/TwoOrganizationNumberGuardTest.php
+++ b/Test/Unit/Model/TwoOrganizationNumberGuardTest.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Model;
+
+use Magento\Framework\Exception\LocalizedException;
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Api\BrandRegistryInterface;
+use Two\Gateway\Model\Two;
+
+/**
+ * Server-side floor for the buyer's company number.
+ *
+ * The client-side validator on the checkout field is the good UX path, but
+ * it is not enforcement: any checkout that does not render that field, or
+ * any client that skips it, previously reached the order request with an
+ * empty company number. These tests pin the refusal that happens before
+ * the request is built.
+ */
+class TwoOrganizationNumberGuardTest extends TestCase
+{
+    private const MSGID = 'Invoice purchase with %1 requires a company number.'
+        . ' Please add your company details and try again.';
+
+    /** @var Two */
+    private $model;
+
+    protected function setUp(): void
+    {
+        $this->model = $this->getMockBuilder(Two::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([])
+            ->getMock();
+
+        $brand = $this->createMock(BrandRegistryInterface::class);
+        $brand->method('getProductName')->willReturn('Two');
+
+        $ref = new \ReflectionClass(Two::class);
+        $prop = $ref->getProperty('brandRegistry');
+        $prop->setValue($this->model, $brand);
+    }
+
+    /**
+     * @param array $additionalInformation
+     */
+    private function invokeGuard(array $additionalInformation): void
+    {
+        $method = new \ReflectionMethod(Two::class, 'assertOrganizationNumberPresent');
+        $method->invoke($this->model, $additionalInformation);
+    }
+
+    /**
+     * @return array<string, array{0: array}>
+     */
+    public static function refusingPayloadProvider(): array
+    {
+        return [
+            'key absent entirely' => [['companyName' => 'Example Trading Ltd']],
+            'empty string' => [['companyId' => '']],
+            'null' => [['companyId' => null]],
+            'single space' => [['companyId' => ' ']],
+            'tabs and newlines only' => [['companyId' => "\t\n "]],
+            'array instead of scalar' => [['companyId' => []]],
+        ];
+    }
+
+    /**
+     * @dataProvider refusingPayloadProvider
+     */
+    public function testGuardRefusesWhenCompanyNumberIsMissing(array $additionalInformation): void
+    {
+        $this->expectException(LocalizedException::class);
+        $this->invokeGuard($additionalInformation);
+    }
+
+    /**
+     * Pin the whole shipped string, not a substring of it. The harness
+     * substitutes placeholders faithfully, so the rendered message is the
+     * msgid with the brand name in place of %1 — asserting equality against
+     * that pins both the wording that goes in the translation catalogues
+     * and the fact that the brand name is passed as an argument.
+     */
+    public function testRefusalNamesTheCompanyNumberAndTheBrand(): void
+    {
+        try {
+            $this->invokeGuard(['companyId' => '']);
+            $this->fail('Expected the guard to refuse an empty company number.');
+        } catch (LocalizedException $e) {
+            $this->assertSame(str_replace('%1', 'Two', self::MSGID), $e->getMessage());
+        }
+    }
+
+    /**
+     * The guard is worthless unless authorize() actually calls it, and calls
+     * it BEFORE the order request is composed — refusing after the request
+     * has been built is the very thing this replaces. authorize() needs the
+     * full framework to execute, so pin the wiring by reading the method's
+     * own source rather than running it.
+     */
+    public function testAuthorizeInvokesTheGuardBeforeComposingTheRequest(): void
+    {
+        $method = new \ReflectionMethod(Two::class, 'authorize');
+        $source = implode('', array_slice(
+            file($method->getFileName()),
+            $method->getStartLine() - 1,
+            $method->getEndLine() - $method->getStartLine() + 1
+        ));
+
+        $guardAt = strpos($source, 'assertOrganizationNumberPresent(');
+        $composeAt = strpos($source, 'compositeOrder->execute(');
+
+        $this->assertNotFalse($guardAt, 'authorize() must call the company-number guard.');
+        $this->assertNotFalse($composeAt, 'authorize() must still compose the order request.');
+        $this->assertLessThan(
+            $composeAt,
+            $guardAt,
+            'The company-number guard must run before the order request is composed.'
+        );
+    }
+
+    /**
+     * @return array<string, array{0: mixed}>
+     */
+    public static function acceptedCompanyNumberProvider(): array
+    {
+        return [
+            'plain digits' => ['123456789'],
+            'formatted with spaces' => ['123 456 789'],
+            'country-prefixed' => ['NO123456789MVA'],
+            'leading and trailing whitespace' => ['  123456789  '],
+            'integer rather than string' => [123456789],
+        ];
+    }
+
+    /**
+     * @dataProvider acceptedCompanyNumberProvider
+     * @param mixed $companyId
+     */
+    public function testGuardAllowsAPopulatedCompanyNumber($companyId): void
+    {
+        $this->invokeGuard(['companyId' => $companyId]);
+        $this->addToAssertionCount(1);
+    }
+}

--- a/Test/Unit/Model/TwoOrganizationNumberGuardTest.php
+++ b/Test/Unit/Model/TwoOrganizationNumberGuardTest.php
@@ -100,6 +100,11 @@ class TwoOrganizationNumberGuardTest extends TestCase
      * has been built is the very thing this replaces. authorize() needs the
      * full framework to execute, so pin the wiring by reading the method's
      * own source rather than running it.
+     *
+     * Ordering alone is not enough: a call that hands the guard some other
+     * array — an empty literal, say — sits in the right place and refuses
+     * every order, so the argument is pinned too. It must be the same
+     * payload authorize() goes on to build the order request from.
      */
     public function testAuthorizeInvokesTheGuardBeforeComposingTheRequest(): void
     {
@@ -114,6 +119,17 @@ class TwoOrganizationNumberGuardTest extends TestCase
         $composeAt = strpos($source, 'compositeOrder->execute(');
 
         $this->assertNotFalse($guardAt, 'authorize() must call the company-number guard.');
+        $this->assertSame(
+            1,
+            preg_match('/assertOrganizationNumberPresent\(([^)]*)\)/', $source, $call),
+            'authorize() must call the company-number guard exactly once, with a simple argument.'
+        );
+        $this->assertSame(
+            '$additionalInformation',
+            $call[1],
+            'The guard must be handed the checkout payload authorize() composes the order'
+            . ' request from, not some other value.'
+        );
         $this->assertNotFalse($composeAt, 'authorize() must still compose the order request.');
         $this->assertLessThan(
             $composeAt,

--- a/i18n/nb_NO.csv
+++ b/i18n/nb_NO.csv
@@ -273,3 +273,4 @@
 "Invoice upload failed: %1","Fakturaopplasting mislyktes: %1"
 "⚠ deployment incomplete — code newer than compiled assets; run setup:static-content:deploy","⚠ distribusjon ufullstendig — koden er nyere enn de kompilerte ressursene; kjør setup:static-content:deploy"
 "Use Website Value","Bruk nettstedsverdi"
+"Invoice purchase with %1 requires a company number. Please add your company details and try again.","Fakturakjøp med %1 krever et organisasjonsnummer. Legg til firmaopplysningene dine og prøv igjen."

--- a/i18n/nl_NL.csv
+++ b/i18n/nl_NL.csv
@@ -269,3 +269,4 @@
 "Invoice upload failed: %1","Uploaden van factuur mislukt: %1"
 "⚠ deployment incomplete — code newer than compiled assets; run setup:static-content:deploy","⚠ implementatie onvolledig — code is nieuwer dan de gecompileerde assets; voer setup:static-content:deploy uit"
 "Use Website Value","Gebruik websitewaarde"
+"Invoice purchase with %1 requires a company number. Please add your company details and try again.","Aankoop op factuur met %1 vereist een KVK-nummer. Vul uw bedrijfsgegevens in en probeer het opnieuw."

--- a/i18n/sv_SE.csv
+++ b/i18n/sv_SE.csv
@@ -270,3 +270,4 @@
 "Invoice upload failed: %1","Fakturauppladdningen misslyckades: %1"
 "⚠ deployment incomplete — code newer than compiled assets; run setup:static-content:deploy","⚠ distributionen är ofullständig — koden är nyare än de kompilerade resurserna; kör setup:static-content:deploy"
 "Use Website Value","Använd webbplatsvärde"
+"Invoice purchase with %1 requires a company number. Please add your company details and try again.","Fakturaköp med %1 kräver ett organisationsnummer. Lägg till dina företagsuppgifter och försök igen."


### PR DESCRIPTION
## Why

Until now the only thing preventing an order with an empty company number was a
client-side validator on the checkout company field. Any storefront that does not
render that field, or any client that skips it, reached the order request with an
empty company number and was refused only by the API — after placement had already
begun.

This is the precondition for the planned removal of the company field from the
payment tile (TWO-25288). Removing that field with nothing else changed would leave
no enforcement at all.

## What

- `Model/Two.php::assertOrganizationNumberPresent()` — refuses when the submitted
  company number is absent, empty, whitespace-only or non-scalar, throwing
  `LocalizedException` so the checkout surfaces a specific buyer-facing message and
  no order is created in a broken state.
- Called from `authorize()` immediately after the existing minimum-order guard and
  **before** the order request is composed. `authorize()` is the single decision
  point every storefront's placement runs through, so no checkout variant can
  diverge from another — one guard covers all of them.
- New translation rows in `i18n/nb_NO.csv`, `i18n/nl_NL.csv`, `i18n/sv_SE.csv`.

No constructor or DI change, so no `setup:di:compile` implications.

## What the buyer sees

> Invoice purchase with {product name} requires a company number. Please add your
> company details and try again.

Rendered through the platform's normal checkout-failure mechanism (the same channel
as the existing below-minimum refusal), with `%1` resolved to the brand product name.

## Deliberately out of scope

- The client-side validator is **untouched**. It remains the good UX path; this is
  the floor beneath it.
- No payment-method withdrawal or hiding — the guard's job is to refuse cleanly.

## Tests

`Test/Unit/Model/TwoOrganizationNumberGuardTest.php`, 13 tests. Full unit suite green
(494 tests, 898 assertions).

Mutation-verified — each of these was applied to the source, confirmed RED, then
restored:

| Mutation | Result |
| --- | --- |
| Drop `trim()` so whitespace-only passes | 2 failures |
| Guard condition replaced with `false` (never throws) | 7 failures |
| Drop the non-scalar arm of the condition | 1 error |
| Remove the guard call from `authorize()` | 1 failure |
| Move the guard call to after the request is composed | 1 failure |
| Change the message wording (msgid drift) | 1 failure |
| Drop the brand argument from the message | 1 failure |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
