### PR TITLE
fix(checkout): payment tile shows the captured company as one text label (TWO-25326 §7)

### DIFF
--- a/Test/Js/tile-company-readonly-fields.test.js
+++ b/Test/Js/tile-company-readonly-fields.test.js
@@ -2,29 +2,44 @@
  * Copyright © Two.inc All rights reserved.
  * See COPYING.txt for license details.
  *
- * TWO-25288 first showed the captured company NAME and NUMBER read-only, as a
- * second `<input readonly>`. Doug's canonical-design ruling that followed
- * (applies across all four platforms) replaced that input outright: the
- * number is now a plain text LABEL, right-aligned immediately below the
- * company-name field, visible only once a number has actually been captured.
+ * The payment tile's company display, as TWO-25326 §7 defines it: ONE line of
+ * plain text, "Name (12345678)", between the term chips and the order-intent
+ * notice — and the tile's own company controls hidden while it shows.
  *
- * This file pins the label-based version. Three groups, and they are NOT the
- * same kind of test. Be honest about which is which before trusting a green
- * run:
+ * This supersedes two earlier shapes in turn. TWO-25288 first made the
+ * captured number a read-only `<input>`; the ruling after that replaced the
+ * input with a "Company Number" caption plus a separately-rendered value.
+ * §7 removes that pair too: a caption and a number below an editable
+ * company-name box is three renderings of one company in one tile.
  *
- *  1. READ-ONLY / NO-INPUT PINS — 'the payment tile shows the number as an
- *     uneditable label, not a field'. These fail against BOTH the old
- *     `<input readonly>` shape and any future reinstatement of an editable
- *     field, because there is no `<input id="company_id">` left to satisfy
- *     either shape.
+ * The control is HIDDEN, not deleted, and that distinction is pinned here
+ * deliberately. The tile's picker is the only company-capture surface for a
+ * buyer on a saved address (no `#shipping-new-address-form` exists, and that
+ * is the only selector address-autocomplete.js binds) or on a virtual cart
+ * (no shipping step at all). Deleting it would block those orders outright.
  *
- *  2. WHAT-THE-BUYER-SEES PINS — 'what each capture mode puts in front of the
+ * Four groups, and they are NOT the same kind of test. Be honest about which
+ * is which before trusting a green run:
+ *
+ *  1. NO-INPUT PINS — 'the payment tile shows the number as an uneditable
+ *     label, not a field'. These fail against the old `<input readonly>`
+ *     shape and against any future reinstatement of an editable NUMBER field,
+ *     because there is no `<input id="company_id">` left to satisfy either.
+ *
+ *  2. SWAP PINS — the capture control and the label are gated on the same
+ *     predicate, in opposite directions, so no state can show both or
+ *     neither. Both `visible:` expressions are read out of the template and
+ *     pinned to an exact shape before being evaluated, so a drift to some
+ *     other predicate (or an always-true stub) fails the string match rather
+ *     than passing on a coincidence.
+ *
+ *  3. WHAT-THE-BUYER-SEES PINS — 'what each capture mode puts in front of the
  *     buyer'. These do not restate the markup: they read the `text:` binding
  *     target out of the template, then evaluate it against a renderer driven
- *     through the real capture flow, so a label bound to the wrong observable
+ *     through the real capture flow, so a label bound to the wrong method
  *     fails here even though the markup is present and correct.
  *
- *  3. ACCEPTED-SOURCE REGRESSION PINS — most of 'an accepted organisation
+ *  4. ACCEPTED-SOURCE REGRESSION PINS — most of 'an accepted organisation
  *     number still reaches the order'. These pass against the pre-change code
  *     too, because every accepted source already wrote the observable. They
  *     do NOT prove anything about the label. They exist because the
@@ -34,7 +49,7 @@
  *     sole-trader routes are the ones most likely to break silently, their
  *     value being minted rather than picked.
  *
- * Group 3 is deliberately asserted through `getData()` rather than the DOM.
+ * Group 4 is deliberately asserted through `getData()` rather than the DOM.
  * That is the actual submit path (`Observer/DataAssignObserver.php` reads
  * `additional_data`), and it reads the observable. Asserting the DOM there
  * would prove nothing.
