### PR TITLE
fix(i18n): add missing Company number/name label translations

### DIFF
--- a/i18n/nb_NO.csv
+++ b/i18n/nb_NO.csv
@@ -33,6 +33,8 @@
 "Click here to log in or sign up as a Sole Trader.","Klikk her for å logge inn eller registrere deg som eneforhandler."
 "Company Number","Organisasjonsnummer"
 "Company Name","Selskapsnavn"
+"Company number:","Organisasjonsnummer:"
+"Company name:","Selskapsnavn:"
 "Could not initiate capture with %1","Kunne ikke starte fangst med %1"
 "Could not initiate refund with %1","Kunne ikke starte refusjon med %1"
 "Could not update %1 order status to cancelled. Please contact support with order ID %2. Error: %3","Kunne ikke oppdatere %1 ordrestatus til kansellert. Ta kontakt med brukerstøtten med ordre-ID %2. Feil: %3"

--- a/i18n/nl_NL.csv
+++ b/i18n/nl_NL.csv
@@ -34,6 +34,8 @@
 "Click here to log in or sign up as a Sole Trader.","Klik hier om in te loggen of u aan te melden als zelfstandig ondernemer."
 "Company Number","Bedrijfsnummer"
 "Company Name","Bedrijfsnaam"
+"Company number:","Bedrijfsnummer:"
+"Company name:","Bedrijfsnaam:"
 "Could not initiate capture with %1","Kon geen vastlegging starten met %1"
 "Could not initiate refund with %1","Kon geen terugbetaling starten met %1"
 "Could not update %1 order status to cancelled. Please contact support with order ID %2. Error: %3","Kon %1 orderstatus niet updaten naar geannuleerd. Neem contact op met support met bestelnummer %2. Fout: %3"

--- a/i18n/sv_SE.csv
+++ b/i18n/sv_SE.csv
@@ -33,6 +33,8 @@
 "Click here to log in or sign up as a Sole Trader.","Klicka här för att logga in eller registrera dig som enskild näringsidkare."
 "Company Number","Organisationsnummer"
 "Company Name","Företagsnamn"
+"Company number:","Organisationsnummer:"
+"Company name:","Företagsnamn:"
 "Could not initiate capture with %1","Kunde inte initiera debitering med %1"
 "Could not initiate refund with %1","Kunde inte initiera återbetalning med %1"
 "Could not update %1 order status to cancelled. Please contact support with order ID %2. Error: %3","Kunde inte uppdatera %1 orderstatus till annullerad. Kontakta supporten med beställnings-ID %2. Fel: %3"


### PR DESCRIPTION
## Summary
- `gateway_method-csp-js.phtml` (magento-hyva-extension) renders `__("Company number:")` and `__("Company name:")` on the payment tile, but those two exact strings (trailing colon included) had no rows in `i18n/nb_NO.csv`, `i18n/nl_NL.csv` or `i18n/sv_SE.csv` — only differently-worded strings like `"Company number is not valid."` were present, so these two silently fell back to English.
- Adds both rows to all three CSVs, reusing the wording already shipped for `"Company Number"`/`"Company Name"` in the same dictionaries, with a trailing colon appended the same way the existing `"Merchant ID:"` row does it. These are not fresh guesses — they reuse translations already live and approved elsewhere in these files.

## Test plan
- [x] All three CSVs parse cleanly as 2-column CSV (verified with Python's `csv` module); the one non-2-column row per file is a pre-existing trailing blank line, confirmed present on `origin/staging` before this change.
- [ ] No live-verify needed per scope (translation-only change).
