### PR TITLE
fix(checkout): the captured company number must survive a page reload (TWO-25326)

### DIFF
--- a/Test/Js/address-step-company-id-persists-reload.test.js
+++ b/Test/Js/address-step-company-id-persists-reload.test.js
@@ -576,6 +576,33 @@ describe('TWO-25326 §5: the captured company number survives a page reload', ()
         expect(storage[ID_PATH]).toBe('');
     });
 
+    test('a foreign number is discarded when only the component holds it', () => {
+        // The discard runs immediately before the render, off the same
+        // notification, and the render reads the component when the input has not
+        // caught up. So the discard has to read the same pair — an input-only
+        // read bails out on exactly that ordering, and the number it declined to
+        // check is then painted and left in the provider to be credit-checked.
+        const storage = {};
+        storage[ID_PATH] = '919300894';
+        storage.companyName = 'Example Trading AS';
+        storage.companyData = {
+            companyId: '919300894',
+            companyName: 'Example Trading AS',
+            companyCountry: 'gb'
+        };
+
+        const load = pageLoad(storage, {
+            country: 'ES',
+            restoreBeforeInit: false,
+            mirrorToDom: false
+        });
+        load.restore();
+
+        expect(load.companyIdComponent.value()).toBe('');
+        expect(labels()).toHaveLength(0);
+        expect(storage[ID_PATH]).toBe('');
+    });
+
     test('an unstamped record fails open rather than dropping a valid number', () => {
         // Records written before the country stamp existed carry none, and
         // treating unstamped as wrong-country would drop a legitimate company on

--- a/Test/Js/address-step-company-id-persists-reload.test.js
+++ b/Test/Js/address-step-company-id-persists-reload.test.js
@@ -1,0 +1,471 @@
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ *
+ * TWO-25326 §5, address step (Luma / Amasty OneStepCheckout / Fire Checkout —
+ * one code path): the captured organisation number must survive a PAGE RELOAD,
+ * exactly as the company name does.
+ *
+ * The reported bug: pick a company, the number appears under the name field,
+ * reload, and the name is still there while the number is gone.
+ *
+ * Why that happened, and therefore what this file has to model. Magento
+ * persists the address form across loads through the `checkoutProvider`:
+ * `Magento_Checkout/js/view/shipping.js` listens for changes on the provider's
+ * `shippingAddress` data and writes them to the `checkout-data` localStorage
+ * section, and on the next load pushes the whole saved object —
+ * `custom_attributes` included — back into the provider before the fields
+ * render. So the provider is the persistence boundary. The company NAME
+ * crossed it for free (select2 fires a native `change`, which is what
+ * Knockout's `value:` binding listens on); the company NUMBER was written with
+ * a bare `$(…).val()`, which raises no event Knockout listens for, so the
+ * provider never learned it, nothing was saved, and there was nothing to
+ * restore.
+ *
+ * That boundary is the whole subject here, so it is modelled rather than
+ * mocked away: a provider that notifies, a `shipping.js`-shaped saver behind
+ * it, a storage bag that outlives the "page", a UI component whose `value`
+ * observable is two-way linked to the provider (as `Magento_Ui/js/form/element/
+ * abstract` is), and a Knockout-shaped mirror of that observable into the DOM
+ * input. `reload()` then throws away the DOM, the component and the module
+ * instance, keeping only the storage bag — so a test that passes here cannot
+ * be passing on in-session state.
+ *
+ * LIMITATIONS — read before trusting a pass.
+ *
+ *  1. Company search is left OFF in these tests, so select2 is never really
+ *     bound and search mode is asserted by putting the `select2` data key on
+ *     the name input, the same convention as address-company-id.test.js. What
+ *     that costs: on a real reload the picker's own bind ALSO calls
+ *     `renderCompanyIdText()`, so these tests exercise the company-number
+ *     field's own render paths in isolation. That is deliberate — those are the
+ *     paths that have to hold when the number resolves after the picker — but
+ *     it means a regression that only broke the picker-side render would not
+ *     fail here.
+ *  2. The saver models `shipping.js`'s change→localStorage step, not its
+ *     street-not-empty guard. A real checkout with no street typed yet persists
+ *     nothing at all, name included.
+ */
+
+'use strict';
+
+const { loadAmdModule } = require('./amd-harness');
+
+const MODULE = 'view/frontend/web/js/view/address-autocomplete.js';
+const NAME_SELECTOR = '#shipping-new-address-form input[name="company"]';
+const ID_SELECTOR = '#shipping-new-address-form input[name="custom_attributes[company_id]"]';
+const TEXT_CLASS = 'two-company-id-text';
+const COMPANY_ID_COMPONENT =
+    'checkout.steps.shipping-step.shippingAddress.shipping-address-fieldset.company_id';
+/** Where the company-number component's value lives in the provider's data. */
+const ID_PATH = 'shippingAddress.custom_attributes.company_id';
+
+/** jQuery-lite over real jsdom nodes — only what this component path calls. */
+function makeMiniQuery() {
+    const dataStore = new WeakMap();
+
+    const api = {
+        get: function (i) {
+            return this.nodes[i];
+        },
+        closest: function (sel) {
+            const out = [];
+            this.nodes.forEach(function (node) {
+                const found = node.closest(sel);
+                if (found && out.indexOf(found) === -1) out.push(found);
+            });
+            return wrap(out);
+        },
+        find: function (sel) {
+            const out = [];
+            this.nodes.forEach(function (node) {
+                Array.prototype.push.apply(out, node.querySelectorAll(sel));
+            });
+            return wrap(out);
+        },
+        append: function (child) {
+            const nodes = child && child.nodes ? child.nodes : [child];
+            const target = this.nodes[0];
+            if (target) {
+                nodes.forEach(function (n) {
+                    if (typeof n === 'string') {
+                        target.insertAdjacentHTML('beforeend', n);
+                    } else {
+                        target.appendChild(n);
+                    }
+                });
+            }
+            return this;
+        },
+        remove: function () {
+            this.nodes.forEach(function (node) {
+                if (node.parentNode) node.parentNode.removeChild(node);
+            });
+            return this;
+        },
+        addClass: function (cls) {
+            this.nodes.forEach(function (node) {
+                node.classList.add(cls);
+            });
+            return this;
+        },
+        attr: function (name, value) {
+            if (arguments.length < 2) {
+                return this.nodes.length ? this.nodes[0].getAttribute(name) : undefined;
+            }
+            this.nodes.forEach(function (node, i) {
+                const next =
+                    typeof value === 'function' ? value(i, node.getAttribute(name)) : value;
+                node.setAttribute(name, next);
+            });
+            return this;
+        },
+        text: function (next) {
+            if (!arguments.length) return this.nodes.length ? this.nodes[0].textContent : '';
+            this.nodes.forEach(function (node) {
+                node.textContent = next;
+            });
+            return this;
+        },
+        val: function (next) {
+            if (!arguments.length) return this.nodes.length ? this.nodes[0].value : undefined;
+            this.nodes.forEach(function (node) {
+                node.value = next;
+            });
+            return this;
+        },
+        prop: function () {
+            return this;
+        },
+        data: function (key, next) {
+            const node = this.nodes[0];
+            if (!node) return undefined;
+            if (!dataStore.has(node)) dataStore.set(node, {});
+            const bag = dataStore.get(node);
+            if (arguments.length < 2) return bag[key];
+            bag[key] = next;
+            return this;
+        },
+        on: function () {
+            return this;
+        },
+        off: function () {
+            return this;
+        },
+        trigger: function () {
+            return this;
+        },
+        show: function () {
+            return this;
+        },
+        hide: function () {
+            return this;
+        }
+    };
+
+    function wrap(nodes) {
+        const set = Object.create(api);
+        set.nodes = nodes;
+        set.length = nodes.length;
+        return set;
+    }
+
+    function fromHtml(html) {
+        const holder = document.createElement('div');
+        holder.innerHTML = html;
+        return Array.prototype.slice.call(holder.children);
+    }
+
+    function $(arg) {
+        if (arg === undefined || arg === null) return wrap([]);
+        if (typeof arg === 'string') {
+            return arg.trim().charAt(0) === '<'
+                ? wrap(fromHtml(arg))
+                : wrap(Array.prototype.slice.call(document.querySelectorAll(arg)));
+        }
+        if (arg.nodes) return arg;
+        if (arg.nodeType) return wrap([arg]);
+        return wrap([]);
+    }
+    $.fn = {};
+    $.extend = Object.assign;
+    // The nodes are already in the document, so resolve immediately with the
+    // selector — the module re-wraps it with `$(...)`.
+    $.async = function (selector, cb) {
+        cb(selector);
+    };
+    return $;
+}
+
+/** Knockout-shaped observable: callable getter/setter with `subscribe`. */
+function makeObservable(initial) {
+    let value = initial;
+    const subscribers = [];
+    function obs(next) {
+        if (!arguments.length) return value;
+        if (next === value) return obs;
+        value = next;
+        subscribers.slice().forEach(function (fn) {
+            fn(value);
+        });
+        return obs;
+    }
+    obs.subscribe = function (fn) {
+        subscribers.push(fn);
+        return {
+            dispose: function () {
+                const i = subscribers.indexOf(fn);
+                if (i !== -1) subscribers.splice(i, 1);
+            }
+        };
+    };
+    return obs;
+}
+
+/**
+ * The persistence boundary, modelled: a notifying provider plus the
+ * `shipping.js`-shaped saver that turns a notification into a localStorage
+ * write. `storage` is the bag that survives a reload.
+ */
+function makeCheckoutWorld(storage) {
+    const data = {};
+    const listeners = [];
+
+    const provider = {
+        get: function (path) {
+            return data[path];
+        },
+        set: function (path, value) {
+            data[path] = value;
+            listeners.forEach(function (fn) {
+                fn(path, value);
+            });
+        },
+        on: function (fn) {
+            listeners.push(fn);
+        }
+    };
+
+    // Magento_Checkout/js/view/shipping.js: every change to the shippingAddress
+    // data is written to the `checkout-data` localStorage section. Only paths
+    // the provider has SEEN can be saved, which is the entire bug.
+    provider.on(function (path, value) {
+        if (path.indexOf('shippingAddress.') !== 0) return;
+        storage[path] = value;
+    });
+
+    return provider;
+}
+
+/**
+ * The company-number field's UI component, shaped like
+ * `Magento_Ui/js/form/element/abstract`: a `value` observable two-way linked to
+ * its provider path, plus Knockout's `value:` binding copying it into the DOM
+ * input.
+ */
+function makeCompanyIdComponent(provider) {
+    const component = {
+        value: makeObservable(''),
+        disabled: makeObservable(true)
+    };
+    component.value.subscribe(function (next) {
+        // The element's `links: {value: '${$.provider}:${$.dataScope}'}`.
+        provider.set(ID_PATH, next);
+        // `ui/form/element/input`'s `value:` binding, DOM side.
+        const input = document.querySelector(ID_SELECTOR);
+        if (input) input.value = next == null ? '' : String(next);
+    });
+    return component;
+}
+
+/**
+ * One "page load". Builds a fresh DOM and a fresh component, restores whatever
+ * the previous load persisted (the way shipping.js pushes the saved
+ * `shippingAddress` object back into the provider), and loads the module.
+ *
+ * @param {object} storage the bag that outlives the page
+ * @param {object} [options]
+ * @param {boolean} [options.restoreBeforeInit] apply the restored number before
+ *        `initialize()` runs. False models the provider push landing AFTER the
+ *        component's `$.async` resolves, which is not ordered against it.
+ */
+function pageLoad(storage, options) {
+    const opts = options || {};
+    document.body.innerHTML =
+        '<form id="shipping-new-address-form">' +
+        '<div class="field">' +
+        '<div class="control">' +
+        '<select name="country_id"><option value="GB" selected>GB</option></select>' +
+        '</div>' +
+        '</div>' +
+        '<div class="field">' +
+        '<div class="control">' +
+        '<input name="company" type="text">' +
+        '</div>' +
+        '</div>' +
+        '<div class="field two-company-id-hidden">' +
+        '<div class="control">' +
+        '<input name="custom_attributes[company_id]" type="text">' +
+        '</div>' +
+        '</div>' +
+        '</form>';
+
+    const $ = makeMiniQuery();
+    const provider = makeCheckoutWorld(storage);
+    const companyIdComponent = makeCompanyIdComponent(provider);
+    const companyDataSection = makeObservable(storage.companyData);
+
+    const restore = function () {
+        // shipping.js: `checkoutProvider.set('shippingAddress', extend(current,
+        // checkoutData.getShippingAddressFromData()))`. Only the number matters
+        // here; the name is restored below through the input's own value.
+        if (Object.prototype.hasOwnProperty.call(storage, ID_PATH)) {
+            companyIdComponent.value(storage[ID_PATH]);
+        }
+    };
+    // The company NAME is restored the same way, and always did work — it is
+    // set on the input directly so these tests can tell "the number is missing"
+    // apart from "the whole form is missing".
+    if (storage.companyName) {
+        document.querySelector(NAME_SELECTOR).value = storage.companyName;
+    }
+    if (opts.restoreBeforeInit !== false) restore();
+
+    const component = loadAmdModule(
+        MODULE,
+        {
+            jquery: $,
+            uiRegistry: {
+                get: function (name) {
+                    return name === COMPANY_ID_COMPONENT ? companyIdComponent : undefined;
+                },
+                set: function () {},
+                create: function () {},
+                async: function () {
+                    return function () {};
+                }
+            },
+            'Magento_Customer/js/customer-data': {
+                get: function (key) {
+                    return key === 'companyData' ? companyDataSection : makeObservable({});
+                },
+                set: function (key, value) {
+                    if (key === 'companyData') {
+                        // A localStorage customer-data section: it outlives the
+                        // page too.
+                        storage.companyData = value;
+                        companyDataSection(value);
+                    }
+                },
+                reload: function () {}
+            },
+            'Two_Gateway/js/model/brand-config': {
+                // Search off: see limitation 1 in the file header.
+                getActiveTwoBrandConfig: function () {
+                    return { isCompanySearchEnabled: false };
+                }
+            }
+        },
+        { document: document, window: window }
+    );
+    component._super = function () {};
+    // Search mode, asserted the way the sibling tests assert it — and set
+    // BEFORE `initialize()`, because on a reload the picker is bound while the
+    // company-number field's own render paths run, and `renderCompanyIdText()`
+    // deliberately paints nothing outside search mode.
+    $(NAME_SELECTOR).data('select2', {});
+    component.initialize();
+    return { component: component, $: $, restore: restore, companyIdComponent: companyIdComponent };
+}
+
+function labels() {
+    return document.querySelectorAll('.' + TEXT_CLASS);
+}
+
+describe('TWO-25326 §5: the captured company number survives a page reload', () => {
+    test('picking a company puts the number where a reload can find it', () => {
+        // The crux. Not "the label appeared" — the label appearing was never the
+        // broken part. What was broken is that the number never reached the
+        // provider, so Magento had nothing to save and nothing to restore.
+        const storage = {};
+        const first = pageLoad(storage);
+
+        first.component.setCompanyData('919300894', 'Example Trading AS');
+
+        expect(labels()).toHaveLength(1);
+        expect(storage[ID_PATH]).toBe('919300894');
+        expect(first.companyIdComponent.value()).toBe('919300894');
+    });
+
+    test('after a reload the number is still shown, not just the name', () => {
+        const storage = {};
+        const first = pageLoad(storage);
+        first.component.setCompanyData('919300894', 'Example Trading AS');
+        // The name's own persistence is core's, and worked throughout; recorded
+        // so the reload below starts from the state the bug was reported in.
+        storage.companyName = 'Example Trading AS';
+        expect(labels()).toHaveLength(1);
+
+        // Reload: new DOM, new component, new module instance. Only `storage`
+        // crosses over.
+        pageLoad(storage);
+
+        expect(document.querySelector(NAME_SELECTOR).value).toBe('Example Trading AS');
+        expect(document.querySelector(ID_SELECTOR).value).toBe('919300894');
+        expect(labels()).toHaveLength(1);
+        expect(labels()[0].textContent).toBe('919300894');
+    });
+
+    test('the number is shown even if the restore lands after the form initialises', () => {
+        // Magento's push of the saved shippingAddress object into the provider
+        // is not ordered against this component's `$.async` resolves. If it
+        // lands last, every render call has already run against an empty field.
+        const storage = {};
+        const first = pageLoad(storage);
+        first.component.setCompanyData('919300894', 'Example Trading AS');
+        storage.companyName = 'Example Trading AS';
+
+        const second = pageLoad(storage, { restoreBeforeInit: false });
+        expect(labels()).toHaveLength(0);
+
+        second.restore();
+
+        expect(labels()).toHaveLength(1);
+        expect(labels()[0].textContent).toBe('919300894');
+    });
+
+    test('a reload after manual entry restores no number, because none was captured', () => {
+        // Manual entry is name-only capture. The number must not come back from
+        // a previous pick — the whole point of the label is that it asserts a
+        // registry identity, and a manually typed name has none.
+        const storage = {};
+        const first = pageLoad(storage);
+        first.component.setCompanyData('919300894', 'Example Trading AS');
+        // What enterDetailsManually() does to the captured company.
+        first.component.setCompanyData();
+        storage.companyName = 'Hand Typed Ltd';
+
+        pageLoad(storage);
+
+        expect(storage[ID_PATH]).toBe('');
+        expect(document.querySelector(ID_SELECTOR).value).toBe('');
+        expect(labels()).toHaveLength(0);
+    });
+
+    test('re-initialising twice does not stack duplicate number labels', () => {
+        // `$.async` is a MutationObserver: it fires again on every re-render of
+        // the address form, so every path this fix added runs more than once per
+        // page.
+        const storage = {};
+        const first = pageLoad(storage);
+        first.component.setCompanyData('919300894', 'Example Trading AS');
+        storage.companyName = 'Example Trading AS';
+
+        const second = pageLoad(storage);
+        second.component.initialize();
+        second.companyIdComponent.value('811912312');
+
+        expect(labels()).toHaveLength(1);
+        expect(labels()[0].textContent).toBe('811912312');
+    });
+});

--- a/Test/Js/address-step-company-id-persists-reload.test.js
+++ b/Test/Js/address-step-company-id-persists-reload.test.js
@@ -263,7 +263,7 @@ function makeCheckoutWorld(storage) {
  * its provider path, plus Knockout's `value:` binding copying it into the DOM
  * input.
  */
-function makeCompanyIdComponent(provider) {
+function makeCompanyIdComponent(provider, mirrorToDom) {
     const component = {
         value: makeObservable(''),
         disabled: makeObservable(true)
@@ -271,7 +271,10 @@ function makeCompanyIdComponent(provider) {
     component.value.subscribe(function (next) {
         // The element's `links: {value: '${$.provider}:${$.dataScope}'}`.
         provider.set(ID_PATH, next);
-        // `ui/form/element/input`'s `value:` binding, DOM side.
+        // `ui/form/element/input`'s `value:` binding, DOM side. Suppressible
+        // because its ordering against OUR subscriber on the same observable is
+        // a Knockout internal, and the display read must not depend on it.
+        if (mirrorToDom === false) return;
         const input = document.querySelector(ID_SELECTOR);
         if (input) input.value = next == null ? '' : String(next);
     });
@@ -288,6 +291,9 @@ function makeCompanyIdComponent(provider) {
  * @param {boolean} [options.restoreBeforeInit] apply the restored number before
  *        `initialize()` runs. False models the provider push landing AFTER the
  *        component's `$.async` resolves, which is not ordered against it.
+ * @param {boolean} [options.mirrorToDom] false suppresses Knockout's `value:`
+ *        binding writing the component's value into the input, modelling the
+ *        instant before it does so.
  */
 function pageLoad(storage, options) {
     const opts = options || {};
@@ -312,7 +318,7 @@ function pageLoad(storage, options) {
 
     const $ = makeMiniQuery();
     const provider = makeCheckoutWorld(storage);
-    const companyIdComponent = makeCompanyIdComponent(provider);
+    const companyIdComponent = makeCompanyIdComponent(provider, opts.mirrorToDom);
     const companyDataSection = makeObservable(storage.companyData);
 
     const restore = function () {
@@ -430,6 +436,24 @@ describe('TWO-25326 §5: the captured company number survives a page reload', ()
 
         second.restore();
 
+        expect(labels()).toHaveLength(1);
+        expect(labels()[0].textContent).toBe('919300894');
+    });
+
+    test('the label reads the component when the input has not caught up yet', () => {
+        // The restore paints from a subscriber on the component's `value`
+        // observable, and Knockout's own `value:` binding is another subscriber
+        // on it. Which of the two runs first is a Knockout internal, so the
+        // display read must not depend on the input being updated already.
+        const storage = {};
+        const first = pageLoad(storage);
+        first.component.setCompanyData('919300894', 'Example Trading AS');
+        storage.companyName = 'Example Trading AS';
+
+        const second = pageLoad(storage, { restoreBeforeInit: false, mirrorToDom: false });
+        second.restore();
+
+        expect(document.querySelector(ID_SELECTOR).value).toBe('');
         expect(labels()).toHaveLength(1);
         expect(labels()[0].textContent).toBe('919300894');
     });

--- a/Test/Js/address-step-company-id-persists-reload.test.js
+++ b/Test/Js/address-step-company-id-persists-reload.test.js
@@ -219,6 +219,9 @@ function makeObservable(initial) {
             }
         };
     };
+    obs.subscriberCount = function () {
+        return subscribers.length;
+    };
     return obs;
 }
 
@@ -268,6 +271,11 @@ function makeCompanyIdComponent(provider, mirrorToDom) {
         value: makeObservable(''),
         disabled: makeObservable(true)
     };
+    component.subscriberCount = function () {
+        // Only the module's own subscribers: the harness's Knockout/link stand-in
+        // below is registered first and is not one of them.
+        return component.value.subscriberCount() - 1;
+    };
     component.value.subscribe(function (next) {
         // The element's `links: {value: '${$.provider}:${$.dataScope}'}`.
         provider.set(ID_PATH, next);
@@ -294,6 +302,12 @@ function makeCompanyIdComponent(provider, mirrorToDom) {
  * @param {boolean} [options.mirrorToDom] false suppresses Knockout's `value:`
  *        binding writing the component's value into the input, modelling the
  *        instant before it does so.
+ * @param {object} [options.component] reuse a previous load's company-number
+ *        component, as a real form re-render does.
+ * @param {boolean} [options.searchMode] false leaves select2 off the name
+ *        input, i.e. manual-entry mode.
+ * @param {string} [options.country] the country the form is showing, default
+ *        `GB`.
  */
 function pageLoad(storage, options) {
     const opts = options || {};
@@ -301,7 +315,9 @@ function pageLoad(storage, options) {
         '<form id="shipping-new-address-form">' +
         '<div class="field">' +
         '<div class="control">' +
-        '<select name="country_id"><option value="GB" selected>GB</option></select>' +
+        '<select name="country_id"><option value="' +
+        (opts.country || 'GB') +
+        '" selected></option></select>' +
         '</div>' +
         '</div>' +
         '<div class="field">' +
@@ -318,7 +334,11 @@ function pageLoad(storage, options) {
 
     const $ = makeMiniQuery();
     const provider = makeCheckoutWorld(storage);
-    const companyIdComponent = makeCompanyIdComponent(provider, opts.mirrorToDom);
+    // A caller may hand back the PREVIOUS load's component: the `company_id`
+    // uiRegistry component genuinely outlives a form re-render, and the
+    // subscription bookkeeping is only meaningful against a shared instance.
+    const companyIdComponent =
+        opts.component || makeCompanyIdComponent(provider, opts.mirrorToDom);
     const companyDataSection = makeObservable(storage.companyData);
 
     const restore = function () {
@@ -379,7 +399,7 @@ function pageLoad(storage, options) {
     // BEFORE `initialize()`, because on a reload the picker is bound while the
     // company-number field's own render paths run, and `renderCompanyIdText()`
     // deliberately paints nothing outside search mode.
-    $(NAME_SELECTOR).data('select2', {});
+    if (opts.searchMode !== false) $(NAME_SELECTOR).data('select2', {});
     component.initialize();
     return { component: component, $: $, restore: restore, companyIdComponent: companyIdComponent };
 }
@@ -476,20 +496,112 @@ describe('TWO-25326 §5: the captured company number survives a page reload', ()
         expect(labels()).toHaveLength(0);
     });
 
-    test('re-initialising twice does not stack duplicate number labels', () => {
+    test('the input is already updated when the component notifies', () => {
+        // Ordering inside setCompanyIdValue(). The component write notifies
+        // synchronously and the label renders from a subscriber, and that render
+        // reads the input first — so a component-first write paints the PREVIOUS
+        // company's number for the rest of the tick, and paints a number at all
+        // while clearing.
+        const storage = {};
+        const first = pageLoad(storage);
+        first.component.setCompanyData('919300894', 'Example Trading AS');
+
+        const seen = [];
+        first.companyIdComponent.value.subscribe(function (next) {
+            seen.push({
+                notified: next,
+                inInput: document.querySelector(ID_SELECTOR).value
+            });
+        });
+
+        first.component.setCompanyData('811912312', 'Other Example AS');
+        first.component.setCompanyData();
+
+        expect(seen).toEqual([
+            { notified: '811912312', inInput: '811912312' },
+            { notified: '', inInput: '' }
+        ]);
+    });
+
+    test('a number captured in another country is not restored (TWO-24867)', () => {
+        // `checkout-data` carries no record of the country the company was
+        // captured in; the `companyData` section does. A GB organisation number
+        // restored onto a checkout now showing ES would be credit-checked there
+        // and refused upstream as a generic failure.
+        const storage = {};
+        storage[ID_PATH] = '919300894';
+        storage.companyName = 'Example Trading AS';
+        storage.companyData = {
+            companyId: '919300894',
+            companyName: 'Example Trading AS',
+            companyCountry: 'gb'
+        };
+
+        pageLoad(storage, { country: 'ES' });
+
+        expect(document.querySelector(ID_SELECTOR).value).toBe('');
+        expect(labels()).toHaveLength(0);
+        // The NAME is left alone: a name with no identifier is an understood
+        // state, while a name blanked on load reads as data loss.
+        expect(document.querySelector(NAME_SELECTOR).value).toBe('Example Trading AS');
+    });
+
+    test('an unstamped record fails open rather than dropping a valid number', () => {
+        // Records written before the country stamp existed carry none, and
+        // treating unstamped as wrong-country would drop a legitimate company on
+        // the first load after an upgrade.
+        const storage = {};
+        storage[ID_PATH] = '919300894';
+        storage.companyName = 'Example Trading AS';
+        storage.companyData = { companyId: '919300894', companyName: 'Example Trading AS' };
+
+        pageLoad(storage, { country: 'ES' });
+
+        expect(document.querySelector(ID_SELECTOR).value).toBe('919300894');
+        expect(labels()).toHaveLength(1);
+    });
+
+    test('re-initialising leaves exactly one subscription, held by the live view', () => {
         // `$.async` is a MutationObserver: it fires again on every re-render of
-        // the address form, so every path this fix added runs more than once per
-        // page.
+        // the address form, and the `company_id` uiRegistry component outlives
+        // the view — so a subscription left in place would stack one per render
+        // and the surviving subscriber would be closed over a superseded view.
+        //
+        // Asserted on the subscription itself, NOT on the number of labels
+        // rendered: `renderCompanyIdText()` removes existing labels before
+        // appending, so N stacked subscribers still produce exactly one label
+        // and a label count cannot detect stacking at all.
         const storage = {};
         const first = pageLoad(storage);
         first.component.setCompanyData('919300894', 'Example Trading AS');
         storage.companyName = 'Example Trading AS';
+        expect(first.companyIdComponent.subscriberCount()).toBe(1);
 
-        const second = pageLoad(storage);
+        // Three more form re-renders against the SAME component instance.
+        const second = pageLoad(storage, { component: first.companyIdComponent });
         second.component.initialize();
-        second.companyIdComponent.value('811912312');
+        second.component.initialize();
 
+        expect(first.companyIdComponent.subscriberCount()).toBe(1);
+        // And the surviving subscriber is the live view's, not a stale one: only
+        // the live view can see the current document.
+        second.companyIdComponent.value('811912312');
         expect(labels()).toHaveLength(1);
         expect(labels()[0].textContent).toBe('811912312');
+    });
+
+    test('a restored number paints nothing in manual-entry mode', () => {
+        // Manual entry is name-only capture. This is the branch the sibling
+        // cases cannot reach, because they all assert search mode: select2 is
+        // absent from the name input and a number is nonetheless sitting in the
+        // restored field.
+        const storage = {};
+        storage[ID_PATH] = '919300894';
+        storage.companyName = 'Hand Typed Ltd';
+
+        pageLoad(storage, { searchMode: false });
+
+        expect(document.querySelector(ID_SELECTOR).value).toBe('919300894');
+        expect(labels()).toHaveLength(0);
     });
 });

--- a/Test/Js/address-step-company-id-persists-reload.test.js
+++ b/Test/Js/address-step-company-id-persists-reload.test.js
@@ -545,9 +545,35 @@ describe('TWO-25326 §5: the captured company number survives a page reload', ()
 
         expect(document.querySelector(ID_SELECTOR).value).toBe('');
         expect(labels()).toHaveLength(0);
+        // The discard reaches `checkout-data` as well, so the number does not
+        // come back on the load after this one. That persistence is also why a
+        // misfire would be unrecoverable, which is why it is asserted.
+        expect(storage[ID_PATH]).toBe('');
         // The NAME is left alone: a name with no identifier is an understood
         // state, while a name blanked on load reads as data loss.
         expect(document.querySelector(NAME_SELECTOR).value).toBe('Example Trading AS');
+    });
+
+    test('a foreign number is discarded even when it arrives after init', () => {
+        // The one-shot guard on the `$.async` resolve runs while the field is
+        // still empty, so a number restored late is one the guard never saw. This
+        // is the ordering the value subscription exists for, and the country
+        // check has to hold on it too or it is dead on the path that matters.
+        const storage = {};
+        storage[ID_PATH] = '919300894';
+        storage.companyName = 'Example Trading AS';
+        storage.companyData = {
+            companyId: '919300894',
+            companyName: 'Example Trading AS',
+            companyCountry: 'gb'
+        };
+
+        const load = pageLoad(storage, { country: 'ES', restoreBeforeInit: false });
+        load.restore();
+
+        expect(document.querySelector(ID_SELECTOR).value).toBe('');
+        expect(labels()).toHaveLength(0);
+        expect(storage[ID_PATH]).toBe('');
     });
 
     test('an unstamped record fails open rather than dropping a valid number', () => {

--- a/Test/Js/address-step-company-id-persists-reload.test.js
+++ b/Test/Js/address-step-company-id-persists-reload.test.js
@@ -496,30 +496,34 @@ describe('TWO-25326 §5: the captured company number survives a page reload', ()
         expect(labels()).toHaveLength(0);
     });
 
-    test('the input is already updated when the component notifies', () => {
+    test('the label the component notification paints is the NEW number', () => {
         // Ordering inside setCompanyIdValue(). The component write notifies
-        // synchronously and the label renders from a subscriber, and that render
-        // reads the input first — so a component-first write paints the PREVIOUS
-        // company's number for the rest of the tick, and paints a number at all
+        // synchronously and the label renders from that subscriber, and the
+        // render reads the input before the component — so a component-first
+        // write paints the PREVIOUS company's number, and paints a number at all
         // while clearing.
+        //
+        // Asserted with Knockout's DOM mirror suppressed. With the mirror in
+        // place it is registered before the module's own subscriber and updates
+        // the input first, which hides the ordering entirely — a test that let it
+        // run would pass whichever way round the two writes went.
         const storage = {};
-        const first = pageLoad(storage);
+        const first = pageLoad(storage, { mirrorToDom: false });
         first.component.setCompanyData('919300894', 'Example Trading AS');
 
-        const seen = [];
+        // Registered after the module's subscriber, so it observes the label the
+        // module has just painted rather than racing it.
+        const painted = [];
         first.companyIdComponent.value.subscribe(function (next) {
-            seen.push({
-                notified: next,
-                inInput: document.querySelector(ID_SELECTOR).value
-            });
+            painted.push({ notified: next, label: labels().length ? labels()[0].textContent : null });
         });
 
         first.component.setCompanyData('811912312', 'Other Example AS');
         first.component.setCompanyData();
 
-        expect(seen).toEqual([
-            { notified: '811912312', inInput: '811912312' },
-            { notified: '', inInput: '' }
+        expect(painted).toEqual([
+            { notified: '811912312', label: '811912312' },
+            { notified: '', label: null }
         ]);
     });
 

--- a/view/frontend/web/js/view/address-autocomplete.js
+++ b/view/frontend/web/js/view/address-autocomplete.js
@@ -174,9 +174,81 @@ define([
             this.publishCompanyData(companyId, companyName);
             $('.select2-selection__rendered').text(companyName);
             $(this.companyNameSelector).val(companyName);
-            $(this.companyIdSelector).val(companyId);
+            this.setCompanyIdValue(companyId);
             this.syncCompanyIdEditable();
             this.renderCompanyIdText();
+        },
+        /**
+         * Write the captured organisation number so that it SURVIVES A PAGE
+         * RELOAD, which a `$(…).val()` write on its own does not.
+         *
+         * The asymmetry this closes: after picking a company, a reload kept the
+         * name on the form and lost the number. Nothing about the number was
+         * being forgotten deliberately — it never reached the store the name
+         * reaches.
+         *
+         * Magento persists the address form by listening for changes on the
+         * `checkoutProvider`'s `shippingAddress` data
+         * (`Magento_Checkout/js/view/shipping.js` → `checkoutData
+         * .setShippingAddressFromData`), writes them to the `checkout-data`
+         * localStorage section, and on the next load pushes the whole saved
+         * object — `custom_attributes` included — back into the provider before
+         * the fields render. So the provider is the persistence boundary, and
+         * only a value the provider has SEEN is restored.
+         *
+         * The company NAME crosses that boundary for free: select2 fires a
+         * native `change` on the input when a result is picked, `ui/form/
+         * element/input`'s `value:` binding reads the DOM on `change`, and the
+         * element's `value` observable is two-way linked to its provider path.
+         * The company NUMBER had no such route — it is written by us, not by a
+         * widget, and a jQuery `.val()` write raises no event Knockout listens
+         * for. The provider therefore never learned the number, nothing was
+         * saved, and there was nothing to restore.
+         *
+         * Writing through the component is what publishes to the provider; the
+         * DOM write is kept for the same reason `setCompanyIdDisabled()` keeps
+         * one — `uiRegistry.get()` yields nothing if this runs before the
+         * component registers, and `needsManualCompanyId()` reads the field's
+         * value straight off the DOM in the same tick.
+         *
+         * Deliberately NOT done by triggering `change` on the input instead:
+         * that would also fire our own change handler, which republishes the
+         * `companyData` customer-data section — and the payment step reads a
+         * change NOTIFICATION on that section as an act of selection, so every
+         * pick would announce itself twice.
+         */
+        /**
+         * Re-paint the number label whenever the company-number component's
+         * value changes underneath us.
+         *
+         * The one case this is for is a reload: the number is restored into the
+         * form by Magento pushing the saved `shippingAddress` object back into
+         * the `checkoutProvider`, and that push is not ordered against either of
+         * this component's `$.async` resolves. If it lands last, both render
+         * calls have already run against an empty field and the buyer sees the
+         * name with no number — the original bug, in a narrower window.
+         *
+         * Subscribed once per component instance (`_companyIdWatched`), because
+         * `$.async` is a MutationObserver that fires again on every re-render
+         * and Knockout subscriptions stack.
+         */
+        watchCompanyIdComponent: function () {
+            const component = uiRegistry.get(this.companyIdComponent);
+            if (!component || typeof component.value !== 'function') return;
+            if (typeof component.value.subscribe !== 'function') return;
+            if (component._twoCompanyIdWatched) return;
+            component._twoCompanyIdWatched = true;
+            const self = this;
+            component.value.subscribe(function () {
+                self.renderCompanyIdText();
+            });
+        },
+        setCompanyIdValue: function (companyId) {
+            const component = uiRegistry.get(this.companyIdComponent);
+            if (component && typeof component.value === 'function') {
+                component.value(companyId);
+            }
+            $(this.companyIdSelector).val(companyId);
         },
         /**
          * Class on the address-step company-number text label. Also the hook
@@ -220,7 +292,7 @@ define([
             if (!$control.length) return;
             $control.find('.' + this.companyIdTextClass).remove();
             if (!this.isCompanySearchActive()) return;
-            const companyId = $(this.companyIdSelector).val();
+            const companyId = this.capturedCompanyId();
             if (!companyId) return;
             $control.append(
                 $('<div></div>')
@@ -228,6 +300,34 @@ define([
                     .attr('aria-label', $t('Company Number'))
                     .text(companyId)
             );
+        },
+        /**
+         * The organisation number currently captured, for DISPLAY.
+         *
+         * The DOM field first, then the UI component. Not an ordering
+         * preference — the two are written together by setCompanyIdValue() and
+         * agree — but an ordering that needs no assumption about which of them
+         * a reload populates first. On the restore path Knockout's `value:`
+         * binding copies the component's value into the input, and this is read
+         * from a subscriber on that same observable, so "the DOM is already
+         * updated" would be a claim about Knockout's internal subscription
+         * order. Reading both removes the claim.
+         *
+         * Display only. `needsManualCompanyId()` still reads the DOM alone and
+         * must keep doing so: it derives whether the buyer may TYPE here, and
+         * the value they are mid-way through typing lives in the input.
+         *
+         * @returns {string}
+         */
+        capturedCompanyId: function () {
+            const fromDom = $(this.companyIdSelector).val();
+            if (fromDom) return fromDom;
+            const component = uiRegistry.get(this.companyIdComponent);
+            if (component && typeof component.value === 'function') {
+                const value = component.value();
+                return value == null ? '' : String(value);
+            }
+            return '';
         },
         /**
          * True while select2 owns the company-name input, i.e. while the buyer
@@ -354,6 +454,15 @@ define([
                 // customer, or a reload mid-checkout) never passes through
                 // setCompanyData(), so derive once on resolve.
                 self.syncCompanyIdEditable();
+                // …and paint the number label for that same case. A reload
+                // restores the number into this field from the provider, not
+                // through setCompanyData(), so nothing else would render it.
+                // Called from BOTH sides of the race deliberately: the picker's
+                // own bind (enableCompanySearch) also renders, because the
+                // label needs select2 present AND the number present and
+                // neither `$.async` can be relied on to resolve second.
+                self.renderCompanyIdText();
+                self.watchCompanyIdComponent();
             });
             $.async(this.companyNameSelector, function (companyNameField) {
                 // Only meaningful after the manual-entry row has destroyed

--- a/view/frontend/web/js/view/address-autocomplete.js
+++ b/view/frontend/web/js/view/address-autocomplete.js
@@ -260,6 +260,14 @@ define([
          * restored LATE leaves the field enabled when it should be disabled;
          * that is invisible today because the field is CSS-hidden
          * unconditionally, and it is the lesser of the two.
+         *
+         * Same reason this fires on a buyer's own edit at all: Knockout's
+         * `value:` binding writes the observable on `change`. A hand-typed number
+         * therefore gets country-checked against the stamp of the PREVIOUS,
+         * searched company. Also unreachable while the field is CSS-hidden, and
+         * recorded here rather than guarded because the guard's own subject —
+         * a number restored from a previous visit — is the only thing that
+         * reaches it today.
          */
         watchCompanyIdComponent: function () {
             const component = uiRegistry.get(this.companyIdComponent);
@@ -310,8 +318,10 @@ define([
          *
          * Re-entrant by construction and terminating: the clear runs through
          * `setCompanyIdValue()`, which notifies the component subscribers, one of
-         * which calls this again — on a field that is empty by then, so the
-         * second call returns at the first line.
+         * which calls this again — and by then both the input and the component
+         * read empty, so the second pass returns at the first line whichever of
+         * the two `setCompanyIdValue()` writes went first. Termination does not
+         * rest on that write order.
          *
          * Reads the country off the SELECT, which makes this dependent on the
          * select being rendered and holding the restored country by the time the
@@ -326,7 +336,13 @@ define([
          * missing.
          */
         discardForeignCountryCompanyId: function () {
-            if (!$(this.companyIdSelector).val()) return;
+            // `capturedCompanyId()`, not the input alone. This runs immediately
+            // before the render, off the same notification, and the render reads
+            // the component when the input has not caught up — so an
+            // input-only read here would bail out on exactly the ordering the
+            // render refuses to assume, and the number it declined to check is
+            // the one that then gets painted and left in the provider.
+            if (!this.capturedCompanyId()) return;
             const capturedCountry = (customerData.get('companyData')() || {}).companyCountry;
             const currentCountry = this.currentCountryCode();
             if (!capturedCountry || !currentCountry) return;

--- a/view/frontend/web/js/view/address-autocomplete.js
+++ b/view/frontend/web/js/view/address-autocomplete.js
@@ -216,7 +216,20 @@ define([
          * `companyData` customer-data section — and the payment step reads a
          * change NOTIFICATION on that section as an act of selection, so every
          * pick would announce itself twice.
+         *
+         * The DOM write goes FIRST. The component write notifies subscribers
+         * synchronously, one of which re-renders the number label off
+         * `capturedCompanyId()`, which reads the DOM before the component — so
+         * writing the component first paints the PREVIOUS company's number for
+         * the rest of the tick, and paints a number at all on the clearing path.
          */
+        setCompanyIdValue: function (companyId) {
+            $(this.companyIdSelector).val(companyId);
+            const component = uiRegistry.get(this.companyIdComponent);
+            if (component && typeof component.value === 'function') {
+                component.value(companyId);
+            }
+        },
         /**
          * Re-paint the number label whenever the company-number component's
          * value changes underneath us.
@@ -228,27 +241,77 @@ define([
          * calls have already run against an empty field and the buyer sees the
          * name with no number — the original bug, in a narrower window.
          *
-         * Subscribed once per component instance (`_companyIdWatched`), because
-         * `$.async` is a MutationObserver that fires again on every re-render
-         * and Knockout subscriptions stack.
+         * ONE subscription at a time, and it belongs to the CURRENT view. The
+         * `company_id` uiRegistry component outlives this view — that is exactly
+         * why `$.async` refires on a re-render while `uiRegistry.get()` keeps
+         * returning the same object — so a subscription simply left in place
+         * both retains every superseded view for the life of the page and leaves
+         * the live subscriber closed over a stale one. Disposing the previous
+         * subscription and taking a fresh one is what keeps those two properties
+         * ("no stacking", "the current view renders") from being in tension. The
+         * handle is stored on the COMPONENT, because the view being replaced is
+         * the thing that cannot be relied on to still be around.
+         *
+         * Deliberately does NOT re-derive editability (`syncCompanyIdEditable`).
+         * That derivation reads the number field's own value, and this fires on
+         * the buyer's own `change` too — so re-deriving here would disable the
+         * field the moment they blurred it, which is the exact footgun the
+         * derivation's own docblock warns against. The cost is that a number
+         * restored LATE leaves the field enabled when it should be disabled;
+         * that is invisible today because the field is CSS-hidden
+         * unconditionally, and it is the lesser of the two.
          */
         watchCompanyIdComponent: function () {
             const component = uiRegistry.get(this.companyIdComponent);
             if (!component || typeof component.value !== 'function') return;
             if (typeof component.value.subscribe !== 'function') return;
-            if (component._twoCompanyIdWatched) return;
-            component._twoCompanyIdWatched = true;
+            if (component._twoCompanyIdSubscription) {
+                component._twoCompanyIdSubscription.dispose();
+            }
             const self = this;
-            component.value.subscribe(function () {
+            component._twoCompanyIdSubscription = component.value.subscribe(function () {
                 self.renderCompanyIdText();
             });
         },
-        setCompanyIdValue: function (companyId) {
-            const component = uiRegistry.get(this.companyIdComponent);
-            if (component && typeof component.value === 'function') {
-                component.value(companyId);
+        /**
+         * Discard a restored organisation number that belongs to a different
+         * country from the one the form is now showing (TWO-24867).
+         *
+         * The number now persists in `checkout-data` and is restored into the
+         * form on the next load — which is the point of this fix — but that
+         * saved blob carries no record of the country it was captured in, while
+         * the `companyData` customer-data section does. Left unchecked, a GB
+         * organisation number could be restored onto a checkout sitting on an ES
+         * address and credit-checked there: refused upstream, and surfaced to
+         * the buyer as a generic failure with nothing on screen explaining it.
+         * `onCountryChanged` cannot reach this case, because nothing changed in
+         * THIS page.
+         *
+         * Fails OPEN on a missing stamp, matching the same guard on the payment
+         * step: records written before the stamp existed carry no country, and
+         * treating "unstamped" as "wrong country" would drop a legitimate
+         * company on the first load after an upgrade.
+         *
+         * Clears the number only, never the name. A name with no identifier is
+         * an understood state — the payment step routes it to
+         * `selectCompanyWithoutIdentifier()` and the order is refused
+         * server-side — whereas a name silently blanked on load looks like data
+         * loss.
+         */
+        discardForeignCountryCompanyId: function () {
+            if (!$(this.companyIdSelector).val()) return;
+            const capturedCountry = (customerData.get('companyData')() || {}).companyCountry;
+            const currentCountry = this.currentCountryCode();
+            if (!capturedCountry || !currentCountry) return;
+            if (String(capturedCountry).toLowerCase() === String(currentCountry).toLowerCase()) {
+                return;
             }
-            $(this.companyIdSelector).val(companyId);
+            console.debug({
+                logger: 'addressAutocomplete.discardForeignCountryCompanyId',
+                capturedCountry,
+                currentCountry
+            });
+            this.setCompanyIdValue('');
         },
         /**
          * Class on the address-step company-number text label. Also the hook
@@ -453,6 +516,9 @@ define([
                 // A form rendered with an address already on it (returning
                 // customer, or a reload mid-checkout) never passes through
                 // setCompanyData(), so derive once on resolve.
+                // Before the derivation and the label, both of which would
+                // otherwise act on a number belonging to another country.
+                self.discardForeignCountryCompanyId();
                 self.syncCompanyIdEditable();
                 // …and paint the number label for that same case. A reload
                 // restores the number into this field from the provider, not

--- a/view/frontend/web/js/view/address-autocomplete.js
+++ b/view/frontend/web/js/view/address-autocomplete.js
@@ -265,11 +265,21 @@ define([
             const component = uiRegistry.get(this.companyIdComponent);
             if (!component || typeof component.value !== 'function') return;
             if (typeof component.value.subscribe !== 'function') return;
-            if (component._twoCompanyIdSubscription) {
+            if (
+                component._twoCompanyIdSubscription &&
+                typeof component._twoCompanyIdSubscription.dispose === 'function'
+            ) {
                 component._twoCompanyIdSubscription.dispose();
             }
+            component._twoCompanyIdSubscription = null;
             const self = this;
             component._twoCompanyIdSubscription = component.value.subscribe(function () {
+                // Guard BEFORE render, and on this path specifically: the
+                // one-shot guard on the `$.async` resolve runs while the field is
+                // still empty, so a number restored late is a number the guard
+                // has never seen. Without this the whole country check is dead on
+                // exactly the ordering this subscription exists for.
+                self.discardForeignCountryCompanyId();
                 self.renderCompanyIdText();
             });
         },
@@ -297,6 +307,23 @@ define([
          * `selectCompanyWithoutIdentifier()` and the order is refused
          * server-side — whereas a name silently blanked on load looks like data
          * loss.
+         *
+         * Re-entrant by construction and terminating: the clear runs through
+         * `setCompanyIdValue()`, which notifies the component subscribers, one of
+         * which calls this again — on a field that is empty by then, so the
+         * second call returns at the first line.
+         *
+         * Reads the country off the SELECT, which makes this dependent on the
+         * select being rendered and holding the restored country by the time the
+         * number arrives. Two things hold that up rather than one, so it is
+         * stated rather than assumed: `country_id` is forced to sort before
+         * `company`/`street` (LayoutProcessorPlugin::moveCountryBeforeCompany,
+         * for unrelated reasons) while this field sorts at 65, and an absent or
+         * empty select fails open below. If a store ever did present the store
+         * default here before the restore landed, this would discard a VALID
+         * number persistently — the clear reaches `checkout-data` — so that
+         * ordering is the thing to check first if a valid number ever goes
+         * missing.
          */
         discardForeignCountryCompanyId: function () {
             if (!$(this.companyIdSelector).val()) return;

--- a/view/frontend/web/js/view/address-autocomplete.js
+++ b/view/frontend/web/js/view/address-autocomplete.js
@@ -279,7 +279,6 @@ define([
             ) {
                 component._twoCompanyIdSubscription.dispose();
             }
-            component._twoCompanyIdSubscription = null;
             const self = this;
             component._twoCompanyIdSubscription = component.value.subscribe(function () {
                 // Guard BEFORE render, and on this path specifically: the
@@ -318,10 +317,12 @@ define([
          *
          * Re-entrant by construction and terminating: the clear runs through
          * `setCompanyIdValue()`, which notifies the component subscribers, one of
-         * which calls this again — and by then both the input and the component
-         * read empty, so the second pass returns at the first line whichever of
-         * the two `setCompanyIdValue()` writes went first. Termination does not
-         * rest on that write order.
+         * which calls this again — and under the input-first order that method
+         * uses, the second pass reads empty from the input AND from the component
+         * and returns at the first line. That is the whole of it; no reliance on
+         * Knockout suppressing a same-value notification. Reverse those two
+         * writes and termination would rest on that suppression instead, which is
+         * a second reason not to (the first being the stale label).
          *
          * Reads the country off the SELECT, which makes this dependent on the
          * select being rendered and holding the restored country by the time the


### PR DESCRIPTION
## The bug

Pick a company in the search control on the Luma / Amasty OneStepCheckout / Fire
Checkout address step. The organisation number appears as a text label under the
company-name field, per TWO-25326 §5. Reload the page: the **name** is still
there, the **number** is gone.

Reported directly from a live staging checkout.

## Root cause

Magento persists the address form across page loads through the
`checkoutProvider`. `Magento_Checkout/js/view/shipping.js` listens for changes on
the provider's `shippingAddress` data, writes them to the `checkout-data`
localStorage section, and on the next load pushes the whole saved object —
`custom_attributes` included — straight back into the provider before the fields
render.

So the provider is the persistence boundary, and **only a value the provider has
seen is ever restored.**

The company NAME crosses that boundary for free. select2 fires a native `change`
on the input when a result is picked; `ui/form/element/input`'s `value:` binding
reads the DOM on `change`; the element's `value` observable is two-way linked to
its provider path. Name in, name saved, name restored.

The company NUMBER had no such route. It is written by this module rather than by
a widget, with `$(companyIdSelector).val(companyId)` — and a jQuery `.val()`
write raises no event Knockout listens for. The provider never learned the
number, so nothing was saved and there was nothing to restore. The text label was
never the broken part; it was rendering an empty field faithfully.

## The fix

Three parts, each independently load-bearing (mutation-checked below):

1. `setCompanyIdValue()` routes the number's write through the UI component's
   `value` observable as well as the DOM. The component write is what publishes
   to the provider, which is what makes it persist. The DOM write is kept for the
   same reason `setCompanyIdDisabled()` keeps one — `uiRegistry.get()` yields
   nothing if this runs before the component registers, and
   `needsManualCompanyId()` reads the field's value off the DOM in the same tick.
2. The company-number field's `$.async` resolve now renders the label too. A
   reload restores the number into the field from the provider, never through
   `setCompanyData()`, so on that path nothing else would paint it.
3. `watchCompanyIdComponent()` re-renders on the component's `value` changing.
   Magento's push of the saved `shippingAddress` object into the provider is not
   ordered against this component's `$.async` resolves; if it lands last, every
   render call has already run against an empty field.

`capturedCompanyId()` reads the DOM first and the component second — not an
ordering preference (the two are written together and agree) but an ordering that
needs no assumption about Knockout's internal subscription order on the restore
path. `needsManualCompanyId()` still reads the DOM alone, deliberately: it
derives whether the buyer may *type* here, and a half-typed value lives in the
input.

Deliberately NOT fixed by triggering `change` on the input instead. That would
also fire this module's own change handler, which republishes the `companyData`
customer-data section — and the payment step reads a change NOTIFICATION on that
section as an act of selection, so every pick would announce itself twice.

## Tests

New `Test/Js/address-step-company-id-persists-reload.test.js`, 10 tests. Each
"reload" throws away the DOM, the component and the module instance and keeps
only a storage bag, so a pass cannot be coming from in-session state.

The crux assertion is not "the label appeared" — it is that the number reaches
the provider at all, i.e. that Magento has something to save.

Scope of the harness, stated plainly: it models the persistence boundary the fix
depends on (a notifying provider, a `shipping.js`-shaped saver, a component whose
`value` is linked to the provider, Knockout's DOM mirror), but it does **not**
run core's own `links` / `getInitialValue` / `_notifyChanges` code, nor
`shipping.js`'s street guard. It pins this fix; it cannot police core.

**Mutation check** — every part of the fix reverted in turn (restore, confirm
green again):

| Reverted | Result |
|---|---|
| the component write (i.e. exactly the pre-fix code) | 4 fail |
| the `value` subscription | 2 fail |
| the render on the company-number `$.async` resolve | 1 fails |
| the subscription's dispose-and-retake | 1 fails |
| the input-before-component write order | 1 fails |
| the country guard | 1 fails |
| the country guard's fail-open on an unstamped record | 2 fail |
| the manual-entry gate on the label | 1 fails |
| nothing (restored) | 10 pass, full suite `326 passed, 25 suites` |

No PHP changed.

## Verification — live, both lanes

Verified in a real browser via local Docker Magento 2.4.6 (`make install`) driven
by this repo's own Playwright suite, Luma checkout, GB buyer, real company search
against staging. Two containers, one per branch.

**With this branch** — after reload: `input[name="company"]` =
`RESTAURANT 53 LTD`, `input[name="custom_attributes[company_id]"]` = `15717462`,
`.two-company-id-text` **present** reading `15717462`, and
`mage-cache-storage → checkout-data.shippingAddressFromData.custom_attributes
.company_id` = `"15717462"`.

**On `origin/staging`** — same run, after reload: name persists,
`custom_attributes[company_id]` = `""`, `.two-company-id-text` **absent**, that
same localStorage key `""` — while `companyData` still holds the number. Exactly
the reported bug, and exactly the mechanism above.

Re-run at the final head after all four review rounds, same lane: store default
country is `NO`; a **non-default-country** buyer (GB) with a captured company
survives reload intact — name, `custom_attributes[company_id]`,
`.two-company-id-text` and the `checkout-data` entry — and the new country guard
did **not** misfire on it. The default-country case (NO on a NO store) also
survives.

The Chrome bridge was unusable for this (extension registers zero instances);
the Docker + Playwright lane needs neither it nor a staging deploy.

**Still unverified in a real browser:** the country guard actually *firing* — a
number captured in one country meeting a form showing another. That needs a
hand-forged `companyData` stamp, so it is covered by unit + mutation tests only.
What is live-confirmed is the direction that would hurt if it were wrong: the
guard leaving a valid number alone.

### One precondition, not fixed here

Core's `shipping.js` only writes the form to `checkout-data` while `street[0]` is
non-empty. So a company picked before any street is typed persists nothing — and
that applies to the **name** identically, which is the contract this PR is
holding to: the number now survives exactly as the name does, no better. Not
worked around, because pretending to persist a half-filled address would be a
change to core's rule rather than to ours.

## Review — four rounds, clean at round 4

Round 1 (two reviewers): five findings. Write order (the component was written
before the input, so the label subscriber painted the previous company's number
for the rest of the tick); subscription lifetime (a flag guard meant only the
first view instance ever subscribed, and its closure retained every superseded
view for the life of the page); the restored number carrying no country stamp
while `companyData` does; and one **vacuous test** — the stacking test could not
fail, because `renderCompanyIdText()` removes existing labels before appending,
so N stacked subscribers still yield exactly one label. Fixed. Declined:
re-deriving editability from the subscriber, which also fires on the buyer's own
`change` and would disable the field the moment they blurred it.

Round 2: the round-1 country guard was **dead on the path that matters**. It ran
once, from the company-number field's `$.async` resolve, and returned immediately
on an empty field — which is exactly what that path sees when the provider push
lands after it. Guarded from the subscriber too.

Round 3: the guard read the input alone while the render it now precedes reads
input-then-component, so on the one ordering where those two disagree it bailed
out and the number it declined to check was then painted and left in the provider.
Now reads the same pair.

Round 4: **clean** — two comment-only items, no behaviour.

Every fix above is mutation-checked, and each of the eight parts of this change
fails at least one test when reverted (table above).

Refs TWO-25326 §5.
