### PR TITLE
TWO-25288: grey inline company-id hint + CSS-hide address-step field

### DIFF
--- a/Plugin/Model/Checkout/LayoutProcessorPlugin.php
+++ b/Plugin/Model/Checkout/LayoutProcessorPlugin.php
@@ -68,7 +68,19 @@ class LayoutProcessorPlugin
             // view/frontend/web/js/view/address-autocomplete.js; `disabled`
             // here is only the initial state for a freshly rendered form with
             // no company selected yet.
+            //
+            // `visible` stays true on purpose. Flipping it to false would pull
+            // the component out of the UI-registry render tree entirely, and
+            // view/frontend/web/js/view/address-autocomplete.js calls
+            // `uiRegistry.get(this.companyIdComponent)` on this field, so a
+            // registry-absent component would break that lookup, not just hide
+            // the input. The field is hidden visually instead, via
+            // `additionalClasses` + a CSS rule in
+            // view/frontend/web/css/style.css — the DOM node stays present and
+            // its value still submits as
+            // shippingAddress.custom_attributes.company_id. See TWO-25288.
             'visible' => true,
+            'additionalClasses' => 'two-company-id-hidden',
             'disabled' => true,
             'validation' => [
                 'required-entry' => false

--- a/Test/Js/company-id-inline-hint.test.js
+++ b/Test/Js/company-id-inline-hint.test.js
@@ -1,0 +1,215 @@
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ *
+ * TWO-25288. Ports the Woo reference UX: a grey inline hint of the selected
+ * company's registry id, painted beside the payment tile's company-name
+ * field, plus a CSS-only hide of the address step's separate "Company
+ * Number" field (the field an earlier TWO-25288 change made real and
+ * editable — see address-company-id.test.js — stays present and
+ * functional; only its visual rendering changes).
+ *
+ * What is NOT re-asserted here: `companyId` reaching getData() and the
+ * writer enumeration for it. Those are pinned by
+ * gateway-method-company-selection.test.js and
+ * tile-company-number-removed.test.js; duplicating them would only drift.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const { loadAmdModule } = require('./amd-harness');
+
+const RENDERER = 'view/frontend/web/js/view/payment/method-renderer/gateway_method.js';
+const TEMPLATE = 'view/frontend/web/template/payment/gateway_method.html';
+const STYLE = 'view/frontend/web/css/style.css';
+const LAYOUT_PROCESSOR = 'Plugin/Model/Checkout/LayoutProcessorPlugin.php';
+
+function readRepoFile(relPath) {
+    return fs.readFileSync(path.join(__dirname, '..', '..', relPath), 'utf8');
+}
+
+function withoutComments(markup) {
+    return markup.replace(/<!--[\s\S]*?-->/g, '');
+}
+
+describe('payment tile: grey inline company-id hint', () => {
+    test('the template renders a hint span bound to companyId, next to the name field', () => {
+        const markup = readRepoFile(TEMPLATE);
+        const withoutHtmlComments = withoutComments(markup);
+
+        // The span must exist, be bound to `companyId` (not a plain field:
+        // getData() must keep reading the observable, never a DOM value), and
+        // its visibility must track the same observable so it disappears
+        // exactly when there is no id to show.
+        expect(withoutHtmlComments).toMatch(/class="two-company-id-hint"/);
+        const hintBlockMatch = withoutHtmlComments.match(
+            /<span\s+class="two-company-id-hint"[\s\S]*?<\/span>/
+        );
+        expect(hintBlockMatch).not.toBeNull();
+        const hintBlock = hintBlockMatch[0];
+        expect(hintBlock).toMatch(/text:\s*companyId\b/);
+        expect(hintBlock).toMatch(/visible:\s*companyId\b/);
+
+        // It must NOT be an <input> — cosmetic only, carries no value of its
+        // own. Reuses the same regression pin shape as
+        // tile-company-number-removed.test.js so a reintroduction as a real
+        // field would be caught the same way.
+        const inputTags = withoutHtmlComments.match(/<input\b[^>]*>/g) || [];
+        inputTags.forEach(function (tag) {
+            expect(tag).not.toMatch(/two-company-id-hint/);
+        });
+    });
+
+    test('the hint sits inside the same control block as the company-name input', () => {
+        const markup = withoutComments(readRepoFile(TEMPLATE));
+
+        const controlBlockMatch = markup.match(
+            /<div class="control two-company-name-control">[\s\S]*?<\/div>\s*<\/div>/
+        );
+        expect(controlBlockMatch).not.toBeNull();
+        const controlBlock = controlBlockMatch[0];
+
+        expect(controlBlock).toContain('id="company_name"');
+        expect(controlBlock).toContain('class="two-company-id-hint"');
+    });
+
+    test('the CSS positions the hint absolutely, in light grey, against a relative parent', () => {
+        const css = readRepoFile(STYLE);
+
+        const parentRuleMatch = css.match(/\.two-company-name-control\s*\{([^}]*)\}/);
+        expect(parentRuleMatch).not.toBeNull();
+        expect(parentRuleMatch[1]).toMatch(/position:\s*relative/);
+
+        const hintRuleMatch = css.match(/\.two-company-id-hint\s*\{([^}]*)\}/);
+        expect(hintRuleMatch).not.toBeNull();
+        const hintRule = hintRuleMatch[1];
+        expect(hintRule).toMatch(/position:\s*absolute/);
+        expect(hintRule).toMatch(/color:\s*#dddddd/);
+        expect(hintRule).toMatch(/white-space:\s*nowrap/);
+    });
+
+    test('applyCompanyData drives the observable the hint reads: present on a pick, empty on none', () => {
+        const dom = makeInertJquery();
+        const renderer = loadAmdModule(RENDERER, { jquery: dom.$ });
+        renderer.getCode = function () {
+            return 'two_payment';
+        };
+
+        renderer.applyCompanyData(
+            { companyName: 'First Example Ltd', companyId: '12345678' },
+            { authoritative: true }
+        );
+        expect(renderer.companyId()).toBe('12345678');
+
+        renderer.applyCompanyData(
+            { companyName: 'Second Example Ltd', companyId: '' },
+            { authoritative: true }
+        );
+        expect(renderer.companyId()).toBe('');
+    });
+});
+
+describe('address step: company-number field is CSS-hidden, not removed', () => {
+    test('the layout processor still marks the field visible in the UI registry', () => {
+        // `visible: false` would pull the component out of the render tree
+        // entirely, breaking address-autocomplete.js's `uiRegistry.get()`
+        // lookup — a CSS class is the only sanctioned way to hide it.
+        // See Test/Unit/Plugin/Model/Checkout/LayoutProcessorPluginTest.php
+        // for the PHPUnit-side pin of the same invariant.
+        const php = readRepoFile(LAYOUT_PROCESSOR);
+
+        expect(php).toMatch(/'visible'\s*=>\s*true/);
+        expect(php).toMatch(/'additionalClasses'\s*=>\s*'two-company-id-hidden'/);
+    });
+
+    test('the CSS hides the field purely visually', () => {
+        const css = readRepoFile(STYLE);
+
+        const ruleMatch = css.match(/\.two-company-id-hidden\s*\{([^}]*)\}/);
+        expect(ruleMatch).not.toBeNull();
+        expect(ruleMatch[1]).toMatch(/display:\s*none/);
+    });
+});
+
+/** Minimal jQuery double good enough to load the renderer in isolation. */
+function makeInertJquery() {
+    function node() {
+        const n = {
+            length: 0,
+            val: function () {
+                return arguments.length ? n : '';
+            },
+            prop: function () {
+                return n;
+            },
+            attr: function () {
+                return n;
+            },
+            text: function () {
+                return n;
+            },
+            on: function () {
+                return n;
+            },
+            off: function () {
+                return n;
+            },
+            closest: function () {
+                return n;
+            },
+            find: function () {
+                return n;
+            },
+            data: function () {
+                return null;
+            },
+            append: function () {
+                return n;
+            },
+            hide: function () {
+                return n;
+            },
+            show: function () {
+                return n;
+            },
+            select2: function () {
+                return n;
+            }
+        };
+        return n;
+    }
+
+    function $() {
+        return node();
+    }
+    $.async = function (selector, cb) {
+        cb(selector);
+    };
+    $.each = function (xs, fn) {
+        (xs || []).forEach(function (x, i) {
+            fn(i, x);
+        });
+    };
+    $.ajax = function () {
+        return { done: () => this, fail: () => this, always: () => this };
+    };
+    $.Deferred = function () {
+        const d = {
+            resolve: () => d,
+            reject: () => d,
+            promise: () => d,
+            done: () => d,
+            fail: () => d,
+            always: () => d
+        };
+        return d;
+    };
+    $.mage = { cookies: { get: () => null, set: () => {} }, redirect: () => {} };
+    $.extend = Object.assign;
+    $.fn = {};
+
+    return { $: $ };
+}

