### PR TITLE
fix(checkout): discard the previous country's company on a country switch (TWO-24867)

### DIFF
--- a/Test/Js/address-company-id.test.js
+++ b/Test/Js/address-company-id.test.js
@@ -340,7 +340,13 @@ describe('what the buyer types reaches the payment step', () => {
 
         const last = writes[writes.length - 1];
         expect(last.key).toBe('companyData');
-        expect(last.value).toEqual({ companyId: '87654321', companyName: 'Second Example Ltd' });
+        // `companyCountry` is TWO-24867's capture stamp — the payment tile
+        // refuses a company whose stamp names a country the buyer has left.
+        expect(last.value).toEqual({
+            companyId: '87654321',
+            companyName: 'Second Example Ltd',
+            companyCountry: 'gb'
+        });
     });
 
     test('a manually typed name and number publish together', () => {
@@ -354,7 +360,11 @@ describe('what the buyer types reaches the payment step', () => {
         node(ID_FIELD).handlers['change']();
 
         const last = writes[writes.length - 1];
-        expect(last.value).toEqual({ companyId: '87654321', companyName: 'Hand Typed Ltd' });
+        expect(last.value).toEqual({
+            companyId: '87654321',
+            companyName: 'Hand Typed Ltd',
+            companyCountry: 'gb'
+        });
     });
 
     test('every companyData write goes through publishCompanyData', () => {

--- a/Test/Js/company-search-country-switch.test.js
+++ b/Test/Js/company-search-country-switch.test.js
@@ -1,0 +1,643 @@
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ *
+ * TWO-24867: switching country mid-checkout must not leave the previous
+ * country's company behind.
+ *
+ * The buyer mis-clicks GB, searches a company, then corrects the country to
+ * ES. Before this change three copies of the GB company survived that
+ * correction — the picker's own selection, the `companyData` customer-data
+ * section the payment tile credit-checks, and the address autofilled from the
+ * GB registry entry — and none of them describes an ES buyer. The organisation
+ * number is the one that bites: it reaches the API paired with an ES billing
+ * country, is refused there, and surfaces to the buyer as a generic failure
+ * with nothing on screen saying which field is wrong.
+ *
+ * Ported from the PrestaShop fix (its country-change listener clears the
+ * company and organisation fields, and its server side discards a session
+ * company whose country marker does not match the address). The mechanism
+ * differs in one deliberate way, pinned below: PrestaShop recreates its
+ * autocomplete on a country change because that widget captures the country at
+ * construction. This one reads it per request, so the picker is left bound and
+ * the NEXT search simply carries the new country.
+ *
+ * LIMITATIONS OF THE DOUBLES BELOW — read before trusting a pass here.
+ *
+ *  1. `node.on()` keeps ONE handler per event name and `off()` is a no-op, so
+ *     nothing here can speak to handler ordering or coexistence. The country
+ *     select's `change` binding is the only handler these tests fire.
+ *  2. There is no select2. `enableCompanySearch()` runs against a `select2()`
+ *     stub, so what is checked is the wiring the module does around it — the
+ *     bind token it records, the ajax options it builds — never select2's own
+ *     behaviour.
+ *  3. `customerData` here is a plain in-memory section store. Its real
+ *     counterpart is backed by localStorage, which is the entire reason the
+ *     country stamp exists; that persistence is not modelled, only the read
+ *     and write shapes are.
+ */
+
+'use strict';
+
+const { loadAmdModule } = require('./amd-harness');
+
+const MODEL = 'view/frontend/web/js/model/company-search.js';
+const ADDRESS_STEP = 'view/frontend/web/js/view/address-autocomplete.js';
+const RENDERER = 'view/frontend/web/js/view/payment/method-renderer/gateway_method.js';
+
+const NAME_FIELD = '#shipping-new-address-form input[name="company"]';
+const ID_FIELD = '#shipping-new-address-form input[name="custom_attributes[company_id]"]';
+const COUNTRY_FIELD = '#shipping-new-address-form select[name="country_id"]';
+
+const CITY = 'input[name="city"]';
+const POSTCODE = 'input[name="postcode"]';
+const STREET = 'input[name="street[0]"]';
+
+const MARKER = 'data-two-autofilled-value';
+
+/**
+ * jQuery double with one persistent node per selector and, unlike the doubles
+ * in the neighbouring files, a REAL attribute store.
+ *
+ * That is load-bearing here rather than incidental: the autofill marker is an
+ * attribute, so against an inert `attr()` (which is what
+ * address-company-id.test.js and gateway-method-company-selection.test.js
+ * ship) every assertion about reverting an autofilled address would pass
+ * whether or not the marker was ever written.
+ */
+function makeDom() {
+    const nodes = {};
+    const triggered = [];
+
+    function node(selector) {
+        if (nodes[selector]) return nodes[selector];
+        const n = {
+            selector: selector,
+            length: 1,
+            value: '',
+            attrs: {},
+            props: {},
+            textValue: '',
+            dataValues: {},
+            handlers: {},
+            appended: [],
+            val: function (next) {
+                if (!arguments.length) return n.value;
+                n.value = next;
+                return n;
+            },
+            attr: function (name, next) {
+                if (arguments.length < 2) return n.attrs[name];
+                n.attrs[name] = next;
+                return n;
+            },
+            removeAttr: function (name) {
+                delete n.attrs[name];
+                return n;
+            },
+            prop: function (name, next) {
+                if (arguments.length < 2) return n.props[name];
+                n.props[name] = next;
+                return n;
+            },
+            text: function (next) {
+                if (!arguments.length) return n.textValue;
+                n.textValue = next;
+                return n;
+            },
+            data: function (key, next) {
+                if (arguments.length < 2) return n.dataValues[key];
+                n.dataValues[key] = next;
+                return n;
+            },
+            on: function (event, fn) {
+                n.handlers[String(event).split('.')[0]] = fn;
+                return n;
+            },
+            off: function () {
+                return n;
+            },
+            trigger: function (event) {
+                triggered.push([selector, event]);
+                return n;
+            },
+            closest: function (sel) {
+                return node(selector + ' >closest> ' + sel);
+            },
+            find: function (sel) {
+                return node(selector + ' >find> ' + sel);
+            },
+            append: function (html) {
+                n.appended.push(html);
+                return n;
+            },
+            addClass: function (cls) {
+                n.classes = (n.classes || []).concat(cls);
+                return n;
+            },
+            remove: function () {
+                n.removed = true;
+                return n;
+            },
+            hide: function () {
+                return n;
+            },
+            show: function () {
+                return n;
+            },
+            select2: function () {
+                return n;
+            }
+        };
+        nodes[selector] = n;
+        return n;
+    }
+
+    function $(selector) {
+        return node(typeof selector === 'string' ? selector : String(selector));
+    }
+    // `$.async` is a MutationObserver in Magento; every node here already
+    // exists, so resolve immediately with the selector — the modules re-wrap
+    // it with `$(...)`, which lands on the same node.
+    $.async = function (selector, cb) {
+        cb(selector);
+    };
+    $.each = function (xs, fn) {
+        (xs || []).forEach(function (x, i) {
+            fn(i, x);
+        });
+    };
+    $.ajax = function () {
+        const r = { done: () => r, fail: () => r, always: () => r };
+        return r;
+    };
+    $.Deferred = function () {
+        const d = {
+            resolve: () => d,
+            reject: () => d,
+            promise: () => d,
+            done: () => d,
+            fail: () => d,
+            always: () => d
+        };
+        return d;
+    };
+    $.mage = { cookies: { get: () => null, set: () => {} }, redirect: () => {} };
+    $.extend = Object.assign;
+    $.fn = {};
+
+    return { $: $, node: node, triggered: triggered };
+}
+
+/** Customer-data double recording every section write, in order. */
+function makeCustomerData() {
+    const writes = [];
+    const sections = {};
+
+    function observable(initial) {
+        let value = initial;
+        const subscribers = [];
+        function obs(next) {
+            if (!arguments.length) return value;
+            value = next;
+            subscribers.forEach(function (s) {
+                s(value);
+            });
+            return obs;
+        }
+        obs.subscribe = function (fn) {
+            subscribers.push(fn);
+            return { dispose: function () {} };
+        };
+        return obs;
+    }
+
+    return {
+        writes: writes,
+        lastWriteTo: function (key) {
+            for (let i = writes.length - 1; i >= 0; i--) {
+                if (writes[i].key === key) return writes[i].value;
+            }
+            return undefined;
+        },
+        api: {
+            get: function (key) {
+                if (!sections[key]) sections[key] = observable(undefined);
+                return sections[key];
+            },
+            set: function (key, value) {
+                writes.push({ key: key, value: value });
+                if (!sections[key]) sections[key] = observable(undefined);
+                sections[key](value);
+            },
+            reload: function () {}
+        }
+    };
+}
+
+/** Load the real shared model against a jQuery whose DOM the test owns. */
+function loadModel() {
+    const dom = makeDom();
+    return { model: loadAmdModule(MODEL, { jquery: dom.$ }), node: dom.node, dom: dom };
+}
+
+/**
+ * Load the address step.
+ *
+ * `companySearch` is a RECORDING double rather than the real module: what is
+ * being pinned on this surface is that the country-change handler CALLS the
+ * abort and the revert, with the live bind token, in the right circumstances.
+ * The revert's own behaviour is pinned directly against the real module in the
+ * first describe block below.
+ */
+function loadAddressStep(options) {
+    const opts = options || {};
+    const dom = makeDom();
+    const cd = makeCustomerData();
+    const calls = { abort: [], revert: 0, applyAddress: [] };
+
+    dom.node(COUNTRY_FIELD).val(opts.country || 'GB');
+
+    const companySearch = {
+        REQUEST_TIMEOUT_MS: 30000,
+        SEARCH_DEBOUNCE_MS: 300,
+        MIN_INPUT_LENGTH: 3,
+        DROPDOWN_CSS_CLASS: 'two-company-search-dropdown',
+        EVENT_NS: '.twoCompanySearch',
+        AUTOFILL_MARKER_ATTR: MARKER,
+        buildLanguageOptions: function () {
+            return {};
+        },
+        buildSearchAjaxOptions: function (o) {
+            calls.ajaxOptions = o;
+            return {};
+        },
+        lookupCompanyAddress: function () {
+            return null;
+        },
+        applyAddress: function (address) {
+            calls.applyAddress.push(address);
+        },
+        revertAutofilledAddress: function () {
+            calls.revert += 1;
+            return 0;
+        },
+        abortActiveRequest: function (token) {
+            calls.abort.push(token);
+            return false;
+        },
+        isDegradedResponse: function () {
+            return false;
+        },
+        clearResultCache: function () {},
+        attachOpenOnType: function () {},
+        getSearchFieldContainer: function () {
+            return null;
+        },
+        attachManualEntryButton: function () {},
+        detachManualEntryButton: function () {},
+        markSearchBinding: function () {},
+        clearSearchChrome: function () {},
+        setSearching: function () {},
+        setUnavailable: function () {},
+        minInputLengthMessage: function () {
+            return '';
+        },
+        noResultsMessage: function () {
+            return '';
+        }
+    };
+
+    const component = loadAmdModule(ADDRESS_STEP, {
+        jquery: dom.$,
+        'Magento_Customer/js/customer-data': cd.api,
+        'Two_Gateway/js/model/company-search': companySearch,
+        'Two_Gateway/js/model/brand-config': {
+            getActiveTwoBrandConfig: function () {
+                return {
+                    isCompanySearchEnabled: !!opts.searchEnabled,
+                    isAddressSearchEnabled: true,
+                    checkoutApiUrl: 'https://api.example.test',
+                    companySearchLimit: 10
+                };
+            }
+        }
+    });
+    component._super = function () {};
+    component.initialize();
+
+    return { component: component, node: dom.node, cd: cd, calls: calls };
+}
+
+/** Fire the `change` handler the address step bound to the country select. */
+function switchCountryTo(ctx, iso) {
+    ctx.node(COUNTRY_FIELD).val(iso);
+    ctx.node(COUNTRY_FIELD).handlers.change();
+}
+
+function loadRenderer() {
+    const dom = makeDom();
+    const renderer = loadAmdModule(RENDERER, { jquery: dom.$ });
+    // `initialize()` seeds this per-country memo and is not run here (it wires
+    // subscriptions these tests do not want). `getSupportedCompanyTypes()`
+    // reads it on the first `fillCountryCode()`, so seed it by hand rather
+    // than leave every country test failing on the memo rather than on the
+    // behaviour it is about.
+    renderer.supportedCompanyTypes = {};
+    return { renderer: renderer, node: dom.node };
+}
+
+describe('reverting an address autofilled from the previous country', () => {
+    test('applyAddress records exactly what it wrote, on every field', () => {
+        const { model, node } = loadModel();
+
+        model.applyAddress({
+            city: 'London',
+            postal_code: 'EC1A 1BB',
+            street_address: '1 Example Street'
+        });
+
+        expect(node(CITY).val()).toBe('London');
+        expect(node(CITY).attr(MARKER)).toBe('London');
+        expect(node(POSTCODE).attr(MARKER)).toBe('EC1A 1BB');
+        expect(node(STREET).attr(MARKER)).toBe('1 Example Street');
+    });
+
+    test('the revert clears an untouched autofill and fires change for it', () => {
+        const { model, node, dom } = loadModel();
+        model.applyAddress({
+            city: 'London',
+            postal_code: 'EC1A 1BB',
+            street_address: '1 Example Street'
+        });
+        dom.triggered.length = 0;
+
+        expect(model.revertAutofilledAddress()).toBe(3);
+
+        expect(node(CITY).val()).toBe('');
+        expect(node(POSTCODE).val()).toBe('');
+        expect(node(STREET).val()).toBe('');
+        // Magento's address-form bookkeeping listens for `change`, so a cleared
+        // field that never fired one would stay in the quote.
+        expect(dom.triggered.filter((t) => t[1] === 'change')).toHaveLength(3);
+    });
+
+    test('a field the buyer edited after the autofill survives the revert', () => {
+        // The whole reason the marker records the VALUE rather than a boolean.
+        // Over-clearing here deletes buyer input on a keystroke they may have
+        // made minutes earlier — worse than leaving a stale value they can see.
+        const { model, node } = loadModel();
+        model.applyAddress({
+            city: 'London',
+            postal_code: 'EC1A 1BB',
+            street_address: '1 Example Street'
+        });
+        node(CITY).val('Madrid');
+
+        expect(model.revertAutofilledAddress()).toBe(2);
+
+        expect(node(CITY).val()).toBe('Madrid');
+        expect(node(POSTCODE).val()).toBe('');
+    });
+
+    test('a hand-filled form with no autofill behind it is left entirely alone', () => {
+        const { model, node } = loadModel();
+        node(CITY).val('Madrid');
+        node(POSTCODE).val('28001');
+        node(STREET).val('Calle Example 1');
+
+        expect(model.revertAutofilledAddress()).toBe(0);
+
+        expect(node(CITY).val()).toBe('Madrid');
+        expect(node(POSTCODE).val()).toBe('28001');
+        expect(node(STREET).val()).toBe('Calle Example 1');
+    });
+
+    test('a second autofill of an unchanged value still re-records the marker', () => {
+        // Two companies sharing a postcode: without the refresh the second
+        // write leaves no recording, and the field reads as buyer-typed — so
+        // the revert would strand it — for the rest of the page's life.
+        const { model, node } = loadModel();
+        model.applyAddress({ city: 'London', postal_code: 'EC1A 1BB', street_address: 'One' });
+        node(POSTCODE).removeAttr(MARKER);
+
+        model.applyAddress({ city: 'London', postal_code: 'EC1A 1BB', street_address: 'Two' });
+
+        expect(node(POSTCODE).attr(MARKER)).toBe('EC1A 1BB');
+        expect(model.revertAutofilledAddress()).toBe(3);
+    });
+
+    test('an empty registry value is a recording, not an absence', () => {
+        // `''` is what the API sends for a field the registry has nothing for.
+        // A falsiness test here would leave the marker unread and the field
+        // permanently un-revertable.
+        const { model, node } = loadModel();
+        model.applyAddress({ city: 'London', postal_code: '', street_address: 'One' });
+
+        expect(node(POSTCODE).attr(MARKER)).toBe('');
+        expect(model.revertAutofilledAddress()).toBe(3);
+    });
+});
+
+describe('the address step on a country change', () => {
+    test('the company in play is discarded, in every place it lives', () => {
+        const ctx = loadAddressStep({ country: 'GB' });
+        ctx.component.setCompanyData('12345678', 'Example Ltd');
+        expect(ctx.node(NAME_FIELD).val()).toBe('Example Ltd');
+
+        switchCountryTo(ctx, 'ES');
+
+        expect(ctx.node(NAME_FIELD).val()).toBe('');
+        expect(ctx.node(ID_FIELD).val()).toBe('');
+        expect(ctx.cd.lastWriteTo('companyData')).toEqual({
+            companyId: '',
+            companyName: '',
+            companyCountry: 'es'
+        });
+    });
+
+    test('an address autofilled from the previous country is reverted', () => {
+        const ctx = loadAddressStep({ country: 'GB' });
+
+        switchCountryTo(ctx, 'ES');
+
+        expect(ctx.calls.revert).toBe(1);
+    });
+
+    test('a search still on the wire for the old country is cancelled', () => {
+        // Up to 30s of window (REQUEST_TIMEOUT_MS) in which a GB response can
+        // land and repaint a dropdown the buyer is now reading as ES results.
+        const ctx = loadAddressStep({ country: 'GB' });
+        const token = {};
+        ctx.component._bindToken = token;
+
+        switchCountryTo(ctx, 'ES');
+
+        expect(ctx.calls.abort).toEqual([token]);
+    });
+
+    test('the live bind token is the one recorded by enableCompanySearch', () => {
+        // Without this the test above would pass against `undefined` — the
+        // handler would be cancelling nothing, in a shape indistinguishable
+        // from cancelling correctly.
+        const ctx = loadAddressStep({ country: 'GB', searchEnabled: true });
+
+        expect(typeof ctx.component._bindToken).toBe('object');
+        expect(ctx.component._bindToken).not.toBeNull();
+        expect(ctx.calls.ajaxOptions.token).toBe(ctx.component._bindToken);
+    });
+
+    test('the next search carries the new country, with no re-bind', () => {
+        // The deliberate divergence from PrestaShop, which recreates its
+        // autocomplete here. `getCountryCode` reads the select per request, so
+        // the bound widget already searches the new country — and a re-bind
+        // would drag a buyer in manual-entry mode back into search mode.
+        const ctx = loadAddressStep({ country: 'GB', searchEnabled: true });
+        const tokenBefore = ctx.component._bindToken;
+
+        switchCountryTo(ctx, 'ES');
+
+        expect(ctx.calls.ajaxOptions.getCountryCode()).toBe('ES');
+        expect(ctx.component._bindToken).toBe(tokenBefore);
+    });
+
+    test('a change event that re-selects the same country discards nothing', () => {
+        // Magento fires `change` as the form initialises, and again on a
+        // re-render that re-selects the same country. Treating those as a
+        // switch would blank a returning customer's prefilled company on load.
+        const ctx = loadAddressStep({ country: 'GB' });
+        ctx.component.setCompanyData('12345678', 'Example Ltd');
+        const token = {};
+        ctx.component._bindToken = token;
+
+        switchCountryTo(ctx, 'GB');
+
+        expect(ctx.node(NAME_FIELD).val()).toBe('Example Ltd');
+        expect(ctx.node(ID_FIELD).val()).toBe('12345678');
+        expect(ctx.calls.abort).toEqual([]);
+        expect(ctx.calls.revert).toBe(0);
+    });
+
+    test('the published company records the country it was captured in', () => {
+        const ctx = loadAddressStep({ country: 'GB' });
+
+        ctx.component.setCompanyData('12345678', 'Example Ltd');
+
+        expect(ctx.cd.lastWriteTo('companyData')).toEqual({
+            companyId: '12345678',
+            companyName: 'Example Ltd',
+            companyCountry: 'gb'
+        });
+    });
+});
+
+describe('the payment tile on a country change', () => {
+    test('a company selected under the previous country is dropped', () => {
+        const { renderer } = loadRenderer();
+        renderer.fillCountryCode('gb');
+        renderer.applyCompanyData(
+            { companyName: 'Example Ltd', companyId: '12345678' },
+            { authoritative: true }
+        );
+
+        renderer.fillCountryCode('es');
+
+        // The organisation number is the one that matters: paired with an ES
+        // billing country it is refused upstream as a generic failure.
+        expect(renderer.companyId()).toBe('');
+        expect(renderer.companyName()).toBe('');
+    });
+
+    test('the first country resolution keeps the company it arrived with', () => {
+        // updateAddress() calls fillCountryCode() immediately before
+        // fillCompanyData(), both off the SAME address, and the observable
+        // starts empty — so treating the first fill as a change would discard
+        // the quote's own company on every page load.
+        const { renderer } = loadRenderer();
+
+        renderer.updateAddress({
+            countryId: 'GB',
+            company: 'Example Ltd',
+            telephone: '+44 20 7946 0000',
+            customAttributes: [{ attribute_code: 'company_id', value: '12345678' }]
+        });
+
+        expect(renderer.countryCode()).toBe('gb');
+        expect(renderer.companyId()).toBe('12345678');
+        expect(renderer.companyName()).toBe('Example Ltd');
+    });
+
+    test('re-resolving the same country keeps the company', () => {
+        const { renderer } = loadRenderer();
+        renderer.fillCountryCode('gb');
+        renderer.applyCompanyData(
+            { companyName: 'Example Ltd', companyId: '12345678' },
+            { authoritative: true }
+        );
+
+        renderer.fillCountryCode('gb');
+
+        expect(renderer.companyId()).toBe('12345678');
+    });
+});
+
+describe('a company restored from a previous visit', () => {
+    test('one captured in another country is refused', () => {
+        // `companyData` is a localStorage section: it outlives the page and the
+        // order, so an in-page reset cannot reach this. Nothing changed in THIS
+        // page — the record simply belongs to a country the buyer is no longer
+        // in.
+        const { renderer } = loadRenderer();
+        renderer.fillCountryCode('es');
+
+        renderer.applyCompanyData(
+            { companyName: 'Example Ltd', companyId: '12345678', companyCountry: 'gb' },
+            { authoritative: true }
+        );
+
+        expect(renderer.companyId()).toBe('');
+        expect(renderer.companyName()).toBe('');
+    });
+
+    test('one captured in the current country is applied', () => {
+        const { renderer } = loadRenderer();
+        renderer.fillCountryCode('es');
+
+        renderer.applyCompanyData(
+            { companyName: 'Ejemplo SL', companyId: 'B12345678', companyCountry: 'es' },
+            { authoritative: true }
+        );
+
+        expect(renderer.companyId()).toBe('B12345678');
+    });
+
+    test('the stamp is matched case-insensitively', () => {
+        // The address step lower-cases; the quote's `countryId` is upper-case
+        // and reaches the observable through updateAddress(). A case-sensitive
+        // compare would refuse every company on the tile.
+        const { renderer } = loadRenderer();
+        renderer.fillCountryCode('ES');
+
+        renderer.applyCompanyData(
+            { companyName: 'Ejemplo SL', companyId: 'B12345678', companyCountry: 'es' },
+            { authoritative: true }
+        );
+
+        expect(renderer.companyId()).toBe('B12345678');
+    });
+
+    test('an unstamped record is applied rather than refused', () => {
+        // Records written before the stamp existed carry no country. Failing
+        // closed on those would drop a legitimate company on the first load
+        // after an upgrade; they gain a stamp on the next write.
+        const { renderer } = loadRenderer();
+        renderer.fillCountryCode('es');
+
+        renderer.applyCompanyData(
+            { companyName: 'Ejemplo SL', companyId: 'B12345678' },
+            { authoritative: true }
+        );
+
+        expect(renderer.companyId()).toBe('B12345678');
+    });
+});

--- a/Test/Js/gateway-method-company-selection.test.js
+++ b/Test/Js/gateway-method-company-selection.test.js
@@ -555,18 +555,34 @@ describe('the shipping-step picker agrees with the payment step', () => {
         autocomplete.setCompanyData('12345678', 'First Example Ltd');
         expect(sections.companyData).toEqual({
             companyId: '12345678',
-            companyName: 'First Example Ltd'
+            companyName: 'First Example Ltd',
+            // TWO-24867. The double's country select is empty, so the stamp is
+            // '' here; what it says under a real country is pinned in
+            // Test/Js/company-search-country-switch.test.js.
+            companyCountry: ''
         });
         // `toEqual` treats a key holding `undefined` as equal to the key being
         // absent, so it alone would pass if `companyId` stopped being written.
         // `toStrictEqual` is not usable here — the harness runs modules in a
         // `vm` context, so every strict compare fails cross-realm with
         // "serializes to the same string". Assert the key set instead.
-        expect(Object.keys(sections.companyData).sort()).toEqual(['companyId', 'companyName']);
+        expect(Object.keys(sections.companyData).sort()).toEqual([
+            'companyCountry',
+            'companyId',
+            'companyName'
+        ]);
 
         autocomplete.setCompanyData('', 'Second Example Ltd');
-        expect(sections.companyData).toEqual({ companyId: '', companyName: 'Second Example Ltd' });
-        expect(Object.keys(sections.companyData).sort()).toEqual(['companyId', 'companyName']);
+        expect(sections.companyData).toEqual({
+            companyId: '',
+            companyName: 'Second Example Ltd',
+            companyCountry: ''
+        });
+        expect(Object.keys(sections.companyData).sort()).toEqual([
+            'companyCountry',
+            'companyId',
+            'companyName'
+        ]);
         expect(dom.node(autocomplete.companyIdSelector).val()).toBe('');
     });
 });

--- a/view/frontend/web/js/model/company-search.js
+++ b/view/frontend/web/js/model/company-search.js
@@ -229,6 +229,18 @@ define(['jquery', 'mage/translate'], function ($, $t) {
      */
     const MANUAL_ENTRY_NS = '.twoManualEntry';
 
+    /**
+     * Attribute applyAddress() records its own write in, so a later revert can
+     * tell an autofilled value apart from one the buyer typed.
+     *
+     * A DOM attribute rather than module state on purpose: the checkout
+     * re-renders the address form (Fire Checkout does it on every totals
+     * change), and the recording has to survive exactly as long as the input
+     * it describes — no longer. A module-level Map would outlive the node and
+     * start describing its replacement.
+     */
+    const AUTOFILL_MARKER_ATTR = 'data-two-autofilled-value';
+
     const SPINNER_CLASS = 'two-company-search__spinner';
     const UNAVAILABLE_CLASS = 'two-company-search__unavailable';
     const MANUAL_ENTRY_CLASS = 'two-company-search__manual-entry';
@@ -431,6 +443,7 @@ define(['jquery', 'mage/translate'], function ($, $t) {
         MIN_INPUT_LENGTH: MIN_INPUT_LENGTH,
         DROPDOWN_CSS_CLASS: DROPDOWN_CSS_CLASS,
         EVENT_NS: EVENT_NS,
+        AUTOFILL_MARKER_ATTR: AUTOFILL_MARKER_ATTR,
         isDegradedResponse: isDegradedResponse,
         minInputLengthMessage: minInputLengthMessage,
         noResultsMessage: noResultsMessage,
@@ -809,16 +822,82 @@ define(['jquery', 'mage/translate'], function ($, $t) {
          * `#billing-new-address-form`, and only one of them is present when a
          * company is picked from that step's search box.
          *
+         * Each field also records the value this wrote, in
+         * `AUTOFILL_MARKER_ATTR`. That recording is what makes the write
+         * REVERSIBLE on a country switch (revertAutofilledAddress() below)
+         * without ever discarding something the buyer typed: a buyer edit
+         * leaves the field's value and its recording different, and that
+         * difference IS the "buyer owns this now" signal.
+         *
+         * The marker is refreshed even when the incoming value already matches
+         * what is in the field. Otherwise two companies sharing a postcode
+         * would leave the second write unrecorded, and the field would read as
+         * buyer-typed for the rest of the page's life.
+         *
          * @param {object} address company address record from the API
          */
         applyAddress: function (address) {
             console.debug({ logger: 'companySearch.applyAddress', address });
-            $('input[name="city"]').val(address.city);
-            $('input[name="postcode"]').val(address.postal_code);
-            $('input[name="street[0]"]').val(address.street_address);
+            const values = {
+                city: address.city,
+                postcode: address.postal_code,
+                'street[0]': address.street_address
+            };
+            // No presence check: jQuery's `.val()` and `.attr()` are no-ops on
+            // an empty set, which is the pre-existing behaviour for a step
+            // whose form is not on screen, and a guard here would only make
+            // the two writes disagree about when they run.
+            Object.keys(values).forEach(function (name) {
+                const value = values[name] == null ? '' : String(values[name]);
+                $(`input[name="${name}"]`).val(value).attr(AUTOFILL_MARKER_ATTR, value);
+            });
             $('input[name="city"], input[name="postcode"], input[name="street[0]"]').trigger(
                 'change'
             );
+        },
+
+        /**
+         * Undo an applyAddress() write, field by field, and forget the
+         * recording.
+         *
+         * Called when the buyer switches country: an address autofilled from
+         * the previous country's registry is not a hint about the new one, it
+         * is a wrong address the buyer may well not re-read before placing the
+         * order.
+         *
+         * Only fields still holding EXACTLY what applyAddress() put there are
+         * cleared. Anything the buyer has since edited — and anything that was
+         * never autofilled at all, including a whole form they filled by hand —
+         * has no matching recording and is left alone. That asymmetry is the
+         * point: over-clearing here silently deletes buyer input on a keystroke
+         * they may have made minutes ago, which is worse than leaving a stale
+         * value they can see and correct.
+         *
+         * `change` is fired only for fields actually cleared, so Magento's
+         * address-form bookkeeping sees the same event shape it does for a
+         * buyer edit.
+         *
+         * @returns {number} how many fields were cleared — for tests, and so a
+         *          caller can tell "nothing was ours" from "reverted"
+         */
+        revertAutofilledAddress: function () {
+            let cleared = 0;
+            ['city', 'postcode', 'street[0]'].forEach(function (name) {
+                const $input = $(`input[name="${name}"]`);
+                const marker = $input.attr(AUTOFILL_MARKER_ATTR);
+                // `undefined` means never autofilled. An empty-string marker is
+                // a real recording (the registry had no value for this field)
+                // and must still be honoured, so this tests for absence rather
+                // than falsiness.
+                if (typeof marker === 'undefined') return;
+                $input.removeAttr(AUTOFILL_MARKER_ATTR);
+                if (($input.val() || '') !== marker) return;
+                $input.val('');
+                $input.trigger('change');
+                cleared += 1;
+            });
+            console.debug({ logger: 'companySearch.revertAutofilledAddress', cleared });
+            return cleared;
         },
 
         /**

--- a/view/frontend/web/js/view/address-autocomplete.js
+++ b/view/frontend/web/js/view/address-autocomplete.js
@@ -53,9 +53,12 @@ define([
 
             $.async(this.countrySelector, function (countrySelector) {
                 self.toggleCompanyVisibility();
-                $(countrySelector).on('change', function () {
-                    self.toggleCompanyVisibility();
-                });
+                self._lastCountryCode = self.currentCountryCode();
+                $(countrySelector)
+                    .off('change' + EVENT_NS)
+                    .on('change' + EVENT_NS, function () {
+                        self.onCountryChanged();
+                    });
             });
             this.enableCompanySearch();
             this.enableManualCompanyId();
@@ -66,8 +69,73 @@ define([
                 customerData.set('shippingTelephone', telephone);
             });
         },
+        /**
+         * The address form's currently selected country, lower-cased, or ''
+         * when the select is absent or has no value.
+         *
+         * Guarded rather than `.val().toLowerCase()`: jQuery's `.val()` on an
+         * empty set is `undefined`, and this runs from a `$.async` callback
+         * whose node can be replaced by a re-render between resolve and call.
+         *
+         * @returns {string}
+         */
+        currentCountryCode: function () {
+            const value = $(this.countrySelector).val();
+            return typeof value === 'string' ? value.toLowerCase() : '';
+        },
+        /**
+         * The buyer changed the address country mid-checkout (TWO-24867).
+         *
+         * Everything the company search produced belongs to the country it was
+         * searched in: the company itself, its organisation number, and the
+         * address autofilled from the registry entry. None of it describes the
+         * new country, and none of it is re-derivable — so a switch has to
+         * retract it rather than leave it on screen looking chosen.
+         *
+         * The concrete failure this closes is not cosmetic. `companyData` is a
+         * localStorage customer-data section and the payment tile credit-checks
+         * whatever is in it, so a GB organisation number survived a switch to
+         * ES and was submitted under an ES billing address — refused upstream,
+         * and surfaced to the buyer as a generic failure with nothing on screen
+         * explaining which field was wrong.
+         *
+         * What this deliberately does NOT do is re-bind the picker. The
+         * PrestaShop equivalent recreates its autocomplete here because that
+         * widget captures the country at construction; this one does not —
+         * `getCountryCode` (enableCompanySearch() below) reads the select on
+         * every request, so the next search already carries the new country.
+         * Re-binding would tear down and rebuild select2 for no behavioural
+         * gain, and would drag a buyer sitting in manual-entry mode back into
+         * search mode. Pinned by the "search after a switch uses the new
+         * country" test rather than left as a claim.
+         */
+        onCountryChanged: function () {
+            const countryCode = this.currentCountryCode();
+            const previous = this._lastCountryCode;
+            this._lastCountryCode = countryCode;
+            // `change` also fires for a re-render that re-selects the same
+            // country, and Magento fires it once as the form initialises. Only
+            // an actual change is a reason to discard a company — doing this on
+            // a no-op would blank a returning customer's prefilled address the
+            // moment their form loads.
+            if (previous === countryCode) {
+                this.toggleCompanyVisibility();
+                return;
+            }
+            // First, before the state it might repaint is cleared: a search
+            // issued under the OLD country is still on the wire for up to 30s,
+            // and its results would populate a dropdown the buyer reads as
+            // results for the new one.
+            companySearch.abortActiveRequest(this._bindToken);
+            companySearch.revertAutofilledAddress();
+            // Clears the name input, the number field, and the published
+            // `companyData` section the payment tile reads — every surviving
+            // copy of the previous country's company.
+            this.setCompanyData();
+            this.toggleCompanyVisibility();
+        },
         toggleCompanyVisibility: function () {
-            const countryCode = $(this.countrySelector).val().toLowerCase();
+            const countryCode = this.currentCountryCode();
             customerData.set('countryCode', countryCode);
             let field = $(this.companyNameSelector).closest('.field');
             field.show();
@@ -85,7 +153,21 @@ define([
          * reading is only sound while the section has exactly one writer.
          */
         publishCompanyData: function (companyId, companyName) {
-            customerData.set('companyData', { companyId: companyId, companyName: companyName });
+            customerData.set('companyData', {
+                companyId: companyId,
+                companyName: companyName,
+                // The country this company was captured in (TWO-24867).
+                //
+                // `companyData` is a localStorage section, so it outlives the
+                // page and the order: a buyer who searched a GB company, left,
+                // and came back to a checkout now sitting on an ES address
+                // would otherwise have the GB organisation number read back and
+                // credit-checked under ES. The in-page country-change reset
+                // cannot reach that case — nothing changed in THIS page — so
+                // the record has to say which country it belongs to and the
+                // reader has to check.
+                companyCountry: this.currentCountryCode()
+            });
         },
         setCompanyData: function (companyId = '', companyName = '') {
             console.debug({ logger: 'addressAutocomplete.setCompanyData', companyId, companyName });
@@ -368,6 +450,13 @@ define([
                     // Identity for this bind, so a previous widget's late
                     // response cannot paint chrome on its replacement.
                     const bindToken = {};
+                    // Also held on the component, so the country-change handler
+                    // — which is bound to the country select, not to this node,
+                    // and therefore closes over no bind of its own — can cancel
+                    // the search the CURRENT picker has in flight. Overwritten
+                    // on every re-bind, which is correct: only the live bind
+                    // can have a request worth cancelling.
+                    self._bindToken = bindToken;
                     // select2's destroy() only clears its own `.select2`
                     // namespace, so our handlers would stack one copy per
                     // re-render and a single pick would fire N address

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -411,6 +411,34 @@ define([
         applyCompanyData: function (companyData, options) {
             const data = companyData || {};
             const authoritative = !!(options && options.authoritative);
+            // Refuse a company captured in a different country (TWO-24867).
+            //
+            // Applies to the authoritative path too: `companyData` is a
+            // localStorage section that outlives the page, so "a change
+            // notification is the shipping-step picker writing it" is only true
+            // WITHIN a page load. A record restored from a previous visit is
+            // indistinguishable from a live pick at this end, and a GB
+            // organisation number applied under an ES billing address is
+            // refused upstream as a generic failure the buyer cannot act on.
+            //
+            // Fails OPEN on an absent stamp, not closed: records written before
+            // this field existed carry no country, and treating "unstamped" as
+            // "wrong country" would drop a legitimate company on the first load
+            // after an upgrade. They gain the stamp on the next write.
+            const capturedCountry = data.companyCountry ? String(data.companyCountry) : '';
+            const currentCountry = this.countryCode();
+            if (
+                capturedCountry &&
+                currentCountry &&
+                capturedCountry.toLowerCase() !== currentCountry.toLowerCase()
+            ) {
+                console.debug({
+                    logger: 'twoPayment.applyCompanyData.countryMismatch',
+                    capturedCountry,
+                    currentCountry
+                });
+                return;
+            }
             const companyName =
                 typeof data.companyName == 'string' && data.companyName ? data.companyName : '';
             // String(), not a typeof test: a non-string id (a numeric
@@ -460,10 +488,43 @@ define([
             if (!telephone) return;
             this.telephone(telephone);
         },
+        /**
+         * Forget the company currently in play, because it belongs to a
+         * country the buyer has just left (TWO-24867).
+         *
+         * Name AND number, unlike clearCompany(), which leaves `companyName()`
+         * standing for the sole-trader signup prefill. There is no such reader
+         * here: the name came out of the previous country's registry, so
+         * carrying it into a signup popup or an intent-approved notice for the
+         * new country would be asserting a company the buyer has not chosen
+         * there.
+         *
+         * The widget is deliberately left bound. disableCompanySearch() would
+         * destroy it and force the buyer to click "Search for company" again to
+         * do the very thing the switch implies they are about to do; the picker
+         * reads `countryCode()` per request (see its `getCountryCode`), so the
+         * bound widget already searches the new country.
+         */
+        clearCompanyForCountryChange: function () {
+            console.debug({ logger: 'twoPayment.clearCompanyForCountryChange' });
+            this.companyName('');
+            this.companyId('');
+            $(this.companyNameSelector).val('');
+            $('#select2-company_name-container')?.text('');
+        },
         fillCountryCode: function (countryCode) {
             console.debug({ logger: 'twoPayment.fillCountryCode', countryCode });
             countryCode = typeof countryCode == 'string' ? countryCode : '';
             if (!countryCode) return;
+            const previousCountryCode = this.countryCode();
+            // A CHANGE, not the first resolution. `countryCode()` starts empty
+            // and is filled from the quote on load, and that first fill must
+            // not discard a company the quote's own address already carries —
+            // updateAddress() calls this immediately before fillCompanyData()
+            // with both values off the SAME address.
+            if (previousCountryCode && previousCountryCode !== countryCode) {
+                this.clearCompanyForCountryChange();
+            }
             this.countryCode(countryCode);
             var self = this;
             this.getSupportedCompanyTypes(countryCode).then(function (types) {

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -510,7 +510,12 @@ define([
             this.companyName('');
             this.companyId('');
             $(this.companyNameSelector).val('');
-            $('#select2-company_name-container')?.text('');
+            // No `?.` here, unlike the two sibling writers of this node. A
+            // jQuery set is always truthy — empty or not — so the optional
+            // chain on those lines can never short-circuit, and reproducing it
+            // would imply a guard that does not exist. `.text()` on an empty
+            // set is already a no-op, which is the behaviour that was wanted.
+            $('#select2-company_name-container').text('');
         },
         fillCountryCode: function (countryCode) {
             console.debug({ logger: 'twoPayment.fillCountryCode', countryCode });


### PR DESCRIPTION
## What

A buyer who mis-clicks the country, searches a company, then corrects the country kept the first country's company. Three copies of it survived the correction:

- the picker's own selection (name input + company-number field),
- the `companyData` customer-data section the payment tile credit-checks,
- the address autofilled from the first country's registry entry.

None of them describes the buyer's actual country. The organisation number is the one that bites: it reaches the API paired with the new billing country, is refused there, and surfaces to the buyer as a generic failure with nothing on screen naming the field that is wrong.

## The port

Mechanism by mechanism, from the PrestaShop fix (`TwoCompanySearch.setupCountryChangeListener()` + the server-side session-company country marker):

| PrestaShop | Here |
|---|---|
| country `change` clears company + organisation fields | address step's `change` handler clears the name, the number and the published section |
| bumps a search sequence and aborts the in-flight request | `companySearch.abortActiveRequest(this._bindToken)` |
| session company discarded on a country-marker mismatch | `companyData` records `companyCountry`; the tile refuses a record stamped with a country the buyer has left |
| — | the payment tile drops its own selection when `countryCode` actually changes |
| — | the autofilled address is reverted |

### Two deliberate divergences, both pinned by tests

**The picker is not re-bound.** PrestaShop recreates its autocomplete on a country change because that widget captures the country at construction. This one reads it per request (`getCountryCode`), so the next search already carries the new country — and a re-bind would tear down and rebuild select2 for no behavioural gain, and would drag a buyer sitting in manual-entry mode back into search mode.

**The address revert is value-matched, not unconditional.** `applyAddress()` records what it wrote in `data-two-autofilled-value`; the revert clears a field only while it still holds exactly that. Anything the buyer has since edited has no matching recording and is left alone — over-clearing here would silently delete input from a keystroke they may have made minutes ago, which is worse than leaving a stale value they can see and correct.

## No PHP change, and why

The ticket describes the PrestaShop symptom as a *500 from stale formatter state*. That is genuinely PrestaShop-specific: its `CustomerAddressFormatter` override shadowed the core formatter's country state instead of delegating, so on a UK to ES switch the format stayed on the old country, Spain's required field never entered it, and persistence fataled.

This module has no equivalent. There is no address or phone formatter in it at all — the browser calls the company API directly, and address-form shape is Magento core's own, country-reactive by construction. The Magento-side manifestation of the same stale state is the cross-country organisation number described above, which is what this PR stops producing.

## Tests

`Test/Js/company-search-country-switch.test.js`, 20 cases across four groups: the autofill marker and revert, the address step's country-change handler, the payment tile, and a company restored from a previous visit.

Mutation-checked — 11 mutations, one per mechanism, each reverted in turn against the full suite. All 11 went red, each caught by the test written for it. Includes the inverse mutations (clear on the *first* resolution too; revert ignores buyer edits; treat every `change` event as a switch), so the guards are pinned as well as the actions.

Full suite: 299 passed, 24 suites.

Three pre-existing assertions were updated for the new `companyCountry` key in the `companyData` payload.

## Also fixed in passing

The country select's `change` binding was un-namespaced and re-bound on every `$.async` fire, so a re-rendered address form stacked one handler per render. Same handler this PR rewrites; now namespaced and `off()`-ed first.

## Verification

See the PR comment thread for live-checkout verification status.

Linear: TWO-24867