@@ -101,38 +116,22 @@ function inputTag(id) {
  * content is two flat `<span>` elements with no nested `<div>`. Throws
  * rather than returning null, same reasoning as inputTag() above.
  */
-function companyIdLabelTag() {
+function companyLabelTag() {
     const markup = withoutComments(readTemplate());
-    const tags = (markup.match(/<div\b[^>]*class="two-company-id-label"[^>]*>[\s\S]*?<\/div>/g) || []);
+    const tags = markup.match(/<div\b[^>]*class="two-company-label"[^>]*>[\s\S]*?<\/div>/g) || [];
     if (tags.length !== 1) {
-        throw new Error('expected exactly one <div class="two-company-id-label">, found ' + tags.length);
-    }
-    return tags[0];
-}
-
-/**
- * The `<span data-bind="text: companyId">` inside the number label — the
- * element that actually paints the number, as opposed to the static
- * "Company Number" caption span alongside it.
- */
-function companyIdNumberSpanTag() {
-    const tag = companyIdLabelTag();
-    const spans = (tag.match(/<span\b[^>]*>/g) || []).filter(function (span) {
-        return /text:\s*companyId\b/.test(span);
-    });
-    if (spans.length !== 1) {
         throw new Error(
-            'expected exactly one <span data-bind="text: companyId">, found ' + spans.length
+            'expected exactly one <div class="two-company-label">, found ' + tags.length
         );
     }
-    return spans[0];
+    return tags[0];
 }
 
 /**
  * What ko would paint into `id`'s value, derived rather than restated: read the
  * `value:` binding target out of the template, look that name up on a live
  * renderer, and evaluate it. A field bound to the wrong observable — or to none
- * — therefore fails here, which a markup substring check cannot catch.
+ * at all — fails here rather than passing on a restated expectation.
  */
 function renderedValue(id, renderer) {
     const bound = inputTag(id).match(/value:\s*([A-Za-z_$][\w$]*)/);
@@ -149,38 +148,65 @@ function renderedValue(id, renderer) {
 }
 
 /**
- * What ko would paint as the number label's text, derived the same way
- * renderedValue() does for an input's `value:` binding, but for the label's
- * `text:` binding.
+ * What ko would paint as the tile's company label, derived the same way
+ * renderedValue() does for an input — read the `text:` binding target out of
+ * the template, look it up on the live renderer, evaluate it. A label rewired
+ * to a different (or missing) method fails here rather than passing on a
+ * restated string.
  */
 function renderedLabelText(renderer) {
-    const bound = companyIdNumberSpanTag().match(/text:\s*([A-Za-z_$][\w$]*)/);
+    const bound = companyLabelTag().match(/text:\s*([A-Za-z_$][\w$]*)\(\)/);
     if (!bound) {
-        throw new Error('the number label has no `text:` binding');
+        throw new Error('the company label has no `text:` binding to a renderer method');
     }
     const target = renderer[bound[1]];
     if (typeof target !== 'function') {
         throw new Error(
-            'the number label is bound to `' + bound[1] + '`, which the renderer has not'
+            'the company label is bound to `' + bound[1] + '`, which the renderer has not'
         );
     }
     return target.call(renderer);
 }
 
 /**
- * Whether the number label would currently render, evaluated the same way
- * renderedLabelText() does — read the `visible:` expression out of the
- * template, PIN it to the exact `!!companyId()` shape (so a drift to some
- * other observable or a always-true/always-false stub fails the string
- * match), then evaluate the same observable directly against the live
- * renderer for the actual truth value.
+ * Whether the tile's company label would currently render: read the
+ * `visible:` expression out of the template, PIN it to the exact
+ * `isCompanyCaptured()` shape (so a drift to some other predicate, or to an
+ * always-true stub, fails the string match), then evaluate that predicate
+ * against the live renderer for the actual truth value.
  */
 function labelVisible(renderer) {
-    const tag = companyIdLabelTag();
-    if (!/visible:\s*!!companyId\(\)/.test(tag)) {
-        throw new Error('the number label\'s `visible:` binding is not the pinned `!!companyId()` shape');
+    const tag = companyLabelTag();
+    if (!/visible:\s*isCompanyCaptured\(\)/.test(tag)) {
+        throw new Error(
+            "the company label's `visible:` binding is not the pinned `isCompanyCaptured()` shape"
+        );
     }
-    return !!renderer.companyId();
+    return !!renderer.isCompanyCaptured();
+}
+
+/**
+ * Whether the tile's company-name FIELD (the capture control) would currently
+ * render. Same derive-then-evaluate discipline: the `visible:` expression is
+ * pinned to the negation of the same predicate the label uses, so the two can
+ * never drift into a state where both show or neither does.
+ */
+function nameFieldVisible(renderer) {
+    const markup = withoutComments(readTemplate());
+    const tags =
+        markup.match(/<div\b[^>]*class="field field-text required"[^>]*>/g) || [];
+    if (tags.length !== 1) {
+        throw new Error(
+            'expected exactly one company-name field wrapper, found ' + tags.length
+        );
+    }
+    if (!/visible:\s*!isCompanyCaptured\(\)/.test(tags[0])) {
+        throw new Error(
+            "the company-name field's `visible:` binding is not the pinned "
+                + '`!isCompanyCaptured()` shape'
+        );
+    }
+    return !renderer.isCompanyCaptured();
 }
 
 /**
@@ -228,8 +254,8 @@ describe('the payment tile shows the number as an uneditable label, not a field'
         expect(markup).not.toMatch(/<input\b[^>]*\bid\s*=\s*["']company_id["']/);
     });
 
-    test('the number label is a plain div, carries no name and no value binding to write to', () => {
-        const tag = companyIdLabelTag();
+    test('the company label is a plain div, carries no name and no value binding to write to', () => {
+        const tag = companyLabelTag();
 
         expect(tag).not.toMatch(/\sname\s*=/);
         expect(tag).not.toMatch(/\svalue\s*=/);
@@ -238,35 +264,108 @@ describe('the payment tile shows the number as an uneditable label, not a field'
         expect(tag).toMatch(/^<div\b/);
     });
 
-    test('the number label is bound to companyId and gated on it being present', () => {
-        const tag = companyIdLabelTag();
+    test('the company label is one element bound to one builder, gated on capture', () => {
+        // TWO-25326 §7 asks for ONE line, "Name (number)". The superseded
+        // shape was a caption span plus a number span, i.e. two renderings of
+        // one company in one tile, which is the defect the ticket names.
+        const tag = companyLabelTag();
 
-        expect(tag).toMatch(/text:\s*companyId\b/);
-        expect(tag).toMatch(/visible:\s*!!companyId\(\)/);
+        expect(tag).toMatch(/text:\s*companyDisplayLabel\(\)/);
+        expect(tag).toMatch(/visible:\s*isCompanyCaptured\(\)/);
+        // No inner elements: the whole string comes from one binding, so
+        // there is no caption/value split that can fall out of step.
+        expect(tag).not.toMatch(/<span\b/);
     });
 
-    test('the label carries a visible "Company Number" caption, not a bare number', () => {
-        // Regression caught in adversarial review: the first draft dropped
-        // the old <label for="company_id"> along with the input it labelled,
-        // leaving a sighted buyer (and a screen reader) with an unexplained
-        // number and no indication of what it was. The caption text must
-        // actually be present in the markup, not just asserted by comment.
-        const tag = companyIdLabelTag();
+    /**
+     * §7 names the position, not just the existence: "between the chips and
+     * the intent message (if rendered) or else the optional fields". Asserted
+     * on real source offsets rather than by eye, because the label is inert
+     * display text — nothing about it would break if it drifted to the bottom
+     * of the tile, so nothing but this test would notice.
+     */
+    test('the label sits between the term chips and the intent message', () => {
+        const markup = withoutComments(readTemplate());
 
-        expect(tag).toMatch(/Company Number/);
-        // Specifically via the `ko i18n` macro, not hardcoded English text —
-        // a second adversarial round flagged that a bare `/Company Number/`
-        // match alone is satisfied equally by a hardcoded
-        // `<span>Company Number</span>` that lost translatability, since
-        // withoutComments() deliberately preserves `ko i18n` comments rather
-        // than stripping them. This pins the delivery mechanism, not just
-        // the string's presence.
-        expect(tag).toMatch(/<!--\s*ko i18n:\s*'Company Number'\s*--><!--\s*\/ko\s*-->/);
-        // Two spans: one static caption, one bound to the number. Not one
-        // span doing both jobs — that would make the caption unable to
-        // update independently were it ever translated per-request.
-        const spanCount = (tag.match(/<span\b/g) || []).length;
-        expect(spanCount).toBe(2);
+        const lastChip = markup.lastIndexOf('two-term-chips__container');
+        const label = markup.indexOf('class="two-company-label"');
+        const intent = markup.indexOf('two-order-intent-message');
+        const invoiceEmail = markup.indexOf('id="invoice_emails"');
+
+        // Guard every anchor before comparing: indexOf returns -1 for a
+        // missing needle, and -1 compares "less than" everything, so a
+        // renamed anchor would make the ordering assertions pass on nonsense.
+        expect(lastChip).toBeGreaterThan(-1);
+        expect(label).toBeGreaterThan(-1);
+        expect(intent).toBeGreaterThan(-1);
+        expect(invoiceEmail).toBeGreaterThan(-1);
+
+        expect(label).toBeGreaterThan(lastChip);
+        expect(label).toBeLessThan(intent);
+        // And ahead of the optional fields, which is where §7 puts it when no
+        // intent message is rendered.
+        expect(label).toBeLessThan(invoiceEmail);
+    });
+
+    test('the superseded caption and its separate number span are gone', () => {
+        // Both halves, because either surviving alone is a defect: the
+        // caption without its number is a label for nothing, and the number
+        // rendered separately is the duplicate display §7 removes.
+        const markup = withoutComments(readTemplate());
+
+        expect(markup).not.toContain('two-company-id-label');
+        expect(markup).not.toContain('two-company-id-label__caption');
+        // The old caption text is not simply relocated — the new label
+        // renders the bare `Name (number)` form with no caption at all.
+        expect(companyLabelTag()).not.toMatch(/Company Number/);
+    });
+
+    /**
+     * The reason the field is HIDDEN rather than deleted, pinned so a future
+     * tidy-up cannot quietly delete it: the tile's picker is the only
+     * company-capture surface for a buyer on a saved address (no
+     * `#shipping-new-address-form` is rendered, and that is the only selector
+     * address-autocomplete.js binds) or on a virtual cart (no shipping step
+     * at all). Removing it blocks those orders outright, because
+     * Model/Two.php::authorize() refuses a company with no organisation
+     * number.
+     */
+    test('the capture control is retained and swaps with the label, never both at once', () => {
+        const { renderer } = loadRendererOnly();
+
+        // Still present in the template — not deleted.
+        expect(withoutComments(readTemplate())).toMatch(
+            /<input\b[^>]*\bid\s*=\s*["']company_name["']/
+        );
+
+        // Nothing captured: the control is available, the label is not.
+        expect(nameFieldVisible(renderer)).toBe(true);
+        expect(labelVisible(renderer)).toBe(false);
+
+        // Captured: they swap.
+        renderer.applyCompanyData(
+            { companyName: 'First Example Ltd', companyId: '12345678' },
+            { authoritative: true }
+        );
+        expect(nameFieldVisible(renderer)).toBe(false);
+        expect(labelVisible(renderer)).toBe(true);
+    });
+
+    test('a name with no number leaves the capture control up — name-only is not captured', () => {
+        // §6: manual entry (name, no number) must not make the payment method
+        // usable, so capture is NOT complete and the buyer must keep the
+        // search box. This is the case most likely to be got wrong by gating
+        // the swap on the name alone.
+        const { renderer } = loadRendererOnly();
+
+        renderer.applyCompanyData(
+            { companyName: 'Typed By Hand Ltd', companyId: '' },
+            { authoritative: true }
+        );
+
+        expect(renderer.isCompanyCaptured()).toBe(false);
+        expect(nameFieldVisible(renderer)).toBe(true);
+        expect(labelVisible(renderer)).toBe(false);
     });
 
     test('the name field is read-only only once a company has been captured', () => {
@@ -393,7 +492,7 @@ describe('the payment tile shows the number as an uneditable label, not a field'
 });
 
 describe('what each capture mode puts in front of the buyer', () => {
-    test('search mode: the buyer sees the picked name AND its number label', () => {
+    test('search mode: the tile shows one line, "Name (number)", and hides the control', () => {
         const { renderer } = loadRendererOnly();
 
         renderer.applyCompanyData(
@@ -401,12 +500,16 @@ describe('what each capture mode puts in front of the buyer', () => {
             { authoritative: true }
         );
 
+        // The name observable still carries the name — the control is only
+        // hidden, so it is still bound and still the thing sole-trader mode
+        // and the picker write to.
         expect(renderedValue('company_name', renderer)).toBe('First Example Ltd');
-        expect(renderedLabelText(renderer)).toBe('12345678');
+        expect(renderedLabelText(renderer)).toBe('First Example Ltd (12345678)');
         expect(labelVisible(renderer)).toBe(true);
+        expect(nameFieldVisible(renderer)).toBe(false);
     });
 
-    test('sole-trader mode: the minted name shows locked, the number label shows', () => {
+    test('sole-trader mode: the minted name and synthetic number show as one line', () => {
         const { renderer } = loadRendererOnly();
 
         renderer.prefetched = {
@@ -420,15 +523,18 @@ describe('what each capture mode puts in front of the buyer', () => {
         renderer.soleTraderMode();
 
         expect(renderedValue('company_name', renderer)).toBe('Sole Trader Example');
-        expect(renderedLabelText(renderer)).toBe('ST-SYNTH-004');
+        expect(renderedLabelText(renderer)).toBe('Sole Trader Example (ST-SYNTH-004)');
         expect(labelVisible(renderer)).toBe(true);
-        // The name too, because a name AND number were actually captured — see
-        // the two "never both empty and locked" cases for the branch where they
-        // were not.
+        expect(nameFieldVisible(renderer)).toBe(false);
+        // The field is hidden here, but its readonly binding must STILL read
+        // locked. Hiding is a display decision and sole trader can be left
+        // (registeredOrganisationMode()) — if the binding had been allowed to
+        // relax on the assumption nobody can see the field, re-showing it
+        // would hand the buyer an editable copy of a name they must not edit.
         expect(isReadOnly('company_name', renderer)).toBe(true);
     });
 
-    test('manual-entry mode: the number label disappears and stays gone', () => {
+    test('manual-entry mode: the label disappears and the capture control comes back', () => {
         // Driven through the real manual-entry path — clearCompany() is what the
         // sentinel row's handler calls — not by poking the observable, so this
         // fails if that path stops clearing the abandoned company's number.
@@ -444,11 +550,14 @@ describe('what each capture mode puts in front of the buyer', () => {
 
         expect(renderer.companyId()).toBe('');
         expect(labelVisible(renderer)).toBe(false);
-        // …and the name is typeable, which is the whole point of the mode.
+        // The control is back, and typeable — which is the whole point of the
+        // mode, and the reason the swap is a visibility toggle rather than a
+        // removal.
+        expect(nameFieldVisible(renderer)).toBe(true);
         expect(isReadOnly('company_name', renderer)).toBe(false);
     });
 
-    test('an identifier-less pick shows the name with no number label', () => {
+    test('an identifier-less pick keeps the control up, with no label', () => {
         // The other route to a blank number: the registry holds no identifier
         // for the picked company. Distinct from manual entry — a company IS
         // selected here.
@@ -465,6 +574,7 @@ describe('what each capture mode puts in front of the buyer', () => {
 
         expect(renderedValue('company_name', renderer)).toBe('Second Example Ltd');
         expect(labelVisible(renderer)).toBe(false);
+        expect(nameFieldVisible(renderer)).toBe(true);
     });
 });
 

--- a/Test/Js/tile-company-readonly-fields.test.js
+++ b/Test/Js/tile-company-readonly-fields.test.js
@@ -557,6 +557,113 @@ describe('what each capture mode puts in front of the buyer', () => {
         expect(isReadOnly('company_name', renderer)).toBe(false);
     });
 
+    /**
+     * The regression §7's swap introduces if nothing is done about it, caught
+     * in adversarial review rather than by the original test set.
+     *
+     * registeredOrganisationMode() did not clear the captured company. While
+     * the tile's control was always visible that was untidy but recoverable —
+     * the buyer could just search, and the pick overwrote the stale identity.
+     * Once the control HIDES on capture it is not recoverable: a buyer
+     * leaving sole-trader mode would face a sole-trader label, no search box,
+     * and no way back.
+     */
+    test('leaving sole-trader mode brings the capture control back', () => {
+        const { renderer } = loadRendererOnly();
+
+        renderer.prefetched = {
+            ready: true,
+            matches: true,
+            buyer: {
+                organization_number: 'ST-SYNTH-004',
+                company_name: 'Sole Trader Example'
+            }
+        };
+        renderer.soleTraderMode();
+        expect(labelVisible(renderer)).toBe(true);
+        expect(nameFieldVisible(renderer)).toBe(false);
+
+        // fillCustomerData() reaches into the quote's address objects
+        // (getCacheKey()), which this file's renderer-only harness does not
+        // model. Stubbed rather than worked around, and asserted below so the
+        // stub cannot quietly hide the call disappearing from the path.
+        const fillCustomerData = jest.fn();
+        renderer.fillCustomerData = fillCustomerData;
+
+        renderer.registeredOrganisationMode();
+
+        expect(fillCustomerData).toHaveBeenCalled();
+
+        expect(renderer.showSoleTrader()).toBe(false);
+        // The sole-trader identity does not survive the mode switch...
+        expect(renderer.companyId()).toBe('');
+        expect(renderer.isCompanyCaptured()).toBe(false);
+        // ...so the buyer gets the search box back.
+        expect(nameFieldVisible(renderer)).toBe(true);
+        expect(labelVisible(renderer)).toBe(false);
+    });
+
+    /**
+     * The other half of that fix: registeredOrganisationMode() is ALSO the
+     * tile's own initialiser (initObservable() calls it), and clearing
+     * unconditionally would wipe a company captured on the ADDRESS step
+     * before the tile ever rendered — silently turning a completed capture
+     * into an unpayable order. The clear is therefore guarded on having
+     * actually been in sole-trader mode, and this pins that guard.
+     */
+    test('initialising the tile does not wipe a company captured upstream', () => {
+        const { renderer } = loadRendererOnly();
+
+        renderer.applyCompanyData(
+            { companyName: 'Captured Upstream Ltd', companyId: '12345678' },
+            { authoritative: true }
+        );
+        expect(renderer.showSoleTrader()).toBe(false);
+
+        // fillCustomerData() reaches into the quote's address objects
+        // (getCacheKey()), which this file's renderer-only harness does not
+        // model. Stubbed rather than worked around, and asserted below so the
+        // stub cannot quietly hide the call disappearing from the path.
+        const fillCustomerData = jest.fn();
+        renderer.fillCustomerData = fillCustomerData;
+
+        // The init-path call, with sole trader never having been entered.
+        renderer.registeredOrganisationMode();
+
+        expect(fillCustomerData).toHaveBeenCalled();
+
+        expect(renderer.companyId()).toBe('12345678');
+        expect(renderer.isCompanyCaptured()).toBe(true);
+        expect(labelVisible(renderer)).toBe(true);
+        expect(nameFieldVisible(renderer)).toBe(false);
+    });
+
+    /**
+     * Hiding rather than removing means select2 can be initialised against a
+     * node that is already `display: none` (a company captured on the address
+     * step before the tile rendered). select2 measures a width at init, and
+     * `_resolveWidth` returns anything that is not `resolve`/`element`/
+     * `style`/`computedstyle` VERBATIM — so the literal `'100%'` this picker
+     * passes is a CSS percentage that resolves whenever the node is shown,
+     * not a pixel count frozen at zero.
+     *
+     * Switching that option to `'resolve'` or `'element'` would measure
+     * `outerWidth()` at init instead, which is 0 on a hidden node, and the
+     * buyer who returns to manual entry would get a zero-width search box.
+     * Pinned as an option value because there is no way to observe the
+     * consequence in jsdom (no layout), and the failure is invisible until a
+     * real browser renders it.
+     */
+    test('the picker takes a percentage width, so a hidden init cannot freeze it at zero', () => {
+        const source = fs.readFileSync(path.join(__dirname, '..', '..', RENDERER), 'utf8');
+        const widths = source.match(/width:\s*'([^']*)'/g) || [];
+
+        expect(widths.length).toBeGreaterThan(0);
+        widths.forEach(function (width) {
+            expect(width).toMatch(/width:\s*'\d+%'/);
+        });
+    });
+
     test('an identifier-less pick keeps the control up, with no label', () => {
         // The other route to a blank number: the registry holds no identifier
         // for the picked company. Distinct from manual entry — a company IS

--- a/view/frontend/web/css/style.css
+++ b/view/frontend/web/css/style.css
@@ -663,38 +663,33 @@
 }
 
 /*
- * The captured organisation number, a plain text label rather than a field
- * (canonical design across all four platforms — Doug's ruling). Positioned
- * immediately below the company-name input and right-aligned to it:
- * `text-align: right` inside `.control` lines it up against the input's own
- * right edge, since `.control` is the input's own containing box.
+ * TWO-25326 §7. The captured company on the payment tile, as ONE line of
+ * text — "Name (12345678)" — between the term chips and the order-intent
+ * notice.
  *
- * Grey, not the form's usual text colour, so it reads as a caption on the
- * field above rather than as another piece of body copy — matching how the
- * removed read-only input used to look (`#666666` on a light background).
+ * This supersedes `.two-company-id-label` and its `__caption`, which
+ * rendered a "Company Number" caption and the number as a second block
+ * below the company-name input. That was two renderings of one company in
+ * one tile, which is the defect the ticket names; one line replaces both.
+ *
+ * Sits in the tile's own vertical flow (block, full width) rather than
+ * aligned against a field's edge, because it is no longer a caption hanging
+ * off an input — it is a statement of what the buyer is paying as. Left to
+ * the reading direction for the same reason: `text-align` is not set at all,
+ * so it inherits, and RTL store views need no special case.
+ *
+ * Slightly muted and small, matching the tile's other secondary text, so it
+ * reads as context for the payment rather than competing with the term
+ * chips above it.
  */
-.two-company-id-label {
+.two-company-label {
     display: block;
-    text-align: right;
-    margin-top: 4px;
+    margin: 8px 0;
     color: #666666;
-    font-size: 12px;
+    font-size: 13px;
+    word-break: break-word;
 }
 
-/*
- * The "Company Number" caption inside the label above, on its OWN line
- * (block, not inline) with the number directly beneath it. Stacked rather
- * than joined on one line with punctuation (a colon, a dash) deliberately —
- * see the template comment: a hardcoded ASCII separator glued outside the
- * translated caption string is exactly the kind of thing that reads wrong
- * in some locales. Slightly bolder than the number so the caption still
- * reads as a caption rather than a second, equally-weighted line of body
- * copy.
- */
-.two-company-id-label__caption {
-    display: block;
-    font-weight: 500;
-}
 
 /*
  * TWO-25288. The address-step "Company Number" field (injected by

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -293,6 +293,80 @@ define([
         isCompanyNameReadOnly: function () {
             return this.showSoleTrader() && !!this.companyId();
         },
+        /**
+         * Has a company actually been CAPTURED — name plus organisation
+         * number — as opposed to merely named?
+         *
+         * This is the switch TWO-25326 §7 turns on. When it is true the tile
+         * shows the captured company as one line of plain text and hides its
+         * own company controls; when it is false those controls stay visible
+         * and fully functional, because they are the buyer's route to
+         * capturing a company in the first place.
+         *
+         * Keeping the controls rather than deleting them is deliberate and
+         * load-bearing. The tile's picker is not a duplicate of the address
+         * step's: address-autocomplete.js binds only
+         * `#shipping-new-address-form`, so a buyer who selects a SAVED
+         * address (no new-address form is rendered) or checks out a VIRTUAL
+         * cart (no shipping step exists at all) has no company search
+         * anywhere else. Removing this surface outright would leave those two
+         * flows with no way to supply a company, and
+         * Model/Two.php::authorize() then refuses the order server-side — an
+         * order-blocking regression, not a cosmetic one.
+         *
+         * Gated on the NUMBER, not on the name alone, and that is the whole
+         * distinction:
+         *
+         *  - a registry pick and sole-trader autofill both yield a number, so
+         *    capture is complete and there is nothing left for the buyer to
+         *    do here — show the label;
+         *  - manual entry yields a name and no number. §6 says name-only must
+         *    NOT make the payment method usable, so capture is precisely NOT
+         *    complete, and swapping the controls for a label at that point
+         *    would take away the search box while telling the buyer they were
+         *    finished. The controls stay.
+         *
+         * A plain function, not a computed — same reasoning as
+         * isCompanyNameReadOnly() above: the template reads it inside `visible`
+         * bindings, so ko tracks both observables as dependencies of those
+         * bindings and re-evaluates when either changes. Nothing to dispose,
+         * and it exists on renderers the unit tests load without booting.
+         *
+         * @returns {boolean}
+         */
+        isCompanyCaptured: function () {
+            return !!(this.companyName() || '').trim() && !!(this.companyId() || '').trim();
+        },
+        /**
+         * The captured company as one line of display text for the payment
+         * tile (TWO-25326 §7): `Name (12345678)`.
+         *
+         * Only ever rendered while isCompanyCaptured() is true, so both parts
+         * are present by construction; the name-only guard below is a
+         * belt-and-braces against a future caller, not a state the template
+         * can reach. Returns '' rather than a bare parenthesised number if a
+         * number ever arrived without a name — nothing to attach it to reads
+         * worse than nothing at all.
+         *
+         * The parentheses are the format the ticket specifies literally, and
+         * they wrap a VALUE rather than a translated caption. That is why
+         * this does not repeat the locale hazard that kept the superseded
+         * "Company Number" caption and its number on separate lines: there is
+         * no caption here for punctuation to be glued to.
+         *
+         * READ-ONLY. Never writes either observable, and the element it feeds
+         * carries no `name`, so it submits nothing. getData() reads
+         * `companyName()`/`companyId()` directly and remains the only path to
+         * the order.
+         *
+         * @returns {string}
+         */
+        companyDisplayLabel: function () {
+            const companyName = (this.companyName() || '').trim();
+            if (!companyName) return '';
+            const companyId = (this.companyId() || '').trim();
+            return companyId ? companyName + ' (' + companyId + ')' : companyName;
+        },
         selectTerm: function (days) {
             surchargeModel.selectTerm(days);
         },

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -1512,8 +1512,34 @@ define([
         },
 
         registeredOrganisationMode() {
+            // Read BEFORE the flag is flipped: this method is both the
+            // "leave sole trader" action and the tile's own initialiser
+            // (initObservable() calls it), and those two need different
+            // behaviour below.
+            const wasSoleTrader = this.showSoleTrader();
             this.showSoleTrader(false);
             this.showPopupMessage(false);
+            if (wasSoleTrader) {
+                // Leaving sole trader discards the sole-trader identity, the
+                // mirror of enterSoleTraderUi() clearing on the way in. A
+                // sole trader's minted name and synthetic number are not a
+                // registered organisation, so carrying them across the mode
+                // switch would submit one identity under the other's mode.
+                //
+                // Load-bearing since TWO-25326 §7 made the tile's company
+                // control HIDE once a company is captured. Before that the
+                // stale identity was untidy but recoverable — the search box
+                // was still on screen, and picking a company overwrote it.
+                // Now it is not: isCompanyCaptured() would still be true, so
+                // the control would stay hidden and the buyer would be
+                // stranded in registered-organisation mode looking at a
+                // sole-trader label with no way to search.
+                //
+                // Before enableCompanySearch(), not after: clearCompany()
+                // ends in destroyCompanySearchWidget(), which would otherwise
+                // tear down the widget that call had just rebuilt.
+                this.clearCompany();
+            }
             this.enableCompanySearch();
             this.fillCustomerData();
         },

--- a/view/frontend/web/template/payment/gateway_method.html
+++ b/view/frontend/web/template/payment/gateway_method.html
@@ -69,6 +69,37 @@
         </div>
         <!-- /ko -->
         <!--
+            The captured company as one line of plain text — "Name (12345678)"
+            — between the term chips and the order-intent notice
+            (TWO-25326 §7). Canonical placement across all four platforms.
+
+            This does NOT replace the tile's company controls, it swaps with
+            them. While a company is captured the controls below are hidden
+            and this line is shown; while one is not, the controls are visible
+            and this line is not. See isCompanyCaptured() in
+            gateway_method.js for why the controls are hidden rather than
+            removed — the tile is the ONLY company-capture surface for a buyer
+            on a saved address or a virtual cart, and deleting it would block
+            those orders outright.
+
+            `visible:`, not `if:`, deliberately. `if:` would tear the node out
+            of the DOM and rebuild it on every change; the node here is inert
+            display text, and keeping it stable costs nothing while avoiding
+            any interaction with the MutationObserver-based rebinding the
+            company picker relies on.
+
+            One element, one binding, so there is no caption/value split to
+            fall out of step and no punctuation glued outside a translated
+            string — companyDisplayLabel() builds the whole string in one
+            place. The element carries no `name` and no writable binding: it
+            displays companyName()/companyId() and never writes either.
+            getData() still reads those observables, never the DOM.
+        -->
+        <div
+            class="two-company-label"
+            data-bind="visible: isCompanyCaptured(), text: companyDisplayLabel()"
+        ></div>
+        <!--
             Persistent inline "order intent approved" notice, inside the
             payment tile next to the term chips. Emitted only when non-empty,
             so a brand that suppresses the notice
@@ -162,7 +193,29 @@
                 class="fieldset payment method"
                 data-bind='attr: {id: "payment_form_" + getCode()}'
             >
-                <div class="field field-text required">
+                <!--
+                    TWO-25326 §7. Hidden once a company is captured, because
+                    the captured company is then shown as a text label above
+                    (between the chips and the intent notice) and a second,
+                    editable copy of the same thing is exactly what the ticket
+                    calls out as the defect.
+
+                    NOT removed, only hidden. This field and the picker bound
+                    to it are the only company-capture route for a buyer on a
+                    saved address or a virtual cart — see isCompanyCaptured()
+                    in gateway_method.js. `visible:` also keeps the node in
+                    the DOM so the select2 binding, its MutationObserver
+                    rebinding and the sole-trader write path all keep working
+                    untouched; `if:` would destroy and rebuild the node under
+                    them.
+
+                    Hiding also takes this `required` input out of jQuery
+                    Validation's way, which only matters in the direction that
+                    helps: `elements()` skips hidden fields, and the only
+                    state where this is hidden is the one where a name has
+                    already been captured.
+                -->
+                <div class="field field-text required" data-bind="visible: !isCompanyCaptured()">
                     <label for="company_name" class="label">
                         <span><!-- ko i18n: 'Company Name'--><!-- /ko --></span>
                     </label>
@@ -203,72 +256,24 @@
                             class="input-text"
                         />
                         <!--
-                            The captured organisation number. Canonical design
-                            across all four platforms (Doug's ruling): not a
-                            second input field of its own — a plain text label
-                            immediately below the company-name field,
-                            right-aligned to it, shown only once a number has
-                            actually been captured. This SUPERSEDES the
-                            earlier `<input id="company_id" readonly>` field
-                            (TWO-25288): that traded the field's original
-                            removal (which hid the number from the buyer
-                            entirely) for a control that looked editable-ish
-                            despite being locked. A label carries no such
-                            ambiguity — there is no control to mistake for
-                            typeable.
+                            The organisation number is NO LONGER shown here.
+                            TWO-25326 §7 replaced the "Company Number"
+                            caption and its separately-rendered value with a
+                            single `Name (number)` text label higher up the
+                            tile, between the term chips and the intent
+                            notice — see `.two-company-label` above and
+                            companyDisplayLabel() in gateway_method.js.
 
-                            The "Company Number" CAPTION is deliberately kept
-                            (an adversarial review round caught its removal:
-                            the first draft of this change dropped the
-                            `<label for="company_id">` along with the input,
-                            leaving a bare number with no indication of what
-                            it was — a real regression for both sighted
-                            buyers and assistive tech, not just a style nit).
-                            A `<span>` rather than a `<label for=...>`: there
-                            is no control left for a `for` attribute to
-                            associate with, and an orphaned `for` pointing at
-                            a retired id is worse than no `for` at all.
-
-                            `visible: !!companyId()` is why it is naturally
-                            blank in manual-entry mode: there is no number to
-                            show, same as the input version, but here that
-                            reads as the whole line simply not being there
-                            rather than as an empty box. Nothing client-side
-                            enforces the number's presence either way;
-                            Model/Two.php::authorize() refuses an order with
-                            an empty organisation number server-side, and
-                            that refusal remains the only enforcement.
-
-                            The number itself is bound straight to
-                            `companyId`, the same observable the removed
-                            input read — every accepted source still writes
-                            exactly one place, and getData() still reads that
-                            observable, never the DOM. See the writer list on
-                            applyCompanyData() in gateway_method.js.
+                            Removed rather than hidden, unlike the input
+                            above it: that input is a capture control and
+                            still has work to do while no company is
+                            captured, whereas this was only ever a DISPLAY of
+                            a number, and the new label is that display. Two
+                            renderings of one value is precisely the defect
+                            §7 names. The value itself is untouched —
+                            `companyId` is still the single carrier and
+                            getData() still reads it, never the DOM.
                         -->
-                        <div class="two-company-id-label" data-bind="visible: !!companyId()">
-                            <!--
-                                No hardcoded punctuation joining the caption and
-                                the number (no colon, no dash): a literal ASCII
-                                separator glued outside the translated string is
-                                exactly the kind of thing that reads wrong in
-                                some locales (spacing/punctuation conventions
-                                around a label vary — see the org's active
-                                nb/nl/sv/es locale-parity work). Reusing the
-                                bare `'Company Number'` string (already
-                                translated everywhere else it's used — the
-                                payment-tile field label, the address-step
-                                tooltip) rather than minting a new
-                                colon-suffixed msgid that would start out
-                                untranslated. Visual separation between caption
-                                and number comes from CSS (stacked lines)
-                                instead of punctuation.
-                            -->
-                            <span class="two-company-id-label__caption">
-                                <!-- ko i18n: 'Company Number'--><!-- /ko -->
-                            </span>
-                            <span data-bind="text: companyId"></span>
-                        </div>
                     </div>
                 </div>
                 <!--


### PR DESCRIPTION
## What

TWO-25326 §7 for the Magento checkout surfaces (Luma, Amasty OneStepCheckout and Fire Checkout — one code path, confirmed: all three store views serve byte-identical assets).

The tile rendered the same company **three times**: an editable company-name control, a static "Company Number" caption, and the number itself below that. §7 asks for one line — `Name (12345678)` — between the term chips and the order-intent notice.

## The controls are hidden, not removed — and that is the point

The first cut of this change deleted the tile's company control outright, which is the literal reading of §7. Investigation found that would be an **order-blocking regression**, so it was not shipped.

The tile's picker is not a duplicate of the address step's. `address-autocomplete.js` binds only `#shipping-new-address-form`, so it never runs for:

- a **logged-in buyer selecting a saved address** — no new-address form is rendered;
- a **virtual cart** — there is no shipping step at all.

For those two flows the tile is the *only* company-capture surface. Remove it and they have no way to supply a company; `Model/Two.php::authorize()` then refuses the order server-side.

So the control and the label **swap**. `isCompanyCaptured()` gates both, in opposite directions, and no state can show both or neither.

## Where the line is drawn

Capture is gated on the **number**, not the name:

| state | number? | tile shows |
|---|---|---|
| registry pick | yes | the label |
| sole trader (synthetic id) | yes | the label |
| manual entry (name only) | no | the control, still functional |
| nothing captured | no | the control |

Manual entry deliberately does **not** count as captured. §6 says name-only must not make the payment method usable, so capture is precisely not complete — swapping in a label there would take the search box away while implying the buyer was finished.

The superseded caption and its separate number span are **removed** outright rather than hidden. Unlike the input above them, they were only ever a *display* of a value, and the new label is that display.

## Knockout `visible:`, not `if:`

Throughout. `if:` would tear the company-name node out of the DOM and rebuild it, underneath the select2 binding and the MutationObserver rebinding the picker depends on. `visible:` keeps the node stable, so the picker, the sole-trader write path and the submit path are all untouched.

One consequence worth stating: the `readonly` binding still reads *locked* while the field is hidden. Sole-trader mode can be left (`registeredOrganisationMode()`), and if the binding had been allowed to relax on the assumption nobody can see the field, re-showing it would hand the buyer an editable copy of a name they must not edit. Pinned by test.

`getData()` is unchanged and still reads the observables, never the DOM. The label carries no `name` and no writable binding, so it submits nothing.

## Tests

`npm run test:js` — **282 passed, 23 suites**.

The tile suite was rewritten around the new shape and gained:

- **swap pins** — both visibility expressions are read out of the template and pinned to an exact shape *before* being evaluated against a live renderer, so a drift to some other predicate (or an always-true stub) fails the string match rather than passing on a coincidence;
- a **name-only** case — the one most likely to be got wrong by gating the swap on the name alone;
- a **position pin** for the between-chips-and-intent placement, with every anchor guarded against `indexOf` returning `-1` (which compares "less than" everything and would make the ordering assertions pass on nonsense).

That position pin matters more than it looks: the label is inert display text, so nothing would *break* if it drifted to the bottom of the tile — nothing but a test would notice.

### Mutation results

Every mutation was confirmed to have actually changed the tree before the suite was run, so a no-op patch cannot be mistaken for a killed mutant.

| mutation | result |
|---|---|
| label always visible | 7 failed ✅ |
| name field always visible | 6 failed ✅ |
| capture gated on name only | 3 failed ✅ |
| label drops the number | 2 failed ✅ |
| readonly binding relaxed | 2 failed ✅ |
| label moved below the intent message | 1 failed ✅ |

Suite green again after each restore.

## Verification status

Code, 282 unit tests and mutation coverage. **Not live-verified.** The Chrome bridge is unavailable (the Windows-side subprocess now fails with an org monthly spend limit) and `kubectl` auth is expired, so there is no route to a real browser from this environment. The live §1–§7 sweep across all three store views remains owed on TWO-25326.

---

Reviewed adversarially and reported by Claude.