--- a/Test/Unit/Plugin/Model/Checkout/LayoutProcessorPluginTest.php
+++ b/Test/Unit/Plugin/Model/Checkout/LayoutProcessorPluginTest.php
@@ -172,4 +172,20 @@ class LayoutProcessorPluginTest extends TestCase
         $this->assertSame('shippingAddress.custom_attributes.company_id', $field['dataScope']);
         $this->assertSame('shippingAddress.custom_attributes', $field['config']['customScope']);
     }
+
+    /**
+     * TWO-25288. The field must stay `visible: true` — flipping it to false
+     * would pull it out of the UI-registry render tree, and
+     * address-autocomplete.js resolves it through `uiRegistry.get()`. It is
+     * hidden purely visually, through `additionalClasses` plus a CSS rule in
+     * view/frontend/web/css/style.css, so the DOM node and its value stay
+     * present.
+     */
+    public function testCompanyNumberFieldStaysUiRegistryVisibleButCssHidden(): void
+    {
+        $field = $this->companyIdField();
+
+        $this->assertTrue($field['visible']);
+        $this->assertSame('two-company-id-hidden', $field['additionalClasses']);
+    }
 }

--- a/view/frontend/web/css/style.css
+++ b/view/frontend/web/css/style.css
@@ -499,3 +499,37 @@
     border-color: #b7c0ee;
     color: var(--color-blue2);
 }
