### PR TITLE
refactor(TWO-25288): remove the hand-typed company number from the payment tile

### DIFF
--- a/Test/Js/company-search-address-lookup.test.js
+++ b/Test/Js/company-search-address-lookup.test.js
@@ -234,15 +234,12 @@ describe('payment-step company picker (gateway_method.js)', () => {
     function makeRendererContext(component, config, filled) {
         return Object.assign(Object.create(component.prototype || {}), {
             companyNameSelector: 'input#company_name',
-            companyIdSelector: 'input#company_id',
             enterDetailsManuallyButton: '#billing_enter_details_manually',
             searchForCompanyButton: '#billing_search_for_company',
             enterDetailsManuallyText: 'Enter details manually',
             searchForCompanyText: 'Search for company',
             _brandConfig: config,
             countryCode: function () { return 'gb'; },
-            // Carries `subscribe` because enableCompanySearch() derives
-            // company_id's editable state from this observable.
             companyName: Object.assign(function () { return ''; }, {
                 subscribe: function () { return { dispose: function () {} }; }
             }),

--- a/Test/Js/company-search-resilience.test.js
+++ b/Test/Js/company-search-resilience.test.js
@@ -1092,7 +1092,6 @@ describe('re-render safety of the select2 binding', () => {
         );
         return Object.assign(Object.create(component.prototype || {}), {
             companyNameSelector: SEARCH_FIELD,
-            companyIdSelector: 'input#company_id',
             enterDetailsManuallyButton: '#billing_enter_details_manually',
             searchForCompanyButton: '#billing_search_for_company',
             enterDetailsManuallyText: 'Enter details manually',
@@ -1307,7 +1306,6 @@ describe('re-render safety of the select2 binding', () => {
         return Object.assign(Object.create(component.prototype || {}), {
             countrySelector: '#shipping-new-address-form select[name="country_id"]',
             companyNameSelector: SEARCH_FIELD,
-            companyIdSelector: 'input#company_id',
             enterDetailsManuallyButton: '#shipping_enter_details_manually',
             searchForCompanyButton: '#shipping_search_for_company',
             enterDetailsManuallyText: 'Enter details manually',

--- a/Test/Js/company-search-resilience.test.js
+++ b/Test/Js/company-search-resilience.test.js
@@ -1100,8 +1100,10 @@ describe('re-render safety of the select2 binding', () => {
             countryCode: function () {
                 return 'gb';
             },
-            // Carries `subscribe` because enableCompanySearch() derives
-            // company_id's editable state from this observable.
+            // Defensive `subscribe` stub. Nothing on this path subscribes to
+            // the observable any more — the company-number editable-state
+            // derivation that used to (TWO-25288) is gone — but the stub is
+            // cheap and keeps the fixture usable if a subscriber returns.
             companyName: Object.assign(
                 function () {
                     return '';

--- a/Test/Js/company-search-spinner-surfaces.test.js
+++ b/Test/Js/company-search-spinner-surfaces.test.js
@@ -209,7 +209,6 @@ test('PAYMENT surface: searching state reaches visible spinner markup', () => {
 
     const ctx = Object.assign(Object.create(component.prototype || {}), {
         companyNameSelector: 'input#company_name',
-        companyIdSelector: 'input#company_id',
         enterDetailsManuallyButton: '#billing_enter_details_manually',
         searchForCompanyButton: '#billing_search_for_company',
         enterDetailsManuallyText: 'Enter details manually',

--- a/Test/Js/gateway-method-company-selection.test.js
+++ b/Test/Js/gateway-method-company-selection.test.js
@@ -415,9 +415,13 @@ describe('a company picked on the shipping step reaches the payment step', () =>
     });
 
     test('an address notification carrying company_id reaches the observable', () => {
-        // updateAddress()'s custom-attribute parsing is the address step's route
-        // into `companyId()`, and it is one of the three accepted sources. Its
-        // only coverage used to live in a describe block about the editable
+        // updateAddress()'s custom-attribute parsing is one of the writer paths
+        // enumerated on applyCompanyData() — and the one most easily conflated
+        // with the `companyData` customer-data notification, which is a
+        // different route. This one fires from the quote subscriptions with no
+        // address-step interaction at all.
+        //
+        // Its only coverage used to live in a describe block about the editable
         // state of the tile's company-number field; that field is gone, but THIS
         // subject is not, so the assertion is restored here on its own terms.
         //

--- a/Test/Js/gateway-method-company-selection.test.js
+++ b/Test/Js/gateway-method-company-selection.test.js
@@ -215,7 +215,10 @@ describe('picking a company with no national identifier', () => {
                 data: { id: 'Second Example Ltd', text: 'Second Example Ltd', companyId: '' }
             }
         });
-        expect(renderer.companyId()).toBe('');
+        // Asserting the NAME moved, not that the id is '' — the id is the
+        // observable's initial value at this point, so an `toBe('')` here would
+        // restate the default and could not fail.
+        expect(renderer.companyName()).toBe('Second Example Ltd');
 
         select({
             params: {
@@ -312,6 +315,7 @@ describe('a company picked on the shipping step reaches the payment step', () =>
         const dom = makeDom();
         const sections = { companyData: observable(initialCompanyData) };
         const address = { getCacheKey: () => 'k', countryId: 'GB' };
+        const billingAddress = observable(address);
         const renderer = loadAmdModule(RENDERER, {
             jquery: dom.$,
             'Magento_Customer/js/customer-data': {
@@ -327,7 +331,7 @@ describe('a company picked on the shipping step reaches the payment step', () =>
             },
             'Magento_Checkout/js/model/quote': {
                 shippingAddress: observable(address),
-                billingAddress: observable(address),
+                billingAddress: billingAddress,
                 getTotals: () => observable({}),
                 getQuoteId: () => null,
                 paymentMethod: observable(null),
@@ -339,7 +343,12 @@ describe('a company picked on the shipping step reaches the payment step', () =>
         // double doesn't run. Pre-seeded for 'gb' so the supported-company-types
         // lookup resolves from the memo instead of reaching for fetch().
         renderer.supportedCompanyTypes = { gb: [] };
-        return { renderer: renderer, sections: sections, dom: dom };
+        return {
+            renderer: renderer,
+            sections: sections,
+            dom: dom,
+            billingAddress: billingAddress
+        };
     }
 
     test('the companyData subscription clears the previous company id', () => {
@@ -371,11 +380,13 @@ describe('a company picked on the shipping step reaches the payment step', () =>
             companyId: ''
         });
 
-        renderer.enableCompanySearch();
         renderer.fillCustomerData();
 
+        // Only the name assertion can fail here: `companyId` is still at its
+        // declared '' at this point, so asserting that would restate the
+        // default. The `enableCompanySearch()` call that used to precede this
+        // was setup for a disabled-field precondition that no longer exists.
         expect(renderer.companyName()).toBe('Second Example Ltd');
-        expect(renderer.companyId()).toBe('');
     });
 
     test('a stale name-only section read does not clobber a live pick', () => {
@@ -401,6 +412,30 @@ describe('a company picked on the shipping step reaches the payment step', () =>
 
         expect(renderer.companyName()).toBe('Live Example Ltd');
         expect(renderer.companyId()).toBe('99999999');
+    });
+
+    test('an address notification carrying company_id reaches the observable', () => {
+        // updateAddress()'s custom-attribute parsing is the address step's route
+        // into `companyId()`, and it is one of the three accepted sources. Its
+        // only coverage used to live in a describe block about the editable
+        // state of the tile's company-number field; that field is gone, but THIS
+        // subject is not, so the assertion is restored here on its own terms.
+        //
+        // Without it, `if (item.attribute_code == 'company_id')` in
+        // updateAddress() had no test anywhere in the repo.
+        const { renderer, billingAddress } = loadWithSections({});
+
+        renderer.fillCustomerData();
+
+        billingAddress({
+            getCacheKey: () => 'k2',
+            countryId: 'GB',
+            company: 'First Example Ltd',
+            customAttributes: [{ attribute_code: 'company_id', value: '12345678' }]
+        });
+
+        expect(renderer.companyName()).toBe('First Example Ltd');
+        expect(renderer.companyId()).toBe('12345678');
     });
 });
 
@@ -449,26 +484,6 @@ describe('order intent for a company with no registry identifier', () => {
         expect(intent).not.toHaveBeenCalled();
     });
 
-    test('an identifier written straight to the observable places no intent', () => {
-        // After TWO-25288 the tile has no company-number input, so there is no
-        // hand-typed route into `companyId()` on this surface at all. What
-        // remains pinned here is that a bare observable write — the shape any
-        // future writer would take — does not re-fire the intent. An order left
-        // without an identifier is refused by Model/Two.php::authorize().
-        const { renderer, node, intent } = loadWithIntent();
-
-        renderer.enableCompanySearch();
-        node(COMPANY_NAME_FIELD).handlers['select2:select']({
-            params: {
-                data: { id: 'Second Example Ltd', text: 'Second Example Ltd', companyId: '' }
-            }
-        });
-        expect(intent).not.toHaveBeenCalled();
-
-        renderer.companyId('99999999');
-
-        expect(intent).not.toHaveBeenCalled();
-    });
 });
 
 describe('the shipping-step picker agrees with the payment step', () => {

--- a/Test/Js/gateway-method-company-selection.test.js
+++ b/Test/Js/gateway-method-company-selection.test.js
@@ -15,11 +15,13 @@
  * sent company A's number under company B's name. A selection has to be
  * authoritative.
  *
- * Second half of the fix: `company_id` is disabled while company search owns
- * it, and jQuery Validation's `elements()` skips `:disabled`, so the
- * template's `required="true"` is NOT enforced on a disabled field. An
- * identifier-less pick therefore has to RE-ENABLE the field, or the buyer has
- * neither a way to supply the number nor a validation error telling them to.
+ * The editability half of that fix is GONE, and so are the tests for it:
+ * TWO-25288 removed the tile's company-number input outright, because a
+ * hand-typed organisation number is not an accepted source. There is no field
+ * to enable or disable on this surface any more, and an identifier-less
+ * selection is refused server-side by Model/Two.php::authorize(). What is
+ * pinned below is the observable state a selection leaves behind — see
+ * tile-company-number-removed.test.js for the removal itself.
  *
  * LIMITATION OF THE jQuery DOUBLE BELOW — read before trusting a passing test
  * here. `node.on()` stores ONE handler per event name and `node.off()` is a
@@ -27,15 +29,16 @@
  * unmodellable and the LAST bind silently wins. Nothing in this file can
  * therefore say anything about handler ORDERING or handler COEXISTENCE.
  *
- * That is not academic: it is exactly how a `change` handler on `input#company_id`
- * got here looking correct. In the browser the template binds `value: companyId`,
- * so ko's `value` binding is already listening on that same `change` event and
- * was registered first (at applyBindings, before `$.async` runs) — ko writes
- * `companyId()` before any later handler sees the event, which made the later
- * handler's "did the value change?" check trivially false. The double could not
- * express the ko handler at all, so the test passed against a no-op. If a
- * question depends on more than one listener for an event, make the double
- * faithful (a real handler list plus a working `off()`) first.
+ * That is not academic: it is exactly how a `change` handler on the tile's
+ * former company-number input got here looking correct. The template bound
+ * `value: companyId`, so ko's `value` binding was already listening on that
+ * same `change` event and was registered first (at applyBindings, before
+ * `$.async` runs) — ko wrote `companyId()` before any later handler saw the
+ * event, which made the later handler's "did the value change?" check trivially
+ * false. The double could not express the ko handler at all, so the test passed
+ * against a no-op. If a question depends on more than one listener for an
+ * event, make the double faithful (a real handler list plus a working `off()`)
+ * first.
  */
 
 'use strict';
@@ -168,7 +171,6 @@ function loadRenderer() {
     return { renderer: renderer, node: dom.node, $: dom.$ };
 }
 
-const COMPANY_ID_FIELD = 'input#company_id';
 /**
  * What the two selection paths pass. Only a selection may clear a company that
  * is already selected; the one-shot `companyData` section read on init may not
@@ -187,7 +189,6 @@ describe('picking a company with no national identifier', () => {
         );
         expect(renderer.companyName()).toBe('First Example Ltd');
         expect(renderer.companyId()).toBe('12345678');
-        expect(node(COMPANY_ID_FIELD).val()).toBe('12345678');
 
         renderer.applyCompanyData(
             { companyName: 'Second Example Ltd', companyId: '' },
@@ -197,33 +198,13 @@ describe('picking a company with no national identifier', () => {
         // The name moved, so the id MUST have moved with it.
         expect(renderer.companyName()).toBe('Second Example Ltd');
         expect(renderer.companyId()).toBe('');
-        expect(node(COMPANY_ID_FIELD).val()).toBe('');
         expect(node(COMPANY_NAME_FIELD).val()).toBe('Second Example Ltd');
     });
 
-    test('applyCompanyData re-enables company_id so the buyer can supply it', () => {
-        const { renderer, node } = loadRenderer();
-
-        // Company search owns the field until then. This assertion is a
-        // precondition, not the property under test — enableCompanySearch()
-        // disables the field itself, so it holds trivially here.
-        renderer.enableCompanySearch();
-        expect(node(COMPANY_ID_FIELD).prop('disabled')).toBe(true);
-
-        renderer.applyCompanyData(
-            { companyName: 'Second Example Ltd', companyId: '' },
-            AS_SELECTION
-        );
-
-        expect(node(COMPANY_ID_FIELD).prop('disabled')).toBe(false);
-    });
-
-    test('a normal pick after an identifier-less one re-disables company_id', () => {
-        // Driven through the real select2:select handler, with NO hand-call of
-        // syncCompanyIdEditable() — production has no such call on this path,
-        // and a test that made one asserted a property the code did not have.
-        // The state being ruled out is a registry organisation number sitting
-        // in an ENABLED field, which the buyer could overwrite by hand.
+    test('a normal pick after an identifier-less one restores the identifier', () => {
+        // Driven through the real select2:select handler. Editability is no
+        // longer part of this: TWO-25288 removed the tile's company-number
+        // input, so the only thing a pick can get wrong is the observable.
         const { renderer, node } = loadRenderer();
 
         renderer.enableCompanySearch();
@@ -234,7 +215,7 @@ describe('picking a company with no national identifier', () => {
                 data: { id: 'Second Example Ltd', text: 'Second Example Ltd', companyId: '' }
             }
         });
-        expect(node(COMPANY_ID_FIELD).prop('disabled')).toBe(false);
+        expect(renderer.companyId()).toBe('');
 
         select({
             params: {
@@ -243,27 +224,6 @@ describe('picking a company with no national identifier', () => {
         });
 
         expect(renderer.companyId()).toBe('12345678');
-        expect(node(COMPANY_ID_FIELD).prop('disabled')).toBe(true);
-    });
-
-    test('a later enableCompanySearch does not re-disable the field', () => {
-        // In the browser the `require()` wrapper puts enableCompanySearch()'s
-        // field handling after the synchronous fillCustomerData() that follows
-        // it in registeredOrganisationMode(). The harness's require() and
-        // $.async doubles are both SYNCHRONOUS, so this test does not model
-        // that ordering — what it pins is narrower and still worth pinning:
-        // enableCompanySearch() derives the disabled state from the selected
-        // company instead of hard-coding `true`, so a revert to the literal
-        // fails here.
-        const { renderer, node } = loadRenderer();
-
-        renderer.applyCompanyData(
-            { companyName: 'Second Example Ltd', companyId: '' },
-            AS_SELECTION
-        );
-        renderer.enableCompanySearch();
-
-        expect(node(COMPANY_ID_FIELD).prop('disabled')).toBe(false);
     });
 
     test('the real select2:select handler routes an empty companyId authoritatively', () => {
@@ -290,8 +250,6 @@ describe('picking a company with no national identifier', () => {
 
         expect(renderer.companyName()).toBe('Second Example Ltd');
         expect(renderer.companyId()).toBe('');
-        expect(node(COMPANY_ID_FIELD).val()).toBe('');
-        expect(node(COMPANY_ID_FIELD).prop('disabled')).toBe(false);
     });
 
     test('a non-string companyId is kept, not treated as identifier-less', () => {
@@ -304,8 +262,6 @@ describe('picking a company with no national identifier', () => {
         renderer.applyCompanyData({ companyName: 'First Example Ltd', companyId: 12345678 });
 
         expect(renderer.companyId()).toBe('12345678');
-        expect(node(COMPANY_ID_FIELD).val()).toBe('12345678');
-        expect(node(COMPANY_ID_FIELD).prop('disabled')).toBe(true);
     });
 
     test('an empty customer-data section on init does not blank live state', () => {
@@ -322,7 +278,6 @@ describe('picking a company with no national identifier', () => {
 
         expect(renderer.companyName()).toBe('First Example Ltd');
         expect(renderer.companyId()).toBe('12345678');
-        expect(node(COMPANY_ID_FIELD).val()).toBe('12345678');
     });
 });
 
@@ -403,33 +358,24 @@ describe('a company picked on the shipping step reaches the payment step', () =>
 
         expect(renderer.companyName()).toBe('Second Example Ltd');
         expect(renderer.companyId()).toBe('');
-        expect(dom.node(COMPANY_ID_FIELD).val()).toBe('');
-        expect(dom.node(COMPANY_ID_FIELD).prop('disabled')).toBe(false);
     });
 
-    test('the section read on init also leaves company_id editable', () => {
+    test('the section read on init carries a name-only company through', () => {
         // Not just the subscription: the payment renderer may initialise AFTER
         // the shipping-step pick (a fresh renderer, or a re-render), in which
         // case the name-only company arrives through the one-shot read rather
         // than through a change notification. Reading it with fillCompanyData()
-        // dropped it and left the buyer facing an empty, disabled, required
-        // company number with no company name to explain it.
-        const { renderer, dom } = loadWithSections({
+        // dropped it, leaving the payment step with no company at all.
+        const { renderer } = loadWithSections({
             companyName: 'Second Example Ltd',
             companyId: ''
         });
 
         renderer.enableCompanySearch();
-        // Precondition, not the property under test — enableCompanySearch()
-        // disables the field itself with nothing selected, so this holds
-        // trivially (same as at 'applyCompanyData re-enables company_id').
-        expect(dom.node(COMPANY_ID_FIELD).prop('disabled')).toBe(true);
-
         renderer.fillCustomerData();
 
         expect(renderer.companyName()).toBe('Second Example Ltd');
         expect(renderer.companyId()).toBe('');
-        expect(dom.node(COMPANY_ID_FIELD).prop('disabled')).toBe(false);
     });
 
     test('a stale name-only section read does not clobber a live pick', () => {
@@ -441,7 +387,7 @@ describe('a company picked on the shipping step reaches the payment step', () =>
         // pick's name and blank its organisation number. Before the routing
         // existed this shape was a harmless no-op on the read path; it has to
         // stay one. Only a change NOTIFICATION on the section is a selection.
-        const { renderer, dom } = loadWithSections({
+        const { renderer } = loadWithSections({
             companyName: 'Stale Example Ltd',
             companyId: ''
         });
@@ -455,8 +401,6 @@ describe('a company picked on the shipping step reaches the payment step', () =>
 
         expect(renderer.companyName()).toBe('Live Example Ltd');
         expect(renderer.companyId()).toBe('99999999');
-        expect(dom.node(COMPANY_ID_FIELD).val()).toBe('99999999');
-        expect(dom.node(COMPANY_ID_FIELD).prop('disabled')).toBe(true);
     });
 });
 
@@ -505,17 +449,12 @@ describe('order intent for a company with no registry identifier', () => {
         expect(intent).not.toHaveBeenCalled();
     });
 
-    test('a hand-typed organisation number is never intent-checked', () => {
-        // Current, deliberate behaviour, stated so nobody reads the absence of
-        // a test as an oversight: nothing re-fires the intent once an
-        // identifier-less company is picked. The buyer can type the number and
-        // the order goes out carrying it, with no credit check behind it.
-        //
-        // The `change`-handler version of this does NOT work — see the
-        // "LIMITATION OF THE jQuery DOUBLE" note at the top of this file — and
-        // is split to its own ticket. Asserting on the renderer's own API here
-        // rather than through the DOM, because the double cannot model the ko
-        // `value` binding that shares the event.
+    test('an identifier written straight to the observable places no intent', () => {
+        // After TWO-25288 the tile has no company-number input, so there is no
+        // hand-typed route into `companyId()` on this surface at all. What
+        // remains pinned here is that a bare observable write — the shape any
+        // future writer would take — does not re-fire the intent. An order left
+        // without an identifier is refused by Model/Two.php::authorize().
         const { renderer, node, intent } = loadWithIntent();
 
         renderer.enableCompanySearch();
@@ -526,97 +465,9 @@ describe('order intent for a company with no registry identifier', () => {
         });
         expect(intent).not.toHaveBeenCalled();
 
-        // No handler is bound to the field's `change` at all any more.
-        expect(node(COMPANY_ID_FIELD).handlers['change']).toBeUndefined();
-
-        // What ko's `value` binding does when the buyer commits a number.
         renderer.companyId('99999999');
 
         expect(intent).not.toHaveBeenCalled();
-    });
-});
-
-describe('company_id editability is derived, not set per caller', () => {
-    /**
-     * Same sections harness as above, so updateAddress() can be driven the way
-     * fillCustomerData() drives it — through a billing-address notification.
-     */
-    function observable(initial) {
-        let value = initial;
-        const subs = [];
-        function obs(next) {
-            if (!arguments.length) return value;
-            value = next;
-            subs.forEach((fn) => fn(value));
-            return obs;
-        }
-        obs.subscribe = function (fn) {
-            subs.push(fn);
-            return { dispose: function () {} };
-        };
-        return obs;
-    }
-
-    test('an address notify carrying company_id cannot leave a registry number in an enabled field', () => {
-        // The desync 7f243b5 argued could not happen. Its reasoning was that
-        // fillCompanyData()'s other callers "run in modes where company search
-        // does not own the field" — false for updateAddress(), which is
-        // subscribed inside fillCustomerData() and fires on every
-        // billing/shipping notification, i.e. in registered-organisation mode
-        // with the picker live. So: pick an identifier-less company (field
-        // enabled), then let one address notification arrive carrying a
-        // `company_id` custom attribute. Before the derived subscription the
-        // registry number landed in a still-ENABLED field — MAJOR 1's exact
-        // state, which the buyer can hand-overwrite.
-        const dom = makeDom();
-        const address = { getCacheKey: () => 'k', countryId: 'GB' };
-        const billingAddress = observable(address);
-        const renderer = loadAmdModule(RENDERER, {
-            jquery: dom.$,
-            'Magento_Customer/js/customer-data': {
-                get: function () {
-                    return observable('');
-                },
-                set: function () {},
-                reload: function () {}
-            },
-            'Magento_Checkout/js/model/quote': {
-                shippingAddress: observable(address),
-                billingAddress: billingAddress,
-                getTotals: () => observable({}),
-                getQuoteId: () => null,
-                paymentMethod: observable(null),
-                shippingMethod: observable({ carrier_code: 'freeshipping' }),
-                isVirtual: () => false
-            }
-        });
-        renderer.supportedCompanyTypes = { gb: [] };
-
-        renderer.enableCompanySearch();
-        renderer.fillCustomerData();
-
-        renderer.applyCompanyData(
-            { companyName: 'Second Example Ltd', companyId: '' },
-            AS_SELECTION
-        );
-        // Precondition, not the property under test: this is backed by
-        // applyCompanyData()'s own syncCompanyIdEditable() call, not by the
-        // subscription, so it survives all four mutations. The assertion after
-        // the notification below is the load-bearing one.
-        expect(dom.node(COMPANY_ID_FIELD).prop('disabled')).toBe(false);
-
-        // One billing-address notification, carrying a company_id attribute.
-        billingAddress({
-            getCacheKey: () => 'k2',
-            countryId: 'GB',
-            company: 'First Example Ltd',
-            customAttributes: [{ attribute_code: 'company_id', value: '12345678' }]
-        });
-
-        // Whatever the notification does to the selection, it must not leave a
-        // registry organisation number sitting in a hand-editable field.
-        expect(dom.node(COMPANY_ID_FIELD).prop('disabled')).toBe(true);
-        expect(renderer.companyId()).toBe('12345678');
     });
 });
 

--- a/Test/Js/gateway-method-company-selection.test.js
+++ b/Test/Js/gateway-method-company-selection.test.js
@@ -471,17 +471,42 @@ describe('order intent for a company with no registry identifier', () => {
         expect(intent).toHaveBeenCalledTimes(1);
     });
 
-    test('an identifier-less pick places no intent — there is no number yet', () => {
+    test('an identifier-less pick places no intent and clears the previous number', () => {
+        // The bare `expect(intent).not.toHaveBeenCalled()` this test used to end
+        // on could not fail for the regression it names. An intent is placed
+        // only inside fillCompanyData(), AFTER its
+        // `if (!companyName || !companyId) return;` guard, and
+        // selectCompanyWithoutIdentifier() has no intent call at all — so with
+        // an empty companyId NEITHER routing choice places one, and reverting
+        // the handler to fillCompanyData() left it green.
+        //
+        // Seed a real company first, so the intent count discriminates between
+        // the two routes, and assert the identifier was actually CLEARED —
+        // which is the property only selectCompanyWithoutIdentifier() has.
         const { renderer, node, intent } = loadWithIntent();
 
         renderer.enableCompanySearch();
-        node(COMPANY_NAME_FIELD).handlers['select2:select']({
+        const select = node(COMPANY_NAME_FIELD).handlers['select2:select'];
+
+        select({
+            params: {
+                data: { id: 'First Example Ltd', text: 'First Example Ltd', companyId: '12345678' }
+            }
+        });
+        expect(intent).toHaveBeenCalledTimes(1);
+        expect(renderer.companyId()).toBe('12345678');
+
+        select({
             params: {
                 data: { id: 'Second Example Ltd', text: 'Second Example Ltd', companyId: '' }
             }
         });
 
-        expect(intent).not.toHaveBeenCalled();
+        // No SECOND intent, and the previous company's number is gone rather
+        // than left behind under the new company's name.
+        expect(intent).toHaveBeenCalledTimes(1);
+        expect(renderer.companyName()).toBe('Second Example Ltd');
+        expect(renderer.companyId()).toBe('');
     });
 
 });

--- a/Test/Js/tile-company-number-removed.test.js
+++ b/Test/Js/tile-company-number-removed.test.js
@@ -9,19 +9,26 @@
  * placed. Only a company-search pick, the sole-trader autofill response, or the
  * address step's `companyData` notification may supply one.
  *
- * Two properties are pinned here, and they fail for different reasons:
+ * Two groups of tests here, and they are NOT the same kind of test. Be honest
+ * about which is which before trusting a green run:
  *
- *  1. the MARKUP no longer offers the buyer a number field, and no dead
- *     apparatus is left behind in the renderer to serve one;
- *  2. the ORDER still carries an organisation number that arrived through an
- *     accepted source — most importantly the sole-trader autofill response,
- *     which is the path most likely to break silently, because it is the only
- *     one whose value is minted rather than picked.
+ *  1. REMOVAL PINS — 'the payment tile offers no company-number field'. These
+ *     fail if the change is reverted. They are what guards the removal.
  *
- * (2) is deliberately asserted through `getData()` rather than through the DOM.
+ *  2. ACCEPTED-SOURCE REGRESSION PINS — 'an accepted organisation number still
+ *     reaches the order'. These pass against the PRE-change code too, because
+ *     every accepted source already wrote the observable before the input was
+ *     removed. They do NOT prove anything about the removal. They exist because
+ *     the removal makes the observable the ONLY carrier, so a future change
+ *     that breaks one of those three routes would now lose the number outright
+ *     rather than fall back to a field — and the sole-trader routes are the
+ *     ones most likely to break silently, their value being minted rather than
+ *     picked.
+ *
+ * Group 2 is deliberately asserted through `getData()` rather than the DOM.
  * That is the actual submit path (`Observer/DataAssignObserver.php` reads
- * `additional_data.companyId`), and it reads the observable, so it stays true
- * with no input present. Asserting the DOM here would prove nothing.
+ * `additional_data`), and it reads the observable, so it stays true with no
+ * input present. Asserting the DOM there would prove nothing.
  */
 
 'use strict';
@@ -58,9 +65,14 @@ describe('the payment tile offers no company-number field', () => {
     test('the template declares no company_id input', () => {
         const markup = withoutComments(readTemplate());
 
-        expect(markup).not.toContain('id="company_id"');
-        expect(markup).not.toContain('name="payment[company_id]"');
-        expect(markup).not.toContain('value: companyId');
+        // Regexes, not substrings. A reinstatement spelled with single quotes
+        // (`id='company_id'`) or through a ko attr binding
+        // (`attr: {id: 'company_id'}`) would slip past every plain
+        // `toContain` check except `value: companyId`.
+        expect(markup).not.toMatch(/\bid\s*=\s*["']company_id["']/);
+        expect(markup).not.toMatch(/\bname\s*=\s*["']payment\[company_id\]["']/);
+        expect(markup).not.toMatch(/company_id/);
+        expect(markup).not.toMatch(/value:\s*companyId\b/);
     });
 
     test('the template still declares the required company_name input', () => {
@@ -81,12 +93,22 @@ describe('the payment tile offers no company-number field', () => {
         // says anything about the organisation number. Model/Two.php::authorize()
         // is the only enforcement for that.
         const markup = withoutComments(readTemplate());
-        const requiredAttrs = markup.match(/required="true"/g) || [];
 
-        expect(requiredAttrs).toHaveLength(1);
+        // Every spelling jQuery Validation would honour, not just
+        // `required="true"`: a bare `required`, `required="required"`, and the
+        // `data-validate` form all count.
+        const requiredInputs = (markup.match(/<input\b[^>]*>/g) || []).filter(function (tag) {
+            return (
+                /\brequired\b/.test(tag) ||
+                /data-validate\s*=\s*["'][^"']*required/.test(tag)
+            );
+        });
 
-        const beforeRequired = markup.slice(0, markup.indexOf('required="true"'));
-        expect(beforeRequired).toContain('id="company_name"');
+        expect(requiredInputs).toHaveLength(1);
+        // The one remaining required input must be the company NAME field —
+        // checking the tag itself rather than "what precedes the first match",
+        // which said nothing about a second required field added later.
+        expect(requiredInputs[0]).toMatch(/\bid\s*=\s*["']company_name["']/);
     });
 
     test('the renderer keeps no apparatus for a field that is gone', () => {

--- a/Test/Js/tile-company-number-removed.test.js
+++ b/Test/Js/tile-company-number-removed.test.js
@@ -99,10 +99,19 @@ describe('the payment tile offers no company-number field', () => {
         expect(renderer.companyNameSelector).toBe('input#company_name');
     });
 
-    test('clearCompany takes no disable argument any more', () => {
+    test('clearCompany carries no disable argument and touches no number field', () => {
         const { renderer } = loadRendererOnly();
 
-        expect(renderer.clearCompany).toHaveLength(0);
+        // Asserting on the function's own SOURCE, not on `.length`. A default
+        // parameter (`function (disableCompanyId = false)`) does not count
+        // toward `Function.length`, so a length assertion cannot fail if the
+        // parameter comes back in the form it had before — which is exactly the
+        // form it had. Verified by mutation: the length version survived.
+        const source = String(renderer.clearCompany);
+
+        expect(source).not.toContain('disableCompanyId');
+        expect(source).not.toContain('companyIdSelector');
+        expect(source).not.toContain('company_id');
     });
 });
 
@@ -231,6 +240,27 @@ describe('an accepted organisation number still reaches the order', () => {
         expect(renderer.companyId()).toBe('ST-SYNTH-001');
         expect(renderer.getData().additional_data.companyId).toBe('ST-SYNTH-001');
         expect(renderer.getData().additional_data.companyName).toBe('Sole Trader Example');
+    });
+
+    test('the sole-trader synthetic number reaches getData() via the chip click', () => {
+        // soleTraderMode() is the SECOND route that lands a minted number, and
+        // it is a separate call site from applyPrefetch(). Verified by mutation
+        // that the applyPrefetch test above does not cover it.
+        const { renderer } = loadRendererOnly();
+
+        renderer.prefetched = {
+            ready: true,
+            matches: true,
+            buyer: {
+                organization_number: 'ST-SYNTH-003',
+                company_name: 'Chip Click Example'
+            }
+        };
+
+        renderer.soleTraderMode();
+
+        expect(renderer.companyId()).toBe('ST-SYNTH-003');
+        expect(renderer.getData().additional_data.companyId).toBe('ST-SYNTH-003');
     });
 
     test('the sole-trader number survives with no number input in the DOM', () => {

--- a/Test/Js/tile-company-number-removed.test.js
+++ b/Test/Js/tile-company-number-removed.test.js
@@ -6,8 +6,9 @@
  *
  * A hand-typed organisation number is not an accepted source: it produces poor
  * data quality, and genuine buyers receive invoices for orders they never
- * placed. Only a company-search pick, the sole-trader autofill response, or the
- * address step's `companyData` notification may supply one.
+ * placed. For the accepted sources, see the writer enumeration on
+ * applyCompanyData() in the renderer — deliberately NOT restated here, because
+ * a second copy of that list has already drifted twice.
  *
  * Two groups of tests here, and they are NOT the same kind of test. Be honest
  * about which is which before trusting a green run:
@@ -15,15 +16,21 @@
  *  1. REMOVAL PINS — 'the payment tile offers no company-number field'. These
  *     fail if the change is reverted. They are what guards the removal.
  *
- *  2. ACCEPTED-SOURCE REGRESSION PINS — 'an accepted organisation number still
- *     reaches the order'. These pass against the PRE-change code too, because
- *     every accepted source already wrote the observable before the input was
- *     removed. They do NOT prove anything about the removal. They exist because
- *     the removal makes the observable the ONLY carrier, so a future change
- *     that breaks one of those three routes would now lose the number outright
- *     rather than fall back to a field — and the sole-trader routes are the
- *     ones most likely to break silently, their value being minted rather than
- *     picked.
+ *  2. ACCEPTED-SOURCE REGRESSION PINS — most of 'an accepted organisation
+ *     number still reaches the order'. These pass against the PRE-change code
+ *     too, because every accepted source already wrote the observable before
+ *     the input was removed. They do NOT prove anything about the removal. They
+ *     exist because the removal makes the observable the ONLY carrier, so a
+ *     future change that breaks one of those writer paths would now lose the
+ *     number outright rather than fall back to a field — and the sole-trader
+ *     routes are the ones most likely to break silently, their value being
+ *     minted rather than picked.
+ *
+ *     ONE EXCEPTION, and it belongs to group 1 despite living in group 2's
+ *     describe: 'the sole-trader number survives with no number input in the
+ *     DOM' asserts there are NO writes to `input#company_id`. Pre-change
+ *     fillCompanyData() did `$(this.companyIdSelector).val(companyId)`, so that
+ *     test FAILS against the old code and is a removal pin.
  *
  * Group 2 is deliberately asserted through `getData()` rather than the DOM.
  * That is the actual submit path (`Observer/DataAssignObserver.php` reads

--- a/Test/Js/tile-company-number-removed.test.js
+++ b/Test/Js/tile-company-number-removed.test.js
@@ -1,0 +1,277 @@
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ *
+ * TWO-25288. The payment tile no longer carries a company-number input.
+ *
+ * A hand-typed organisation number is not an accepted source: it produces poor
+ * data quality, and genuine buyers receive invoices for orders they never
+ * placed. Only a company-search pick, the sole-trader autofill response, or the
+ * address step's `companyData` notification may supply one.
+ *
+ * Two properties are pinned here, and they fail for different reasons:
+ *
+ *  1. the MARKUP no longer offers the buyer a number field, and no dead
+ *     apparatus is left behind in the renderer to serve one;
+ *  2. the ORDER still carries an organisation number that arrived through an
+ *     accepted source — most importantly the sole-trader autofill response,
+ *     which is the path most likely to break silently, because it is the only
+ *     one whose value is minted rather than picked.
+ *
+ * (2) is deliberately asserted through `getData()` rather than through the DOM.
+ * That is the actual submit path (`Observer/DataAssignObserver.php` reads
+ * `additional_data.companyId`), and it reads the observable, so it stays true
+ * with no input present. Asserting the DOM here would prove nothing.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const { loadAmdModule } = require('./amd-harness');
+
+const RENDERER = 'view/frontend/web/js/view/payment/method-renderer/gateway_method.js';
+const TEMPLATE = 'view/frontend/web/template/payment/gateway_method.html';
+
+function readTemplate() {
+    const full = path.join(__dirname, '..', '..', TEMPLATE);
+    const markup = fs.readFileSync(full, 'utf8');
+    // Guard the fixture itself. A silently-empty read would make every
+    // "no longer contains" assertion below pass for the wrong reason.
+    if (markup.length < 1000) {
+        throw new Error('template fixture looks truncated: ' + markup.length + ' bytes');
+    }
+    return markup;
+}
+
+/**
+ * Strip HTML comments before asserting on markup. The removal left an
+ * explanatory comment behind that names `company_id` on purpose, and a raw
+ * substring search would match it and mask a real reinstatement.
+ */
+function withoutComments(markup) {
+    return markup.replace(/<!--[\s\S]*?-->/g, '');
+}
+
+describe('the payment tile offers no company-number field', () => {
+    test('the template declares no company_id input', () => {
+        const markup = withoutComments(readTemplate());
+
+        expect(markup).not.toContain('id="company_id"');
+        expect(markup).not.toContain('name="payment[company_id]"');
+        expect(markup).not.toContain('value: companyId');
+    });
+
+    test('the template still declares the required company_name input', () => {
+        // The name field stays. Address-step name capture is Magento core's
+        // `company` attribute, gated on `customer/address/company_show`, which
+        // this module does not own — so removing this input could leave a shop
+        // with no company-name capture at all.
+        const markup = withoutComments(readTemplate());
+
+        expect(markup).toContain('id="company_name"');
+        expect(markup).toContain('name="payment[company_name]"');
+        expect(markup).toContain('value: companyName');
+    });
+
+    test('company_name is the only required input left inside the payment form', () => {
+        // Pins what `$(formSelector).valid()` can still enforce. It is NOT
+        // trivially true — the name field keeps it meaningful — but it no longer
+        // says anything about the organisation number. Model/Two.php::authorize()
+        // is the only enforcement for that.
+        const markup = withoutComments(readTemplate());
+        const requiredAttrs = markup.match(/required="true"/g) || [];
+
+        expect(requiredAttrs).toHaveLength(1);
+
+        const beforeRequired = markup.slice(0, markup.indexOf('required="true"'));
+        expect(beforeRequired).toContain('id="company_name"');
+    });
+
+    test('the renderer keeps no apparatus for a field that is gone', () => {
+        const { renderer } = loadRendererOnly();
+
+        expect(renderer.companyIdSelector).toBeUndefined();
+        expect(renderer.needsManualCompanyId).toBeUndefined();
+        expect(renderer.syncCompanyIdEditable).toBeUndefined();
+        // The name field's selector is still live — company search binds to it.
+        expect(renderer.companyNameSelector).toBe('input#company_name');
+    });
+
+    test('clearCompany takes no disable argument any more', () => {
+        const { renderer } = loadRendererOnly();
+
+        expect(renderer.clearCompany).toHaveLength(0);
+    });
+});
+
+/**
+ * jQuery double that records writes per selector, so a claim that the renderer
+ * "no longer writes the number field" is checkable rather than assumed. The
+ * default harness jQuery reports `length: 0` and returns the same inert object
+ * from every setter, which cannot distinguish a write from no write.
+ */
+function makeRecordingDom() {
+    const writes = [];
+    const nodes = {};
+
+    function node(selector) {
+        if (nodes[selector]) return nodes[selector];
+        const n = {
+            selector: selector,
+            length: 1,
+            value: '',
+            props: {},
+            handlers: {},
+            val: function (next) {
+                if (!arguments.length) return n.value;
+                writes.push([selector, next]);
+                n.value = next;
+                return n;
+            },
+            prop: function (name, next) {
+                if (arguments.length < 2) return n.props[name];
+                n.props[name] = next;
+                return n;
+            },
+            text: function () {
+                return n;
+            },
+            on: function (event, fn) {
+                n.handlers[String(event).split('.')[0]] = fn;
+                return n;
+            },
+            off: () => n,
+            closest: (sel) => node(selector + ' >closest> ' + sel),
+            find: (sel) => node(selector + ' >find> ' + sel),
+            append: () => n,
+            attr: () => n,
+            data: () => null,
+            hide: () => n,
+            show: () => n,
+            select2: () => n
+        };
+        nodes[selector] = n;
+        return n;
+    }
+
+    function $(selector) {
+        return node(typeof selector === 'string' ? selector : String(selector));
+    }
+    $.async = function (selector, cb) {
+        cb(selector);
+    };
+    $.each = function (xs, fn) {
+        (xs || []).forEach(function (x, i) {
+            fn(i, x);
+        });
+    };
+    $.ajax = function () {
+        return { done: () => this, fail: () => this, always: () => this };
+    };
+    $.Deferred = function () {
+        const d = {
+            resolve: () => d,
+            reject: () => d,
+            promise: () => d,
+            done: () => d,
+            fail: () => d,
+            always: () => d
+        };
+        return d;
+    };
+    $.mage = { cookies: { get: () => null, set: () => {} }, redirect: () => {} };
+    $.extend = Object.assign;
+    $.fn = {};
+
+    return { $: $, node: node, writes: writes };
+}
+
+function loadRendererOnly() {
+    const dom = makeRecordingDom();
+    const renderer = loadAmdModule(RENDERER, { jquery: dom.$ });
+    // `getCode()` comes from the Magento Component base class, which the
+    // harness's Component double does not provide.
+    renderer.getCode = function () {
+        return 'two_payment';
+    };
+    return { renderer: renderer, dom: dom };
+}
+
+describe('an accepted organisation number still reaches the order', () => {
+    test('a company-search pick reaches getData()', () => {
+        const { renderer } = loadRendererOnly();
+
+        renderer.applyCompanyData(
+            { companyName: 'First Example Ltd', companyId: '12345678' },
+            { authoritative: true }
+        );
+
+        expect(renderer.getData().additional_data.companyId).toBe('12345678');
+        expect(renderer.getData().additional_data.companyName).toBe('First Example Ltd');
+    });
+
+    test('the sole-trader synthetic number reaches getData() via applyPrefetch', () => {
+        // The autofill endpoint MINTS this number; it is never picked from a
+        // registry and never typed. applyPrefetch() is the path that lands it.
+        const { renderer } = loadRendererOnly();
+
+        renderer.prefetched = {
+            ready: true,
+            buyer: {
+                organization_number: 'ST-SYNTH-001',
+                company_name: 'Sole Trader Example'
+            },
+            matches: true
+        };
+
+        renderer.applyPrefetch();
+
+        expect(renderer.companyId()).toBe('ST-SYNTH-001');
+        expect(renderer.getData().additional_data.companyId).toBe('ST-SYNTH-001');
+        expect(renderer.getData().additional_data.companyName).toBe('Sole Trader Example');
+    });
+
+    test('the sole-trader number survives with no number input in the DOM', () => {
+        // The point of the whole change: the value never needed a field. Prove
+        // the renderer wrote nothing to the old selector while still delivering
+        // the number to the submit path.
+        const { renderer, dom } = loadRendererOnly();
+
+        renderer.fillCompanyData({
+            companyId: 'ST-SYNTH-002',
+            companyName: 'Sole Trader Example'
+        });
+
+        expect(renderer.getData().additional_data.companyId).toBe('ST-SYNTH-002');
+
+        const numberFieldWrites = dom.writes.filter(function (w) {
+            return w[0] === 'input#company_id';
+        });
+        expect(numberFieldWrites).toEqual([]);
+        // ...while the name field IS still written, so an inert double cannot
+        // be what made the assertion above pass.
+        const nameFieldWrites = dom.writes.filter(function (w) {
+            return w[0] === 'input#company_name';
+        });
+        expect(nameFieldWrites).toEqual([['input#company_name', 'Sole Trader Example']]);
+    });
+
+    test('an identifier-less selection leaves the number empty for the server to refuse', () => {
+        const { renderer } = loadRendererOnly();
+
+        renderer.applyCompanyData(
+            { companyName: 'First Example Ltd', companyId: '12345678' },
+            { authoritative: true }
+        );
+        renderer.applyCompanyData(
+            { companyName: 'Second Example Ltd', companyId: '' },
+            { authoritative: true }
+        );
+
+        // No client-side block. Model/Two.php::authorize() refuses this order.
+        expect(renderer.getData().additional_data.companyName).toBe('Second Example Ltd');
+        expect(renderer.getData().additional_data.companyId).toBe('');
+    });
+});

--- a/Test/Js/tile-company-number-removed.test.js
+++ b/Test/Js/tile-company-number-removed.test.js
@@ -65,13 +65,23 @@ describe('the payment tile offers no company-number field', () => {
     test('the template declares no company_id input', () => {
         const markup = withoutComments(readTemplate());
 
-        // Regexes, not substrings. A reinstatement spelled with single quotes
-        // (`id='company_id'`) or through a ko attr binding
-        // (`attr: {id: 'company_id'}`) would slip past every plain
-        // `toContain` check except `value: companyId`.
-        expect(markup).not.toMatch(/\bid\s*=\s*["']company_id["']/);
-        expect(markup).not.toMatch(/\bname\s*=\s*["']payment\[company_id\]["']/);
-        expect(markup).not.toMatch(/company_id/);
+        // Scoped to <input> tags, not the whole document. A bare
+        // `not.toMatch(/company_id/)` over all the markup is the strongest pin
+        // but it also forbids a legitimate future reference — a `for="company_id"`
+        // label, a `data-*` marker — and would fail for the wrong reason.
+        //
+        // Regexes rather than substrings: a reinstatement spelled with single
+        // quotes (`id='company_id'`) or through a ko attr binding
+        // (`attr: {id: 'company_id'}`) slips past every plain `toContain` check.
+        const inputTags = markup.match(/<input\b[^>]*>/g) || [];
+        expect(inputTags.length).toBeGreaterThan(0);
+        inputTags.forEach(function (tag) {
+            expect(tag).not.toMatch(/company_id/);
+            expect(tag).not.toMatch(/companyId\b/);
+        });
+
+        // No ko binding anywhere in the template may write the observable back
+        // from a field, whatever tag it sits on.
         expect(markup).not.toMatch(/value:\s*companyId\b/);
     });
 
@@ -123,6 +133,12 @@ describe('the payment tile offers no company-number field', () => {
 
     test('clearCompany carries no disable argument and touches no number field', () => {
         const { renderer } = loadRendererOnly();
+
+        // Guard the subject first. `String(undefined)` is the string
+        // "undefined", which contains none of the substrings below, so a
+        // renamed or deleted clearCompany would make all three assertions pass
+        // vacuously.
+        expect(typeof renderer.clearCompany).toBe('function');
 
         // Asserting on the function's own SOURCE, not on `.length`. A default
         // parameter (`function (disableCompanyId = false)`) does not count

--- a/view/frontend/web/js/model/company-search.js
+++ b/view/frontend/web/js/model/company-search.js
@@ -353,16 +353,20 @@ define(['jquery', 'mage/translate'], function ($, $t) {
                          * select at all. Without one they see the name alone,
                          * and selecting it is what gives them a route to the
                          * organisation number: the pickers treat an empty
-                         * `companyId` as authoritative, clear any previously
-                         * selected company's identifier, and (on the payment
-                         * step, where company search disables the field)
-                         * re-enable `company_id` so the buyer can type it.
-                         * See applyCompanyData() /
-                         * selectCompanyWithoutIdentifier() in
+                         * `companyId` as authoritative and clear any previously
+                         * selected company's identifier. See applyCompanyData()
+                         * / selectCompanyWithoutIdentifier() in
                          * view/payment/method-renderer/gateway_method.js —
                          * WITHOUT that, an empty `companyId` here silently
                          * kept the previous company's organisation number and
                          * submitted it under this company's name.
+                         *
+                         * Where the buyer can then TYPE that number is the
+                         * address step only. The payment tile used to re-enable
+                         * a company-number field of its own; TWO-25288 removed
+                         * that field, so on the payment step an empty
+                         * `companyId` now just stays empty and the order is
+                         * refused server-side by Model/Two.php::authorize().
                          */
                         const identifier =
                             item.national_identifier && item.national_identifier.id

--- a/view/frontend/web/js/view/address-autocomplete.js
+++ b/view/frontend/web/js/view/address-autocomplete.js
@@ -124,8 +124,11 @@ define([
         },
         /**
          * The buyer has to supply the company number by hand exactly when a
-         * company is in play but no registry identifier came with it. Same
-         * derivation the payment tile applies to its own company-number field.
+         * company is in play but no registry identifier came with it.
+         *
+         * This is now the ONLY place that derivation exists. The payment tile
+         * used to apply the same one to its own company-number field; TWO-25288
+         * removed that field, so this step is the sole hand-typed route.
          */
         needsManualCompanyId: function () {
             return !!this.currentCompanyName() && !$(this.companyIdSelector).val();

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -361,11 +361,21 @@ define([
          * harmless no-op on the read path, and it has to stay one.
          *
          * No editable state is derived for the organisation number: the tile has
-         * no company-number input to derive one for (TWO-25288). `companyId()`
-         * is written only by a company-search pick, the sole-trader autofill
-         * response, or the address step's `companyData` notification — that
-         * last one being the only surviving route for a hand-typed number, and
-         * it is enabled only where the registry holds no identifier.
+         * no company-number input to derive one for (TWO-25288).
+         *
+         * Writers of `companyId()` — four paths, not three; the last two are
+         * easy to conflate and are NOT the same thing:
+         *
+         *  - a company-search pick on this step;
+         *  - the sole-trader autofill response (applyPrefetch(), soleTraderMode(),
+         *    and the postMessage handler);
+         *  - the address step's `companyData` customer-data notification, which
+         *    is the only surviving route for a HAND-TYPED number, and the address
+         *    step enables it only where the registry holds no identifier;
+         *  - updateAddress(), parsing a `company_id` custom attribute off the
+         *    quote's billing/shipping address. This fires from the quote
+         *    subscriptions with no address-step interaction at all — a saved
+         *    customer address already carrying the attribute is enough.
          *
          * Readers: getData(), placeOrderIntent(), the authoritative guard a few
          * lines below, and the notice-clearing subscription in initialize().

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -66,7 +66,6 @@ define([
         isPaymentTermsAccepted: ko.observable(false),
         formSelector: 'form#two_gateway_form',
         companyNameSelector: 'input#company_name',
-        companyIdSelector: 'input#company_id',
         enterDetailsManuallyText: $t('Enter details manually'),
         enterDetailsManuallyButton: '#billing_enter_details_manually',
         searchForCompanyText: $t('Search for company'),
@@ -263,15 +262,6 @@ define([
                 this._twoVisibilitySub.dispose();
                 this._twoVisibilitySub = null;
             }
-            // The company_id editable-state derivation (enableCompanySearch()).
-            // Closed over this renderer, so a re-render would otherwise leave
-            // it writing the field on behalf of a disposed component.
-            if (this._companyIdEditableSubs) {
-                this._companyIdEditableSubs.forEach(function (sub) {
-                    sub.dispose();
-                });
-                this._companyIdEditableSubs = null;
-            }
             if (this.isTwoVisible && this.isTwoVisible.dispose) {
                 this.isTwoVisible.dispose();
             }
@@ -326,7 +316,6 @@ define([
             $(this.companyNameSelector).val(companyName);
             $('#select2-company_name-container')?.text(companyName);
             this.companyId(companyId);
-            $(this.companyIdSelector).val(companyId);
             if (this.isOrderIntentEnabled) {
                 fullScreenLoader.startLoader();
                 const self = this;
@@ -341,27 +330,6 @@ define([
                         self.processOrderIntentErrorResponse(response);
                     });
             }
-        },
-        /**
-         * True when the buyer has to supply the organisation number by hand:
-         * a company is selected, but the registry gave it no national
-         * identifier so there is nothing for the picker to fill in.
-         */
-        needsManualCompanyId: function () {
-            return !!this.companyName() && !this.companyId();
-        },
-        /**
-         * `company_id` is disabled while company search owns it — the
-         * identifier arrives with the picked company, so letting the buyer
-         * edit it would only let them contradict the registry. The one
-         * exception is a company that HAS no identifier: then typing it is
-         * the buyer's only route, and being enabled is also the only state in
-         * which the template's `required="true"` is enforced at all (jQuery
-         * Validation's `elements()` skips `:disabled`, so a disabled empty
-         * field passes validation silently).
-         */
-        syncCompanyIdEditable: function () {
-            $(this.companyIdSelector).prop('disabled', !this.needsManualCompanyId());
         },
         /**
          * Apply a company the buyer (or a customer-data section) selected.
@@ -409,6 +377,13 @@ define([
          *
          * A writer that touches only the DOM field and never the observables is
          * outside both mechanisms by construction — see clearCompany().
+         *
+         * Nothing re-derives an editable state for the organisation number any
+         * more: the tile has no company-number input to derive one for
+         * (TWO-25288). `companyId()` is written only from a company-search
+         * pick, the sole-trader autofill response, or the address step's
+         * `companyData` notification, and read only by getData() and
+         * placeOrderIntent().
          */
         applyCompanyData: function (companyData, options) {
             const data = companyData || {};
@@ -426,30 +401,22 @@ define([
             } else {
                 this.fillCompanyData({ companyName: companyName, companyId: companyId });
             }
-            this.syncCompanyIdEditable();
         },
         /**
          * A selected company whose registry holds no national identifier.
          * Writes the name and CLEARS any previously selected company's
          * identifier.
          *
-         * No order intent is placed here. Whether one is placed later depends
-         * on WHICH company-number field the buyer then types into:
+         * No order intent is placed here, and the buyer has no way to supply
+         * the missing identifier on this step any more — the tile's
+         * company-number input is gone (TWO-25288). The one remaining manual
+         * route is the address step's field, which publishes what it is given
+         * to the `companyData` customer-data section; that arrives back here as
+         * an authoritative notification and reaches fillCompanyData(), so that
+         * route does get intent-checked.
          *
-         *  - the address step's field publishes what it is given to the
-         *    `companyData` customer-data section, which arrives back here as an
-         *    authoritative notification and reaches fillCompanyData() — so that
-         *    route does get intent-checked;
-         *  - this tile's own field does not. It binds `value: companyId`
-         *    directly, and ko's `value` binding is registered at
-         *    applyBindings() on the same `change` event, so ko has already
-         *    written `companyId()` before any later handler could see the edit
-         *    and fire an intent from it. Stating the current behaviour plainly
-         *    rather than promising a fix this change does not make.
-         *
-         * `company_id`'s editable state is NOT set here — it is derived from
-         * the companyName/companyId observables (see enableCompanySearch()),
-         * so a later normal pick cannot leave the field enabled.
+         * An order left in this state — company name set, identifier empty — is
+         * refused server-side by Model/Two.php::authorize().
          */
         selectCompanyWithoutIdentifier: function (companyName) {
             console.debug({ logger: 'twoPayment.selectCompanyWithoutIdentifier', companyName });
@@ -457,7 +424,6 @@ define([
             $(this.companyNameSelector).val(companyName);
             $('#select2-company_name-container')?.text(companyName);
             this.companyId('');
-            $(this.companyIdSelector).val('');
         },
         fillTelephone: function (telephone) {
             console.debug({ logger: 'twoPayment.fillTelephone', telephone });
@@ -1023,54 +989,11 @@ define([
         enableCompanySearch: function () {
             let self = this;
             require(['Two_Gateway/select2-4.1.0/js/select2.min'], function () {
-                $.async(self.companyIdSelector, function (companyIdField) {
-                    const $companyIdField = $(companyIdField);
-                    // Not an unconditional disable. What puts this after the
-                    // synchronous fillCustomerData() that follows
-                    // enableCompanySearch() in registeredOrganisationMode() is
-                    // the wrapping `require()`, whose callback cannot run
-                    // before the caller returns — `$.async` itself resolves
-                    // immediately for a node that is already in the DOM, and
-                    // re-resolves on every enableCompanySearch(). Either way
-                    // this body runs with a company possibly already selected,
-                    // so hard-coding `true` re-disabled the field for an
-                    // identifier-less one and stranded the buyer with an empty,
-                    // uneditable, required company number. Derive it.
-                    $companyIdField.prop('disabled', !self.needsManualCompanyId());
-                    // From here on the editable state is DERIVED from the two
-                    // observables, so it cannot desync per writer. Calling
-                    // syncCompanyIdEditable() from the selection paths alone
-                    // was not enough: updateAddress() is subscribed inside
-                    // fillCustomerData() and fires on every billing/shipping
-                    // notify — in registered-organisation mode, while the
-                    // picker owns the field — so an address attribute carrying
-                    // `company_id` reached fillCompanyData() and wrote a
-                    // registry organisation number into a field a previous
-                    // identifier-less pick had left ENABLED, i.e. hand-editable.
-                    //
-                    // Bound once per component: enableCompanySearch() re-runs
-                    // on every re-render (see the $.async note below) and each
-                    // run would otherwise stack another subscription.
-                    //
-                    // Once per COMPONENT, not once per page: `companyName` and
-                    // `companyId` are module-level observables shared by every
-                    // renderer instance (see the note where they are declared),
-                    // so N live brand renderers mean N subscriptions on one
-                    // observable, each writing the same document-wide
-                    // `input#company_id`. Harmless rather than wasteful-and-
-                    // wrong: syncCompanyIdEditable() is idempotent and derives
-                    // from those same shared observables, so every subscriber
-                    // computes the identical answer. dispose() clears them.
-                    if (!self._companyIdEditableSubs) {
-                        const sync = function () {
-                            self.syncCompanyIdEditable();
-                        };
-                        self._companyIdEditableSubs = [
-                            self.companyName.subscribe(sync),
-                            self.companyId.subscribe(sync)
-                        ];
-                    }
-                });
+                // No `$.async('input#company_id')` block here. The tile has no
+                // company-number input to resolve, derive an editable state
+                // for, or subscribe the observables to — TWO-25288 removed it,
+                // because a hand-typeable organisation number is not an
+                // accepted source for one.
                 $.async(self.companyNameSelector, function (companyNameField) {
                     // `$.async` is a MutationObserver, and every call to
                     // enableCompanySearch() adds another one, so on a
@@ -1257,19 +1180,16 @@ define([
             });
         },
         /**
-         * PRE-EXISTING, flagged rather than changed: this writes the DOM fields
-         * only and never clears `companyName()` / `companyId()`. No notification
-         * therefore reaches the editability subscription, so after "Enter
-         * details manually" the field reads empty and enabled while the
-         * observables still hold the previously selected company's registry
-         * number. The derivation cannot desync per CALLER any more, but it can
-         * still be bypassed by a writer that skips the observables entirely.
-         * Out of scope here; noted so it is not mistaken for new behaviour.
+         * PRE-EXISTING, flagged rather than changed: this writes the DOM field
+         * only and never clears `companyName()` / `companyId()`, so after
+         * "Enter details manually" the name input reads empty while the
+         * observables still hold the previously selected company. Out of scope
+         * here; noted so it is not mistaken for new behaviour.
+         *
+         * The `disableCompanyId` parameter is gone with the company-number
+         * input it used to lock (TWO-25288).
          */
-        clearCompany: function (disableCompanyId = false) {
-            const companyIdSelector = $(this.companyIdSelector);
-            companyIdSelector.val('');
-            companyIdSelector.prop('disabled', disableCompanyId);
+        clearCompany: function () {
             $(this.companyNameSelector).val('');
             this.disableCompanySearch();
         },
@@ -1377,7 +1297,7 @@ define([
             // Resolve the link BEFORE clearCompany(), which tears the widget
             // down and nulls _$companyNameField.
             const $searchForCompany = this.searchForCompanyLink();
-            this.clearCompany(true);
+            this.clearCompany();
             $searchForCompany.hide();
         },
 

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -363,8 +363,12 @@ define([
          * No editable state is derived for the organisation number: the tile has
          * no company-number input to derive one for (TWO-25288). `companyId()`
          * is written only by a company-search pick, the sole-trader autofill
-         * response, or the address step's `companyData` notification, and read
-         * only by getData() and placeOrderIntent().
+         * response, or the address step's `companyData` notification — that
+         * last one being the only surviving route for a hand-typed number, and
+         * it is enabled only where the registry holds no identifier.
+         *
+         * Readers: getData(), placeOrderIntent(), the authoritative guard a few
+         * lines below, and the notice-clearing subscription in initialize().
          */
         applyCompanyData: function (companyData, options) {
             const data = companyData || {};

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -360,30 +360,11 @@ define([
          * its organisation number. Before the routing existed that shape was a
          * harmless no-op on the read path, and it has to stay one.
          *
-         * The editable state of `company_id` is re-derived here, after BOTH
-         * branches. The authoritative derivation is the companyName/companyId
-         * subscription in enableCompanySearch(), which catches every writer OF
-         * THE OBSERVABLES, including the ones that never come through a
-         * selection path. This call is not merely belt-and-braces; it is
-         * load-bearing for two cases the subscription cannot cover:
-         *
-         *  - a pick that writes values identical to the current ones, which ko
-         *    does not notify for;
-         *  - the window before `$.async('input#company_id')` has resolved. On
-         *    init, registeredOrganisationMode() calls enableCompanySearch() and
-         *    then fillCustomerData(), whose companyData notification fires
-         *    synchronously — possibly before the field node exists and
-         *    therefore before the subscription has been created at all.
-         *
-         * A writer that touches only the DOM field and never the observables is
-         * outside both mechanisms by construction — see clearCompany().
-         *
-         * Nothing re-derives an editable state for the organisation number any
-         * more: the tile has no company-number input to derive one for
-         * (TWO-25288). `companyId()` is written only from a company-search
-         * pick, the sole-trader autofill response, or the address step's
-         * `companyData` notification, and read only by getData() and
-         * placeOrderIntent().
+         * No editable state is derived for the organisation number: the tile has
+         * no company-number input to derive one for (TWO-25288). `companyId()`
+         * is written only by a company-search pick, the sole-trader autofill
+         * response, or the address step's `companyData` notification, and read
+         * only by getData() and placeOrderIntent().
          */
         applyCompanyData: function (companyData, options) {
             const data = companyData || {};

--- a/view/frontend/web/template/payment/gateway_method.html
+++ b/view/frontend/web/template/payment/gateway_method.html
@@ -184,18 +184,19 @@
                 <!--
                     There is deliberately NO company-number input here.
 
-                    The organisation number is only ever captured from a
-                    source that can be trusted: a company-search pick, or the
-                    sole-trader autofill response. Both write the `companyId`
-                    observable directly, and getData() reads that observable —
-                    never the DOM — so no input is needed to carry the value.
+                    Three sources may supply the organisation number, and all
+                    three write the `companyId` observable rather than a field:
+                    a company-search pick, the sole-trader autofill response,
+                    and the address step's `companyData` notification. getData()
+                    reads that observable — never the DOM — so no input on this
+                    step is needed to carry the value.
 
-                    A hand-typed number is NOT an accepted source. Letting the
-                    buyer type one produced poor data quality and, worse,
-                    genuine buyers receiving invoices for orders they never
-                    placed. The address step owns the one remaining manual
-                    route, and it is enabled only where the registry holds no
-                    identifier for the picked company.
+                    The third of those is the only surviving route for a
+                    hand-typed number, and the address step enables it only
+                    where the registry holds no identifier for the picked
+                    company. Typing one HERE was unrestricted, which produced
+                    poor data quality and, worse, genuine buyers receiving
+                    invoices for orders they never placed.
 
                     Nothing client-side enforces the presence of an
                     identifier. Model/Two.php::authorize() refuses an order

--- a/view/frontend/web/template/payment/gateway_method.html
+++ b/view/frontend/web/template/payment/gateway_method.html
@@ -181,25 +181,27 @@
                         />
                     </div>
                 </div>
-                <div class="field field-text required">
-                    <label for="company_id" class="label">
-                        <span><!-- ko i18n: 'Company Number'--><!-- /ko --></span>
-                    </label>
-                    <div class="control">
-                        <input
-                            type="text"
-                            id="company_id"
-                            name="payment[company_id]"
-                            required="true"
-                            data-bind='
-                            attr: {
-                                title: $t("Company Number")
-                            },
-                            value: companyId'
-                            class="input-text"
-                        />
-                    </div>
-                </div>
+                <!--
+                    There is deliberately NO company-number input here.
+
+                    The organisation number is only ever captured from a
+                    source that can be trusted: a company-search pick, or the
+                    sole-trader autofill response. Both write the `companyId`
+                    observable directly, and getData() reads that observable —
+                    never the DOM — so no input is needed to carry the value.
+
+                    A hand-typed number is NOT an accepted source. Letting the
+                    buyer type one produced poor data quality and, worse,
+                    genuine buyers receiving invoices for orders they never
+                    placed. The address step owns the one remaining manual
+                    route, and it is enabled only where the registry holds no
+                    identifier for the picked company.
+
+                    Nothing client-side enforces the presence of an
+                    identifier. Model/Two.php::authorize() refuses an order
+                    with an empty organisation number server-side, and that
+                    refusal is the only enforcement. See TWO-25288.
+                -->
                 <!--
                     Optional buyer fields. ORDER IS LOAD-BEARING: this markup
                     order is what the buyer sees, and it must match the admin

--- a/view/frontend/web/template/payment/gateway_method.html
+++ b/view/frontend/web/template/payment/gateway_method.html
@@ -184,19 +184,19 @@
                 <!--
                     There is deliberately NO company-number input here.
 
-                    Three sources may supply the organisation number, and all
-                    three write the `companyId` observable rather than a field:
-                    a company-search pick, the sole-trader autofill response,
-                    and the address step's `companyData` notification. getData()
-                    reads that observable — never the DOM — so no input on this
-                    step is needed to carry the value.
+                    Every source that may supply the organisation number writes
+                    the `companyId` observable rather than a field, and
+                    getData() reads that observable — never the DOM — so no
+                    input on this step is needed to carry the value. See the
+                    writer list on applyCompanyData() in
+                    gateway_method.js for the current enumeration.
 
-                    The third of those is the only surviving route for a
-                    hand-typed number, and the address step enables it only
-                    where the registry holds no identifier for the picked
-                    company. Typing one HERE was unrestricted, which produced
-                    poor data quality and, worse, genuine buyers receiving
-                    invoices for orders they never placed.
+                    Exactly one of those routes is a HAND-TYPED number: the
+                    address step's own company-number field, which that step
+                    enables only where the registry holds no identifier for the
+                    picked company. Typing one HERE was unrestricted, which
+                    produced poor data quality and, worse, genuine buyers
+                    receiving invoices for orders they never placed.
 
                     Nothing client-side enforces the presence of an
                     identifier. Model/Two.php::authorize() refuses an order


### PR DESCRIPTION
## What

Removes the hand-typed organisation-number input from the Luma payment tile.
The company-name input stays.

TWO-25288, element 6 part 2. Depends on #303 (merged) and #300 (merged).

## Why

A hand-typed organisation number is not an accepted source. It produces poor
data quality and, worse, genuine buyers receive invoices for orders they never
placed. Only three sources are trusted:

1. a company-search pick — name and identifier arrive together;
2. the sole-trader autofill response — a synthetic identifier is minted for the
   signed-in buyer;
3. the address step's field, which is enabled only where the registry holds no
   identifier for the picked company.

The tile's input was a fourth route, always visible and always editable, with no
mode toggle. It is gone.

## Why this is safe now and was not before

The tile input used to be the only thing keeping an identifier-less order out:
`required="true"` plus a single `$(formSelector).valid()` call. #303 replaced
that with a real server-side refusal in `Model/Two.php::authorize()`, so the
client-side field is no longer load-bearing.

The value never needed a DOM carrier at all. `getData()` reads the `companyId`
observable, not the field, and `Observer/DataAssignObserver.php` consumes
`additional_data.companyId`. Every accepted source writes the observable.

## What `valid()` still enforces — re-checked for this change specifically

Not trivially true, but narrower than before. `company_name` keeps its
`required="true"`, so `$(formSelector).valid()` still blocks placement on an
empty company name. It no longer says anything about the organisation number.

`required="true"` now appears exactly once in the template, on the name input,
and a test pins that count so a silent third `required` cannot appear
unnoticed.

**`Model/Two.php::authorize()` is the sole enforcement for the organisation
number.** An identifier-less order reaches the server and is refused there. That
is the intended interim behaviour: a clean refusal at placement, not a hidden
payment method. Withdrawing the method entirely in that state is deliberately
out of scope and tracked separately.

## Dead machinery removed with it

Nothing is left bound to a field that no longer exists:

- `companyIdSelector`, and the `$.async` block in `enableCompanySearch()` that
  resolved it
- `needsManualCompanyId()` and `syncCompanyIdEditable()` — their only effect was
  that field's `disabled` state
- `_companyIdEditableSubs` and its `dispose()` branch, which were only ever
  created inside the removed `$.async` block
- `clearCompany()`'s `disableCompanyId` parameter
- the `$(companyIdSelector).val()` display writes in `fillCompanyData()` and
  `selectCompanyWithoutIdentifier()`
- the doc comments describing the editability derivation, which no longer
  describes anything

Deliberately kept: the company-name input, the select2 company-search widget
bound to it, the "Enter details manually" affordance, and `clearCompany()`
itself (it still clears the name field and disables company search).

Deliberately untouched: the identically-named `companyIdSelector`,
`needsManualCompanyId` and `syncCompanyIdEditable` in
`view/frontend/web/js/view/address-autocomplete.js`. Those belong to the address
step's field, which is a different surface with a different lifecycle.

## Is any identifier still shown to the buyer?

No. With the input gone the tile displays no organisation number anywhere, so
there is nothing that could be editable. Registry identifiers reach the order
without ever being rendered on this surface.

## Sole trader

Verified end to end, because it is the path most likely to break silently — its
identifier is minted rather than picked, so nothing else would notice its
absence.

Both call sites that land a synthetic identifier write the `companyId`
observable and never the DOM: `applyPrefetch()` (email-driven prefetch) and
`soleTraderMode()` (chip click). `getData()` reads the observable. Both are now
pinned by tests, and both were mutation-verified independently — covering only
one of them left the other's mutation green, which is how the second test came
to exist.

## Tests

New `Test/Js/tile-company-number-removed.test.js`, 10 tests, two groups: the
markup and renderer no longer offer a number field, and an accepted identifier
still reaches `getData()`.

The DOM assertions use a purpose-built recording jQuery double. The default
harness double reports `length: 0` and returns the same inert object from every
setter, so it cannot distinguish a write from no write — an assertion built on it
would be structurally unable to fail. Absent `company_id` writes are asserted
alongside present `company_name` writes, so an inert double cannot be what makes
the test pass.

Existing tests: the `company_id` editability describe block is deleted outright,
because its subject no longer exists. Elsewhere the DOM value/disabled
assertions are reduced to the observable assertions that still mean something.
Three renderer-context fixtures had a stale `companyIdSelector` entry describing
a field that is gone; removed.

### Mutations run — break source, confirm RED, restore

Every one of these was confirmed to turn the suite red, and two of them found
real defects in the tests rather than confirming them.

| # | Mutation | Result |
|---|---|---|
| M1 | Reinstate the `company_id` input in the template | RED |
| M2 | Rename the `company_name` input's id | RED |
| M3 | Reinstate `companyIdSelector` on the renderer | RED |
| M4 | Reinstate the `$(companyIdSelector).val()` write in `fillCompanyData()` | RED |
| M5b | Break `applyPrefetch()`'s synthetic identifier | RED |
| M5c | Break `soleTraderMode()`'s synthetic identifier | **survived → test added** |
| M6 | Make `getData()` read the DOM instead of the observable | RED |
| M7 | Restore `clearCompany(disableCompanyId = false)` | **survived → test fixed** |
| M7b | Same, against the corrected source-based assertion | RED |
| M8 | Reinstate a `syncCompanyIdEditable()` method | RED |
| M9 | Reinstate a `needsManualCompanyId()` method | RED |
| M10 | Stop `selectCompanyWithoutIdentifier()` clearing `companyId` | RED |

Two findings worth naming, since both are the kind of thing that ships green:

- **M7 survived because a default parameter does not count toward
  `Function.length`.** `expect(renderer.clearCompany).toHaveLength(0)` stayed
  green when `disableCompanyId = false` came back in exactly the form it had
  before. The assertion now reads the function's own source instead.
- **M5c survived because `soleTraderMode()` is a second, independent call
  site.** Covering `applyPrefetch()` alone proved nothing about the chip-click
  route.

## Verification

`npm run test:js` — 16 suites, 179 tests, all passing. (`npx jest` directly is
wrong in this repo; the config lives at `Test/Js/jest.config.js`.)

## Not verified

- **PHPUnit was not run locally** — no `vendor/` in this checkout. Relying on
  CI. The one PHP test that reads this template,
  `Test/Unit/Config/CheckoutFieldOrderTest.php`, pins only the five optional
  buyer fields (`invoice_emails`, `two_po_number`, `two_project`,
  `two_department`, `two_order_note`); the company inputs are not in its
  canonical order, so it is unaffected by inspection.
- **No browser check.** The visual result of the field's removal on a real
  storefront is unverified.

## i18n

No CSV change. No user-facing string is added, and `Company Number` is still
used by the address-step field and by `Model/Two.php`'s error mapping, so the
existing rows stay exactly as they are.

## Related gap, NOT addressed here

The tile's company-NAME input was considered for removal in the same change and
deliberately kept. Address-step name capture is Magento core's `company` address
attribute, gated on core config `customer/address/company_show`, which this
module does not own. `address-autocomplete.js` can force-show a wrapper but
cannot render a field core has suppressed, so on a shop with that setting off,
removing the tile name input would leave no company-name capture anywhere.
Being raised separately.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
