### PR TITLE
feat(company-search): TWO-25288 own the below-threshold search hint on the address step

### DIFF
--- a/Test/Js/amd-harness.js
+++ b/Test/Js/amd-harness.js
@@ -121,6 +121,7 @@ function defaultMocks() {
             clearResultCache: function () {},
             EVENT_NS: '.twoCompanySearch',
             MIN_INPUT_LENGTH: 3,
+            minInputLengthMessage: function () { return 'Please enter 3 or more characters'; },
             getSearchFieldContainer: function () { return null; },
             markSearchBinding: function () {},
             clearSearchChrome: function () {},

--- a/Test/Js/amd-harness.js
+++ b/Test/Js/amd-harness.js
@@ -121,7 +121,13 @@ function defaultMocks() {
             clearResultCache: function () {},
             EVENT_NS: '.twoCompanySearch',
             MIN_INPUT_LENGTH: 3,
-            minInputLengthMessage: function () { return 'Please enter 3 or more characters'; },
+            // Derived from this mock's own MIN_INPUT_LENGTH so the harness
+            // does not reintroduce the literal the real module centralises.
+            // Both production call sites invoke this as
+            // `companySearch.minInputLengthMessage()`, so `this` is the mock.
+            minInputLengthMessage: function () {
+                return 'Please enter ' + this.MIN_INPUT_LENGTH + ' or more characters';
+            },
             getSearchFieldContainer: function () { return null; },
             markSearchBinding: function () {},
             clearSearchChrome: function () {},

--- a/Test/Js/company-search-input-hints.test.js
+++ b/Test/Js/company-search-input-hints.test.js
@@ -6,13 +6,17 @@
  * (address) surface:
  *
  *  - the empty-field hint, painted through select2's `templateSelection`
- *    when the picker has nothing selected;
- *  - the below-threshold hint, which must be OUR translatable string naming
- *    a FIXED number, not select2's built-in English remaining-count text.
+ *    when the picker has nothing selected. This one PRE-DATES this change —
+ *    `templateSelection`, the placeholder property and its msgid all already
+ *    shipped. The cases below are regression pins on existing behaviour, not
+ *    coverage of anything introduced here;
+ *  - the below-threshold hint, which this change makes OUR translatable
+ *    string naming a FIXED number instead of select2's built-in English
+ *    remaining-count text.
  *
- * And the centralisation both hints depend on: neither surface may repeat a
- * literal minimum length. Each must read the shared constant, or the number
- * the hint claims and the number select2 enforces can drift apart.
+ * And the centralisation the below-threshold hint depends on: neither surface
+ * may repeat a literal minimum length. Each must read the shared constant, or
+ * the number the hint claims and the number select2 enforces can drift apart.
  *
  * Mutation-resistance notes, because this repo's AMD harness makes it easy
  * to write assertions that cannot fail:
@@ -147,8 +151,11 @@ function boundOptions(recorder) {
     return recorder.select2Options;
 }
 
-describe('empty-field hint (element 3)', () => {
-    test('shipping surface paints the placeholder when nothing is selected', () => {
+// Regression pins only — the empty-field placeholder hint already shipped
+// before this change. Kept so a later refactor of the picker options cannot
+// drop it silently.
+describe('empty-field hint (element 3) — pre-existing behaviour', () => {
+    test('regression: shipping surface still paints the placeholder when nothing is selected', () => {
         const recorder = { select2Options: null, select2Calls: 0 };
         const $ = makeJQuery(recorder);
         const companySearch = loadCompanySearchWithWrongThreshold($);
@@ -166,7 +173,7 @@ describe('empty-field hint (element 3)', () => {
         );
     });
 
-    test('the placeholder is a translatable msgid, present in every catalogue', () => {
+    test('regression: the placeholder is still a translatable msgid, present in every catalogue', () => {
         const msgid = 'Enter company name to search';
         expect(readSource('view/frontend/web/js/view/address-autocomplete.js')).toContain(
             "$t('" + msgid + "')"
@@ -215,7 +222,16 @@ describe('below-threshold hint (element 4)', () => {
     test('the vendored select2 bundle is left untouched', () => {
         const bundle = 'view/frontend/web/select2-4.1.0/js/select2.min.js';
         expect(fs.existsSync(path.resolve(__dirname, '..', '..', bundle))).toBe(true);
-        expect(readSource(bundle)).not.toContain('Please enter %1 or more characters');
+        // Asserting the ABSENCE of our placeholder form here would be
+        // vacuous: upstream never had a `%1` message, it concatenates the
+        // remaining count. So pin its own implementation verbatim instead —
+        // that fails the moment anyone edits the vendored bundle to localise
+        // the hint in place, which is the mistake this override exists to
+        // avoid.
+        expect(readSource(bundle)).toContain(
+            'inputTooShort:function(e){return"Please enter "'
+                + '+(e.minimum-e.input.length)+" or more characters"'
+        );
     });
 });
 

--- a/Test/Js/company-search-input-hints.test.js
+++ b/Test/Js/company-search-input-hints.test.js
@@ -1,0 +1,269 @@
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ *
+ * TWO-25288. Pins the two company-search input hints on the shipping-step
+ * (address) surface:
+ *
+ *  - the empty-field hint, painted through select2's `templateSelection`
+ *    when the picker has nothing selected;
+ *  - the below-threshold hint, which must be OUR translatable string naming
+ *    a FIXED number, not select2's built-in English remaining-count text.
+ *
+ * And the centralisation both hints depend on: neither surface may repeat a
+ * literal minimum length. Each must read the shared constant, or the number
+ * the hint claims and the number select2 enforces can drift apart.
+ *
+ * Mutation-resistance notes, because this repo's AMD harness makes it easy
+ * to write assertions that cannot fail:
+ *  - The shared model is injected with a DELIBERATELY WRONG threshold (7).
+ *    An assertion against 3 would pass whether the source read the constant
+ *    or repeated a literal; asserting 7 can only pass if it reads it.
+ *  - Translation is asserted on the msgid, not on a rendered label, because
+ *    the harness resolves `$t` to identity.
+ *  - Every case first asserts the surface actually bound select2. Without
+ *    that, a surface that returned early would present as green.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { loadAmdModule } = require('./amd-harness');
+
+const BASE_CONFIG = {
+    checkoutApiUrl: 'https://api.example.test',
+    companySearchLimit: 50,
+    isCompanySearchEnabled: true,
+    isAddressSearchEnabled: true
+};
+
+/** Nothing here is 3, so a surviving literal 3 cannot pass. */
+const WRONG_THRESHOLD = 7;
+
+function readSource(relPath) {
+    return fs.readFileSync(path.resolve(__dirname, '..', '..', relPath), 'utf8');
+}
+
+function makeJQuery(recorder) {
+    function $() {
+        const obj = {
+            length: 0,
+            val: function () { return arguments.length ? obj : ''; },
+            trigger: function () { return obj; },
+            prop: function () { return obj; },
+            text: function () { return obj; },
+            attr: function () { return obj; },
+            off: function () { return obj; },
+            on: function () { return obj; },
+            hide: function () { return obj; },
+            show: function () { return obj; },
+            closest: function () { return obj; },
+            append: function () { return obj; },
+            find: function () { return obj; },
+            data: function () { return obj; },
+            select2: function (opts) {
+                if (typeof opts === 'object') {
+                    recorder.select2Options = opts;
+                    recorder.select2Calls += 1;
+                }
+                return obj;
+            }
+        };
+        return obj;
+    }
+    $.async = function (selector, fn) { fn(selector); };
+    $.ajax = function () {
+        const jqxhr = {
+            done: function () { return jqxhr; },
+            fail: function () { return jqxhr; },
+            always: function () { return jqxhr; }
+        };
+        return jqxhr;
+    };
+    $.mage = { cookies: { get: function () { return null; } }, redirect: function () {} };
+    $.extend = Object.assign;
+    $.fn = {};
+    return $;
+}
+
+/**
+ * The real shared model, but loaded so its threshold is WRONG_THRESHOLD.
+ * Patching the source rather than the returned object matters: the hint
+ * helper closes over the module-local constant, so an object-level override
+ * would leave the message quoting 3 and the test would prove nothing about
+ * the two staying in step.
+ */
+function loadCompanySearchWithWrongThreshold($) {
+    const relPath = 'view/frontend/web/js/model/company-search.js';
+    const src = readSource(relPath);
+    const needle = 'const MIN_INPUT_LENGTH = 3;';
+    expect(src).toContain(needle);
+    const patched = src.replace(needle, 'const MIN_INPUT_LENGTH = ' + WRONG_THRESHOLD + ';');
+
+    const tmp = path.join(__dirname, '__tmp_company_search_threshold.js');
+    fs.writeFileSync(tmp, patched, 'utf8');
+    try {
+        return loadAmdModule(path.relative(path.resolve(__dirname, '..', '..'), tmp), {
+            jquery: $
+        });
+    } finally {
+        fs.unlinkSync(tmp);
+    }
+}
+
+function loadShippingSurface($, companySearch) {
+    const brandConfig = function () { return BASE_CONFIG; };
+    brandConfig.getActiveTwoBrandCode = function () { return 'two_payment'; };
+    brandConfig.getActiveTwoBrandConfig = function () { return BASE_CONFIG; };
+
+    const component = loadAmdModule('view/frontend/web/js/view/address-autocomplete.js', {
+        jquery: $,
+        'Two_Gateway/js/model/brand-config': brandConfig,
+        'Two_Gateway/js/model/company-search': companySearch
+    });
+
+    const ctx = Object.assign(Object.create(component.prototype || {}), {
+        countrySelector: '#shipping-new-address-form select[name="country_id"]',
+        companyNameSelector: '#shipping-new-address-form input[name="company"]',
+        enterDetailsManuallyButton: '#shipping_enter_details_manually',
+        searchForCompanyButton: '#shipping_search_for_company',
+        enterDetailsManuallyText: 'Enter details manually',
+        searchForCompanyText: 'Search for company',
+        companyNamePlaceholder: component.companyNamePlaceholder,
+        setCompanyData: function () {},
+        addressLookup: component.addressLookup,
+        enableCompanySearch: component.enableCompanySearch
+    });
+    ctx.enableCompanySearch();
+    return { component: component, ctx: ctx };
+}
+
+function boundOptions(recorder) {
+    // Bootstrapped guard: if the surface returned before binding select2,
+    // every assertion below would be vacuous.
+    expect(recorder.select2Calls).toBeGreaterThan(0);
+    expect(recorder.select2Options).toBeTruthy();
+    return recorder.select2Options;
+}
+
+describe('empty-field hint (element 3)', () => {
+    test('shipping surface paints the placeholder when nothing is selected', () => {
+        const recorder = { select2Options: null, select2Calls: 0 };
+        const $ = makeJQuery(recorder);
+        const companySearch = loadCompanySearchWithWrongThreshold($);
+        const { component } = loadShippingSurface($, companySearch);
+
+        expect(component.companyNamePlaceholder).toBe('Enter company name to search');
+
+        const opts = boundOptions(recorder);
+        expect(typeof opts.templateSelection).toBe('function');
+        // No selection yet -> the placeholder, not an empty rendered box.
+        expect(opts.templateSelection({})).toBe('Enter company name to search');
+        // A real selection must win over it.
+        expect(opts.templateSelection({ text: 'Example Trading Ltd' })).toBe(
+            'Example Trading Ltd'
+        );
+    });
+
+    test('the placeholder is a translatable msgid, present in every catalogue', () => {
+        const msgid = 'Enter company name to search';
+        expect(readSource('view/frontend/web/js/view/address-autocomplete.js')).toContain(
+            "$t('" + msgid + "')"
+        );
+        ['nb_NO', 'nl_NL', 'sv_SE'].forEach((locale) => {
+            expect(readSource('i18n/' + locale + '.csv')).toContain('"' + msgid + '",');
+        });
+    });
+});
+
+describe('below-threshold hint (element 4)', () => {
+    test('shipping surface overrides select2 with our fixed-number message', () => {
+        const recorder = { select2Options: null, select2Calls: 0 };
+        const $ = makeJQuery(recorder);
+        const companySearch = loadCompanySearchWithWrongThreshold($);
+        loadShippingSurface($, companySearch);
+
+        const opts = boundOptions(recorder);
+        expect(opts.language).toBeTruthy();
+        expect(typeof opts.language.inputTooShort).toBe('function');
+
+        // select2 hands its own args in; ours must ignore them and quote the
+        // configured threshold, not the remaining count.
+        const message = opts.language.inputTooShort({ minimum: 3, input: 'a' });
+        expect(message).toBe('Please enter ' + WRONG_THRESHOLD + ' or more characters');
+        expect(message).not.toContain('%1');
+    });
+
+    test('the hint msgid is placeholder-form and translated in every catalogue', () => {
+        const msgid = 'Please enter %1 or more characters';
+        const model = readSource('view/frontend/web/js/model/company-search.js');
+        expect(model).toContain("$t('" + msgid + "')");
+        // The literal-number form must be gone, or translators keep a row
+        // that no longer matches any msgid the code emits.
+        expect(model).not.toContain("$t('Please enter 3 or more characters')");
+
+        ['nb_NO', 'nl_NL', 'sv_SE'].forEach((locale) => {
+            const csv = readSource('i18n/' + locale + '.csv');
+            expect(csv).toContain('"' + msgid + '","');
+            expect(csv).not.toContain('"Please enter 3 or more characters"');
+            // Magento drops rows whose translation equals the msgid.
+            expect(csv).not.toContain('"' + msgid + '","' + msgid + '"');
+        });
+    });
+
+    test('the vendored select2 bundle is left untouched', () => {
+        const bundle = 'view/frontend/web/select2-4.1.0/js/select2.min.js';
+        expect(fs.existsSync(path.resolve(__dirname, '..', '..', bundle))).toBe(true);
+        expect(readSource(bundle)).not.toContain('Please enter %1 or more characters');
+    });
+});
+
+describe('threshold centralisation', () => {
+    test('the shipping surface enforces the shared constant, not a literal', () => {
+        const recorder = { select2Options: null, select2Calls: 0 };
+        const $ = makeJQuery(recorder);
+        const companySearch = loadCompanySearchWithWrongThreshold($);
+        expect(companySearch.MIN_INPUT_LENGTH).toBe(WRONG_THRESHOLD);
+        loadShippingSurface($, companySearch);
+
+        expect(boundOptions(recorder).minimumInputLength).toBe(WRONG_THRESHOLD);
+    });
+
+    test('the payment surface enforces the shared constant, not a literal', () => {
+        const recorder = { select2Options: null, select2Calls: 0 };
+        const $ = makeJQuery(recorder);
+        const companySearch = loadCompanySearchWithWrongThreshold($);
+
+        const component = loadAmdModule(
+            'view/frontend/web/js/view/payment/method-renderer/gateway_method.js',
+            { jquery: $, 'Two_Gateway/js/model/company-search': companySearch }
+        );
+        const ctx = Object.assign(Object.create(component.prototype || {}), {
+            companyNameSelector: 'input#company_name',
+            enterDetailsManuallyButton: '#billing_enter_details_manually',
+            searchForCompanyButton: '#billing_search_for_company',
+            enterDetailsManuallyText: 'Enter details manually',
+            searchForCompanyText: 'Search for company',
+            _brandConfig: BASE_CONFIG,
+            countryCode: function () { return 'gb'; },
+            companyName: Object.assign(function () { return ''; }, {
+                subscribe: function () { return { dispose: function () {} }; }
+            }),
+            fillCompanyData: function () {},
+            addressLookup: component.addressLookup,
+            enableCompanySearch: component.enableCompanySearch
+        });
+        ctx.enableCompanySearch();
+
+        expect(boundOptions(recorder).minimumInputLength).toBe(WRONG_THRESHOLD);
+    });
+
+    test('the hint and the enforced threshold come from one source', () => {
+        const $ = makeJQuery({ select2Options: null, select2Calls: 0 });
+        const companySearch = loadCompanySearchWithWrongThreshold($);
+        expect(companySearch.minInputLengthMessage()).toContain(
+            String(companySearch.MIN_INPUT_LENGTH)
+        );
+    });
+});

--- a/i18n/nb_NO.csv
+++ b/i18n/nb_NO.csv
@@ -112,7 +112,7 @@
 "Zip/Postal Code","Postnummer"
 "Invoice email address","E-postadresse for faktura"
 "Please ensure that your invoice email address list only contains valid email addresses separated by commas.","Sørg for at listen over e-postadresser for faktura bare inneholder gyldige e-postadresser atskilt med komma."
-"Please enter 3 or more characters","Vennligst skriv inn 3 eller flere tegn"
+"Please enter %1 or more characters","Vennligst skriv inn %1 eller flere tegn"
 "Show Invoice email field","Vis feltet for faktura-e-post"
 "Payment Terms Type","Betalingsvilkårstype"
 "Payment Terms Duration","Betalingsvilkårs varighet"

--- a/i18n/nl_NL.csv
+++ b/i18n/nl_NL.csv
@@ -113,7 +113,7 @@
 "Zip/Postal Code","Postcode"
 "Invoice email address","E-mailadres factuur"
 "Please ensure that your invoice email address list only contains valid email addresses separated by commas.","Zorg ervoor dat uw factuur-e-mailadreslijst alleen geldige e-mailadressen bevat, gescheiden door komma's."
-"Please enter 3 or more characters","Voer 3 of meer tekens in"
+"Please enter %1 or more characters","Voer %1 of meer tekens in"
 "Show Invoice email field","Factuur-e-mailveld weergeven"
 "Payment Terms Type","Type betaaltermijnen"
 "Payment Terms Duration","Duur betaaltermijnen"

--- a/i18n/sv_SE.csv
+++ b/i18n/sv_SE.csv
@@ -112,7 +112,7 @@
 "Zip/Postal Code","Postnummer"
 "Invoice email address","E-postadress för faktura"
 "Please ensure that your invoice email address list only contains valid email addresses separated by commas.","Se till att din e-postadresslista för faktura endast innehåller giltiga e-postadresser separerade med kommatecken."
-"Please enter 3 or more characters","Ange 3 eller fler tecken"
+"Please enter %1 or more characters","Ange %1 eller fler tecken"
 "Show Invoice email field","Visa fältet för fakturamejl"
 "Payment Terms Type","Betalningsvillkorstyp"
 "Payment Terms Duration","Betalningsvillkors varaktighet"

--- a/view/frontend/web/js/model/company-search.js
+++ b/view/frontend/web/js/model/company-search.js
@@ -89,10 +89,15 @@ define(['jquery', 'mage/translate'], function ($, $t) {
      * select2 ships its own English `inputTooShort` message, hard-coded
      * inside the vendored bundle and phrased as the REMAINING character
      * count. Neither is acceptable: the vendored bundle is not ours to edit
-     * and its literals never reach Magento's translation dictionaries. Call
-     * sites override it via select2's `language.inputTooShort` option with
-     * this instead — a plugin-owned, translatable string quoting a FIXED
-     * threshold.
+     * and its literals never reach Magento's translation dictionaries. The
+     * address-step picker overrides it via select2's `language.inputTooShort`
+     * option with this instead — a plugin-owned, translatable string quoting
+     * a FIXED threshold.
+     *
+     * The payment-step picker does NOT. It passes `minimumInputLength` only,
+     * so it still renders select2's built-in English remaining-count text.
+     * That is deliberately out of scope here; this change covers the
+     * address-step surface only.
      *
      * Resolved per call, not once at module load, because Magento's JS
      * dictionary can arrive after this module is defined. Magento's `$t`
@@ -489,10 +494,10 @@ define(['jquery', 'mage/translate'], function ($, $t) {
             // Below `minimumInputLength` select2's decorator returns after
             // firing `results:message` WITHOUT delegating to the ajax adapter,
             // and `_request.abort()` lives inside that adapter. So dropping
-            // from three characters to two neither runs a new transport nor
-            // cancels the running one: nothing clears the spinner, and 30s
-            // later the abandoned request repaints results or the
-            // "unavailable" notice under "Please enter 3 or more characters".
+            // from MIN_INPUT_LENGTH characters to one below it neither runs a
+            // new transport nor cancels the running one: nothing clears the
+            // spinner, and 30s later the abandoned request repaints results
+            // or the "unavailable" notice under the below-threshold hint.
             // Cancel it ourselves, then clear the chrome.
             instance.$dropdown
                 .find('.select2-search__field')
@@ -508,7 +513,7 @@ define(['jquery', 'mage/translate'], function ($, $t) {
                     // either. Backspacing from 4 characters to 2 inside 300ms
                     // (trivial on key-repeat) would otherwise fire a fresh
                     // search for the abandoned term, bringing the spinner back
-                    // up under "Please enter 3 or more characters".
+                    // up under the below-threshold hint.
                     const instance = $field.data('select2');
                     const dataAdapter = instance && instance.dataAdapter;
                     if (dataAdapter && dataAdapter._queryTimeout) {
@@ -528,7 +533,7 @@ define(['jquery', 'mage/translate'], function ($, $t) {
          * children appended into `.select2-search--dropdown`. Without this,
          * a buyer who hits a failed search, closes the picker and reopens it
          * sees the stale "unavailable" notice above an empty search box —
-         * and it survives until three or more characters are retyped.
+         * and it survives until MIN_INPUT_LENGTH characters are retyped.
          *
          * @param {object} $field jQuery-wrapped picker input
          * @param {object} token identity stamped by markSearchBinding()

--- a/view/frontend/web/js/model/company-search.js
+++ b/view/frontend/web/js/model/company-search.js
@@ -73,12 +73,36 @@ define(['jquery', 'mage/translate'], function ($, $t) {
     const activeRequests = new WeakMap();
 
     /**
-     * Mirrors the `minimumInputLength: 3` both call sites pass to select2.
+     * The `minimumInputLength` both call sites pass to select2 — they read
+     * this constant rather than repeating a literal, so the enforced
+     * threshold and the hint below can never drift apart.
+     *
      * Below it select2's decorator short-circuits `query()` and never reaches
      * the data adapter, so no transport runs — which the chrome has to know
      * about, or nothing ever takes the spinner down.
      */
     const MIN_INPUT_LENGTH = 3;
+
+    /**
+     * The "keep typing" hint shown while the term is below MIN_INPUT_LENGTH.
+     *
+     * select2 ships its own English `inputTooShort` message, hard-coded
+     * inside the vendored bundle and phrased as the REMAINING character
+     * count. Neither is acceptable: the vendored bundle is not ours to edit
+     * and its literals never reach Magento's translation dictionaries. Call
+     * sites override it via select2's `language.inputTooShort` option with
+     * this instead — a plugin-owned, translatable string quoting a FIXED
+     * threshold.
+     *
+     * Resolved per call, not once at module load, because Magento's JS
+     * dictionary can arrive after this module is defined. Magento's `$t`
+     * does not interpolate, hence the explicit replace.
+     *
+     * @returns {string} translated hint naming MIN_INPUT_LENGTH
+     */
+    function minInputLengthMessage() {
+        return $t('Please enter %1 or more characters').replace('%1', MIN_INPUT_LENGTH);
+    }
 
     /** jQuery event namespace for everything this module binds. */
     const EVENT_NS = '.twoCompanySearch';
@@ -123,6 +147,7 @@ define(['jquery', 'mage/translate'], function ($, $t) {
         MIN_INPUT_LENGTH: MIN_INPUT_LENGTH,
         EVENT_NS: EVENT_NS,
         isDegradedResponse: isDegradedResponse,
+        minInputLengthMessage: minInputLengthMessage,
 
         /**
          * Cancel the in-flight search for a bind, if any.

--- a/view/frontend/web/js/view/address-autocomplete.js
+++ b/view/frontend/web/js/view/address-autocomplete.js
@@ -106,7 +106,17 @@ define([
                     $companyNameField.off(companySearch.EVENT_NS);
                     $companyNameField
                         .select2({
-                            minimumInputLength: 3,
+                            minimumInputLength: companySearch.MIN_INPUT_LENGTH,
+                            // Displaces select2's own built-in English
+                            // "input too short" text, which is baked into the
+                            // vendored bundle and counts down the REMAINING
+                            // characters. Ours is translatable and names the
+                            // threshold outright.
+                            language: {
+                                inputTooShort: function () {
+                                    return companySearch.minInputLengthMessage();
+                                }
+                            },
                             width: '100%',
                             escapeMarkup: function (markup) {
                                 return markup;

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -1102,7 +1102,7 @@ define([
                     $companyNameField.off(companySearch.EVENT_NS);
                     $companyNameField
                         .select2({
-                            minimumInputLength: 3,
+                            minimumInputLength: companySearch.MIN_INPUT_LENGTH,
                             width: '100%',
                             escapeMarkup: function (markup) {
                                 return markup;


### PR DESCRIPTION
## TWO-25288 — company-search input hints (address step)

Elements 3 and 4 of the ticket, shipping/address surface only.

### Element 3 — empty-field hint (verified, no change needed)
`Enter company name to search` was already implemented on the address step: a
translatable `$t()` string used both as the `templateSelection` fallback when
nothing is selected and painted directly into the rendered box on first render.
Verified against the current base; left as-is. It is now pinned by tests, which
it previously was not.

### Element 4 — below-threshold hint (new)
The address picker fell through to select2's own built-in "input too short"
message. That message lives inside the vendored select2 bundle, so it is
hard-coded English that no translation dictionary can reach, and it is phrased
as a countdown of the characters still needed rather than naming the threshold.

Now overridden through select2's `language.inputTooShort` option with a
plugin-owned, translatable string that quotes a fixed number. **The vendored
bundle is not modified.**

### Threshold centralisation
The minimum-length constant already existed and was already exported from the
shared company-search model; the defect was that both pickers passed their own
literal to `minimumInputLength`. Both now read the shared constant, and the
hint text interpolates that same constant — so the number the hint claims and
the number select2 enforces cannot drift apart.

### Translations
The three catalogues already carried a row for the literal-number wording.
Because the message id becomes the placeholder form, each of those rows is
replaced in place with the `%1` form, source and translation both. Row count
and position are unchanged — one line per file — and no identity rows were
added (Magento drops those).

### Tests
`npm run test:js` — 14 suites, 160 tests, green. New suite
`Test/Js/company-search-input-hints.test.js`.

Every assertion was mutation-verified after committing; each of these made the
suite red, and the tree was restored from git in between:

1. address picker's `minimumInputLength` back to a literal
2. payment picker's `minimumInputLength` back to a literal
3. `language.inputTooShort` override removed entirely
4. hint text hard-codes the number instead of interpolating the constant
5. one catalogue row reverted to the literal-number message id
6. `templateSelection` drops its empty-field fallback (element 3)
7. the address surface returns before binding select2 — the bootstrapped
   guard, which caught 8 tests including this suite's

The suite deliberately injects a *wrong* threshold into the shared model, so an
assertion against the real number cannot pass by coincidence, and asserts on
message ids rather than rendered labels because the test harness resolves
translation calls to identity.

### Not in scope
No change to any company-number / organisation-id field, and no change to the
payment tile's company field beyond the one `minimumInputLength` literal — that
surface is tracked separately.

No version files bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
