### PR TITLE
fix(checkout): company search — open on any key, No matches found, Tab focus, company-number label (TWO-25326)

### DIFF
--- a/Test/Js/address-company-id.test.js
+++ b/Test/Js/address-company-id.test.js
@@ -106,6 +106,18 @@ function makeDom() {
             attr: function () {
                 return n;
             },
+            // TWO-25326 §5's company-number text label builds and tears
+            // itself down through these. Recorded rather than inert so a
+            // future test can assert on them; this file only needs them not
+            // to throw.
+            addClass: function (cls) {
+                n.classes = (n.classes || []).concat(cls);
+                return n;
+            },
+            remove: function () {
+                n.removed = true;
+                return n;
+            },
             show: function () {
                 return n;
             },

--- a/Test/Js/address-step-company-id-hidden.test.js
+++ b/Test/Js/address-step-company-id-hidden.test.js
@@ -56,9 +56,51 @@ describe('address step: company-number field is CSS-hidden, not removed', () => 
     test('the CSS hides the field purely visually', () => {
         const css = readRepoFile(STYLE);
 
-        const ruleMatch = css.match(/\.two-company-id-hidden\s*\{([^}]*)\}/);
+        const ruleMatch = css.match(/\.two-company-id-hidden[^{]*\{([^}]*)\}/);
         expect(ruleMatch).not.toBeNull();
         expect(ruleMatch[1]).toMatch(/display:\s*none/);
+    });
+
+    /**
+     * TWO-25326 §5/§7. The rule above EXISTED and the field was visible on
+     * Luma anyway, which is why the ticket lists it as a live defect on three
+     * separate Magento checkout surfaces — this test is the one that would
+     * have caught it, and its absence is why the previous test read as
+     * passing while the buyer saw an editable "Company Number" box.
+     *
+     * `.two-company-id-hidden` alone scores (0,1,0). Luma's own
+     * `.fieldset.address > .field { display: inline-block }` scores (0,3,0)
+     * and wins on specificity regardless of source order, so the plugin's
+     * hide never applied. Confirmed live in a browser against a Luma
+     * checkout: computed display was `inline-block`.
+     *
+     * The declaration therefore has to be `!important`. That is not a style
+     * preference here: the plugin cannot know what a merchant's theme (or
+     * Amasty / Fire Checkout, which restyle the same fieldset) declares
+     * against `.field`, so out-scoring an unknown selector by hand is not
+     * something a static selector can guarantee.
+     */
+    test('the hide out-ranks the theme rule that beat it — !important, not bare display:none', () => {
+        const css = readRepoFile(STYLE);
+
+        const ruleMatch = css.match(/\.two-company-id-hidden[^{]*\{([^}]*)\}/);
+        expect(ruleMatch).not.toBeNull();
+        expect(ruleMatch[1]).toMatch(/display:\s*none\s*!important/);
+    });
+
+    /**
+     * The replacement surface: a plain-text company number, which §5 requires
+     * to sit under the name field and align to its end edge. `text-align:
+     * end` rather than `right` so RTL store views follow the writing
+     * direction — the ticket calls that out explicitly.
+     */
+    test('the company-number text label is end-aligned rather than physically right-aligned', () => {
+        const css = readRepoFile(STYLE);
+
+        const ruleMatch = css.match(/\.two-company-id-text\s*\{([^}]*)\}/);
+        expect(ruleMatch).not.toBeNull();
+        expect(ruleMatch[1]).toMatch(/text-align:\s*end/);
+        expect(ruleMatch[1]).not.toMatch(/text-align:\s*right/);
     });
 
     test('the superseded payment-tile hint is gone from markup and stylesheet', () => {

--- a/Test/Js/address-step-company-id-text.test.js
+++ b/Test/Js/address-step-company-id-text.test.js
@@ -1,0 +1,311 @@
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ *
+ * TWO-25326 §5 and §7, address step (Luma / Amasty OneStepCheckout / Fire
+ * Checkout — one code path).
+ *
+ * The captured organisation number must appear as PLAIN TEXT under the
+ * company-name field once a search result has been selected, and must appear
+ * in no other state:
+ *
+ *  - never before a selection ("not visible before a result is selected");
+ *  - never in manual-entry mode, which is name-only capture, so a number
+ *    rendered there would assert a registry identity the buyer never picked;
+ *  - never as an editable control at any point.
+ *
+ * The separate `custom_attributes[company_id]` INPUT is a different object
+ * and stays in the DOM (it still submits) — hidden by CSS, pinned by
+ * address-step-company-id-hidden.test.js. This file is about the text label
+ * that replaced it visually.
+ *
+ * Backed by a real jsdom tree rather than a recording double: every
+ * assertion here is about what is actually in the document and what it says,
+ * which is the property that kept being claimed and kept not holding.
+ */
+
+'use strict';
+
+const { loadAmdModule } = require('./amd-harness');
+
+const MODULE = 'view/frontend/web/js/view/address-autocomplete.js';
+const NAME_SELECTOR = '#shipping-new-address-form input[name="company"]';
+const ID_SELECTOR =
+    '#shipping-new-address-form input[name="custom_attributes[company_id]"]';
+const TEXT_CLASS = 'two-company-id-text';
+
+/** jQuery-lite over real jsdom nodes — only what this component path calls. */
+function makeMiniQuery() {
+    const dataStore = new WeakMap();
+
+    const api = {
+        get: function (i) {
+            return this.nodes[i];
+        },
+        closest: function (sel) {
+            const out = [];
+            this.nodes.forEach(function (node) {
+                const found = node.closest(sel);
+                if (found && out.indexOf(found) === -1) out.push(found);
+            });
+            return wrap(out);
+        },
+        find: function (sel) {
+            const out = [];
+            this.nodes.forEach(function (node) {
+                Array.prototype.push.apply(out, node.querySelectorAll(sel));
+            });
+            return wrap(out);
+        },
+        append: function (child) {
+            const nodes = child && child.nodes ? child.nodes : [child];
+            const target = this.nodes[0];
+            if (target) {
+                nodes.forEach(function (n) {
+                    target.appendChild(n);
+                });
+            }
+            return this;
+        },
+        remove: function () {
+            this.nodes.forEach(function (node) {
+                if (node.parentNode) node.parentNode.removeChild(node);
+            });
+            return this;
+        },
+        addClass: function (cls) {
+            this.nodes.forEach(function (node) {
+                node.classList.add(cls);
+            });
+            return this;
+        },
+        attr: function (name, value) {
+            if (arguments.length < 2) {
+                return this.nodes.length ? this.nodes[0].getAttribute(name) : undefined;
+            }
+            this.nodes.forEach(function (node) {
+                node.setAttribute(name, value);
+            });
+            return this;
+        },
+        text: function (next) {
+            if (!arguments.length) return this.nodes.length ? this.nodes[0].textContent : '';
+            this.nodes.forEach(function (node) {
+                node.textContent = next;
+            });
+            return this;
+        },
+        val: function (next) {
+            if (!arguments.length) return this.nodes.length ? this.nodes[0].value : undefined;
+            this.nodes.forEach(function (node) {
+                node.value = next;
+            });
+            return this;
+        },
+        prop: function () {
+            return this;
+        },
+        data: function (key, next) {
+            const node = this.nodes[0];
+            if (!node) return undefined;
+            if (!dataStore.has(node)) dataStore.set(node, {});
+            const bag = dataStore.get(node);
+            if (arguments.length < 2) return bag[key];
+            bag[key] = next;
+            return this;
+        },
+        on: function () {
+            return this;
+        },
+        off: function () {
+            return this;
+        },
+        trigger: function () {
+            return this;
+        },
+        show: function () {
+            return this;
+        },
+        hide: function () {
+            return this;
+        }
+    };
+
+    function wrap(nodes) {
+        const set = Object.create(api);
+        set.nodes = nodes;
+        set.length = nodes.length;
+        return set;
+    }
+
+    function fromHtml(html) {
+        const holder = document.createElement('div');
+        holder.innerHTML = html;
+        return Array.prototype.slice.call(holder.children);
+    }
+
+    function $(arg) {
+        if (arg === undefined || arg === null) return wrap([]);
+        if (typeof arg === 'string') {
+            return arg.trim().charAt(0) === '<'
+                ? wrap(fromHtml(arg))
+                : wrap(Array.prototype.slice.call(document.querySelectorAll(arg)));
+        }
+        if (arg.nodes) return arg;
+        if (arg.nodeType) return wrap([arg]);
+        return wrap([]);
+    }
+    $.fn = {};
+    $.extend = Object.assign;
+    $.async = function () {};
+    return $;
+}
+
+function load() {
+    document.body.innerHTML =
+        '<form id="shipping-new-address-form">' +
+        '<div class="field">' +
+        '<div class="control">' +
+        '<input name="company" type="text">' +
+        '</div>' +
+        '</div>' +
+        '<div class="field two-company-id-hidden">' +
+        '<div class="control">' +
+        '<input name="custom_attributes[company_id]" type="text">' +
+        '</div>' +
+        '</div>' +
+        '</form>';
+
+    const $ = makeMiniQuery();
+    const component = loadAmdModule(
+        MODULE,
+        {
+            jquery: $,
+            'Magento_Customer/js/customer-data': {
+                set: function () {},
+                get: function () {
+                    return function () {
+                        return {};
+                    };
+                }
+            },
+            'Two_Gateway/js/model/brand-config': {
+                getActiveTwoBrandConfig: function () {
+                    return { isCompanySearchEnabled: false };
+                }
+            }
+        },
+        { document: document, window: window }
+    );
+    return { component: component, $: $ };
+}
+
+/** Put select2 "on" the company-name input, i.e. search mode is active. */
+function activateSearch($) {
+    $(NAME_SELECTOR).data('select2', {});
+}
+
+function labels() {
+    return document.querySelectorAll('.' + TEXT_CLASS);
+}
+
+describe('TWO-25326 §5: the company number is a plain text label, and only after selection', () => {
+    test('nothing is rendered before a result has been selected', () => {
+        const { component, $ } = load();
+        activateSearch($);
+
+        component.renderCompanyIdText();
+
+        expect(labels()).toHaveLength(0);
+    });
+
+    test('selecting a result renders the number as text under the name field', () => {
+        const { component, $ } = load();
+        activateSearch($);
+
+        component.setCompanyData('919300894', 'Example Trading AS');
+
+        expect(labels()).toHaveLength(1);
+        const label = labels()[0];
+        expect(label.textContent).toBe('919300894');
+        // Under the NAME field specifically — inside that field's own
+        // `.control`, after the input. §5 pins the position, not just the
+        // existence, because a number rendered somewhere else on the form is
+        // exactly the "visible in the address area" defect §7 forbids.
+        const nameControl = document.querySelector('input[name="company"]').closest('.control');
+        expect(label.parentElement).toBe(nameControl);
+        expect(
+            label.compareDocumentPosition(document.querySelector('input[name="company"]')) &
+                window.Node.DOCUMENT_POSITION_PRECEDING
+        ).toBeTruthy();
+    });
+
+    test('it is not an input, and carries nothing the buyer could type into', () => {
+        const { component, $ } = load();
+        activateSearch($);
+
+        component.setCompanyData('919300894', 'Example Trading AS');
+
+        const label = labels()[0];
+        expect(label.tagName).toBe('DIV');
+        expect(label.querySelector('input, textarea, select, [contenteditable]')).toBeNull();
+        // `isContentEditable` is unimplemented in jsdom (always undefined),
+        // so assert the attribute that would set it instead.
+        expect(label.hasAttribute('contenteditable')).toBe(false);
+    });
+
+    test('it has an accessible name, since the visible text is a bare number', () => {
+        // §7 forbids an extra VISIBLE caption in the address area, so the
+        // caption has to be an accessible one — a bare number with no
+        // accessible name is unreadable to a screen reader.
+        const { component, $ } = load();
+        activateSearch($);
+
+        component.setCompanyData('919300894', 'Example Trading AS');
+
+        expect(labels()[0].getAttribute('aria-label')).toBe('Company Number');
+    });
+
+    test('a company with no registry identifier renders no label at all', () => {
+        const { component, $ } = load();
+        activateSearch($);
+
+        component.setCompanyData('', 'Identifier-less Example AS');
+
+        expect(labels()).toHaveLength(0);
+    });
+
+    test('re-selecting replaces the number rather than stacking a second label', () => {
+        const { component, $ } = load();
+        activateSearch($);
+
+        component.setCompanyData('919300894', 'Example Trading AS');
+        component.setCompanyData('811912312', 'Other Example AS');
+
+        expect(labels()).toHaveLength(1);
+        expect(labels()[0].textContent).toBe('811912312');
+    });
+
+    /**
+     * The manual-entry case, and the reason renderCompanyIdText() decides on
+     * `isCompanySearchActive()` rather than only on whether a number is
+     * present: the hidden input can still be holding the previous pick's
+     * number at the moment the buyer switches to typing a name by hand.
+     * Rendering it there would attach a registry identity to a company the
+     * buyer typed themselves.
+     */
+    test('manual-entry mode shows no number even when one is still in the hidden input', () => {
+        const { component, $ } = load();
+        activateSearch($);
+        component.setCompanyData('919300894', 'Example Trading AS');
+        expect(labels()).toHaveLength(1);
+
+        // Manual entry: select2 is gone from the node.
+        $(NAME_SELECTOR).data('select2', undefined);
+        $(ID_SELECTOR).val('919300894');
+
+        component.renderCompanyIdText();
+
+        expect(labels()).toHaveLength(0);
+    });
+});

--- a/Test/Js/amd-harness.js
+++ b/Test/Js/amd-harness.js
@@ -128,6 +128,20 @@ function defaultMocks() {
             minInputLengthMessage: function () {
                 return 'Please enter ' + this.MIN_INPUT_LENGTH + ' or more characters';
             },
+            // TWO-25326 §1 wording, mirrored here so a call site that reads
+            // it through the mock gets the same string the real module
+            // returns rather than select2's vendored "No results found".
+            noResultsMessage: function () {
+                return 'No matches found';
+            },
+            buildLanguageOptions: function () {
+                const self = this;
+                return {
+                    inputTooShort: function () { return self.minInputLengthMessage(); },
+                    noResults: function () { return self.noResultsMessage(); }
+                };
+            },
+            attachOpenOnType: function () {},
             getSearchFieldContainer: function () { return null; },
             abortActiveRequest: function () { return false; },
             attachManualEntryButton: function () {},

--- a/Test/Js/company-search-manual-entry.test.js
+++ b/Test/Js/company-search-manual-entry.test.js
@@ -71,9 +71,16 @@ function loadModelWithWrongThreshold($) {
     const tmp = path.join(__dirname, '__tmp_manual_entry_threshold.js');
     fs.writeFileSync(tmp, patched, 'utf8');
     try {
-        return loadAmdModule(path.relative(path.resolve(__dirname, '..', '..'), tmp), {
-            jquery: $
-        });
+        return loadAmdModule(
+            path.relative(path.resolve(__dirname, '..', '..'), tmp),
+            { jquery: $ },
+            // The real jsdom document and window, not the harness's inert
+            // stubs: TWO-25326's Tab handling walks `document.querySelectorAll`
+            // for tab stops and reads `window.getComputedStyle` to skip hidden
+            // ones, and both have to hit the fixture's actual nodes for the
+            // focus assertions below to mean anything.
+            { document: document, window: window }
+        );
     } finally {
         fs.unlinkSync(tmp);
     }
@@ -327,6 +334,12 @@ function makeMiniQuery() {
         // resize nudge silently no-opped, which is exactly what hid the
         // round-3 nudge-ordering bug from the whole suite.
         if (arg && typeof arg === 'object' && 'checkoutConfig' in arg) return wrap([window]);
+        // Since TWO-25326 this file hands the module jsdom's OWN `window`
+        // (it needs `getComputedStyle` for the tab-stop visibility walk), so
+        // the duck-type above no longer fires — the real window has no
+        // `checkoutConfig`. Identity works for that case and, unlike the
+        // duck-type, cannot misroute anything else.
+        if (arg === window) return wrap([window]);
         return wrap([]);
     }
     $.fn = {};
@@ -345,8 +358,30 @@ function makeMiniQuery() {
 
 /** A picker's real DOM, shaped the way select2 4.1 renders it. */
 function makePickerDom($) {
+    // Shaped the way select2 renders it INCLUDING the combobox and the
+    // surrounding form, because TWO-25326 §4 made Tab a focus-MOVING
+    // operation rather than merely a closing one: the assertions below need
+    // a real previous/next tab stop around the picker to observe. `prevField`
+    // and `nextField` stand in for the address form's other inputs;
+    // `#shipping_search_for_company` is the hidden return-to-search link,
+    // present in the DOM but `display: none` while search mode is active, and
+    // is here specifically so a Tab out of the dropdown can be shown to SKIP
+    // it rather than land on something invisible.
     document.body.innerHTML =
-        '<input id="company_name" type="text">' +
+        '<input id="prev-field" type="text">' +
+        '<div class="field">' +
+        '<div class="control">' +
+        '<input id="company_name" type="text" tabindex="-1">' +
+        '<span class="select2 select2-container">' +
+        '<span class="selection">' +
+        '<span class="select2-selection" role="combobox" tabindex="0"></span>' +
+        '</span>' +
+        '</span>' +
+        '</div>' +
+        '<div id="shipping_search_for_company" role="button" tabindex="0" ' +
+        'style="display: none"></div>' +
+        '</div>' +
+        '<input id="next-field" type="text">' +
         '<span class="select2-dropdown">' +
         '<span class="select2-search select2-search--dropdown">' +
         '<input class="select2-search__field" type="text">' +
@@ -359,7 +394,10 @@ function makePickerDom($) {
     const $field = $('#company_name');
     const token = {};
     $field.data('twoSearchBind', token);
-    $field.data('select2', { $dropdown: $('.select2-dropdown') });
+    $field.data('select2', {
+        $dropdown: $('.select2-dropdown'),
+        $selection: $('.select2-selection')
+    });
 
     return {
         $field: $field,
@@ -368,7 +406,11 @@ function makePickerDom($) {
         $wrapper: $('.select2-results'),
         results: $('.select2-results__options').get(0),
         wrapper: $('.select2-results').get(0),
-        search: $('.select2-search__field').get(0)
+        search: $('.select2-search__field').get(0),
+        combobox: document.querySelector('.select2-selection'),
+        prevField: document.getElementById('prev-field'),
+        nextField: document.getElementById('next-field'),
+        searchForCompany: document.getElementById('shipping_search_for_company')
     };
 }
 
@@ -701,11 +743,14 @@ describe('keyboard reachability (round 2 — Tab is not free)', () => {
      * fires for Shift+Tab identically), so without interception here
      * Shift+Tab from the search field silently selects the auto-highlighted
      * first result and closes the picker — committing a company the buyer
-     * never chose. Round 2 closes this the same way as forward Tab: prevent
-     * it from reaching select2, and close the dropdown ourselves rather
-     * than route to select2's own (buggy, for this key) handling.
+     * never chose.
+     *
+     * TWO-25326 §1 also fixes where it goes: tabbing out of the dropdown
+     * moves focus to the adjacent tab stop, so backwards Tab lands on the
+     * control BEFORE the combobox rather than dumping the buyer back onto
+     * the combobox they were just leaving.
      */
-    test('Shift+Tab is ALSO intercepted — select2 would otherwise silently commit a selection', () => {
+    test('Shift+Tab is ALSO intercepted, and lands on the tab stop before the combobox', () => {
         const select2Committed = bindFakeSelect2TabHandler(dom);
         dom.$field.select2 = jest.fn();
         model.attachManualEntryButton(dom.$field, dom.token, function () {});
@@ -722,6 +767,7 @@ describe('keyboard reachability (round 2 — Tab is not free)', () => {
         expect(event.defaultPrevented).toBe(true);
         expect(select2Committed()).toBe(false);
         expect(dom.$field.select2).toHaveBeenCalledWith('close');
+        expect(document.activeElement).toBe(dom.prevField);
     });
 
     test('detaching removes the capture-phase Tab listener itself, not just the button it targets', () => {
@@ -804,14 +850,55 @@ describe('keyboard reachability (round 2 — Tab is not free)', () => {
 
         // select2's own handler must still be preempted (it would otherwise
         // preventDefault() and swallow the key with nothing to show for it —
-        // a keyboard trap), but with no button to route to, native Tab is
-        // left alone so focus advances to the next checkout field.
+        // a keyboard trap). With no button to route to, TWO-25326 §1's rule
+        // for tabbing out of the dropdown applies instead: close it and move
+        // focus to the next tab stop after the combobox. We move focus
+        // ourselves, so the native Tab must be suppressed or the browser
+        // would advance a second time.
         expect(select2Committed()).toBe(false);
-        expect(event.defaultPrevented).toBe(false);
+        expect(event.defaultPrevented).toBe(true);
         expect(dom.$field.select2).toHaveBeenCalledWith('close');
+        expect(document.activeElement).toBe(dom.nextField);
     });
 
-    test("the button's own Tab and Shift+Tab close the picker rather than trapping or falling through to the page", () => {
+    /**
+     * The no-trap escape hatch: when there is genuinely no adjacent tab stop
+     * to move to, the key must fall through to the browser rather than be
+     * swallowed. Proved by stripping the fixture down to the picker alone —
+     * without this branch, `preventDefault()` with nowhere to go is exactly
+     * the keyboard trap §4 forbids.
+     */
+    test('Tab falls through to the browser when there is no adjacent tab stop to move to', () => {
+        bindFakeSelect2TabHandler(dom);
+        dom.$field.select2 = jest.fn();
+        model.attachManualEntryButton(dom.$field, dom.token, function () {});
+        dom.prevField.remove();
+        dom.nextField.remove();
+        dom.combobox.remove();
+
+        const event = new window.KeyboardEvent('keydown', {
+            key: 'Tab',
+            bubbles: true,
+            cancelable: true
+        });
+        dom.search.dispatchEvent(event);
+
+        expect(event.defaultPrevented).toBe(false);
+    });
+
+    /**
+     * TWO-25326 §4: "Tab from the 'not on the list' control moves to the next
+     * control in the tab order AND closes the dropdown area." Forward Tab is
+     * therefore a real exit — not the close-and-bounce-back-to-the-combobox
+     * the earlier round implemented, which left the buyer one Tab short of
+     * where they asked to be.
+     *
+     * The next control is deliberately `#next-field`, NOT
+     * `#shipping_search_for_company`: that link sits between them in document
+     * order but is `display: none` while search mode is active, and Tab must
+     * skip anything the buyer cannot see.
+     */
+    test("the button's forward Tab closes the picker and advances past it", () => {
         dom.$field.select2 = jest.fn();
         model.attachManualEntryButton(dom.$field, dom.token, function () {});
         typeTerm(dom, 'example');
@@ -826,8 +913,25 @@ describe('keyboard reachability (round 2 — Tab is not free)', () => {
         button.dispatchEvent(forwardTab);
         expect(forwardTab.defaultPrevented).toBe(true);
         expect(dom.$field.select2).toHaveBeenCalledWith('close');
+        expect(document.activeElement).toBe(dom.nextField);
+        expect(document.activeElement).not.toBe(dom.searchForCompany);
+    });
 
+    /**
+     * Shift+Tab off the button is the exact inverse of the forward shortcut
+     * that got the buyer here (query field -> button), so it steps back INTO
+     * the query field and leaves the dropdown OPEN. Closing here would make
+     * the shortcut a one-way door: the buyer could reach the button by
+     * keyboard but never return to refine the search that produced it.
+     */
+    test("the button's Shift+Tab returns to the query field and leaves the dropdown open", () => {
+        dom.$field.select2 = jest.fn();
+        model.attachManualEntryButton(dom.$field, dom.token, function () {});
+        typeTerm(dom, 'example');
+        const button = manualButtons(dom)[0];
+        button.focus();
         dom.$field.select2.mockClear();
+
         const shiftTab = new window.KeyboardEvent('keydown', {
             key: 'Tab',
             shiftKey: true,
@@ -836,7 +940,8 @@ describe('keyboard reachability (round 2 — Tab is not free)', () => {
         });
         button.dispatchEvent(shiftTab);
         expect(shiftTab.defaultPrevented).toBe(true);
-        expect(dom.$field.select2).toHaveBeenCalledWith('close');
+        expect(document.activeElement).toBe(dom.search);
+        expect(dom.$field.select2).not.toHaveBeenCalledWith('close');
     });
 
     test('Escape on the focused button closes the picker via select2, not a hand-rolled refocus', () => {

--- a/Test/Js/company-search-open-on-type.test.js
+++ b/Test/Js/company-search-open-on-type.test.js
@@ -1,0 +1,333 @@
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ *
+ * TWO-25326 §1, the two wording/opening defects that are shared by all three
+ * Magento checkout surfaces (Luma, Amasty OneStepCheckout, Fire Checkout —
+ * one code path, three renderings):
+ *
+ *  - the dropdown opened on click, Enter and Space but on NO other key, so a
+ *    buyer who focused the company field and simply started typing their
+ *    company name saw nothing happen;
+ *  - a zero-result search said "No results found", select2's vendored English
+ *    literal, where the cross-platform wording is "No matches found".
+ *
+ * Both are properties of the shared model, so both are pinned here rather
+ * than twice over at the two call sites.
+ *
+ * What this file does NOT pin: that the call sites actually invoke these.
+ * That is a separate failure mode — the fix existing but never being wired
+ * up — and it gets its own assertions at the bottom, read off the two
+ * sources, because a mocked call site would prove nothing about the real one.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { loadAmdModule } = require('./amd-harness');
+
+const MODEL_PATH = 'view/frontend/web/js/model/company-search.js';
+const ADDRESS_PATH = 'view/frontend/web/js/view/address-autocomplete.js';
+const TILE_PATH = 'view/frontend/web/js/view/payment/method-renderer/gateway_method.js';
+
+function readRepoFile(relPath) {
+    const contents = fs.readFileSync(path.join(__dirname, '..', '..', relPath), 'utf8');
+    if (contents.length < 200) {
+        throw new Error(relPath + ' fixture looks truncated: ' + contents.length + ' bytes');
+    }
+    return contents;
+}
+
+/**
+ * jQuery-lite over real jsdom nodes — only the calls attachOpenOnType()
+ * makes. Backed by the real document so `document.activeElement`, the seeded
+ * value and the dispatched `input` event are the DOM's own answers rather
+ * than a recording of our intentions.
+ */
+function makeMiniQuery() {
+    const dataStore = new WeakMap();
+
+    const api = {
+        get: function (i) {
+            return this.nodes[i];
+        },
+        find: function (sel) {
+            const out = [];
+            this.nodes.forEach(function (node) {
+                Array.prototype.push.apply(out, node.querySelectorAll(sel));
+            });
+            return wrap(out);
+        },
+        val: function (next) {
+            if (!arguments.length) return this.nodes.length ? this.nodes[0].value : undefined;
+            this.nodes.forEach(function (node) {
+                node.value = next;
+            });
+            return this;
+        },
+        data: function (key, next) {
+            const node = this.nodes[0];
+            if (!node) return undefined;
+            if (!dataStore.has(node)) dataStore.set(node, {});
+            const bag = dataStore.get(node);
+            if (arguments.length < 2) return bag[key];
+            bag[key] = next;
+            return this;
+        },
+        on: function (spec, fn) {
+            const type = String(spec).split('.')[0];
+            this.nodes.forEach(function (node) {
+                node.addEventListener(type, fn);
+            });
+            return this;
+        },
+        off: function () {
+            return this;
+        }
+    };
+
+    function wrap(nodes) {
+        const set = Object.create(api);
+        set.nodes = nodes;
+        set.length = nodes.length;
+        return set;
+    }
+
+    function $(arg) {
+        if (arg === undefined || arg === null) return wrap([]);
+        if (typeof arg === 'string') {
+            return wrap(Array.prototype.slice.call(document.querySelectorAll(arg)));
+        }
+        if (arg.nodes) return arg;
+        if (arg.nodeType) return wrap([arg]);
+        return wrap([]);
+    }
+    $.fn = {};
+    $.extend = Object.assign;
+    return $;
+}
+
+/**
+ * The picker as select2 renders it, plus the `select2('open')` behaviour the
+ * model depends on: opening is what CREATES the search field select2 focuses
+ * and our handler then seeds. Modelled as an actual state change (the
+ * dropdown moves from absent to present) rather than a bare spy, so a fix
+ * that seeds before opening — and would therefore find nothing to seed —
+ * fails here instead of passing.
+ */
+function makePickerDom($) {
+    document.body.innerHTML =
+        '<div class="control">' +
+        '<input id="company_name" type="text" tabindex="-1">' +
+        '<span class="select2 select2-container">' +
+        '<span class="selection">' +
+        '<span class="select2-selection" role="combobox" tabindex="0"></span>' +
+        '</span>' +
+        '</span>' +
+        '</div>';
+
+    const $field = $('#company_name');
+    const token = {};
+    const state = { openCalls: 0 };
+
+    function openDropdown() {
+        state.openCalls++;
+        if (document.querySelector('.select2-dropdown')) return;
+        const dropdown = document.createElement('span');
+        dropdown.className = 'select2-dropdown';
+        dropdown.innerHTML =
+            '<span class="select2-search select2-search--dropdown">' +
+            '<input class="select2-search__field" type="text">' +
+            '</span>' +
+            '<span class="select2-results">' +
+            '<ul class="select2-results__options" role="listbox"></ul>' +
+            '</span>';
+        document.body.appendChild(dropdown);
+        state.instance.$dropdown = $('.select2-dropdown');
+    }
+
+    state.instance = {
+        $dropdown: $('.select2-dropdown'),
+        $selection: $('.select2-selection')
+    };
+    $field.data('twoSearchBind', token);
+    $field.data('select2', state.instance);
+    $field.select2 = function (verb) {
+        if (verb === 'open') openDropdown();
+        return $field;
+    };
+
+    return {
+        $field: $field,
+        token: token,
+        state: state,
+        combobox: document.querySelector('.select2-selection'),
+        searchField: function () {
+            return document.querySelector('.select2-search__field');
+        }
+    };
+}
+
+function pressKey(target, key, extra) {
+    const event = new window.KeyboardEvent(
+        'keydown',
+        Object.assign({ key: key, bubbles: true, cancelable: true }, extra || {})
+    );
+    target.dispatchEvent(event);
+    return event;
+}
+
+describe('TWO-25326 §1: any character opens the dropdown', () => {
+    let $;
+    let model;
+    let dom;
+
+    beforeEach(() => {
+        $ = makeMiniQuery();
+        model = loadAmdModule(
+            MODEL_PATH,
+            { jquery: $ },
+            { document: document, window: window }
+        );
+        dom = makePickerDom($);
+        model.attachOpenOnType(dom.$field, dom.token);
+    });
+
+    test('a printable character opens the picker and is seeded into the query field', () => {
+        const inputEvents = [];
+        const event = pressKey(dom.combobox, 'a');
+
+        expect(event.defaultPrevented).toBe(true);
+        expect(dom.state.openCalls).toBe(1);
+        expect(dom.searchField()).toBeTruthy();
+        // Seeded, not swallowed. Without this the buyer's first keystroke is
+        // consumed by the open and they have to type the letter twice.
+        expect(dom.searchField().value).toBe('a');
+        expect(inputEvents).toEqual([]);
+    });
+
+    test('the seeded character is announced with a NATIVE input event, which is what select2 listens for', () => {
+        // select2's own search handler is a native listener inside the
+        // vendored bundle. A jQuery-synthesised trigger would not reach it,
+        // so the search would never fire for the first character and the
+        // dropdown would sit on the too-short hint until the buyer typed
+        // again. Asserted via a native listener for exactly that reason.
+        pressKey(dom.combobox, 'a');
+        const search = dom.searchField();
+
+        const seen = [];
+        search.addEventListener('input', function (e) {
+            seen.push(e.bubbles);
+        });
+        // Re-seeding through the same path must fire it again.
+        pressKey(dom.combobox, 'b');
+        expect(seen).toEqual([true]);
+    });
+
+    test('digits and punctuation count as characters too — an org number is a valid query', () => {
+        pressKey(dom.combobox, '9');
+        expect(dom.searchField().value).toBe('9');
+    });
+
+    test('Space and Enter are left to select2, which already opens on both', () => {
+        const space = pressKey(dom.combobox, ' ');
+        const enter = pressKey(dom.combobox, 'Enter');
+
+        expect(space.defaultPrevented).toBe(false);
+        expect(enter.defaultPrevented).toBe(false);
+        expect(dom.state.openCalls).toBe(0);
+    });
+
+    test('Tab is never intercepted — §1 excludes it explicitly, and §4 needs it to navigate', () => {
+        const tab = pressKey(dom.combobox, 'Tab');
+
+        expect(tab.defaultPrevented).toBe(false);
+        expect(dom.state.openCalls).toBe(0);
+    });
+
+    test('navigation and editing keys do not open the picker', () => {
+        ['Escape', 'ArrowDown', 'ArrowUp', 'Backspace', 'Shift', 'F5', 'Home'].forEach(function (
+            key
+        ) {
+            const event = pressKey(dom.combobox, key);
+            expect(event.defaultPrevented).toBe(false);
+        });
+        expect(dom.state.openCalls).toBe(0);
+    });
+
+    test('Ctrl/Cmd/Alt combinations are browser shortcuts, not text entry', () => {
+        expect(pressKey(dom.combobox, 'v', { ctrlKey: true }).defaultPrevented).toBe(false);
+        expect(pressKey(dom.combobox, 'v', { metaKey: true }).defaultPrevented).toBe(false);
+        expect(pressKey(dom.combobox, 'v', { altKey: true }).defaultPrevented).toBe(false);
+        expect(dom.state.openCalls).toBe(0);
+    });
+
+    test('a superseded bind no longer opens anything — same fail-closed rule as the rest of the module', () => {
+        dom.$field.data('twoSearchBind', {});
+
+        const event = pressKey(dom.combobox, 'a');
+
+        expect(event.defaultPrevented).toBe(false);
+        expect(dom.state.openCalls).toBe(0);
+    });
+
+    test('a torn-down widget does not open anything either', () => {
+        dom.$field.data('select2', undefined);
+
+        const event = pressKey(dom.combobox, 'a');
+
+        expect(event.defaultPrevented).toBe(false);
+        expect(dom.state.openCalls).toBe(0);
+    });
+});
+
+describe('TWO-25326 §1: zero-result wording', () => {
+    let model;
+
+    beforeEach(() => {
+        model = loadAmdModule(MODEL_PATH, { jquery: makeMiniQuery() });
+    });
+
+    test('the message is "No matches found", not select2\'s "No results found"', () => {
+        expect(model.noResultsMessage()).toBe('No matches found');
+    });
+
+    test('the language block both pickers share carries it, and the threshold hint', () => {
+        const language = model.buildLanguageOptions();
+
+        expect(typeof language.noResults).toBe('function');
+        expect(language.noResults()).toBe('No matches found');
+        expect(language.inputTooShort()).toContain(String(model.MIN_INPUT_LENGTH));
+    });
+
+    /**
+     * The bundled default is what the fix displaces, so pin that it is still
+     * the thing being displaced. If a future select2 upgrade changes the
+     * vendored literal, this test says so rather than letting the override
+     * quietly become a no-op equivalent.
+     */
+    test('the vendored select2 default really is the wording being overridden', () => {
+        const bundle = readRepoFile('view/frontend/web/select2-4.1.0/js/select2.min.js');
+        expect(bundle).toContain('No results found');
+    });
+});
+
+describe('both call sites are actually wired to the shared fixes', () => {
+    test('the address-step picker passes the shared language block and opens on type', () => {
+        const src = readRepoFile(ADDRESS_PATH);
+
+        expect(src).toContain('language: companySearch.buildLanguageOptions()');
+        expect(src).toContain('companySearch.attachOpenOnType(');
+        // The inline override this replaced would silently win over the
+        // shared block if it were left behind.
+        expect(src).not.toContain('inputTooShort: function');
+    });
+
+    test('the payment-tile picker does too', () => {
+        const src = readRepoFile(TILE_PATH);
+
+        expect(src).toContain('language: companySearch.buildLanguageOptions()');
+        expect(src).toContain('companySearch.attachOpenOnType(');
+    });
+});

--- a/Test/Js/gateway-method-company-selection.test.js
+++ b/Test/Js/gateway-method-company-selection.test.js
@@ -110,6 +110,17 @@ function makeDom() {
             attr: function () {
                 return n;
             },
+            // TWO-25326 §5's company-number text label builds and tears
+            // itself down through these; this file only needs them not to
+            // throw while it exercises setCompanyData's id/name write.
+            addClass: function (cls) {
+                n.classes = (n.classes || []).concat(cls);
+                return n;
+            },
+            remove: function () {
+                n.removed = true;
+                return n;
+            },
             data: function () {
                 return null;
             },

--- a/view/frontend/web/css/style.css
+++ b/view/frontend/web/css/style.css
@@ -705,6 +705,31 @@
  * its value stay intact and still submit as
  * shippingAddress.custom_attributes.company_id.
  */
-.two-company-id-hidden {
-    display: none;
+.two-company-id-hidden,
+.fieldset .field.two-company-id-hidden {
+    display: none !important;
+}
+
+/*
+ * The address-step company number, rendered as a plain text label (TWO-25326
+ * §5) rather than the input above — which is hidden outright.
+ *
+ * Appended into the company field's `.control` by
+ * view/frontend/web/js/view/address-autocomplete.js only once a search result
+ * has actually been selected, so it is absent before selection and absent in
+ * manual-entry mode (name-only capture). `text-align: end` rather than
+ * `right` so it follows the writing direction on RTL store views instead of
+ * pinning to the physical right edge.
+ *
+ * `.control` is the input's own containing box, so aligning to its end edge
+ * lines the number up with the input's end edge exactly.
+ */
+.two-company-id-text {
+    display: block;
+    text-align: end;
+    margin-top: 4px;
+    margin-bottom: 4px;
+    color: #666666;
+    font-size: 12px;
+    word-break: break-word;
 }

--- a/view/frontend/web/js/model/company-search.js
+++ b/view/frontend/web/js/model/company-search.js
@@ -119,6 +119,104 @@ define(['jquery', 'mage/translate'], function ($, $t) {
         return $t('Please enter %1 or more characters').replace('%1', MIN_INPUT_LENGTH);
     }
 
+    /**
+     * The zero-results message.
+     *
+     * select2's vendored bundle hardcodes English "No results found"
+     * (`noResults:function(){return"No results found"}`). TWO-25326 §1 pins
+     * the cross-platform wording as "No matches found", so both pickers
+     * override it — same reason as minInputLengthMessage() above: the
+     * vendored literal is neither ours to edit nor reachable by Magento's
+     * translation dictionaries.
+     *
+     * @returns {string} translated zero-results message
+     */
+    function noResultsMessage() {
+        return $t('No matches found');
+    }
+
+    /**
+     * Everything focusable by Tab, in document order.
+     *
+     * Deliberately a hand-rolled walk rather than select2's own bookkeeping:
+     * the dropdown is appended to `<body>` by AttachBody, so "the next thing
+     * after the dropdown" is meaningless. What the buyer means by "Tab out of
+     * the picker" is "the next form control after the COMBOBOX", and the
+     * combobox does sit in natural document order inside the address form.
+     * So every caller passes the combobox as the reference element, never
+     * anything inside the dropdown.
+     *
+     * Visibility is decided by walking computed styles up the ancestor
+     * chain, NOT by `offsetParent === null`. Both work in a browser, but
+     * offsetParent additionally reports null for `position: fixed` elements
+     * and for anything in a detached tree, and it is meaningless under jsdom
+     * — where it is always null, so a test could never observe this function
+     * returning anything at all. The style walk is the same answer in both
+     * places, which is what makes the behaviour testable rather than only
+     * assertable by hand in a live browser.
+     *
+     * What the walk has to exclude, concretely: the select2-hidden original
+     * `<input name="company">` (also `tabindex="-1"`, so doubly filtered),
+     * and the "Search for company" link, which is jQuery `.hide()`n — an
+     * inline `display: none` — for the whole time search mode is active. Tab
+     * must skip it, or leaving the dropdown would land on a control the
+     * buyer cannot see.
+     *
+     * @returns {Array<Element>} tabbable elements, document order
+     */
+    function isVisibleForTabbing(el) {
+        let node = el;
+        while (node && node.nodeType === 1) {
+            const style = window.getComputedStyle(node);
+            if (style && (style.display === 'none' || style.visibility === 'hidden')) {
+                return false;
+            }
+            node = node.parentElement;
+        }
+        return true;
+    }
+
+    function tabbableElements() {
+        const selector = [
+            'a[href]',
+            'button',
+            'input:not([type="hidden"])',
+            'select',
+            'textarea',
+            '[tabindex]'
+        ].join(',');
+        return Array.prototype.filter.call(document.querySelectorAll(selector), function (el) {
+            if (el.disabled) return false;
+            if (el.getAttribute('aria-hidden') === 'true') return false;
+            const tabindex = el.getAttribute('tabindex');
+            if (tabindex !== null && parseInt(tabindex, 10) < 0) return false;
+            return isVisibleForTabbing(el);
+        });
+    }
+
+    /**
+     * Move focus to the tab stop before or after `referenceEl`.
+     *
+     * Returns false — and moves nothing — when there is no such element, so
+     * the caller can fall back to the browser's native Tab rather than
+     * swallowing the key and trapping the buyer (TWO-25326 §4: "no keyboard
+     * trap anywhere in this control under any state").
+     *
+     * @param {Element} referenceEl element to move away from
+     * @param {boolean} backwards true for Shift+Tab
+     * @returns {boolean} whether focus was actually moved
+     */
+    function focusAdjacentTabbable(referenceEl, backwards) {
+        if (!referenceEl) return false;
+        const tabbable = tabbableElements();
+        const index = tabbable.indexOf(referenceEl);
+        if (index === -1) return false;
+        const next = tabbable[backwards ? index - 1 : index + 1];
+        if (!next) return false;
+        next.focus();
+        return true;
+    }
+
     /** jQuery event namespace for everything this module binds. */
     const EVENT_NS = '.twoCompanySearch';
 
@@ -229,6 +327,64 @@ define(['jquery', 'mage/translate'], function ($, $t) {
     }
 
     /**
+     * The focusable combobox select2 renders in place of the original input —
+     * `.select2-selection`, the element that carries `role="combobox"` and
+     * `tabindex="0"`.
+     *
+     * This, not the dropdown and not the hidden original `<input>`, is the
+     * picker's position in the page's natural tab order, so it is the
+     * reference every focus-advancing path uses.
+     *
+     * Resolved from the instance's OWN `$selection`, and tolerant of what
+     * that actually is. In select2 4.1 the core does
+     * `this.$selection = this.selection.render()`, and SingleSelection's
+     * `render()` returns the `.select2-selection` span itself — so
+     * `$selection` IS the combobox, not a wrapper around it. A `.find()`
+     * alone therefore returns nothing, silently, and every focus-advancing
+     * path degrades to "Tab does nothing" with no error to show for it.
+     * Checked directly first, then by descendant, so a future select2 that
+     * hands back the `.selection` wrapper instead still resolves.
+     *
+     * @param {object} $field jQuery-wrapped picker input
+     * @returns {Element|null}
+     */
+    function comboboxElement($field) {
+        const instance = $field && $field.data && $field.data('select2');
+        if (!instance || !instance.$selection) return null;
+        const $selection = instance.$selection;
+        const direct = typeof $selection.get === 'function' ? $selection.get(0) : null;
+        if (direct && direct.classList && direct.classList.contains('select2-selection')) {
+            return direct;
+        }
+        const nested =
+            typeof $selection.find === 'function'
+                ? $selection.find('.select2-selection').get(0)
+                : null;
+        return nested || direct || null;
+    }
+
+    /**
+     * Close the dropdown and put focus on the next (or previous) tab stop
+     * around the combobox — TWO-25326 §1/§4: "close the dropdown by tabbing
+     * out of it, in which case focus moves to the next tabstop".
+     *
+     * The refocus has to happen AFTER the close, not before: select2's own
+     * `close()` ends by focusing the combobox, so a focus moved first is
+     * immediately taken back. Doing it in this order means the buyer briefly
+     * passes through the combobox and lands where they asked to go.
+     *
+     * @param {object} $field jQuery-wrapped picker input
+     * @param {boolean} backwards true for Shift+Tab
+     * @returns {boolean} whether focus was actually moved — false means the
+     *          caller must let the browser's native Tab through instead
+     */
+    function closeAndAdvanceFocus($field, backwards) {
+        const combobox = comboboxElement($field);
+        closeDropdown($field);
+        return focusAdjacentTabbable(combobox, backwards);
+    }
+
+    /**
      * Tell select2 to recalculate the dropdown's geometry.
      *
      * select2 only recalculates height/position from its OWN mutations
@@ -277,6 +433,99 @@ define(['jquery', 'mage/translate'], function ($, $t) {
         EVENT_NS: EVENT_NS,
         isDegradedResponse: isDegradedResponse,
         minInputLengthMessage: minInputLengthMessage,
+        noResultsMessage: noResultsMessage,
+
+        /**
+         * The `language` option block both pickers pass to select2.
+         *
+         * Shared rather than repeated so the two surfaces cannot drift on
+         * wording — the whole reason TWO-25326 §1 lists "No results found"
+         * as a per-platform defect is that each surface was inheriting a
+         * different default.
+         *
+         * Functions, not strings: Magento's JS translation dictionary can
+         * arrive after this module is defined, so each message is resolved at
+         * render time.
+         *
+         * @returns {object} select2 `language` option
+         */
+        buildLanguageOptions: function () {
+            return {
+                inputTooShort: function () {
+                    return minInputLengthMessage();
+                },
+                noResults: function () {
+                    return noResultsMessage();
+                }
+            };
+        },
+
+        /**
+         * Open the dropdown when the buyer types a character into the closed
+         * combobox — TWO-25326 §1: "clicking into the company-name field, or
+         * pressing a key (other than Tab) while it has focus, opens the
+         * dropdown".
+         *
+         * select2 4.1 does not do this. Its core keypress handler only opens
+         * on ENTER, SPACE and Alt+Down
+         * (`(t===ENTER||t===SPACE||t===DOWN&&e.altKey)&&(n.open(),...)`);
+         * every other printable character falls through and is simply lost,
+         * so a buyer who focuses the field and starts typing their company
+         * name sees nothing happen at all.
+         *
+         * ENTER and SPACE are deliberately left to select2 — it already
+         * opens on both, and intercepting them here would only double up.
+         * Everything else with a single-character `key` is treated as the
+         * first character of a search: the dropdown opens, and the character
+         * is seeded into the query field with an `input` event so select2's
+         * own debounce/threshold pipeline picks it up exactly as if it had
+         * been typed there. Without the seed the character would be
+         * swallowed, and the buyer would have to type their first letter
+         * twice.
+         *
+         * Modifier combinations (Ctrl/Cmd/Alt) are left alone: those are
+         * browser and OS shortcuts, not text entry.
+         *
+         * @param {object} $field jQuery-wrapped picker input
+         * @param {object} token identity stamped by markSearchBinding()
+         */
+        attachOpenOnType: function ($field, token) {
+            const self = this;
+            const combobox = comboboxElement($field);
+            if (!combobox) return;
+
+            $(combobox)
+                .off('keydown' + EVENT_NS)
+                .on('keydown' + EVENT_NS, function (e) {
+                    if (e.ctrlKey || e.metaKey || e.altKey) return;
+                    if (typeof e.key !== 'string' || e.key.length !== 1) return;
+                    // select2 opens on Space by itself; Enter likewise (and
+                    // its `key` is longer than one character anyway).
+                    if (e.key === ' ') return;
+                    if (!$field.data('select2')) return;
+                    if ($field.data('twoSearchBind') !== token) return;
+
+                    e.preventDefault();
+                    $field.select2('open');
+
+                    const $search = self
+                        .getSearchFieldContainer($field, token)
+                        .find('.select2-search__field');
+                    if (!$search.length) return;
+                    $search.val(e.key);
+                    // A native `input` event, not jQuery's `.trigger('input')`:
+                    // select2's own search handler is a native listener added
+                    // by the vendored bundle, and jQuery-synthesised events do
+                    // not reach native listeners. Our own manual-entry
+                    // `input` handler is jQuery-bound, and jQuery DOES observe
+                    // native events, so one dispatch feeds both.
+                    // `window.Event`, not the bare `Event` global: this module
+                    // is also loaded outside a browser window scope by the
+                    // Jest AMD harness, where only the globals the sandbox
+                    // declares exist. Same object in a browser.
+                    $search.get(0).dispatchEvent(new window.Event('input', { bubbles: true }));
+                });
+        },
 
         /**
          * Cancel the in-flight search for a bind, if any.
@@ -855,21 +1104,42 @@ define(['jquery', 'mage/translate'], function ($, $t) {
                     // Escape is select2's own "close the dropdown" key, but
                     // once focus has moved onto this button (a sibling of the
                     // listbox, outside select2's own keydown delegation)
-                    // select2 never sees the keypress.
-                    //
-                    // Tab (either direction) is handled the same way,
-                    // deliberately, rather than trying to move focus
-                    // somewhere "natural": with AttachBody this button's
-                    // dropdown is appended as the LAST child of `<body>`, so
-                    // forward Tab from here has nothing sensible to land on
-                    // in real document order (it walks out of the page
-                    // entirely), and Shift+Tab has no defined "previous"
-                    // element either. Closing and returning to the combobox
-                    // keeps the buyer inside the checkout form instead of
-                    // ejecting them into browser chrome.
-                    e.preventDefault();
-                    if (isTab) e.stopPropagation();
-                    closeDropdown($field);
+                    // select2 never sees the keypress. Close, and let
+                    // select2's own close() put focus back on the combobox —
+                    // TWO-25326 §1: Escape reverts focus to company-name.
+                    if (isEscape) {
+                        e.preventDefault();
+                        closeDropdown($field);
+                        return;
+                    }
+                    e.stopPropagation();
+                    if (e.shiftKey) {
+                        // Shift+Tab is the exact inverse of the forward Tab
+                        // shortcut that got the buyer here (query field ->
+                        // this button), so it goes back to the query field
+                        // rather than out of the picker. Leaving the dropdown
+                        // open is the point: the buyer is stepping back INTO
+                        // the search, not abandoning it.
+                        e.preventDefault();
+                        const $search = self
+                            .getSearchFieldContainer($field, token)
+                            .find('.select2-search__field');
+                        if ($search.length) {
+                            $search.trigger('focus');
+                            return;
+                        }
+                        closeDropdown($field);
+                        return;
+                    }
+                    // Forward Tab: close the dropdown AND advance to the next
+                    // control after the combobox (TWO-25326 §4). Only
+                    // preventDefault when we actually moved focus ourselves —
+                    // if there is no next tab stop to find, swallowing the key
+                    // would be a keyboard trap, so the native Tab is allowed
+                    // through instead.
+                    if (closeAndAdvanceFocus($field, false)) {
+                        e.preventDefault();
+                    }
                 });
             return $button;
         },
@@ -1019,39 +1289,38 @@ define(['jquery', 'mage/translate'], function ($, $t) {
                     // superseding re-bind and this node's own teardown)
                     // must not act on behalf of a widget it no longer owns.
                     if (!self.getSearchFieldContainer($field, token).length) return;
+                    // select2's own handler must never see a Tab: it treats
+                    // Tab exactly like Enter, with no shiftKey guard, so it
+                    // would commit the auto-highlighted first result — a
+                    // company the buyer never chose.
+                    e.stopPropagation();
                     if (e.shiftKey) {
-                        // Shift+Tab: select2's own handler would otherwise
-                        // silently select the auto-highlighted first result
-                        // and close the picker — worse than the forward-Tab
-                        // defect this fix exists for, since it commits a
-                        // choice the buyer never made. There is no sibling
-                        // element to send focus "back" to here (the search
-                        // field is where the event fired), so close and let
-                        // select2's own close() refocus the combobox.
-                        e.preventDefault();
-                        e.stopPropagation();
-                        closeDropdown($field);
+                        // Shift+Tab leaves the picker backwards: close, and
+                        // land on the control BEFORE the combobox. Same
+                        // no-trap rule as everywhere else here — if there is
+                        // nothing before it, let the native Tab through.
+                        if (closeAndAdvanceFocus($field, true)) {
+                            e.preventDefault();
+                        }
                         return;
                     }
                     const $wrapper = self.getResultsList($field, token).parent();
                     const $button = $wrapper.children(`.${MANUAL_ENTRY_CLASS}`);
                     if (!$button.length) {
                         // Below MIN_INPUT_LENGTH there is no button to reach,
-                        // but select2's own handler treats forward Tab
-                        // exactly like Enter regardless — it would otherwise
-                        // select nothing (nothing is highlighted this early)
-                        // yet still `preventDefault()`, silently swallowing
-                        // the key and trapping keyboard focus in the field.
-                        // Stop select2 from seeing it, but do NOT
-                        // preventDefault ourselves: with no button to route
-                        // to, the right behaviour is the native one — Tab
-                        // advances to the next checkout field.
-                        e.stopPropagation();
-                        closeDropdown($field);
+                        // so the right behaviour is to leave the picker:
+                        // close it and move to the next control after the
+                        // combobox (TWO-25326 §1 — tabbing out of the
+                        // dropdown moves focus to the next tabstop).
+                        if (closeAndAdvanceFocus($field, false)) {
+                            e.preventDefault();
+                        }
                         return;
                     }
+                    // The deliberate shortcut (TWO-25326 §4): forward Tab
+                    // from the query field reaches the "not on the list"
+                    // button directly, without walking the results.
                     e.preventDefault();
-                    e.stopPropagation();
                     $button.trigger('focus');
                 };
                 searchFieldNode.addEventListener('keydown', tabHandler, true);

--- a/view/frontend/web/js/view/address-autocomplete.js
+++ b/view/frontend/web/js/view/address-autocomplete.js
@@ -94,6 +94,58 @@ define([
             $(this.companyNameSelector).val(companyName);
             $(this.companyIdSelector).val(companyId);
             this.syncCompanyIdEditable();
+            this.renderCompanyIdText();
+        },
+        /**
+         * Class on the address-step company-number text label. Also the hook
+         * style.css aligns it against the name field's end edge.
+         */
+        companyIdTextClass: 'two-company-id-text',
+        /**
+         * Render the captured company number as PLAIN TEXT under the
+         * company-name field (TWO-25326 §5), replacing whatever was there.
+         *
+         * Not an input, and not a second copy of the hidden
+         * `custom_attributes[company_id]` field: that input still exists and
+         * still submits, but it is display:none'd outright
+         * (`.two-company-id-hidden`) precisely because a visible box implies
+         * the number is typeable, and it is not — an identifier-less company
+         * is refused by Model/Two.php::authorize() rather than hand-filled.
+         *
+         * Three states, and only one of them shows anything:
+         *
+         *  - search mode, a result selected -> the number, right-aligned;
+         *  - search mode, nothing selected yet -> nothing (§5: "not visible
+         *    before a result is selected");
+         *  - manual-entry mode -> nothing, ever, whatever the number field
+         *    happens to still hold. Manual entry is name-only capture per the
+         *    three-mode model, so a number rendered here would be claiming a
+         *    registry identity the buyer never picked.
+         *
+         * Rebuilt from scratch on each call rather than toggled: the label is
+         * a single text node with no state worth preserving, and a `.remove()`
+         * first means the manual-entry and pre-selection cases share the exact
+         * same code path as "hide it".
+         *
+         * The caption is an `aria-label`, not visible text: §7 forbids any
+         * additional visible text label in the address area, but a bare number
+         * with no accessible name is unreadable to a screen reader.
+         */
+        renderCompanyIdText: function () {
+            const $field = $(this.companyNameSelector);
+            if (!$field.length) return;
+            const $control = $field.closest('.control');
+            if (!$control.length) return;
+            $control.find('.' + this.companyIdTextClass).remove();
+            if (!this.isCompanySearchActive()) return;
+            const companyId = $(this.companyIdSelector).val();
+            if (!companyId) return;
+            $control.append(
+                $('<div></div>')
+                    .addClass(this.companyIdTextClass)
+                    .attr('aria-label', $t('Company Number'))
+                    .text(companyId)
+            );
         },
         /**
          * True while select2 owns the company-name input, i.e. while the buyer
@@ -271,6 +323,10 @@ define([
             $companyNameField.attr('type', 'text');
             $companyNameField.val('');
             $(this.searchForCompanyButton).show();
+            // After the destroy above, not before: renderCompanyIdText()
+            // decides on isCompanySearchActive(), which only reports
+            // manual-entry once select2 is actually gone from the node.
+            this.renderCompanyIdText();
             // select2('destroy') removes the manual-entry button — the
             // element that had focus when the buyer activated it — from the
             // document, and destroy() does not route through select2's own
@@ -321,15 +377,13 @@ define([
                         .select2({
                             minimumInputLength: companySearch.MIN_INPUT_LENGTH,
                             // Displaces select2's own built-in English
-                            // "input too short" text, which is baked into the
-                            // vendored bundle and counts down the REMAINING
-                            // characters. Ours is translatable and names the
-                            // threshold outright.
-                            language: {
-                                inputTooShort: function () {
-                                    return companySearch.minInputLengthMessage();
-                                }
-                            },
+                            // "input too short" and "No results found" text,
+                            // both baked into the vendored bundle. Ours are
+                            // translatable, name the threshold outright, and
+                            // use the cross-platform "No matches found"
+                            // wording pinned by TWO-25326 §1. Shared with the
+                            // payment-tile picker so the two cannot drift.
+                            language: companySearch.buildLanguageOptions(),
                             // A stable, non-generated hook for style.css's
                             // dropdown-row CSS fixes (text-transform,
                             // vertical alignment). select2 IDs its own
@@ -421,6 +475,14 @@ define([
                             self.addressLookup(selectedItem);
                         });
                     companySearch.markSearchBinding($companyNameField, bindToken);
+                    // TWO-25326 §1: typing any character (not just Space or
+                    // Enter, which is all select2 4.1 handles) opens the
+                    // dropdown and starts the search.
+                    companySearch.attachOpenOnType($companyNameField, bindToken);
+                    // Re-derive on every bind: a re-render rebuilds the
+                    // `.control` this label lives in, so a label written on a
+                    // previous bind is gone by now.
+                    self.renderCompanyIdText();
                     // Set initial placeholder text for the company search
                     if (!$(self.companyNameSelector).val()) {
                         $(self.companyNameSelector)

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -1089,6 +1089,13 @@ define([
                     $companyNameField
                         .select2({
                             minimumInputLength: companySearch.MIN_INPUT_LENGTH,
+                            // Shared with the address-step picker so the two
+                            // surfaces cannot show different wording for the
+                            // same state. Before TWO-25326 this picker passed
+                            // no `language` at all and fell back to select2's
+                            // vendored English "No results found" / remaining-
+                            // character countdown.
+                            language: companySearch.buildLanguageOptions(),
                             // Same stable dropdown-row hook as the
                             // address-step picker (address-autocomplete.js)
                             // — this field's `input#company_name` id DOES
@@ -1215,6 +1222,9 @@ define([
                             self.addressLookup(selectedItem);
                         });
                     companySearch.markSearchBinding($companyNameField, bindToken);
+                    // TWO-25326 §1: any character opens the dropdown, not
+                    // just the Space/Enter select2 4.1 handles on its own.
+                    companySearch.attachOpenOnType($companyNameField, bindToken);
                     $('#select2-company_name-container').text(self.companyName());
                     // Scoped to the container of the node THIS bind owns.
                     // With two Two-family renderers there is one


### PR DESCRIPTION
## What

TWO-25326 §1/§2/§4/§5/§7 for the Magento checkout surfaces.

**Surface scope, checked rather than assumed:** Luma, Amasty OneStepCheckout and Fire Checkout are three store views over ONE code path. There is no Amasty- or Fire-specific company-search JS, template or layout in this module — the only references to either are backend availability logic in `Model/Two.php` and comments. So these fixes land on all three at once, and all three still get tested separately.

## Fixes

**§1 — the dropdown did not open on typing.** select2 4.1's core opens only on Enter, Space and Alt+Down (`(t===ENTER||t===SPACE||t===DOWN&&e.altKey)&&(n.open(),...)`); every other printable character fell through and was lost. `attachOpenOnType()` opens on any single-character key and seeds that character into the query field with a native `input` event, so the search fires on the first keystroke rather than the buyer having to type their first letter twice. Tab is excluded (§1 says so explicitly, and §4 needs it), as are navigation keys and Ctrl/Cmd/Alt combinations.

**§1 — "No results found" -> "No matches found".** The vendored bundle hardcodes the English literal. Both pickers now pass a shared `language` block carrying the new wording plus the existing threshold hint, so the address step and the payment tile cannot drift on it — the payment tile previously passed no `language` at all.

**§1/§4 — Tab now moves focus, not just closes.** Previously every Tab path ended in "close and let select2 refocus the combobox", which left the buyer one Tab short of where they asked to be. Now:

- Tab from the query field with the button present -> the button (the deliberate §4 shortcut, unchanged);
- Tab from the query field with no button (below threshold) -> close, and focus the next control after the combobox;
- Tab from the button -> close, and focus the next control after the combobox;
- Shift+Tab from the button -> back into the query field, dropdown left open (the exact inverse of the forward shortcut; closing here would make it a one-way door);
- Shift+Tab from the query field -> close, and focus the previous control;
- Escape anywhere -> close, focus reverts to the company-name combobox (unchanged).

Every one of these falls through to the browser's native Tab when there is no adjacent tab stop, so no state can trap the keyboard (§4). Tab-stop resolution skips anything `display:none`, which is what keeps focus off the hidden "Search for company" link while search mode is active.

**§5/§7 — the "Company Number" input was visible on all three surfaces.** Root cause was CSS specificity, not a missing rule: `.two-company-id-hidden { display: none }` scores (0,1,0) and loses to the theme's own `.fieldset.address > .field { display: inline-block }` at (0,3,0). The hide has been in the tree for some time and never applied. Raised to `!important` — the plugin cannot out-scope an unknown merchant theme by hand, and Amasty and Fire restyle the same fieldset.

The captured number now renders as a plain text label under the name field instead: end-aligned (`text-align: end`, RTL-safe as §5 asks), present only once a search result has been selected, absent in manual-entry mode (name-only capture), and not a control the buyer could mistake for typeable. The caption is an `aria-label` rather than visible text, because §7 forbids extra visible labels in the address area but a bare number needs an accessible name.

## A bug this nearly shipped with

`comboboxElement()` first resolved the combobox with `$selection.find('.select2-selection')`. In select2 4.1 the core does `this.$selection = this.selection.render()`, and `SingleSelection.render()` returns the `.select2-selection` span **itself** — so `.find()` matched nothing, silently, and every focus move would have no-opped with no error. Caught by reading the vendored bundle before deploying. It now checks the element directly first and falls back to a descendant lookup.

## Tests

`npm run test:js` — 279 passed, 23 suites.

Two new suites:

- `Test/Js/company-search-open-on-type.test.js` — the full key matrix (printable / digits / Space / Enter / Tab / navigation / modifier combos), that the seed is announced with a *native* `input` event (a jQuery-synthesised one would never reach select2's own listener), fail-closed on a superseded bind, the shared wording, and that both call sites are actually wired to it.
- `Test/Js/address-step-company-id-text.test.js` — the label's three states against real jsdom nodes, including the one that matters most: manual-entry mode renders nothing *even when the hidden input is still holding the previous pick's number*.

`Test/Js/address-step-company-id-hidden.test.js` gained the assertion that was missing. Its existing test only checked that a `display: none` rule existed — which is exactly why it passed green throughout the whole period the field was visible to buyers. It now pins the specificity, which was the actual defect.

The manual-entry fixture was also corrected: it had been modelling `instance.$selection` as a wrapper around the combobox, which is not what select2 returns.

## Verification status

Code and unit tests only so far. Live browser verification against all three store views follows immediately after this lands, because the dev shop git-syncs `staging` and there is no way to point it at a feature branch (kubectl auth is expired in this environment). Anything the live run finds goes back as a follow-up on TWO-25326 rather than being quietly folded in.

---

Reviewed adversarially and reported by Claude.
