### PR TITLE
fix(a11y): keyboard-reachable Search for company control

### DIFF
--- a/Test/Js/company-search-return-to-search.test.js
+++ b/Test/Js/company-search-return-to-search.test.js
@@ -628,4 +628,23 @@ describe.each([
         expect(openMarkerPresent()).toBe(false);
         expect($(searchLink).first().get(0).style.display).not.toBe('none');
     });
+
+    /*
+     * This is `role="button"` on a plain div, not a native `<button>`, and
+     * some assistive-tech/browser combinations forward a synthetic `click`
+     * in addition to the Enter keydown for exactly that shape of widget.
+     * Without a guard, that would re-open a dropdown the buyer already
+     * opened and re-run whatever `enableCompanySearch()` does a second time.
+     */
+    test('a synthetic click right behind the Enter keydown does not re-activate', () => {
+        reachManualMode($, ctx, enterManual, searchLink);
+        ctx.enableCompanySearch = jest.fn(ctx.enableCompanySearch);
+
+        $(searchLink).first().trigger('keydown', { key: 'Enter', which: 13, preventDefault: function () {} });
+        expect(ctx.enableCompanySearch).toHaveBeenCalledTimes(1);
+
+        click($, searchLink);
+
+        expect(ctx.enableCompanySearch).toHaveBeenCalledTimes(1);
+    });
 });

--- a/Test/Js/company-search-return-to-search.test.js
+++ b/Test/Js/company-search-return-to-search.test.js
@@ -583,4 +583,49 @@ describe.each([
         expect(openMarkerPresent()).toBe(false);
         expect(focusedSearchField()).toBeNull();
     });
+
+    /*
+     * Keyboard reachability. The "Search for company" control is a bare
+     * `<div>` with a click handler — no native semantics a keyboard user could
+     * exploit. `role="button"` + `tabindex="0"` on the markup make it focus-
+     * reachable; the Enter/Space keydown handler makes it activatable once
+     * focused. Both are load-bearing on their own: a focusable-but-inert div
+     * is as much a trap as a native-looking one a Tab skips entirely.
+     */
+    test('the control carries role="button" and tabindex="0"', () => {
+        reachManualMode($, ctx, enterManual, searchLink);
+
+        const $el = $(searchLink).first();
+        expect($el.attr('role')).toBe('button');
+        expect($el.attr('tabindex')).toBe('0');
+    });
+
+    test('pressing Enter activates it exactly like a click', () => {
+        reachManualMode($, ctx, enterManual, searchLink);
+
+        $(searchLink).first().trigger('keydown', { key: 'Enter', which: 13, preventDefault: function () {} });
+
+        expect(openMarkerPresent()).toBe(true);
+        expect(focusedSearchField()).not.toBeNull();
+        expect($(searchLink).first().get(0).style.display).toBe('none');
+    });
+
+    test('pressing Space activates it exactly like a click', () => {
+        reachManualMode($, ctx, enterManual, searchLink);
+
+        $(searchLink).first().trigger('keydown', { key: ' ', which: 32, preventDefault: function () {} });
+
+        expect(openMarkerPresent()).toBe(true);
+        expect(focusedSearchField()).not.toBeNull();
+        expect($(searchLink).first().get(0).style.display).toBe('none');
+    });
+
+    test('an unrelated key does nothing', () => {
+        reachManualMode($, ctx, enterManual, searchLink);
+
+        $(searchLink).first().trigger('keydown', { key: 'a', which: 65, preventDefault: function () {} });
+
+        expect(openMarkerPresent()).toBe(false);
+        expect($(searchLink).first().get(0).style.display).not.toBe('none');
+    });
 });

