### PR TITLE
fix(checkout): Luma company-search CSS, number label, country order

### DIFF
--- a/Plugin/Model/Checkout/LayoutProcessorPlugin.php
+++ b/Plugin/Model/Checkout/LayoutProcessorPlugin.php
@@ -92,6 +92,57 @@ class LayoutProcessorPlugin
             'id' => 'company-id',
             'value' => ''
         ];
+
+        $this->moveCountryBeforeCompany($jsLayout);
+
         return $jsLayout;
+    }
+
+    /**
+     * Force `country_id` to render before the native `company` field.
+     *
+     * `checkout_index_index.xml` declares `country_id`'s sortOrder as a
+     * static 50, which DOES win over Magento core's EAV-derived default (90)
+     * — `Magento\Checkout\Block\Checkout\AttributeMerger::getFieldConfig()`
+     * prefers a layout-XML sortOrder over the attribute's own when both
+     * exist. The problem is what it is being compared against: `company`
+     * and `street` carry no layout-XML override of their own from this
+     * module, so THEIR position is whatever the store's Customer Address
+     * Attributes admin screen has configured for those two attributes —
+     * out of the box that is 60/70 (after our 50), but any store free to
+     * reconfigure it can push either below 50, and this staging store's
+     * live behaviour (country rendering after street) shows exactly that
+     * happening. A static number picked once cannot track an admin setting
+     * this module does not own.
+     *
+     * Read `company`'s sortOrder back out of the array this plugin's own
+     * `afterProcess` runs AFTER — i.e. once the core merge has already
+     * resolved it against whatever the store's real config says — and
+     * place country immediately before it. Mirrors PrestaShop's
+     * `CustomerAddressFormatter::moveFieldBefore('id_country', 'company')`:
+     * dynamic relative-to-company positioning rather than a static number,
+     * so it holds regardless of admin configuration.
+     *
+     * @param array $jsLayout
+     * @return void
+     */
+    private function moveCountryBeforeCompany(array &$jsLayout)
+    {
+        if (!isset(
+            $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']
+            ['children']['shippingAddress']['children']['shipping-address-fieldset']['children']
+        )) {
+            return;
+        }
+        $fieldset = &$jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']
+            ['children']['shippingAddress']['children']['shipping-address-fieldset']['children'];
+
+        if (!isset($fieldset['country_id']) || !isset($fieldset['company']['sortOrder'])) {
+            return;
+        }
+        if (!is_numeric($fieldset['company']['sortOrder'])) {
+            return;
+        }
+        $fieldset['country_id']['sortOrder'] = $fieldset['company']['sortOrder'] - 1;
     }
 }

--- a/Plugin/Model/Checkout/LayoutProcessorPlugin.php
+++ b/Plugin/Model/Checkout/LayoutProcessorPlugin.php
@@ -99,7 +99,8 @@ class LayoutProcessorPlugin
     }
 
     /**
-     * Force `country_id` to render before the native `company` field.
+     * Force `country_id` to render before the native `company` AND `street`
+     * fields on the SHIPPING address step, only when it does not already.
      *
      * `checkout_index_index.xml` declares `country_id`'s sortOrder as a
      * static 50, which DOES win over Magento core's EAV-derived default (90)
@@ -110,18 +111,34 @@ class LayoutProcessorPlugin
      * module, so THEIR position is whatever the store's Customer Address
      * Attributes admin screen has configured for those two attributes —
      * out of the box that is 60/70 (after our 50), but any store free to
-     * reconfigure it can push either below 50, and this staging store's
-     * live behaviour (country rendering after street) shows exactly that
-     * happening. A static number picked once cannot track an admin setting
-     * this module does not own.
+     * reconfigure EITHER below 50 reproduces "country after an address
+     * field", and this staging store's live behaviour (country after
+     * street specifically) is exactly that. A static number picked once
+     * cannot track an admin setting this module does not own. Anchoring to
+     * `company` alone is not enough — `street` is independently
+     * configurable and was the actual field reported live, so this anchors
+     * to whichever of the two currently sorts first.
      *
-     * Read `company`'s sortOrder back out of the array this plugin's own
+     * Read both sortOrders back out of the array this plugin's own
      * `afterProcess` runs AFTER — i.e. once the core merge has already
-     * resolved it against whatever the store's real config says — and
-     * place country immediately before it. Mirrors PrestaShop's
-     * `CustomerAddressFormatter::moveFieldBefore('id_country', 'company')`:
-     * dynamic relative-to-company positioning rather than a static number,
-     * so it holds regardless of admin configuration.
+     * resolved them against whatever the store's real config says — and
+     * place country immediately before the earlier of the two. Mirrors
+     * PrestaShop's `CustomerAddressFormatter::moveFieldBefore('id_country',
+     * 'company')`: dynamic relative positioning rather than a static
+     * number, so it holds regardless of admin configuration.
+     *
+     * Deliberately CONDITIONAL, not an unconditional overwrite: a store
+     * where country already sorts correctly is left untouched, so this
+     * cannot push country past some OTHER field (region, city, postcode, a
+     * custom EAV attribute) that happened to land between country's
+     * original position and `min(company, street) - 1`. Only a store that
+     * actually reproduces the reported bug gets reordered.
+     *
+     * Scoped to the SHIPPING address step only. The payment step's billing
+     * address form (when "same as shipping" is unchecked) is a separate
+     * jsLayout subtree this method does not touch — out of scope for this
+     * fix; the same live-config-dependent ordering issue can in principle
+     * reproduce there too and would need its own follow-up if reported.
      *
      * @param array $jsLayout
      * @return void
@@ -137,12 +154,30 @@ class LayoutProcessorPlugin
         $fieldset = &$jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']
             ['children']['shippingAddress']['children']['shipping-address-fieldset']['children'];
 
-        if (!isset($fieldset['country_id']) || !isset($fieldset['company']['sortOrder'])) {
+        if (!isset($fieldset['country_id']) || !is_array($fieldset['country_id'])
+            || !isset($fieldset['country_id']['sortOrder'])
+            || !is_numeric($fieldset['country_id']['sortOrder'])
+        ) {
             return;
         }
-        if (!is_numeric($fieldset['company']['sortOrder'])) {
+
+        $anchors = [];
+        foreach (['company', 'street'] as $fieldName) {
+            if (isset($fieldset[$fieldName]['sortOrder']) && is_numeric($fieldset[$fieldName]['sortOrder'])) {
+                $anchors[] = $fieldset[$fieldName]['sortOrder'];
+            }
+        }
+        if (empty($anchors)) {
             return;
         }
-        $fieldset['country_id']['sortOrder'] = $fieldset['company']['sortOrder'] - 1;
+        $target = min($anchors);
+
+        if ($fieldset['country_id']['sortOrder'] < $target) {
+            // Already correctly ordered — leave it exactly as core/XML set
+            // it, so this never shoves country past some third field that
+            // happens to sit between its current position and the target.
+            return;
+        }
+        $fieldset['country_id']['sortOrder'] = $target - 1;
     }
 }

--- a/Test/Js/tile-company-readonly-fields.test.js
+++ b/Test/Js/tile-company-readonly-fields.test.js
@@ -2,47 +2,37 @@
  * Copyright © Two.inc All rights reserved.
  * See COPYING.txt for license details.
  *
- * TWO-25288. The payment tile shows the captured company NAME and NUMBER, and
- * the buyer can neither edit nor remove what was captured.
+ * TWO-25288 first showed the captured company NAME and NUMBER read-only, as a
+ * second `<input readonly>`. Doug's canonical-design ruling that followed
+ * (applies across all four platforms) replaced that input outright: the
+ * number is now a plain text LABEL, right-aligned immediately below the
+ * company-name field, visible only once a number has actually been captured.
  *
- * This SUPERSEDES the earlier removal of the number input. The reason that
- * input went away holds — a hand-typed organisation number is not an accepted
- * source; it produced poor data quality and genuine buyers receiving invoices
- * for orders they never placed — but removing it also stopped the buyer seeing
- * what the order would be invoiced against. Read-only keeps the first and
- * restores the second. For the accepted sources, see the writer enumeration on
- * applyCompanyData() in the renderer — deliberately NOT restated here, because
- * a second copy of that list has already drifted twice.
+ * This file pins the label-based version. Three groups, and they are NOT the
+ * same kind of test. Be honest about which is which before trusting a green
+ * run:
  *
- * Three groups of tests here, and they are NOT the same kind of test. Be honest
- * about which is which before trusting a green run:
- *
- *  1. READ-ONLY PINS — 'the payment tile shows both company fields, uneditable'.
- *     These fail against BOTH the removal and any reinstatement as an editable
- *     field. They are what guards the change.
+ *  1. READ-ONLY / NO-INPUT PINS — 'the payment tile shows the number as an
+ *     uneditable label, not a field'. These fail against BOTH the old
+ *     `<input readonly>` shape and any future reinstatement of an editable
+ *     field, because there is no `<input id="company_id">` left to satisfy
+ *     either shape.
  *
  *  2. WHAT-THE-BUYER-SEES PINS — 'what each capture mode puts in front of the
- *     buyer'. These do not restate the markup: they read the `value:` binding
+ *     buyer'. These do not restate the markup: they read the `text:` binding
  *     target out of the template, then evaluate it against a renderer driven
- *     through the real capture flow, so a field bound to the wrong observable
+ *     through the real capture flow, so a label bound to the wrong observable
  *     fails here even though the markup is present and correct.
  *
  *  3. ACCEPTED-SOURCE REGRESSION PINS — most of 'an accepted organisation
  *     number still reaches the order'. These pass against the pre-change code
- *     too, because every accepted source already wrote the observable. They do
- *     NOT prove anything about the fields. They exist because the observable is
- *     the ONLY carrier — the read-only input has no `name` and so submits
- *     nothing — so a future change that breaks one of those writer paths loses
- *     the number outright rather than falling back to a field, and the
+ *     too, because every accepted source already wrote the observable. They
+ *     do NOT prove anything about the label. They exist because the
+ *     observable is the ONLY carrier — the label has no `name` and submits
+ *     nothing — so a future change that breaks one of those writer paths
+ *     loses the number outright rather than falling back to a field, and the
  *     sole-trader routes are the ones most likely to break silently, their
  *     value being minted rather than picked.
- *
- *     ONE EXCEPTION, and it belongs to group 1 despite living in group 3's
- *     describe: 'the sole-trader number survives with no write to the number
- *     field' asserts there are NO writes to `input#company_id`. The renderer
- *     used to do `$(this.companyIdSelector).val(companyId)`; that must not come
- *     back, because ko's `value: companyId` binding is now the only painter and
- *     a second one would let the two desync.
  *
  * Group 3 is deliberately asserted through `getData()` rather than the DOM.
  * That is the actual submit path (`Observer/DataAssignObserver.php` reads
@@ -72,10 +62,10 @@ function readTemplate() {
 }
 
 /**
- * Strip HTML comments before asserting on markup. Both fields carry long
- * explanatory comments that name `company_id`, `readonly` and `disabled` on
- * purpose, and a raw substring search would match those and report a passing
- * pin for prose.
+ * Strip HTML comments before asserting on markup. The name field and the
+ * number label both carry long explanatory comments that name `company_id`,
+ * `readonly` and `input` on purpose, and a raw substring search would match
+ * those and report a passing pin for prose.
  */
 function withoutComments(markup) {
     return markup.replace(/<!--[\s\S]*?-->/g, '');
@@ -93,6 +83,19 @@ function inputTag(id) {
     });
     if (tags.length !== 1) {
         throw new Error('expected exactly one <input id="' + id + '">, found ' + tags.length);
+    }
+    return tags[0];
+}
+
+/**
+ * The `<div class="two-company-id-label">` tag, comments already stripped.
+ * Throws rather than returning null, same reasoning as inputTag() above.
+ */
+function companyIdLabelTag() {
+    const markup = withoutComments(readTemplate());
+    const tags = (markup.match(/<div\b[^>]*class="two-company-id-label"[^>]*><\/div>/g) || []);
+    if (tags.length !== 1) {
+        throw new Error('expected exactly one <div class="two-company-id-label">, found ' + tags.length);
     }
     return tags[0];
 }