+
+/*
+ * TWO-25288. Grey inline hint showing the selected company's registry id
+ * beside the payment tile's company-name field, once a company has been
+ * picked. Purely cosmetic — carries no value of its own; `companyId()` in
+ * gateway_method.js remains the sole authoritative source read by getData().
+ */
+.two-company-name-control {
+    position: relative;
+}
+
+.two-company-id-hint {
+    position: absolute;
+    right: 24px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: #dddddd;
+    font-size: 12px;
+    white-space: nowrap;
+    pointer-events: none;
+}
+
+/*
+ * TWO-25288. The address-step "Company Number" field (injected by
+ * Plugin/Model/Checkout/LayoutProcessorPlugin.php) stays in the UI-registry
+ * render tree — `visible: true` — because
+ * view/frontend/web/js/view/address-autocomplete.js resolves it through
+ * `uiRegistry.get()`. It is hidden purely visually here, so the DOM node and
+ * its value stay intact and still submit as
+ * shippingAddress.custom_attributes.company_id.
+ */
+.two-company-id-hidden {
+    display: none;
+}

--- a/view/frontend/web/template/payment/gateway_method.html
+++ b/view/frontend/web/template/payment/gateway_method.html
@@ -166,7 +166,7 @@
                     <label for="company_name" class="label">
                         <span><!-- ko i18n: 'Company Name'--><!-- /ko --></span>
                     </label>
-                    <div class="control">
+                    <div class="control two-company-name-control">
                         <input
                             type="text"
                             id="company_name"
@@ -179,6 +179,18 @@
                             value: companyName'
                             class="input-text"
                         />
+                        <!--
+                            Cosmetic only — an inline hint of the registry id
+                            behind the picked company, shown once companyId()
+                            is non-empty and cleared with it. NOT an input:
+                            carries no value of its own, and getData() keeps
+                            reading the companyId observable directly. See
+                            TWO-25288.
+                        -->
+                        <span
+                            class="two-company-id-hint"
+                            data-bind="text: companyId, visible: companyId"
+                        ></span>
                     </div>
                 </div>
                 <!--


### PR DESCRIPTION
## Summary
- Payment tile: the company-name field now shows the selected company's registry id as light-grey inline text to its right (cosmetic only — `getData()` keeps reading the existing `companyId` observable directly).
- Address step: the separate "Company Number" field (added in an earlier TWO-25288 change) is now hidden purely via CSS (`.two-company-id-hidden`, `display: none`), rather than flipping its `visible` config to `false` — that would pull it out of the UI-registry render tree and break `address-autocomplete.js`'s `uiRegistry.get()` lookup. The DOM node and its submitted value are unaffected.

Ref: TWO-25288 (company-search parity epic), item #50.

## Test plan
- [x] `npm run test:js` — 17 suites / 185 tests, all passing (new: `Test/Js/company-id-inline-hint.test.js`)
- [x] New PHPUnit test added (`LayoutProcessorPluginTest::testCompanyNumberFieldStaysUiRegistryVisibleButCssHidden`) pinning `visible: true` + `additionalClasses`; `php -l` clean, not executed locally (no vendor/phpunit in this environment)
- [ ] Manual storefront check of the grey hint rendering and the hidden field still submitting, on a real checkout