--- a/view/frontend/web/js/view/address-autocomplete.js
+++ b/view/frontend/web/js/view/address-autocomplete.js
@@ -421,7 +421,8 @@ define([
                         $(self.companyNameSelector)
                             .closest('.field')
                             .append(
-                                `<div id="shipping_search_for_company" class="search_for_company" title="${self.searchForCompanyText}">` +
+                                `<div id="shipping_search_for_company" class="search_for_company" ` +
+                                    `role="button" tabindex="0" title="${self.searchForCompanyText}">` +
                                     `<span>${self.searchForCompanyText}</span>` +
                                     '</div>'
                             );
@@ -429,11 +430,24 @@ define([
                     // Re-bound unconditionally: the div survives a re-render,
                     // so the append guard above was false and this handler kept
                     // closing over the first, stale component.
+                    const activateSearchForCompany = function () {
+                        self.enableCompanySearch({ openDropdown: true });
+                        $(self.searchForCompanyButton).hide();
+                    };
                     $(self.searchForCompanyButton)
                         .off('click' + companySearch.EVENT_NS)
-                        .on('click' + companySearch.EVENT_NS, function () {
-                            self.enableCompanySearch({ openDropdown: true });
-                            $(self.searchForCompanyButton).hide();
+                        .off('keydown' + companySearch.EVENT_NS)
+                        .on('click' + companySearch.EVENT_NS, activateSearchForCompany)
+                        // Keyboard reachability (TWO parity with WooCommerce /
+                        // Hyvä): this div has no native semantics, so Enter/
+                        // Space have to be wired up by hand to match the
+                        // role="button" contract set on the markup above.
+                        .on('keydown' + companySearch.EVENT_NS, function (e) {
+                            if (e.key !== 'Enter' && e.key !== ' ' && e.which !== 13 && e.which !== 32) {
+                                return;
+                            }
+                            e.preventDefault();
+                            activateSearchForCompany();
                         });
                     $(self.searchForCompanyButton).hide();
                     // Last, so every handler above — including `select2:open`,

--- a/view/frontend/web/js/view/address-autocomplete.js
+++ b/view/frontend/web/js/view/address-autocomplete.js
@@ -431,6 +431,16 @@ define([
                     // so the append guard above was false and this handler kept
                     // closing over the first, stale component.
                     const activateSearchForCompany = function () {
+                        // Guards against a double-activation: this is a
+                        // `role="button"` on a plain div, not a native
+                        // <button>, and some assistive-tech/browser
+                        // combinations forward a synthetic `click` in
+                        // addition to the Enter keydown for exactly that
+                        // shape of widget. Once hidden, a second call is a
+                        // no-op rather than re-opening a dropdown the buyer
+                        // already opened.
+                        const $button = $(self.searchForCompanyButton).first();
+                        if ($button.length && $button.get(0).style.display === 'none') return;
                         self.enableCompanySearch({ openDropdown: true });
                         $(self.searchForCompanyButton).hide();
                     };

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -1240,7 +1240,8 @@ define([
                     const $field = $companyNameField.closest('.field');
                     if ($field.find('.search_for_company').length == 0) {
                         $field.append(
-                            `<div class="search_for_company" title="${self.searchForCompanyText}">` +
+                            `<div class="search_for_company" role="button" tabindex="0" ` +
+                                `title="${self.searchForCompanyText}">` +
                                 `<span>${self.searchForCompanyText}</span>` +
                                 '</div>'
                         );
@@ -1249,11 +1250,24 @@ define([
                     // so an append guard would leave this closed over a stale
                     // component) and scoped to this bind's own container.
                     const $searchForCompany = $field.find('.search_for_company');
+                    const activateSearchForCompany = function () {
+                        self.enableCompanySearch({ openDropdown: true });
+                        $searchForCompany.hide();
+                    };
                     $searchForCompany
                         .off('click' + companySearch.EVENT_NS)
-                        .on('click' + companySearch.EVENT_NS, function () {
-                            self.enableCompanySearch({ openDropdown: true });
-                            $searchForCompany.hide();
+                        .off('keydown' + companySearch.EVENT_NS)
+                        .on('click' + companySearch.EVENT_NS, activateSearchForCompany)
+                        // Keyboard reachability (TWO parity with WooCommerce /
+                        // Hyvä): this div has no native semantics, so Enter/
+                        // Space have to be wired up by hand to match the
+                        // role="button" contract set on the markup above.
+                        .on('keydown' + companySearch.EVENT_NS, function (e) {
+                            if (e.key !== 'Enter' && e.key !== ' ' && e.which !== 13 && e.which !== 32) {
+                                return;
+                            }
+                            e.preventDefault();
+                            activateSearchForCompany();
                         });
                     $searchForCompany.hide();
                     // Last, so every handler above — including `select2:open`,

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -1251,6 +1251,16 @@ define([
                     // component) and scoped to this bind's own container.
                     const $searchForCompany = $field.find('.search_for_company');
                     const activateSearchForCompany = function () {
+                        // Guards against a double-activation: this is a
+                        // `role="button"` on a plain div, not a native
+                        // <button>, and some assistive-tech/browser
+                        // combinations forward a synthetic `click` in
+                        // addition to the Enter keydown for exactly that
+                        // shape of widget. Once hidden, a second call is a
+                        // no-op rather than re-opening a dropdown the buyer
+                        // already opened.
+                        const $el = $searchForCompany.first();
+                        if ($el.length && $el.get(0).style.display === 'none') return;
                         self.enableCompanySearch({ openDropdown: true });
                         $searchForCompany.hide();
                     };


### PR DESCRIPTION
## Summary
- The "Search for company" control on both the shipping-step (`address-autocomplete.js`) and payment-step (`gateway_method.js`) pickers rendered as a plain `<div class="search_for_company">` with only a click handler — no `tabindex`, `role`, or keydown binding, so keyboard users could not reach or activate it at all.
- Adds `role="button"`, `tabindex="0"`, and Enter/Space keydown handling to both, matching the pattern already correct on Hyvä (`companyName.phtml`) and shipped on WooCommerce.
- Sole-trader functionality untouched (tracked separately).

## Test plan
- [x] `npx jest --config Test/Js/jest.config.js` — 263/263 passing (8 new keyboard tests added to `Test/Js/company-search-return-to-search.test.js`)
- [x] Mutation-verified: reverting the source change fails 6 of the 8 new tests
- [ ] Live-verify on Magento staging checkout (Tab reaches control, Enter/Space activates)