@@ -118,6 +121,41 @@ function renderedValue(id, renderer) {
 }
 
 /**
+ * What ko would paint as the number label's text, derived the same way
+ * renderedValue() does for an input's `value:` binding, but for the label's
+ * `text:` binding.
+ */
+function renderedLabelText(renderer) {
+    const bound = companyIdLabelTag().match(/text:\s*([A-Za-z_$][\w$]*)/);
+    if (!bound) {
+        throw new Error('the number label has no `text:` binding');
+    }
+    const target = renderer[bound[1]];
+    if (typeof target !== 'function') {
+        throw new Error(
+            'the number label is bound to `' + bound[1] + '`, which the renderer has not'
+        );
+    }
+    return target.call(renderer);
+}
+
+/**
+ * Whether the number label would currently render, evaluated the same way
+ * renderedLabelText() does — read the `visible:` expression out of the
+ * template, PIN it to the exact `!!companyId()` shape (so a drift to some
+ * other observable or a always-true/always-false stub fails the string
+ * match), then evaluate the same observable directly against the live
+ * renderer for the actual truth value.
+ */
+function labelVisible(renderer) {
+    const tag = companyIdLabelTag();
+    if (!/visible:\s*!!companyId\(\)/.test(tag)) {
+        throw new Error('the number label\'s `visible:` binding is not the pinned `!!companyId()` shape');
+    }
+    return !!renderer.companyId();
+}
+
+/**
  * Whether `tag` carries `name` as a real HTML ATTRIBUTE — preceded by
  * whitespace and followed by `=`, `>`, `/` or more whitespace.
  *
@@ -134,9 +172,9 @@ function hasAttribute(tag, name) {
 /**
  * Whether the buyer can type into `id`, in the state `renderer` is currently
  * in. A static `readonly`/`disabled` attribute settles it outright; otherwise
- * the ko `attr` binding's target is evaluated the same way renderedValue() does
- * it, so a `readonly` bound to an observable is answered for THIS state rather
- * than assumed.
+ * the ko `attr` binding's target is evaluated the same way renderedValue()
+ * does it, so a `readonly` bound to an observable is answered for THIS state
+ * rather than assumed.
  */
 function isReadOnly(id, renderer) {
     const tag = inputTag(id);
@@ -156,30 +194,27 @@ function isReadOnly(id, renderer) {
     return !!target.call(renderer);
 }
 
-describe('the payment tile shows both company fields, uneditable', () => {
-    test('the number field is declared, bound to companyId, and statically read-only', () => {
-        const tag = inputTag('company_id');
-
-        // `readonly`, NOT `disabled`. A disabled control is dropped from the
-        // submitted form and skipped by jQuery Validation's `elements()`; the
-        // distinction is what made the old editable-state derivation load-bearing
-        // and is exactly what must not come back.
-        expect(hasAttribute(tag, 'readonly')).toBe(true);
-        expect(hasAttribute(tag, 'disabled')).toBe(false);
-        expect(tag).toMatch(/value:\s*companyId\b/);
-
-        // Static, not bound: there is no mode in which this may be typed, so no
-        // observable may be able to turn it off. `readonly: <expr>` inside a
-        // data-bind would match the `\breadonly\b` above, so rule it out
-        // explicitly rather than relying on that assertion to have meant it.
-        expect(tag).not.toMatch(/\breadonly\s*:/);
+describe('the payment tile shows the number as an uneditable label, not a field', () => {
+    test('there is no input#company_id left in the template', () => {
+        const markup = withoutComments(readTemplate());
+        expect(markup).not.toMatch(/<input\b[^>]*\bid\s*=\s*["']company_id["']/);
     });
 
-    test('the number field carries no name, so it submits nothing', () => {
-        // getData() → `additional_data` is the submit path. A `name` here would
-        // add a SECOND carrier for the same value, free to disagree with the
-        // observable, which is how a stale number reaches an order.
-        expect(inputTag('company_id')).not.toMatch(/\sname\s*=/);
+    test('the number label is a plain div, carries no name and no value binding to write to', () => {
+        const tag = companyIdLabelTag();
+
+        expect(tag).not.toMatch(/\sname\s*=/);
+        expect(tag).not.toMatch(/\svalue\s*=/);
+        // Not an input, not a button, not anything with default interactive
+        // semantics — a plain div reads unambiguously as non-editable.
+        expect(tag).toMatch(/^<div\b/);
+    });
+
+    test('the number label is bound to companyId and gated on it being present', () => {
+        const tag = companyIdLabelTag();
+
+        expect(tag).toMatch(/text:\s*companyId\b/);
+        expect(tag).toMatch(/visible:\s*!!companyId\(\)/);
     });
 
     test('the name field is read-only only once a company has been captured', () => {
@@ -201,9 +236,10 @@ describe('the payment tile shows both company fields, uneditable', () => {
     });
 
     test('the name field is never both empty and locked', () => {
-        // THE REGRESSION THIS GUARDS, and it is not hypothetical — the first
-        // draft of this change shipped it. The input is `required`, and jQuery
-        // Validation enforces `required` on a `[readonly]` field (its
+        // THE REGRESSION THIS GUARDS, and it is not hypothetical — an earlier
+        // draft of the read-only-input version shipped it, and nothing about
+        // the label change touches this path. The input is `required`, and
+        // jQuery Validation enforces `required` on a `[readonly]` field (its
         // `elements()` skips `:disabled` only). So a state that is both empty
         // and locked is a validation error with no buyer action that clears it.
         //
@@ -212,18 +248,12 @@ describe('the payment tile shows both company fields, uneditable', () => {
         // lands, because fillCompanyData() early-returns unless BOTH name and
         // number are non-empty. Keying `readonly` on the mode alone stranded the
         // buyer here.
-        //
-        // Driven through enterSoleTraderUi(), which is the sub-path
-        // soleTraderMode() runs FIRST on every branch. The rest of the unmatched
-        // branch is signup-popup plumbing — getAutofillData() needs `btoa` and
-        // openIframe() needs `window.open`, neither of which the AMD sandbox
-        // provides — and none of it touches the state under test.
         const { renderer } = loadRendererOnly();
 
         renderer.enterSoleTraderUi();
 
         expect(renderer.showSoleTrader()).toBe(true);
-        expect(renderedValue('company_id', renderer)).toBe('');
+        expect(renderer.companyId()).toBe('');
         // The name the buyer must now supply by hand — so the field cannot be
         // locked, whatever mode says.
         expect(isReadOnly('company_name', renderer)).toBe(false);
@@ -241,7 +271,7 @@ describe('the payment tile shows both company fields, uneditable', () => {
         );
         renderer.enterSoleTraderUi();
 
-        expect(renderedValue('company_id', renderer)).toBe('');
+        expect(renderer.companyId()).toBe('');
         expect(isReadOnly('company_name', renderer)).toBe(false);
     });
 
@@ -257,10 +287,8 @@ describe('the payment tile shows both company fields, uneditable', () => {
     });
 
     test('company_name is still the only required input in the payment form', () => {
-        // Pins what `$(formSelector).valid()` enforces. The number field is
-        // deliberately NOT required: a read-only empty required field fails
-        // validation with no way for the buyer to satisfy it.
-        // Model/Two.php::authorize() is the only enforcement for the number.
+        // Pins what `$(formSelector).valid()` enforces. The number is
+        // deliberately not a validatable input at all any more.
         const markup = withoutComments(readTemplate());
 
         // Every spelling jQuery Validation would honour, not just
@@ -278,8 +306,9 @@ describe('the payment tile shows both company fields, uneditable', () => {
     });
 
     test('the renderer keeps no editable-state apparatus for the number', () => {
-        // The field is back but its editability derivation is not, and must not
-        // be: `readonly` is static, so nothing may compute it.
+        // The number is shown but has no editability derivation of its own —
+        // it never had one to remove, and a label reinstating one would be a
+        // sign the label is on its way to becoming a field again.
         const { renderer } = loadRendererOnly();
 
         expect(renderer.companyIdSelector).toBeUndefined();
@@ -307,12 +336,12 @@ describe('the payment tile shows both company fields, uneditable', () => {
 
         expect(source).not.toContain('disableCompanyId');
         expect(source).not.toContain('companyIdSelector');
-        expect(source).not.toContain('company_id');
+        expect(source).not.toContain('input#company_id');
     });
 });
 
 describe('what each capture mode puts in front of the buyer', () => {
-    test('search mode: the buyer sees the picked name AND its number', () => {
+    test('search mode: the buyer sees the picked name AND its number label', () => {
         const { renderer } = loadRendererOnly();
 
         renderer.applyCompanyData(
@@ -321,12 +350,11 @@ describe('what each capture mode puts in front of the buyer', () => {
         );
 
         expect(renderedValue('company_name', renderer)).toBe('First Example Ltd');
-        expect(renderedValue('company_id', renderer)).toBe('12345678');
-        // Visible, and still not editable.
-        expect(isReadOnly('company_id', renderer)).toBe(true);
+        expect(renderedLabelText(renderer)).toBe('12345678');
+        expect(labelVisible(renderer)).toBe(true);
     });
 
-    test('sole-trader mode: the minted name and number show, both uneditable', () => {
+    test('sole-trader mode: the minted name shows locked, the number label shows', () => {
         const { renderer } = loadRendererOnly();
 
         renderer.prefetched = {
@@ -340,15 +368,15 @@ describe('what each capture mode puts in front of the buyer', () => {
         renderer.soleTraderMode();
 
         expect(renderedValue('company_name', renderer)).toBe('Sole Trader Example');
-        expect(renderedValue('company_id', renderer)).toBe('ST-SYNTH-004');
-        expect(isReadOnly('company_id', renderer)).toBe(true);
+        expect(renderedLabelText(renderer)).toBe('ST-SYNTH-004');
+        expect(labelVisible(renderer)).toBe(true);
         // The name too, because a name AND number were actually captured — see
         // the two "never both empty and locked" cases for the branch where they
         // were not.
         expect(isReadOnly('company_name', renderer)).toBe(true);
     });
 
-    test('manual-entry mode: the number reads blank and stays read-only', () => {
+    test('manual-entry mode: the number label disappears and stays gone', () => {
         // Driven through the real manual-entry path — clearCompany() is what the
         // sentinel row's handler calls — not by poking the observable, so this
         // fails if that path stops clearing the abandoned company's number.
@@ -358,17 +386,17 @@ describe('what each capture mode puts in front of the buyer', () => {
             { companyName: 'First Example Ltd', companyId: '12345678' },
             { authoritative: true }
         );
-        expect(renderedValue('company_id', renderer)).toBe('12345678');
+        expect(labelVisible(renderer)).toBe(true);
 
         renderer.clearCompany();
 
-        expect(renderedValue('company_id', renderer)).toBe('');
-        expect(isReadOnly('company_id', renderer)).toBe(true);
+        expect(renderer.companyId()).toBe('');
+        expect(labelVisible(renderer)).toBe(false);
         // …and the name is typeable, which is the whole point of the mode.
         expect(isReadOnly('company_name', renderer)).toBe(false);
     });
 
-    test('an identifier-less pick shows the name with a blank number', () => {
+    test('an identifier-less pick shows the name with no number label', () => {
         // The other route to a blank number: the registry holds no identifier
         // for the picked company. Distinct from manual entry — a company IS
         // selected here.
@@ -384,8 +412,7 @@ describe('what each capture mode puts in front of the buyer', () => {
         );
 
         expect(renderedValue('company_name', renderer)).toBe('Second Example Ltd');
-        expect(renderedValue('company_id', renderer)).toBe('');
-        expect(isReadOnly('company_id', renderer)).toBe(true);
+        expect(labelVisible(renderer)).toBe(false);
     });
 });
 
@@ -540,11 +567,12 @@ describe('an accepted organisation number still reaches the order', () => {
         expect(renderer.getData().additional_data.companyId).toBe('ST-SYNTH-003');
     });
 
-    test('the sole-trader number survives with no write to the number field', () => {
-        // ko's `value: companyId` binding is the ONLY painter of the read-only
-        // input. Prove the renderer writes nothing to that selector itself while
-        // still delivering the number to the submit path — a second painter
-        // could disagree with the observable, and the observable is what ships.
+    test('the sole-trader number survives with no write to any company_id node', () => {
+        // ko's `text: companyId` binding is the ONLY painter of the label.
+        // Prove the renderer writes nothing to a `company_id` selector itself
+        // while still delivering the number to the submit path — a second
+        // painter could disagree with the observable, and the observable is
+        // what ships.
         const { renderer, dom } = loadRendererOnly();
 
         renderer.fillCompanyData({
@@ -555,7 +583,7 @@ describe('an accepted organisation number still reaches the order', () => {
         expect(renderer.getData().additional_data.companyId).toBe('ST-SYNTH-002');
 
         const numberFieldWrites = dom.writes.filter(function (w) {
-            return w[0] === 'input#company_id';
+            return /company_id/.test(w[0]);
         });
         expect(numberFieldWrites).toEqual([]);
         // ...while the name field IS still written, so an inert double cannot
@@ -566,12 +594,12 @@ describe('an accepted organisation number still reaches the order', () => {
         expect(nameFieldWrites).toEqual([['input#company_name', 'Sole Trader Example']]);
     });
 
-    test('showing the number read-only does not change what the form submits', () => {
-        // The regression this guards: reinstating the input as a carrier — a
-        // `name`, or a DOM read in getData() — so the payload could come from
-        // the field instead of the observable. Asserted against the WHOLE
-        // additional_data payload rather than the two keys, because a new
-        // company key smuggled in beside them is the same defect.
+    test('showing the number does not change what the form submits', () => {
+        // The regression this guards: reinstating a carrier for the number
+        // beside the observable — a `name`, or a DOM read in getData() — so
+        // the payload could come from the DOM instead. Asserted against the
+        // WHOLE additional_data payload rather than the two keys, because a
+        // new company key smuggled in beside them is the same defect.
         const { renderer, dom } = loadRendererOnly();
 
         renderer.applyCompanyData(
@@ -591,10 +619,10 @@ describe('an accepted organisation number still reaches the order', () => {
         // getData() must not have consulted the DOM for either value: with a
         // recording double every node reports an empty `val()`, so a DOM read
         // would have produced '' above. Belt-and-braces on that, prove the
-        // renderer never wrote the number field either.
+        // renderer never wrote any company_id node either.
         expect(
             dom.writes.filter(function (w) {
-                return w[0] === 'input#company_id';
+                return /company_id/.test(w[0]);
             })
         ).toEqual([]);
     });

--- a/Test/Js/tile-company-readonly-fields.test.js
+++ b/Test/Js/tile-company-readonly-fields.test.js
@@ -254,6 +254,14 @@ describe('the payment tile shows the number as an uneditable label, not a field'
         const tag = companyIdLabelTag();
 
         expect(tag).toMatch(/Company Number/);
+        // Specifically via the `ko i18n` macro, not hardcoded English text —
+        // a second adversarial round flagged that a bare `/Company Number/`
+        // match alone is satisfied equally by a hardcoded
+        // `<span>Company Number</span>` that lost translatability, since
+        // withoutComments() deliberately preserves `ko i18n` comments rather
+        // than stripping them. This pins the delivery mechanism, not just
+        // the string's presence.
+        expect(tag).toMatch(/<!--\s*ko i18n:\s*'Company Number'\s*--><!--\s*\/ko\s*-->/);
         // Two spans: one static caption, one bound to the number. Not one
         // span doing both jobs — that would make the caption unable to
         // update independently were it ever translated per-request.

--- a/Test/Js/tile-company-readonly-fields.test.js
+++ b/Test/Js/tile-company-readonly-fields.test.js
@@ -62,13 +62,20 @@ function readTemplate() {
 }
 
 /**
- * Strip HTML comments before asserting on markup. The name field and the
- * number label both carry long explanatory comments that name `company_id`,
- * `readonly` and `input` on purpose, and a raw substring search would match
- * those and report a passing pin for prose.
+ * Strip explanatory PROSE comments before asserting on markup — but NOT
+ * knockout's own `<!-- ko ... -->` / `<!-- /ko -->` virtual-element comments,
+ * which are real template syntax (e.g. the i18n macro around "Company
+ * Number") rather than developer prose. The name field and the number label
+ * both carry long explanatory comments that name `company_id`, `readonly`
+ * and `input` on purpose, and a raw substring search would match those and
+ * report a passing pin for prose; stripping ko's own comments too would
+ * instead make every i18n-wrapped string invisible to these assertions.
  */
 function withoutComments(markup) {
-    return markup.replace(/<!--[\s\S]*?-->/g, '');
+    return markup.replace(/<!--[\s\S]*?-->/g, function (comment) {
+        const inner = comment.slice(4, -3).trim();
+        return /^(ko\b|\/ko$)/.test(inner) ? comment : '';
+    });
 }
 
 /**
@@ -88,16 +95,37 @@ function inputTag(id) {
 }
 
 /**
- * The `<div class="two-company-id-label">` tag, comments already stripped.
- * Throws rather than returning null, same reasoning as inputTag() above.
+ * The `<div class="two-company-id-label">...</div>` block, comments already
+ * stripped, INCLUDING its children (the caption span and the number span).
+ * Non-greedy up to the first `</div>` — safe because this block's own
+ * content is two flat `<span>` elements with no nested `<div>`. Throws
+ * rather than returning null, same reasoning as inputTag() above.
  */
 function companyIdLabelTag() {
     const markup = withoutComments(readTemplate());
-    const tags = (markup.match(/<div\b[^>]*class="two-company-id-label"[^>]*><\/div>/g) || []);
+    const tags = (markup.match(/<div\b[^>]*class="two-company-id-label"[^>]*>[\s\S]*?<\/div>/g) || []);
     if (tags.length !== 1) {
         throw new Error('expected exactly one <div class="two-company-id-label">, found ' + tags.length);
     }
     return tags[0];
+}
+
+/**
+ * The `<span data-bind="text: companyId">` inside the number label — the
+ * element that actually paints the number, as opposed to the static
+ * "Company Number" caption span alongside it.
+ */
+function companyIdNumberSpanTag() {
+    const tag = companyIdLabelTag();
+    const spans = (tag.match(/<span\b[^>]*>/g) || []).filter(function (span) {
+        return /text:\s*companyId\b/.test(span);
+    });
+    if (spans.length !== 1) {
+        throw new Error(
+            'expected exactly one <span data-bind="text: companyId">, found ' + spans.length
+        );
+    }
+    return spans[0];
 }
 
 /**
@@ -126,7 +154,7 @@ function renderedValue(id, renderer) {
  * `text:` binding.
  */
 function renderedLabelText(renderer) {
-    const bound = companyIdLabelTag().match(/text:\s*([A-Za-z_$][\w$]*)/);
+    const bound = companyIdNumberSpanTag().match(/text:\s*([A-Za-z_$][\w$]*)/);
     if (!bound) {
         throw new Error('the number label has no `text:` binding');
     }
@@ -215,6 +243,22 @@ describe('the payment tile shows the number as an uneditable label, not a field'
 
         expect(tag).toMatch(/text:\s*companyId\b/);
         expect(tag).toMatch(/visible:\s*!!companyId\(\)/);
+    });
+
+    test('the label carries a visible "Company Number" caption, not a bare number', () => {
+        // Regression caught in adversarial review: the first draft dropped
+        // the old <label for="company_id"> along with the input it labelled,
+        // leaving a sighted buyer (and a screen reader) with an unexplained
+        // number and no indication of what it was. The caption text must
+        // actually be present in the markup, not just asserted by comment.
+        const tag = companyIdLabelTag();
+
+        expect(tag).toMatch(/Company Number/);
+        // Two spans: one static caption, one bound to the number. Not one
+        // span doing both jobs — that would make the caption unable to
+        // update independently were it ever translated per-request.
+        const spanCount = (tag.match(/<span\b/g) || []).length;
+        expect(spanCount).toBe(2);
     });
 
     test('the name field is read-only only once a company has been captured', () => {

--- a/Test/Unit/Plugin/Model/Checkout/LayoutProcessorPluginTest.php
+++ b/Test/Unit/Plugin/Model/Checkout/LayoutProcessorPluginTest.php
@@ -284,6 +284,31 @@ class LayoutProcessorPluginTest extends TestCase
     }
 
     /**
+     * The symmetric case to testMissingStreetStillAnchorsOnCompany(): the
+     * anchor loop is `foreach (['company', 'street'] as $fieldName)`, so
+     * `company` missing entirely (a store somehow without that attribute, or
+     * a jsLayout shape without it) must still anchor correctly on `street`
+     * alone.
+     */
+    public function testMissingCompanyStillAnchorsOnStreet(): void
+    {
+        $seeded = $this->seededLayout();
+        $seeded['components']['checkout']['children']['steps']['children']['shipping-step']
+            ['children']['shippingAddress']['children']['shipping-address-fieldset']['children'] = [
+                'street' => ['label' => 'Street Address', 'sortOrder' => 70],
+                'country_id' => ['label' => 'Country', 'sortOrder' => 90],
+            ];
+
+        $jsLayout = $this->plugin(true)->afterProcess(
+            $this->createMock(LayoutProcessor::class),
+            $seeded
+        );
+        $fieldset = $this->fieldset($jsLayout);
+
+        $this->assertSame(69, $fieldset['country_id']['sortOrder']);
+    }
+
+    /**
      * Absent `country_id` (a store somehow without the field at all, or a
      * jsLayout shape this plugin does not recognise) must not blow up or
      * conjure a field that was never there.

--- a/Test/Unit/Plugin/Model/Checkout/LayoutProcessorPluginTest.php
+++ b/Test/Unit/Plugin/Model/Checkout/LayoutProcessorPluginTest.php
@@ -190,61 +190,96 @@ class LayoutProcessorPluginTest extends TestCase
     }
 
     /**
-     * A `jsLayout` shaped like seededLayout(), but with `country_id` also
-     * already present carrying some sortOrder — i.e. the shape the fieldset
-     * is ACTUALLY in by the time this plugin's afterProcess runs, once
-     * Magento_Checkout's own `AttributeMerger::getFieldConfig()` has already
-     * resolved every core field's sortOrder from the store's live Customer
-     * Address Attributes configuration (or, for `country_id`, from this
-     * module's own checkout_index_index.xml layout-XML override, since
-     * `getFieldConfig()` prefers a layout-XML sortOrder over the EAV one when
-     * both exist).
+     * A `jsLayout` shaped like seededLayout(), but with `country_id`,
+     * `company` and (optionally) `street` all already present carrying some
+     * sortOrder — i.e. the shape the fieldset is ACTUALLY in by the time
+     * this plugin's afterProcess runs, once Magento_Checkout's own
+     * `AttributeMerger::getFieldConfig()` has already resolved every core
+     * field's sortOrder from the store's live Customer Address Attributes
+     * configuration (or, for `country_id`, from this module's own
+     * checkout_index_index.xml layout-XML override, since `getFieldConfig()`
+     * prefers a layout-XML sortOrder over the EAV one when both exist).
      *
-     * @param int|string $companySortOrder
-     * @param int|string $countrySortOrder
+     * @param mixed $companySortOrder
+     * @param mixed $countrySortOrder
+     * @param mixed $streetSortOrder pass null to omit the field entirely
      * @return array<string,mixed>
      */
-    private function seededLayoutWithCountry($companySortOrder, $countrySortOrder): array
+    private function seededLayoutWithCountry($companySortOrder, $countrySortOrder, $streetSortOrder = 999): array
     {
         $seeded = $this->seededLayout();
+        $children = [
+            'company' => ['label' => 'Company', 'sortOrder' => $companySortOrder],
+            'country_id' => ['label' => 'Country', 'sortOrder' => $countrySortOrder],
+        ];
+        if ($streetSortOrder !== null) {
+            $children['street'] = ['label' => 'Street Address', 'sortOrder' => $streetSortOrder];
+        }
         $seeded['components']['checkout']['children']['steps']['children']['shipping-step']
-            ['children']['shippingAddress']['children']['shipping-address-fieldset']['children'] = [
-                'company' => ['label' => 'Company', 'sortOrder' => $companySortOrder],
-                'country_id' => ['label' => 'Country', 'sortOrder' => $countrySortOrder],
-            ];
+            ['children']['shippingAddress']['children']['shipping-address-fieldset']['children'] = $children;
 
         return $seeded;
     }
 
     /**
-     * Country must come before company regardless of what the store's admin
-     * configuration (or this module's own static layout-XML number) put in
-     * `country_id`'s sortOrder — mirroring PrestaShop's
+     * Country must come before company AND street regardless of what the
+     * store's admin configuration (or this module's own static layout-XML
+     * number) put in `country_id`'s sortOrder — mirroring PrestaShop's
      * `CustomerAddressFormatter::moveFieldBefore('id_country', 'company')`.
-     * Read `company`'s sortOrder back out of the array (already resolved by
-     * core by this point) rather than assume a fixed number, so this holds
-     * for any store configuration.
+     * Read both sortOrders back out of the array (already resolved by core
+     * by this point) rather than assume a fixed number, so this holds for
+     * any store configuration. Anchoring to company ALONE was the exact gap
+     * an earlier round of this fix shipped with — street is independently
+     * configurable and was the field actually reported live.
      */
-    public function testCountrySortsBeforeCompanyRegardlessOfConfiguredSortOrder(): void
+    public function testCountrySortsBeforeCompanyAndStreetRegardlessOfConfiguredSortOrder(): void
     {
-        // country_id ALREADY has a lower sortOrder than company: nothing
-        // should change.
+        // Both already sort after country: nothing should change, and this
+        // is asserted as a NO-OP (exact value), not just "still less than" —
+        // an earlier draft of this method rewrote sortOrder unconditionally
+        // even when nothing was wrong, which this pins against.
         $jsLayout = $this->plugin(true)->afterProcess(
             $this->createMock(LayoutProcessor::class),
-            $this->seededLayoutWithCountry(60, 50)
+            $this->seededLayoutWithCountry(60, 50, 70)
         );
         $fieldset = $this->fieldset($jsLayout);
-        $this->assertLessThan($fieldset['company']['sortOrder'], $fieldset['country_id']['sortOrder']);
+        $this->assertSame(50, $fieldset['country_id']['sortOrder']);
 
-        // country_id's sortOrder is HIGHER than company's — the exact bug
-        // reported live (country rendering after street/company). Must be
-        // forced below company's.
+        // country_id's sortOrder is HIGHER than company's (street is out of
+        // the way) — the fix must anchor on company.
         $jsLayout = $this->plugin(true)->afterProcess(
             $this->createMock(LayoutProcessor::class),
-            $this->seededLayoutWithCountry(60, 90)
+            $this->seededLayoutWithCountry(60, 90, 999)
         );
         $fieldset = $this->fieldset($jsLayout);
+        $this->assertSame(59, $fieldset['country_id']['sortOrder']);
+
+        // street reconfigured BELOW company — the exact bug reported live
+        // (country after STREET specifically). Must anchor on street, the
+        // lower of the two, not on company.
+        $jsLayout = $this->plugin(true)->afterProcess(
+            $this->createMock(LayoutProcessor::class),
+            $this->seededLayoutWithCountry(60, 90, 30)
+        );
+        $fieldset = $this->fieldset($jsLayout);
+        $this->assertSame(29, $fieldset['country_id']['sortOrder']);
         $this->assertLessThan($fieldset['company']['sortOrder'], $fieldset['country_id']['sortOrder']);
+        $this->assertLessThan($fieldset['street']['sortOrder'], $fieldset['country_id']['sortOrder']);
+    }
+
+    /**
+     * `street` absent (a jsLayout shape without it, or a store that somehow
+     * has no street attribute) must still anchor correctly on `company`
+     * alone, not blow up on the missing key.
+     */
+    public function testMissingStreetStillAnchorsOnCompany(): void
+    {
+        $jsLayout = $this->plugin(true)->afterProcess(
+            $this->createMock(LayoutProcessor::class),
+            $this->seededLayoutWithCountry(60, 90, null)
+        );
+        $fieldset = $this->fieldset($jsLayout);
+
         $this->assertSame(59, $fieldset['country_id']['sortOrder']);
     }
 
@@ -265,17 +300,41 @@ class LayoutProcessorPluginTest extends TestCase
     }
 
     /**
-     * `company` present but with no numeric sortOrder yet resolved (a shape
-     * this plugin cannot safely reorder against) must leave country_id's
-     * sortOrder exactly as core/layout-XML left it, not corrupt it with
-     * `null - 1` or similar.
+     * `country_id` present as a non-array scalar (a foreign/malformed
+     * component contributed by some other module) must not crash trying to
+     * write an array offset onto it.
      */
-    public function testCompanyWithoutASortOrderLeavesCountryIdUntouched(): void
+    public function testScalarCountryIdDoesNotCrash(): void
+    {
+        $seeded = $this->seededLayout();
+        $seeded['components']['checkout']['children']['steps']['children']['shipping-step']
+            ['children']['shippingAddress']['children']['shipping-address-fieldset']['children'] = [
+                'company' => ['label' => 'Company', 'sortOrder' => 60],
+                'country_id' => 'not-an-array',
+            ];
+
+        $jsLayout = $this->plugin(true)->afterProcess(
+            $this->createMock(LayoutProcessor::class),
+            $seeded
+        );
+        $fieldset = $this->fieldset($jsLayout);
+
+        $this->assertSame('not-an-array', $fieldset['country_id']);
+    }
+
+    /**
+     * `company` (and `street`, if present) with no numeric sortOrder yet
+     * resolved — a shape this plugin cannot safely reorder against — must
+     * leave country_id's sortOrder exactly as core/layout-XML left it, not
+     * corrupt it with `null - 1` or similar.
+     */
+    public function testFieldsWithoutASortOrderLeaveCountryIdUntouched(): void
     {
         $seeded = $this->seededLayout();
         $seeded['components']['checkout']['children']['steps']['children']['shipping-step']
             ['children']['shippingAddress']['children']['shipping-address-fieldset']['children'] = [
                 'company' => ['label' => 'Company'],
+                'street' => ['label' => 'Street Address'],
                 'country_id' => ['label' => 'Country', 'sortOrder' => 90],
             ];
 

--- a/Test/Unit/Plugin/Model/Checkout/LayoutProcessorPluginTest.php
+++ b/Test/Unit/Plugin/Model/Checkout/LayoutProcessorPluginTest.php
@@ -188,4 +188,103 @@ class LayoutProcessorPluginTest extends TestCase
         $this->assertTrue($field['visible']);
         $this->assertSame('two-company-id-hidden', $field['additionalClasses']);
     }
+
+    /**
+     * A `jsLayout` shaped like seededLayout(), but with `country_id` also
+     * already present carrying some sortOrder — i.e. the shape the fieldset
+     * is ACTUALLY in by the time this plugin's afterProcess runs, once
+     * Magento_Checkout's own `AttributeMerger::getFieldConfig()` has already
+     * resolved every core field's sortOrder from the store's live Customer
+     * Address Attributes configuration (or, for `country_id`, from this
+     * module's own checkout_index_index.xml layout-XML override, since
+     * `getFieldConfig()` prefers a layout-XML sortOrder over the EAV one when
+     * both exist).
+     *
+     * @param int|string $companySortOrder
+     * @param int|string $countrySortOrder
+     * @return array<string,mixed>
+     */
+    private function seededLayoutWithCountry($companySortOrder, $countrySortOrder): array
+    {
+        $seeded = $this->seededLayout();
+        $seeded['components']['checkout']['children']['steps']['children']['shipping-step']
+            ['children']['shippingAddress']['children']['shipping-address-fieldset']['children'] = [
+                'company' => ['label' => 'Company', 'sortOrder' => $companySortOrder],
+                'country_id' => ['label' => 'Country', 'sortOrder' => $countrySortOrder],
+            ];
+
+        return $seeded;
+    }
+
+    /**
+     * Country must come before company regardless of what the store's admin
+     * configuration (or this module's own static layout-XML number) put in
+     * `country_id`'s sortOrder — mirroring PrestaShop's
+     * `CustomerAddressFormatter::moveFieldBefore('id_country', 'company')`.
+     * Read `company`'s sortOrder back out of the array (already resolved by
+     * core by this point) rather than assume a fixed number, so this holds
+     * for any store configuration.
+     */
+    public function testCountrySortsBeforeCompanyRegardlessOfConfiguredSortOrder(): void
+    {
+        // country_id ALREADY has a lower sortOrder than company: nothing
+        // should change.
+        $jsLayout = $this->plugin(true)->afterProcess(
+            $this->createMock(LayoutProcessor::class),
+            $this->seededLayoutWithCountry(60, 50)
+        );
+        $fieldset = $this->fieldset($jsLayout);
+        $this->assertLessThan($fieldset['company']['sortOrder'], $fieldset['country_id']['sortOrder']);
+
+        // country_id's sortOrder is HIGHER than company's — the exact bug
+        // reported live (country rendering after street/company). Must be
+        // forced below company's.
+        $jsLayout = $this->plugin(true)->afterProcess(
+            $this->createMock(LayoutProcessor::class),
+            $this->seededLayoutWithCountry(60, 90)
+        );
+        $fieldset = $this->fieldset($jsLayout);
+        $this->assertLessThan($fieldset['company']['sortOrder'], $fieldset['country_id']['sortOrder']);
+        $this->assertSame(59, $fieldset['country_id']['sortOrder']);
+    }
+
+    /**
+     * Absent `country_id` (a store somehow without the field at all, or a
+     * jsLayout shape this plugin does not recognise) must not blow up or
+     * conjure a field that was never there.
+     */
+    public function testMissingCountryIdIsLeftAlone(): void
+    {
+        $jsLayout = $this->plugin(true)->afterProcess(
+            $this->createMock(LayoutProcessor::class),
+            $this->seededLayout()
+        );
+        $fieldset = $this->fieldset($jsLayout);
+
+        $this->assertArrayNotHasKey('country_id', $fieldset);
+    }
+
+    /**
+     * `company` present but with no numeric sortOrder yet resolved (a shape
+     * this plugin cannot safely reorder against) must leave country_id's
+     * sortOrder exactly as core/layout-XML left it, not corrupt it with
+     * `null - 1` or similar.
+     */
+    public function testCompanyWithoutASortOrderLeavesCountryIdUntouched(): void
+    {
+        $seeded = $this->seededLayout();
+        $seeded['components']['checkout']['children']['steps']['children']['shipping-step']
+            ['children']['shippingAddress']['children']['shipping-address-fieldset']['children'] = [
+                'company' => ['label' => 'Company'],
+                'country_id' => ['label' => 'Country', 'sortOrder' => 90],
+            ];
+
+        $jsLayout = $this->plugin(true)->afterProcess(
+            $this->createMock(LayoutProcessor::class),
+            $seeded
+        );
+        $fieldset = $this->fieldset($jsLayout);
+
+        $this->assertSame(90, $fieldset['country_id']['sortOrder']);
+    }
 }

--- a/view/frontend/web/css/style.css
+++ b/view/frontend/web/css/style.css
@@ -127,12 +127,39 @@
     cursor: pointer;
 }
 
+/*
+ * The "Search for company" return-to-search control (`search_for_company` in
+ * address-autocomplete.js / gateway_method.js). It carries `role="button"
+ * tabindex="0"` and Enter/Space keydown handling in JS (a11y fix), but that
+ * only makes it FOCUSABLE and ACTIVATABLE — the CSS side of the same
+ * accessibility work never landed alongside it:
+ *
+ *  - `text-transform: none !important`: this is a plain `<div>`, not a native
+ *    element a host theme would normally style, but plenty of Luma themes
+ *    apply casing rules broadly enough (e.g. `.field ~ div, [role="button"]`)
+ *    to catch it anyway, and a theme's own rule is routinely `!important`
+ *    itself for exactly this kind of CTA-style text.
+ *  - the reserved-space dotted border + `:focus` colour gives Tab-users a
+ *    visible focus indicator, which a bare `role="button"` div otherwise has
+ *    none of by default (unlike a real `<button>`, which gets the browser's
+ *    native focus ring). The border is reserved (transparent) even when not
+ *    focused so gaining focus never changes this element's box size.
+ */
 .search_for_company {
     text-align: right;
     cursor: pointer;
     padding-top: 5px;
     color: var(--color-blue2);
     right: 4px;
+    text-transform: none !important;
+    border: 1px dotted transparent;
+    padding-left: 2px;
+    padding-right: 2px;
+}
+
+.search_for_company:focus {
+    outline: none;
+    border-color: #808080 !important;
 }
 
 .two-payment-method {
@@ -429,6 +456,64 @@
 }
 
 /*
+ * Company-search combobox: placeholder / selected-value text and result-row
+ * vertical alignment.
+ *
+ * `#select2-company-container` is the address-step field's rendered span —
+ * select2 4.1 gives it `id="select2-<original element id>-container"`, and
+ * the address input's own id is `company` (Magento core's native address
+ * attribute). `#select2-company_name-container` is the payment-tile
+ * equivalent, whose backing input is `input#company_name`.
+ *
+ * Some Luma themes apply a blanket `text-transform: uppercase` broad enough
+ * to catch select2's own rendered span, and give the selection box a custom
+ * height with no matching line-height on the rendered text, leaving it a few
+ * pixels off true vertical centre. `!important` because a theme's own
+ * form-control casing/height rules are routinely `!important` themselves.
+ *
+ * Flex + `align-items: center` on both the outer selection box AND the
+ * rendered span (not just the outer box) matters: centring only the outer
+ * box centres the BOX, not text sitting off-centre within it from a
+ * theme-supplied height with the wrong line-height.
+ */
+#select2-company-container,
+#select2-company_name-container {
+    text-transform: none !important;
+    line-height: normal;
+}
+
+#shipping-new-address-form input[name='company'] + .select2-container .select2-selection--single,
+#two_gateway_form input#company_name + .select2-container .select2-selection--single {
+    display: flex;
+    align-items: center;
+}
+
+#shipping-new-address-form input[name='company'] + .select2-container .select2-selection__rendered,
+#two_gateway_form input#company_name + .select2-container .select2-selection__rendered {
+    display: flex;
+    align-items: center;
+    height: 100%;
+}
+
+/*
+ * Result rows in the dropdown itself (company names picked from the search),
+ * same class of bug: a theme's list/option styling can apply uppercase and
+ * an icon/text baseline mismatch to `.select2-results__option`. select2
+ * detaches the dropdown to `<body>` on open (outside either form's own DOM
+ * subtree), so this cannot be scoped by ancestry from the field the way the
+ * selection-box rules above are — instead scoped by the results listbox's
+ * own id, which select2 derives from the backing element's id
+ * (`select2-<id>-results`), so this never touches an unrelated select2
+ * instance elsewhere on the page.
+ */
+#select2-company-results .select2-results__option,
+#select2-company_name-results .select2-results__option {
+    display: flex;
+    align-items: center;
+    text-transform: none !important;
+}
+
+/*
  * The manual-entry row in the company-search results list.
  *
  * A SINGLE FLAT CLASS, for the same reason as the spinner above: overlay
@@ -531,28 +616,40 @@
 }
 
 /*
- * TWO-25288. The payment tile's read-only company-number input. It replaced the
- * grey inline hint that briefly stood in for it: the number is now a labelled
- * field of its own, shown to the buyer so they can check what the order will be
- * invoiced against, and never editable on this step.
+ * The company-NAME input's read-only affordance. `readonly` is bound and true
+ * in sole-trader mode only (see gateway_method.html), and `readonly` alone
+ * renders identically to a normal input in most themes — an input the buyer
+ * cannot type into but which looks like they can is worse than either state
+ * on its own.
  *
- * Styled to READ as uneditable, because `readonly` alone renders identically to
- * a normal input in most themes and an input the buyer cannot type into but
- * which looks like they can is worse than either state on its own. The
- * `readonly` attribute in the template is what actually enforces it; this is
- * only the affordance.
- *
- * The second selector covers the company-NAME input, whose `readonly` is bound
- * and true in sole-trader mode only. Scoped to this module's own form rather
- * than written as a bare `input[readonly]`: this stylesheet is loaded for the
- * whole storefront and an unscoped rule would repaint every read-only input on
- * the page, none of which this module owns.
+ * Scoped to this module's own form rather than written as a bare
+ * `input[readonly]`: this stylesheet is loaded for the whole storefront and
+ * an unscoped rule would repaint every read-only input on the page, none of
+ * which this module owns.
  */
-.two-company-id-readonly,
 #two_gateway_form input.input-text[readonly] {
     background-color: #f5f5f5;
     color: #666666;
     cursor: default;
+}
+
+/*
+ * The captured organisation number, a plain text label rather than a field
+ * (canonical design across all four platforms — Doug's ruling). Positioned
+ * immediately below the company-name input and right-aligned to it:
+ * `text-align: right` inside `.control` lines it up against the input's own
+ * right edge, since `.control` is the input's own containing box.
+ *
+ * Grey, not the form's usual text colour, so it reads as a caption on the
+ * field above rather than as another piece of body copy — matching how the
+ * removed read-only input used to look (`#666666` on a light background).
+ */
+.two-company-id-label {
+    display: block;
+    text-align: right;
+    margin-top: 4px;
+    color: #666666;
+    font-size: 12px;
 }
 
 /*

--- a/view/frontend/web/css/style.css
+++ b/view/frontend/web/css/style.css
@@ -459,11 +459,17 @@
  * Company-search combobox: placeholder / selected-value text and result-row
  * vertical alignment.
  *
- * `#select2-company-container` is the address-step field's rendered span —
- * select2 4.1 gives it `id="select2-<original element id>-container"`, and
- * the address input's own id is `company` (Magento core's native address
- * attribute). `#select2-company_name-container` is the payment-tile
- * equivalent, whose backing input is `input#company_name`.
+ * Scoped by ADJACENT SIBLING from the backing input, not by select2's own
+ * generated element ids: select2 4.1 derives those from the backing
+ * element's `id` attribute when it has one, or `name + 2 random characters`
+ * when it doesn't (`generateId()` in the vendored select2.min.js) — the
+ * address-step company field carries no explicit `id` (only `name`), so an
+ * `#select2-company-container`-style selector is NOT a stable target for it
+ * (confirmed by review — flagged before this shipped as select2-id-scoped
+ * dead CSS with nothing to catch the drift). `input[name] + .select2-container`
+ * has no such dependency: select2 always inserts its container immediately
+ * after the original element (`insertAfter()`, confirmed in the vendored
+ * bundle), regardless of what id it ends up generating.
  *
  * Some Luma themes apply a blanket `text-transform: uppercase` broad enough
  * to catch select2's own rendered span, and give the selection box a custom
@@ -476,12 +482,6 @@
  * box centres the BOX, not text sitting off-centre within it from a
  * theme-supplied height with the wrong line-height.
  */
-#select2-company-container,
-#select2-company_name-container {
-    text-transform: none !important;
-    line-height: normal;
-}
-
 #shipping-new-address-form input[name='company'] + .select2-container .select2-selection--single,
 #two_gateway_form input#company_name + .select2-container .select2-selection--single {
     display: flex;
@@ -493,21 +493,23 @@
     display: flex;
     align-items: center;
     height: 100%;
+    text-transform: none !important;
+    line-height: normal;
 }
 
 /*
- * Result rows in the dropdown itself (company names picked from the search),
- * same class of bug: a theme's list/option styling can apply uppercase and
- * an icon/text baseline mismatch to `.select2-results__option`. select2
- * detaches the dropdown to `<body>` on open (outside either form's own DOM
- * subtree), so this cannot be scoped by ancestry from the field the way the
- * selection-box rules above are — instead scoped by the results listbox's
- * own id, which select2 derives from the backing element's id
- * (`select2-<id>-results`), so this never touches an unrelated select2
- * instance elsewhere on the page.
+ * Result rows in the dropdown itself (company names picked from the
+ * search), same class of bug: a theme's list/option styling can apply
+ * uppercase and an icon/text baseline mismatch to `.select2-results__option`.
+ * select2 detaches the dropdown to `<body>` on open (outside either form's
+ * own DOM subtree), so this cannot be scoped by ancestry from the field the
+ * way the selection-box rules above are. `dropdownCssClass:
+ * 'two-company-search-dropdown'` (set on BOTH pickers' `.select2({...})`
+ * init — address-autocomplete.js and gateway_method.js) is select2's own
+ * supported hook for exactly this, and — unlike an id — is not subject to
+ * select2's id-generation fallback at all.
  */
-#select2-company-results .select2-results__option,
-#select2-company_name-results .select2-results__option {
+.two-company-search-dropdown .select2-results__option {
     display: flex;
     align-items: center;
     text-transform: none !important;
@@ -650,6 +652,15 @@
     margin-top: 4px;
     color: #666666;
     font-size: 12px;
+}
+
+/*
+ * The "Company Number" caption inside the label above. Slightly bolder than
+ * the number itself so the line reads as "Company Number: 12345678" rather
+ * than two equally-weighted pieces of grey text.
+ */
+.two-company-id-label__caption {
+    font-weight: 500;
 }
 
 /*

--- a/view/frontend/web/css/style.css
+++ b/view/frontend/web/css/style.css
@@ -655,11 +655,17 @@
 }
 
 /*
- * The "Company Number" caption inside the label above. Slightly bolder than
- * the number itself so the line reads as "Company Number: 12345678" rather
- * than two equally-weighted pieces of grey text.
+ * The "Company Number" caption inside the label above, on its OWN line
+ * (block, not inline) with the number directly beneath it. Stacked rather
+ * than joined on one line with punctuation (a colon, a dash) deliberately —
+ * see the template comment: a hardcoded ASCII separator glued outside the
+ * translated caption string is exactly the kind of thing that reads wrong
+ * in some locales. Slightly bolder than the number so the caption still
+ * reads as a caption rather than a second, equally-weighted line of body
+ * copy.
  */
 .two-company-id-label__caption {
+    display: block;
     font-weight: 500;
 }
 

--- a/view/frontend/web/js/model/company-search.js
+++ b/view/frontend/web/js/model/company-search.js
@@ -84,6 +84,16 @@ define(['jquery', 'mage/translate'], function ($, $t) {
     const MIN_INPUT_LENGTH = 3;
 
     /**
+     * select2's `dropdownCssClass` option for both company-search pickers
+     * (address step and payment tile). A single exported constant, same
+     * reason as MIN_INPUT_LENGTH above: the two call sites (`select2({...})`
+     * in address-autocomplete.js and gateway_method.js) must agree with
+     * style.css's dropdown-row selector, and a hardcoded literal at each
+     * site can drift silently if one is renamed without the others.
+     */
+    const DROPDOWN_CSS_CLASS = 'two-company-search-dropdown';
+
+    /**
      * The "keep typing" hint shown while the term is below MIN_INPUT_LENGTH.
      *
      * select2 ships its own English `inputTooShort` message, hard-coded
@@ -181,6 +191,7 @@ define(['jquery', 'mage/translate'], function ($, $t) {
         REQUEST_TIMEOUT_MS: REQUEST_TIMEOUT_MS,
         SEARCH_DEBOUNCE_MS: SEARCH_DEBOUNCE_MS,
         MIN_INPUT_LENGTH: MIN_INPUT_LENGTH,
+        DROPDOWN_CSS_CLASS: DROPDOWN_CSS_CLASS,
         EVENT_NS: EVENT_NS,
         isDegradedResponse: isDegradedResponse,
         minInputLengthMessage: minInputLengthMessage,

--- a/view/frontend/web/js/view/address-autocomplete.js
+++ b/view/frontend/web/js/view/address-autocomplete.js
@@ -331,8 +331,13 @@ define([
                             // company field carries no explicit `id`, so
                             // that fallback is NOT a stable selector CSS
                             // could target. `dropdownCssClass` is select2's
-                            // own supported hook for exactly this.
-                            dropdownCssClass: 'two-company-search-dropdown',
+                            // own supported hook for exactly this — the
+                            // literal class name lives once, on
+                            // companySearch.DROPDOWN_CSS_CLASS, same
+                            // convention as MIN_INPUT_LENGTH above, so this
+                            // and the payment-tile picker's init (and
+                            // style.css) can't drift apart on a rename.
+                            dropdownCssClass: companySearch.DROPDOWN_CSS_CLASS,
                             width: '100%',
                             escapeMarkup: function (markup) {
                                 return markup;

--- a/view/frontend/web/js/view/address-autocomplete.js
+++ b/view/frontend/web/js/view/address-autocomplete.js
@@ -322,6 +322,17 @@ define([
                                     return companySearch.minInputLengthMessage();
                                 }
                             },
+                            // A stable, non-generated hook for style.css's
+                            // dropdown-row CSS fixes (text-transform,
+                            // vertical alignment). select2 IDs its own
+                            // rendered/results elements off the backing
+                            // element's `id` attribute when present, or
+                            // `name + 2 random chars` when it isn't — this
+                            // company field carries no explicit `id`, so
+                            // that fallback is NOT a stable selector CSS
+                            // could target. `dropdownCssClass` is select2's
+                            // own supported hook for exactly this.
+                            dropdownCssClass: 'two-company-search-dropdown',
                             width: '100%',
                             escapeMarkup: function (markup) {
                                 return markup;

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -1097,8 +1097,11 @@ define([
                             // `#select2-company_name-container` references
                             // below), but using the same explicit class here
                             // too keeps both pickers' dropdown CSS keyed off
-                            // one mechanism rather than two.
-                            dropdownCssClass: 'two-company-search-dropdown',
+                            // one mechanism rather than two. Drawn from
+                            // companySearch.DROPDOWN_CSS_CLASS, same shared
+                            // constant address-autocomplete.js uses, so the
+                            // two call sites and style.css can't drift.
+                            dropdownCssClass: companySearch.DROPDOWN_CSS_CLASS,
                             width: '100%',
                             escapeMarkup: function (markup) {
                                 return markup;

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -1089,6 +1089,16 @@ define([
                     $companyNameField
                         .select2({
                             minimumInputLength: companySearch.MIN_INPUT_LENGTH,
+                            // Same stable dropdown-row hook as the
+                            // address-step picker (address-autocomplete.js)
+                            // — this field's `input#company_name` id DOES
+                            // give select2 a stable `select2-company_name-*`
+                            // id already (confirmed by the existing
+                            // `#select2-company_name-container` references
+                            // below), but using the same explicit class here
+                            // too keeps both pickers' dropdown CSS keyed off
+                            // one mechanism rather than two.
+                            dropdownCssClass: 'two-company-search-dropdown',
                             width: '100%',
                             escapeMarkup: function (markup) {
                                 return markup;

--- a/view/frontend/web/template/payment/gateway_method.html
+++ b/view/frontend/web/template/payment/gateway_method.html
@@ -217,27 +217,41 @@
                             ambiguity — there is no control to mistake for
                             typeable.
 
+                            The "Company Number" CAPTION is deliberately kept
+                            (an adversarial review round caught its removal:
+                            the first draft of this change dropped the
+                            `<label for="company_id">` along with the input,
+                            leaving a bare number with no indication of what
+                            it was — a real regression for both sighted
+                            buyers and assistive tech, not just a style nit).
+                            A `<span>` rather than a `<label for=...>`: there
+                            is no control left for a `for` attribute to
+                            associate with, and an orphaned `for` pointing at
+                            a retired id is worse than no `for` at all.
+
                             `visible: !!companyId()` is why it is naturally
                             blank in manual-entry mode: there is no number to
                             show, same as the input version, but here that
-                            reads as the label simply not being there rather
-                            than as an empty box. Nothing client-side
+                            reads as the whole line simply not being there
+                            rather than as an empty box. Nothing client-side
                             enforces the number's presence either way;
                             Model/Two.php::authorize() refuses an order with
                             an empty organisation number server-side, and
                             that refusal remains the only enforcement.
 
-                            Bound straight to `companyId`, the same observable
-                            the removed input read — every accepted source
-                            still writes exactly one place, and getData()
-                            still reads that observable, never the DOM. See
-                            the writer list on applyCompanyData() in
-                            gateway_method.js.
+                            The number itself is bound straight to
+                            `companyId`, the same observable the removed
+                            input read — every accepted source still writes
+                            exactly one place, and getData() still reads that
+                            observable, never the DOM. See the writer list on
+                            applyCompanyData() in gateway_method.js.
                         -->
-                        <div
-                            class="two-company-id-label"
-                            data-bind="visible: !!companyId(), text: companyId"
-                        ></div>
+                        <div class="two-company-id-label" data-bind="visible: !!companyId()">
+                            <span class="two-company-id-label__caption">
+                                <!-- ko i18n: 'Company Number'--><!-- /ko -->:
+                            </span>
+                            <span data-bind="text: companyId"></span>
+                        </div>
                     </div>
                 </div>
                 <!--

--- a/view/frontend/web/template/payment/gateway_method.html
+++ b/view/frontend/web/template/payment/gateway_method.html
@@ -202,55 +202,42 @@
                             value: companyName'
                             class="input-text"
                         />
-                    </div>
-                </div>
-                <!--
-                    The captured organisation number, VISIBLE and never
-                    editable. TWO-25288 first removed this input outright; that
-                    hid the number from the buyer, who could then not check
-                    what the order would be invoiced against. Showing it
-                    read-only keeps the reason the input was removed — a
-                    hand-typed organisation number is not an accepted source,
-                    it produced poor data quality and genuine buyers receiving
-                    invoices for orders they never placed — while giving the
-                    buyer back the confirmation.
+                        <!--
+                            The captured organisation number. Canonical design
+                            across all four platforms (Doug's ruling): not a
+                            second input field of its own — a plain text label
+                            immediately below the company-name field,
+                            right-aligned to it, shown only once a number has
+                            actually been captured. This SUPERSEDES the
+                            earlier `<input id="company_id" readonly>` field
+                            (TWO-25288): that traded the field's original
+                            removal (which hid the number from the buyer
+                            entirely) for a control that looked editable-ish
+                            despite being locked. A label carries no such
+                            ambiguity — there is no control to mistake for
+                            typeable.
 
-                    `readonly` is a STATIC attribute, unlike the name field
-                    above: there is no mode in which this number may be typed
-                    on this step. It is deliberately `readonly` rather than
-                    `disabled`, because a disabled control is dropped from the
-                    submitted form and skipped by jQuery Validation's
-                    `elements()` — this field must render and read like the
-                    others without changing what the form carries.
+                            `visible: !!companyId()` is why it is naturally
+                            blank in manual-entry mode: there is no number to
+                            show, same as the input version, but here that
+                            reads as the label simply not being there rather
+                            than as an empty box. Nothing client-side
+                            enforces the number's presence either way;
+                            Model/Two.php::authorize() refuses an order with
+                            an empty organisation number server-side, and
+                            that refusal remains the only enforcement.
 
-                    Not `required`, and it carries no `name`: every accepted
-                    source writes the `companyId` observable and getData()
-                    reads that observable, never the DOM, so this input is a
-                    display of the value rather than a carrier of it. See the
-                    writer list on applyCompanyData() in gateway_method.js.
-
-                    Blank in manual-entry mode, which is correct — there is no
-                    number to show. Nothing client-side enforces its presence;
-                    Model/Two.php::authorize() refuses an order with an empty
-                    organisation number server-side, and that refusal is the
-                    only enforcement.
-                -->
-                <div class="field field-text">
-                    <label for="company_id" class="label">
-                        <span><!-- ko i18n: 'Company Number'--><!-- /ko --></span>
-                    </label>
-                    <div class="control">
-                        <input
-                            type="text"
-                            id="company_id"
-                            readonly="readonly"
-                            data-bind='
-                            attr: {
-                                title: $t("Company Number")
-                            },
-                            value: companyId'
-                            class="input-text two-company-id-readonly"
-                        />
+                            Bound straight to `companyId`, the same observable
+                            the removed input read — every accepted source
+                            still writes exactly one place, and getData()
+                            still reads that observable, never the DOM. See
+                            the writer list on applyCompanyData() in
+                            gateway_method.js.
+                        -->
+                        <div
+                            class="two-company-id-label"
+                            data-bind="visible: !!companyId(), text: companyId"
+                        ></div>
                     </div>
                 </div>
                 <!--

--- a/view/frontend/web/template/payment/gateway_method.html
+++ b/view/frontend/web/template/payment/gateway_method.html
@@ -247,8 +247,25 @@
                             applyCompanyData() in gateway_method.js.
                         -->
                         <div class="two-company-id-label" data-bind="visible: !!companyId()">
+                            <!--
+                                No hardcoded punctuation joining the caption and
+                                the number (no colon, no dash): a literal ASCII
+                                separator glued outside the translated string is
+                                exactly the kind of thing that reads wrong in
+                                some locales (spacing/punctuation conventions
+                                around a label vary — see the org's active
+                                nb/nl/sv/es locale-parity work). Reusing the
+                                bare `'Company Number'` string (already
+                                translated everywhere else it's used — the
+                                payment-tile field label, the address-step
+                                tooltip) rather than minting a new
+                                colon-suffixed msgid that would start out
+                                untranslated. Visual separation between caption
+                                and number comes from CSS (stacked lines)
+                                instead of punctuation.
+                            -->
                             <span class="two-company-id-label__caption">
-                                <!-- ko i18n: 'Company Number'--><!-- /ko -->:
+                                <!-- ko i18n: 'Company Number'--><!-- /ko -->
                             </span>
                             <span data-bind="text: companyId"></span>
                         </div>


### PR DESCRIPTION
## Summary

Three live bugs Doug found testing Luma checkout this morning:

- **Company search CSS never got last night's WC/PS a11y polish.** PR #311 already fixed the JS keyboard behaviour on the "Search for company" control (`role="button" tabindex="0"`, Enter/Space). The matching CSS — a visible focus indicator, `text-transform` scoping, select2 vertical-alignment fixes — never landed alongside it. Confirmed by `git log`/grep: zero `text-transform`/`align-items` rules touched select2 or `search_for_company` anywhere in `style.css` before this PR.
- **Payment tile showed the company number as a separate input.** Canonical design across all four platforms (Doug's ruling): a plain text label immediately below the company-name field, right-aligned to it, visible only once a number has been captured. Supersedes the TWO-25288 `<input id="company_id" readonly>`.
- **Country rendered after street/company.** `checkout_index_index.xml` already declares `country_id`'s sortOrder as a static 50 (has since 2022), which does win over core's EAV default when set — but `company`/`street` carry no override of their own, so their actual position depends on the store's live Customer Address Attributes configuration. This staging store's config pushes them below 50. `LayoutProcessorPlugin` now reads `company`'s resolved sortOrder back out of the array (after core's own merge) and forces `country_id` immediately before it — dynamic, mirrors PrestaShop's `CustomerAddressFormatter::moveFieldBefore('id_country', 'company')`.

## Test plan

- [x] `npx jest --config Test/Js/jest.config.js` — 21 suites, 266 tests, all green (rewrote `tile-company-readonly-fields.test.js` for the label-based markup; mutation-verified the new visibility/text pins by breaking the binding and confirming failure, then restoring).
- [x] `LayoutProcessorPluginTest.php` extended with the country/company sort-order cases; verified the extracted `moveCountryBeforeCompany()` logic against a standalone PHP harness (no local Magento/composer environment available in this sandbox to run PHPUnit directly — logic traced and array-mutation confirmed manually).
- [x] Live-verified on `magento.staging.two.inc` before and after: confirmed the field order bug (Company → Street → Country) and the missing keyboard focus indicator pre-fix; confirmed dropdown text-transform/alignment were NOT actually broken on this theme instance (defensive CSS added anyway, matching WC's own scoped, non-destructive pattern) — reran post-commit.
- [ ] Live-verify of the payment-tile label rendering was blocked by a Chrome extension popup during the automated browser check; markup change is covered by the Jest suite (`text:`/`visible:` bindings pinned) and by direct template review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)