### PR TITLE
fix(checkout): TWO-25326 §6a/§7 gating + tile alignment (2026-08-03 ruling)

### DIFF
--- a/Api/BrandRegistryInterface.php
+++ b/Api/BrandRegistryInterface.php
@@ -78,6 +78,26 @@ interface BrandRegistryInterface
     public function getIntentApprovedNotice(): ?string;
 
     /**
+     * Per-brand COPY override for the buyer-facing "order intent NOT
+     * approved" notice rendered inline in the checkout payment tile
+     * (TWO-25326 §7.3/§7.4, added 2026-08-03). Sourced from brand.xml
+     * <intent_declined_notice>. Wording only, and independent of the
+     * approved-notice override — a brand overlay with its own approved copy
+     * is not forced to also take the vanilla declined copy.
+     *
+     * Suppressed by the SAME switch as the approved notice —
+     * isIntentApprovedNoticeEnabled() — since the ruling treats "the intent
+     * message" as one on/off unit, approved or declined, not two.
+     *
+     *  - `null`  — no override (element absent, empty or whitespace-only):
+     *              platform default translated copy. Never ''.
+     *  - non-''  — used verbatim as the company-known copy template
+     *              (%1 = brand product name, %2 = buyer company name,
+     *              %3 = buyer organisation number).
+     */
+    public function getIntentDeclinedNotice(): ?string;
+
+    /**
      * Short brand tag used to decorate non-production checkout URLs
      * (e.g. `?brand=<tag>`). Empty string ('') means do not decorate
      * — the URL host already conveys the brand. Implementations may

--- a/Brand/DescriptorBackedBrandRegistry.php
+++ b/Brand/DescriptorBackedBrandRegistry.php
@@ -61,6 +61,11 @@ class DescriptorBackedBrandRegistry implements BrandRegistryInterface
         return $this->activeBrandResolver->resolve()->getIntentApprovedNotice();
     }
 
+    public function getIntentDeclinedNotice(): ?string
+    {
+        return $this->activeBrandResolver->resolve()->getIntentDeclinedNotice();
+    }
+
     public function getSignUpUrl(): string
     {
         return $this->activeBrandResolver->resolve()->getSignUpUrl();

--- a/Model/Brand.php
+++ b/Model/Brand.php
@@ -122,6 +122,19 @@ class Brand implements BrandRegistryInterface
         );
     }
 
+    /**
+     * @deprecated 2.0.0 See note on getCode().
+     */
+    public function getIntentDeclinedNotice(): ?string
+    {
+        throw new \LogicException(
+            'Two\\Gateway\\Model\\Brand is deprecated; consume '
+            . 'BrandRegistryInterface via DescriptorBackedBrandRegistry instead. '
+            . 'The intent-declined notice override now comes from brand.xml '
+            . '`<intent_declined_notice>` via ActiveBrandResolver.'
+        );
+    }
+
     public function getSignUpUrl(): string
     {
         return $this->signUpUrl;

--- a/Model/Brand/Descriptor.php
+++ b/Model/Brand/Descriptor.php
@@ -46,6 +46,7 @@ final class Descriptor
      * @param float[] $surchargeRoundingSteps Buyer-surcharge rounding steps offered in the admin Rounding Step dropdown, ascending.
      * @param string|null $intentApprovedNotice Copy override for the buyer-facing intent-approved notice; null = use the platform default copy. Never ''. See getIntentApprovedNotice().
      * @param bool $intentApprovedNoticeEnabled Whether the buyer-facing intent-approved notice is rendered at all. Default true. See isIntentApprovedNoticeEnabled().
+     * @param string|null $intentDeclinedNotice Copy override for the buyer-facing intent-NOT-approved notice; null = use the platform default copy. Never ''. See getIntentDeclinedNotice().
      */
     public function __construct(
         private readonly string $code,
@@ -72,7 +73,8 @@ final class Descriptor
         private readonly string $checkoutSubtitle = '',
         private readonly array $surchargeRoundingSteps = [],
         private readonly ?string $intentApprovedNotice = null,
-        private readonly bool $intentApprovedNoticeEnabled = true
+        private readonly bool $intentApprovedNoticeEnabled = true,
+        private readonly ?string $intentDeclinedNotice = null
     ) {
     }
 
@@ -116,6 +118,18 @@ final class Descriptor
     public function getIntentApprovedNotice(): ?string
     {
         return $this->intentApprovedNotice;
+    }
+
+    /**
+     * Per-brand COPY override for the buyer-facing "order intent NOT
+     * approved" notice (TWO-25326 §7.3/§7.4, 2026-08-03 ruling). Same
+     * null-means-default contract as getIntentApprovedNotice(), and gated
+     * by the SAME isIntentApprovedNoticeEnabled() switch — a brand that
+     * suppresses the notice gets neither variant.
+     */
+    public function getIntentDeclinedNotice(): ?string
+    {
+        return $this->intentDeclinedNotice;
     }
 
     /**

--- a/Model/Brand/Loader.php
+++ b/Model/Brand/Loader.php
@@ -208,6 +208,16 @@ class Loader
             $intentApprovedNotice = null;
         }
 
+        // Copy override ONLY, same contract as $intentApprovedNotice above
+        // — added by the 2026-08-03 ruling (TWO-25326 §7.3/§7.4). No
+        // separate enabled/disabled element: suppression is the approved
+        // notice's switch, since the ruling treats "the intent message" as
+        // one on/off unit.
+        $intentDeclinedNotice = trim((string)($brand->intent_declined_notice ?? ''));
+        if ($intentDeclinedNotice === '') {
+            $intentDeclinedNotice = null;
+        }
+
         $inlineTermFees = true;
         if (isset($brand->inline_term_fees)) {
             $inlineTermFees = filter_var(
@@ -242,7 +252,8 @@ class Loader
             (string)($brand->checkout_subtitle ?? ''),
             $roundingSteps,
             $intentApprovedNotice,
-            $intentApprovedNoticeEnabled
+            $intentApprovedNoticeEnabled,
+            $intentDeclinedNotice
         );
     }
 }

--- a/Model/Ui/ConfigProvider.php
+++ b/Model/Ui/ConfigProvider.php
@@ -217,15 +217,16 @@ class ConfigProvider implements ConfigProviderInterface
                     // every update, so the notice was effectively invisible.
                     'orderIntentApprovedNotice' => $this->getOrderIntentApprovedNotice(),
                     'orderIntentDeclinedNotice' => $this->getOrderIntentDeclinedNotice(),
-                    // Kept for the generic HTTP/technical failure path
-                    // (processOrderIntentErrorResponse's default branch) —
-                    // that is not the "declined" business outcome §7.3's
-                    // wording is about, so it stays a plain toast rather
-                    // than joining the persistent tile notice.
-                    'orderIntentDeclinedMessage' => __(
-                        'Your invoice purchase with %1 has been declined.',
-                        $this->brandRegistry->getProductName()
-                    ),
+                    // The former `orderIntentDeclinedMessage` toast (a plain
+                    // "declined" string, fed to the renderer's message
+                    // region) is removed — the 2026-08-03 ruling replaced it
+                    // with the persistent `orderIntentDeclinedNotice` above.
+                    // Found dead in adversarial review, 2026-08-04: a comment
+                    // here once claimed it was kept for the generic HTTP/
+                    // technical-failure path, but
+                    // processOrderIntentErrorResponse() has only ever used
+                    // `generalErrorMessage` for that — this key was assigned
+                    // once on the renderer and never read.
                     'generalErrorMessage' => __(
                         'Something went wrong with your request to %1. %2',
                         $this->brandRegistry->getProductName(),
@@ -333,8 +334,8 @@ class ConfigProvider implements ConfigProviderInterface
      * forced to also take the vanilla declined wording (§7.4).
      *
      * This is the "not approved" business outcome only (a clean response
-     * with `approved: false`) — a technical/HTTP failure keeps using
-     * `orderIntentDeclinedMessage` as a toast; see
+     * with `approved: false`) — a technical/HTTP failure is a different
+     * surface, `generalErrorMessage`, handled by
      * processOrderIntentErrorResponse() in gateway_method.js.
      *
      * @return array{withCompany:string,withoutCompany:string,companyNameToken:string,companyNumberToken:string}|null

--- a/Model/Ui/ConfigProvider.php
+++ b/Model/Ui/ConfigProvider.php
@@ -48,6 +48,14 @@ class ConfigProvider implements ConfigProviderInterface
      */
     public const COMPANY_NAME_TOKEN = '{{companyName}}';
 
+    /**
+     * Same sentinel mechanism as COMPANY_NAME_TOKEN, for the organisation
+     * number (TWO-25326 §7.3: the tile's ONLY company display is now this
+     * sentence, so the number has to be substitutable into it same as the
+     * name).
+     */
+    public const COMPANY_NUMBER_TOKEN = '{{companyNumber}}';
+
     /** @var string */
     private $code;
 
@@ -208,6 +216,12 @@ class ConfigProvider implements ConfigProviderInterface
                     // the KO `messages` region — a surface checkout clears on
                     // every update, so the notice was effectively invisible.
                     'orderIntentApprovedNotice' => $this->getOrderIntentApprovedNotice(),
+                    'orderIntentDeclinedNotice' => $this->getOrderIntentDeclinedNotice(),
+                    // Kept for the generic HTTP/technical failure path
+                    // (processOrderIntentErrorResponse's default branch) —
+                    // that is not the "declined" business outcome §7.3's
+                    // wording is about, so it stays a plain toast rather
+                    // than joining the persistent tile notice.
                     'orderIntentDeclinedMessage' => __(
                         'Your invoice purchase with %1 has been declined.',
                         $this->brandRegistry->getProductName()
@@ -216,6 +230,15 @@ class ConfigProvider implements ConfigProviderInterface
                         'Something went wrong with your request to %1. %2',
                         $this->brandRegistry->getProductName(),
                         $tryAgainLater
+                    ),
+                    // TWO-25326 §6a: the Two method stays selectable with a
+                    // manual (name-only, no organisation number) capture —
+                    // it is blocked at submit instead, matching the WC/PS/
+                    // Hyvä pattern rather than Magento's previous silent
+                    // no-op (no block, no message, no order).
+                    'companyRequiredMessage' => __(
+                        'Please select your company before paying with %1.',
+                        $this->brandRegistry->getProductName()
                     ),
                     'invalidEmailListMessage' => __('Please ensure that your invoice email address list only contains valid email addresses separated by commas.'),
                     'paymentTermsMessage' => __(
@@ -254,7 +277,13 @@ class ConfigProvider implements ConfigProviderInterface
      * company-known variant, absent/empty leaves the platform default.
      * See BrandRegistryInterface for both contracts.
      *
-     * @return array{withCompany:string,withoutCompany:string,companyNameToken:string}|null
+     * TWO-25326 2026-08-03 ruling, §7.3: this is now the ONLY place the
+     * captured company name/number are displayed in the payment tile — the
+     * standalone `.two-company-label` text (§7, pre-ruling) is removed, not
+     * supplemented. Default wording is the literal ticket copy, with the
+     * company number substituted the same way the company name always was.
+     *
+     * @return array{withCompany:string,withoutCompany:string,companyNameToken:string,companyNumberToken:string}|null
      */
     private function getOrderIntentApprovedNotice(): ?array
     {
@@ -270,22 +299,73 @@ class ConfigProvider implements ConfigProviderInterface
         // through a variable, so `i18n:collect-phrases` and the overlay
         // repos' i18n audit can both still see it. The override branch
         // takes a variable by necessity — a brand's own copy is its own
-        // module's msgid and lives in that module's i18n CSV.
+        // module's msgid and lives in that module's i18n CSV. %3 (company
+        // number) is a new argument as of the 2026-08-03 ruling; an
+        // existing override string that only references %1/%2 keeps
+        // working unchanged, and one that wants the number can add %3.
         $withCompany = $override === null
             ? __(
-                'Your invoice with %1 is likely to be accepted for %2, subject to additional checks.',
+                'This order by %2 (%3) is likely to be accepted by %1',
                 $productName,
-                self::COMPANY_NAME_TOKEN
+                self::COMPANY_NAME_TOKEN,
+                self::COMPANY_NUMBER_TOKEN
             )
-            : __($override, $productName, self::COMPANY_NAME_TOKEN);
+            : __($override, $productName, self::COMPANY_NAME_TOKEN, self::COMPANY_NUMBER_TOKEN);
 
         return [
             'withCompany' => (string)$withCompany,
             'withoutCompany' => (string)__(
-                'Your invoice with %1 is likely to be accepted, subject to additional checks.',
+                'This order is likely to be accepted by %1',
                 $productName
             ),
             'companyNameToken' => self::COMPANY_NAME_TOKEN,
+            'companyNumberToken' => self::COMPANY_NUMBER_TOKEN,
+        ];
+    }
+
+    /**
+     * Resolve the buyer-facing "order intent NOT approved" notice — the
+     * §7.3 counterpart to getOrderIntentApprovedNotice() above, added by the
+     * 2026-08-03 ruling. Same shape, same suppression switch (a brand that
+     * turns the notice off gets neither variant — TWO-25326 §7.2 treats
+     * "the intent message" as one on/off unit, approved or declined), and a
+     * SEPARATE copy override so a brand with its own approved wording is not
+     * forced to also take the vanilla declined wording (§7.4).
+     *
+     * This is the "not approved" business outcome only (a clean response
+     * with `approved: false`) — a technical/HTTP failure keeps using
+     * `orderIntentDeclinedMessage` as a toast; see
+     * processOrderIntentErrorResponse() in gateway_method.js.
+     *
+     * @return array{withCompany:string,withoutCompany:string,companyNameToken:string,companyNumberToken:string}|null
+     */
+    private function getOrderIntentDeclinedNotice(): ?array
+    {
+        if (!$this->brandRegistry->isIntentApprovedNoticeEnabled()) {
+            return null;
+        }
+
+        $override = $this->brandRegistry->getIntentDeclinedNotice();
+
+        $productName = $this->brandRegistry->getProductName();
+
+        $withCompany = $override === null
+            ? __(
+                '%1 is not available for this order by %2 (%3)',
+                $productName,
+                self::COMPANY_NAME_TOKEN,
+                self::COMPANY_NUMBER_TOKEN
+            )
+            : __($override, $productName, self::COMPANY_NAME_TOKEN, self::COMPANY_NUMBER_TOKEN);
+
+        return [
+            'withCompany' => (string)$withCompany,
+            'withoutCompany' => (string)__(
+                '%1 is not available for this order',
+                $productName
+            ),
+            'companyNameToken' => self::COMPANY_NAME_TOKEN,
+            'companyNumberToken' => self::COMPANY_NUMBER_TOKEN,
         ];
     }
 

--- a/Test/Js/amd-harness.js
+++ b/Test/Js/amd-harness.js
@@ -225,6 +225,7 @@ function makeJQueryMock() {
             attr: function () { return obj; },
             data: function () { return obj; },
             find: function () { return obj; },
+            closest: function () { return obj; },
             first: function () { return obj; },
             last: function () { return obj; },
             eq: function () { return obj; },
@@ -291,6 +292,19 @@ function makeJQueryMock() {
     };
     $.Deferred = function () {
         return { resolve: function () { return this; }, reject: function () { return this; }, promise: function () { return this; }, done: function () { return this; }, fail: function () { return this; }, always: function () { return this; } };
+    };
+    // Magento_Ui/js/lib/view/utils/async's `$.async` decorator — a
+    // MutationObserver wrapper real modules call as `$.async(selector, cb)`
+    // to defer against a node that may not exist yet. This default runs the
+    // callback synchronously against the (inert) mock node so a module that
+    // reaches this call path incidentally — e.g. gateway_method.js's
+    // enableCompanySearch(), now called from address-change handlers — does
+    // not throw "not a function" in specs that never meant to exercise the
+    // company-search widget itself. Specs that DO care about the widget's
+    // real async/MutationObserver behaviour already supply their own richer
+    // jquery double (see makeRecordingDom() in tile-company-readonly-fields.test.js).
+    $.async = function (selector, cb) {
+        cb($(selector));
     };
     return $;
 }

--- a/Test/Js/gateway-method-customer-data-subscription-leak.test.js
+++ b/Test/Js/gateway-method-customer-data-subscription-leak.test.js
@@ -139,6 +139,37 @@ describe('fillCustomerData() subscription lifecycle (TWO-25347)', () => {
 
         expect(applyCalls).toBe(1);
     });
+
+    test('a synchronous throw during the one-shot company read does not abort the rest of fillCustomerData() (found in round-2 adversarial review, 2026-08-04)', () => {
+        // Han's round-2 finding: fillCustomerData() calls applyCompanyData()
+        // (the one-shot companyData read) BEFORE wiring the shippingTelephone/
+        // countryCode/shippingAddress/billingAddress subscriptions. If that
+        // one-shot call reaches fillCompanyData() → placeOrderIntent() and
+        // THAT throws synchronously, an unswallowed throw would abort
+        // fillCustomerData() mid-function and permanently skip every
+        // subscription after the throw point — for the rest of the page
+        // session, not just this one company pick. This is why the round-1
+        // fix (swallow-and-message, not rethrow) matters beyond the guard
+        // itself: fillCompanyData() must never let an internal throw escape
+        // into a caller with mandatory follow-up work.
+        const { renderer, shippingAddress, billingAddress, companyDataSection } = loadRenderer();
+        renderer.isOrderIntentEnabled = true;
+        renderer.showErrorMessage = function () {};
+        renderer.placeOrderIntent = function () {
+            throw new Error('billingAddress was transiently null');
+        };
+        // Seeded so the one-shot `customerData.get('companyData')()` read
+        // inside fillCustomerData() has both name and id — otherwise
+        // fillCompanyData() early-returns before ever reaching
+        // placeOrderIntent(), and the throw path is never exercised.
+        companyDataSection({ companyName: 'Acme Widgets AS', companyId: '123' });
+
+        expect(() => renderer.fillCustomerData()).not.toThrow();
+
+        expect(shippingAddress.subscriberCount()).toBe(1);
+        expect(billingAddress.subscriberCount()).toBe(1);
+        expect(companyDataSection.subscriberCount()).toBe(1);
+    });
 });
 
 describe('fillCompanyData() in-flight guard (TWO-25347 belt-and-braces)', () => {
@@ -207,8 +238,8 @@ describe('fillCompanyData() in-flight guard (TWO-25347 belt-and-braces)', () => 
         return fn;
     }
 
-    test('a synchronous throw from placeOrderIntent() clears the guard instead of locking it forever (found in adversarial review, 2026-08-04)', () => {
-        // BLOCKER found reviewing this PR: placeOrderIntent() can throw
+    test('a synchronous throw from placeOrderIntent() clears the guard, shows a message, and does NOT propagate (found in adversarial review, 2026-08-04; refined in round 2)', () => {
+        // BLOCKER found in round 1: placeOrderIntent() can throw
         // synchronously (quote.billingAddress() can legitimately be null for
         // a transient window; placeOrderIntent() reads
         // `billingAddress.countryId` unguarded). Before the fix, an
@@ -216,12 +247,26 @@ describe('fillCompanyData() in-flight guard (TWO-25347 belt-and-braces)', () => 
         // `_orderIntentInFlightFor` stayed set to that companyId FOREVER —
         // every later pick of the SAME company would silently no-op against
         // the in-flight guard, with no recovery short of a page reload.
+        //
+        // Round 2 found the FIRST fix (try/catch + rethrow, mirroring
+        // placeOrderBackend()) was still wrong: every caller of
+        // fillCompanyData() is an unguarded synchronous context with its own
+        // statements AFTER the call (updateAddress()'s project/department
+        // writes, the select2:select handler's addressLookup() call,
+        // refreshTileCompanySearchBinding()) — rethrowing aborted all of
+        // those too, and gave the buyer no visible sign anything went wrong.
+        // The catch now shows a message and does NOT rethrow.
         const component = loadAmdModule(RENDERER);
         let placeOrderIntentCalls = 0;
+        const errors = [];
         const ctx = Object.assign({}, component, {
             companyName: plainObservable(''),
             companyId: plainObservable(''),
             isOrderIntentEnabled: true,
+            generalErrorMessage: 'Something went wrong.',
+            showErrorMessage: function (message) {
+                errors.push(message);
+            },
             placeOrderIntent: function () {
                 placeOrderIntentCalls += 1;
                 if (placeOrderIntentCalls === 1) {
@@ -243,10 +288,14 @@ describe('fillCompanyData() in-flight guard (TWO-25347 belt-and-braces)', () => 
             }
         });
 
-        expect(() =>
-            ctx.fillCompanyData({ companyName: 'Acme Widgets AS', companyId: '123' })
-        ).toThrow('billingAddress was transiently null');
+        // No longer throws out of fillCompanyData() — a caller's own
+        // statements after this call must still run.
+        let statementAfterRan = false;
+        ctx.fillCompanyData({ companyName: 'Acme Widgets AS', companyId: '123' });
+        statementAfterRan = true;
+        expect(statementAfterRan).toBe(true);
 
+        expect(errors).toEqual(['Something went wrong.']);
         expect(ctx._orderIntentInFlightFor).toBeNull();
 
         // The buyer picks the SAME company again (e.g. re-selecting after

--- a/Test/Js/gateway-method-customer-data-subscription-leak.test.js
+++ b/Test/Js/gateway-method-customer-data-subscription-leak.test.js
@@ -195,4 +195,254 @@ describe('fillCompanyData() in-flight guard (TWO-25347 belt-and-braces)', () => 
 
         expect(placeOrderIntentCalls).toBe(2);
     });
+
+    /** Plain (non-ko) observable factory, matching the pattern above. */
+    function plainObservable(initial) {
+        let v = initial;
+        const fn = function (next) {
+            if (!arguments.length) return v;
+            v = next;
+            return fn;
+        };
+        return fn;
+    }
+
+    test('a synchronous throw from placeOrderIntent() clears the guard instead of locking it forever (found in adversarial review, 2026-08-04)', () => {
+        // BLOCKER found reviewing this PR: placeOrderIntent() can throw
+        // synchronously (quote.billingAddress() can legitimately be null for
+        // a transient window; placeOrderIntent() reads
+        // `billingAddress.countryId` unguarded). Before the fix, an
+        // unhandled throw here skipped `.always()` entirely, and
+        // `_orderIntentInFlightFor` stayed set to that companyId FOREVER —
+        // every later pick of the SAME company would silently no-op against
+        // the in-flight guard, with no recovery short of a page reload.
+        const component = loadAmdModule(RENDERER);
+        let placeOrderIntentCalls = 0;
+        const ctx = Object.assign({}, component, {
+            companyName: plainObservable(''),
+            companyId: plainObservable(''),
+            isOrderIntentEnabled: true,
+            placeOrderIntent: function () {
+                placeOrderIntentCalls += 1;
+                if (placeOrderIntentCalls === 1) {
+                    // Simulates the transient-null-billingAddress window —
+                    // only the FIRST attempt hits it.
+                    throw new Error('billingAddress was transiently null');
+                }
+                return {
+                    always: function () {
+                        return this;
+                    },
+                    done: function () {
+                        return this;
+                    },
+                    fail: function () {
+                        return this;
+                    }
+                };
+            }
+        });
+
+        expect(() =>
+            ctx.fillCompanyData({ companyName: 'Acme Widgets AS', companyId: '123' })
+        ).toThrow('billingAddress was transiently null');
+
+        expect(ctx._orderIntentInFlightFor).toBeNull();
+
+        // The buyer picks the SAME company again (e.g. re-selecting after
+        // the transient null window has passed) — must not be swallowed by
+        // a stuck guard.
+        ctx.fillCompanyData({ companyName: 'Acme Widgets AS', companyId: '123' });
+
+        expect(placeOrderIntentCalls).toBe(2);
+    });
+
+    test('a stale response for a PREVIOUS company does not overwrite the notice for the CURRENT one (cross-company race, found in adversarial review, 2026-08-04)', () => {
+        // BLOCKER found reviewing this PR: the in-flight guard only dedupes
+        // a repeat request for the SAME company. It does nothing to stop a
+        // stale response for company A landing AFTER the buyer has already
+        // moved on to company B — resolveCompanyNotice() reads
+        // companyName()/companyId() LIVE at settle time, so A's verdict
+        // would render with B's name/number substituted in.
+        const component = loadAmdModule(RENDERER);
+        const deferreds = {};
+        const processed = [];
+        const ctx = Object.assign({}, component, {
+            companyName: plainObservable(''),
+            companyId: plainObservable(''),
+            isOrderIntentEnabled: true,
+            placeOrderIntent: function () {
+                const companyId = ctx.companyId();
+                const deferred = {
+                    always: function (fn) {
+                        deferred._always = fn;
+                        return deferred;
+                    },
+                    done: function (fn) {
+                        deferred._done = fn;
+                        return deferred;
+                    },
+                    fail: function () {
+                        return deferred;
+                    }
+                };
+                deferreds[companyId] = deferred;
+                return deferred;
+            },
+            processOrderIntentSuccessResponse: function (response) {
+                processed.push({ company: this.companyName(), response: response });
+            }
+        });
+
+        // Company A selected — request A fires and is left hanging.
+        ctx.fillCompanyData({ companyName: 'Company A', companyId: 'aaa' });
+        // Buyer changes their mind before A settles — company B selected.
+        // The in-flight guard is keyed per-company, so this does not get
+        // deduped against A's still-open request.
+        ctx.fillCompanyData({ companyName: 'Company B', companyId: 'bbb' });
+
+        // A's stale response finally lands, AFTER the buyer moved to B.
+        deferreds['aaa']._always();
+        deferreds['aaa']._done({ approved: true });
+
+        // A's verdict must be dropped, not rendered against the now-current
+        // companyName/companyId (which are B's).
+        expect(processed).toEqual([]);
+
+        // B's own response landing normally still works.
+        deferreds['bbb']._always();
+        deferreds['bbb']._done({ approved: true });
+        expect(processed).toEqual([{ company: 'Company B', response: { approved: true } }]);
+    });
+});
+
+describe('tile company-search re-binds on an address-type switch (found in adversarial review, 2026-08-04)', () => {
+    /**
+     * BLOCKER found reviewing this PR: enableCompanySearch() only runs from
+     * three call sites (initObservable()'s registeredOrganisationMode(), the
+     * "Search for company" link, and the supported-company-types callback)
+     * — NONE of which fire when a buyer switches between a NEW and a SAVED
+     * shipping/billing address. `#shipping-new-address-form` appears and
+     * disappears exactly on that switch, which is the live DOM signal
+     * isTileCompanySearchActive() reads. Fixed by having
+     * updateShippingAddress()/updateBillingAddress() call
+     * refreshTileCompanySearchBinding() unconditionally.
+     *
+     * `formHasCompanyField` is mutable so a single jquery mock can simulate
+     * the address-area form appearing/disappearing across two calls in one
+     * test — the real module closes over this `$` at require time, so the
+     * double has to be able to change its answer without a new require.
+     */
+    function loadRendererWithToggleableAddressForm() {
+        let formHasCompanyField = true; // address-area form present (NEW address)
+
+        function makeNode() {
+            const node = {
+                length: 0,
+                on: () => node,
+                off: () => node,
+                val: () => node,
+                text: () => node,
+                attr: () => node,
+                data: () => null,
+                find: () => node,
+                closest: () => node,
+                each: () => node,
+                hide: () => node,
+                show: () => node,
+                select2: () => node
+            };
+            return node;
+        }
+        function $(selector) {
+            if (selector === '#shipping-new-address-form input[name="company"]') {
+                const node = makeNode();
+                node.length = formHasCompanyField ? 1 : 0;
+                return node;
+            }
+            return makeNode();
+        }
+        $.fn = {};
+        $.extend = Object.assign;
+        $.async = function (sel, cb) {
+            cb($(sel));
+        };
+        $.Deferred = function () {
+            const d = {
+                resolve: () => d,
+                reject: () => d,
+                promise: () => d,
+                done: () => d,
+                fail: () => d,
+                always: () => d
+            };
+            return d;
+        };
+        $.mage = { cookies: { get: () => null, set: () => {} }, redirect: () => {} };
+        $.validator = { methods: {}, addMethod: function () {} };
+
+        const address = { getCacheKey: () => 'k', countryId: 'GB' };
+        const renderer = loadAmdModule(RENDERER, {
+            jquery: $,
+            'Magento_Checkout/js/model/quote': {
+                shippingAddress: { subscribe: () => ({ dispose: () => {} }), peek: () => address },
+                billingAddress: (function () {
+                    const fn = function () {
+                        return address;
+                    };
+                    return fn;
+                })(),
+                getTotals: () => ({}),
+                getQuoteId: () => null,
+                paymentMethod: { subscribe: () => ({ dispose: () => {} }) },
+                shippingMethod: { subscribe: () => ({ dispose: () => {} }) },
+                isVirtual: () => false
+            }
+        });
+        renderer.supportedCompanyTypes = { gb: [] };
+        renderer.isAddressAreaCompanySearchEnabled = true;
+
+        const enableCalls = [];
+        const destroyCalls = [];
+        renderer.enableCompanySearch = function () {
+            enableCalls.push(1);
+        };
+        renderer.destroyCompanySearchWidget = function () {
+            destroyCalls.push(1);
+        };
+
+        return {
+            renderer,
+            enableCalls,
+            destroyCalls,
+            setFormPresent: (present) => {
+                formHasCompanyField = present;
+            }
+        };
+    }
+
+    test('switching from a NEW address (form present) to a SAVED one (form gone) re-binds the tile widget', () => {
+        const { renderer, enableCalls, destroyCalls, setFormPresent } =
+            loadRendererWithToggleableAddressForm();
+
+        // Address-area form present → tile is NOT the active location.
+        setFormPresent(true);
+        renderer.updateBillingAddress({ getCacheKey: () => 'k', countryId: 'GB' });
+        expect(enableCalls.length).toBe(0);
+        expect(destroyCalls.length).toBe(1);
+
+        // Buyer switches to a saved address → the address-area form is gone.
+        setFormPresent(false);
+        renderer.updateBillingAddress({ getCacheKey: () => 'k', countryId: 'GB' });
+        expect(enableCalls.length).toBe(1);
+    });
+
+    test('shipping-address changes also trigger the refresh (not only billing)', () => {
+        const { renderer, enableCalls, setFormPresent } = loadRendererWithToggleableAddressForm();
+
+        setFormPresent(false);
+        renderer.updateShippingAddress({ getCacheKey: () => 'k', countryId: 'GB' });
+
+        expect(enableCalls.length).toBe(1);
+    });
 });

--- a/Test/Js/gateway-method-customer-data-subscription-leak.test.js
+++ b/Test/Js/gateway-method-customer-data-subscription-leak.test.js
@@ -1,0 +1,198 @@
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ *
+ * TWO-25347: fillCustomerData() subscribes to four shared quote/
+ * customerData singletons and, before this fix, never disposed the
+ * previous set on a re-render — dispose() tore down only
+ * `_twoVisibilitySub`. fillCustomerData() is re-callable
+ * (registeredOrganisationMode(), reached whenever initObservable() runs
+ * again), and Fire Checkout re-renders this payment renderer on every
+ * totals/shipping change, so stacked subscriptions accumulated fast enough
+ * to be visible there: a single company pick fired one order_intent POST
+ * per SURVIVING subscription, not one.
+ *
+ * These specs use a real-dispose observable double (the shared harness's
+ * makeObservable() stubs dispose() as a no-op, which would make this fix
+ * untestable against it) to prove the actual subscriber count, not just
+ * that dispose() was called.
+ */
+
+'use strict';
+
+const { loadAmdModule } = require('./amd-harness');
+
+const RENDERER = 'view/frontend/web/js/view/payment/method-renderer/gateway_method.js';
+
+/** Observable whose subscribe() returns a dispose() that actually removes the subscriber. */
+function realDisposeObservable(initial) {
+    let value = initial;
+    let subs = [];
+    function obs(next) {
+        if (!arguments.length) return value;
+        value = next;
+        subs.forEach((fn) => fn(value));
+        return obs;
+    }
+    obs.subscribe = function (fn) {
+        subs.push(fn);
+        return {
+            dispose: function () {
+                subs = subs.filter((s) => s !== fn);
+            }
+        };
+    };
+    obs.subscriberCount = function () {
+        return subs.length;
+    };
+    obs.extend = function () {
+        return obs;
+    };
+    obs.peek = function () {
+        return value;
+    };
+    return obs;
+}
+
+function loadRenderer() {
+    const address = { getCacheKey: () => 'k', countryId: 'GB' };
+    const shippingAddress = realDisposeObservable(address);
+    const billingAddress = realDisposeObservable(address);
+    const companyDataSection = realDisposeObservable('');
+    const shippingTelephoneSection = realDisposeObservable('');
+    const countryCodeSection = realDisposeObservable('');
+
+    const renderer = loadAmdModule(RENDERER, {
+        'Magento_Customer/js/customer-data': {
+            get: function (key) {
+                if (key === 'companyData') return companyDataSection;
+                if (key === 'shippingTelephone') return shippingTelephoneSection;
+                if (key === 'countryCode') return countryCodeSection;
+                return realDisposeObservable('');
+            },
+            set: function () {},
+            reload: function () {}
+        },
+        'Magento_Checkout/js/model/quote': {
+            shippingAddress: shippingAddress,
+            billingAddress: billingAddress,
+            getTotals: () => realDisposeObservable({}),
+            getQuoteId: () => null,
+            paymentMethod: realDisposeObservable(null),
+            shippingMethod: realDisposeObservable({ carrier_code: 'freeshipping' }),
+            isVirtual: () => false
+        }
+    });
+
+    // Normally seeded by initialize(), which this harness deliberately
+    // bypasses to keep fillCustomerData() the only thing under test.
+    renderer.supportedCompanyTypes = { gb: [] };
+
+    return { renderer, shippingAddress, billingAddress, companyDataSection };
+}
+
+describe('fillCustomerData() subscription lifecycle (TWO-25347)', () => {
+    test('a re-call without an intervening dispose() still leaves exactly one live subscriber per singleton', () => {
+        const { renderer, shippingAddress, billingAddress, companyDataSection } = loadRenderer();
+
+        renderer.fillCustomerData();
+        renderer.fillCustomerData();
+        renderer.fillCustomerData();
+
+        // Three calls, no dispose() between them — this is exactly Fire
+        // Checkout's re-render pattern. Before the fix these would be 3, not 1.
+        expect(shippingAddress.subscriberCount()).toBe(1);
+        expect(billingAddress.subscriberCount()).toBe(1);
+        expect(companyDataSection.subscriberCount()).toBe(1);
+    });
+
+    test('dispose() removes fillCustomerData()\'s subscriptions', () => {
+        const { renderer, shippingAddress, billingAddress, companyDataSection } = loadRenderer();
+        renderer._super = function () {};
+
+        renderer.fillCustomerData();
+        expect(shippingAddress.subscriberCount()).toBe(1);
+
+        renderer.dispose();
+
+        expect(shippingAddress.subscriberCount()).toBe(0);
+        expect(billingAddress.subscriberCount()).toBe(0);
+        expect(companyDataSection.subscriberCount()).toBe(0);
+    });
+
+    test('a single company-data change fires applyCompanyData exactly once after three stacked calls', () => {
+        const { renderer, companyDataSection } = loadRenderer();
+
+        let applyCalls = 0;
+        renderer.applyCompanyData = function () {
+            applyCalls += 1;
+        };
+
+        renderer.fillCustomerData();
+        renderer.fillCustomerData();
+        renderer.fillCustomerData();
+        // Each fillCustomerData() call above also does its own one-shot
+        // read; only count the NOTIFICATION-driven calls that follow.
+        applyCalls = 0;
+
+        companyDataSection({ companyName: 'Acme Widgets AS', companyId: '123' });
+
+        expect(applyCalls).toBe(1);
+    });
+});
+
+describe('fillCompanyData() in-flight guard (TWO-25347 belt-and-braces)', () => {
+    test('a second call for the SAME company while a request is in flight does not re-fire placeOrderIntent', () => {
+        const component = loadAmdModule(RENDERER);
+        let placeOrderIntentCalls = 0;
+        let resolveDeferred;
+        const ctx = Object.assign({}, component, {
+            companyName: (function () {
+                let v = '';
+                const fn = function (next) {
+                    if (!arguments.length) return v;
+                    v = next;
+                    return fn;
+                };
+                return fn;
+            })(),
+            companyId: (function () {
+                let v = '';
+                const fn = function (next) {
+                    if (!arguments.length) return v;
+                    v = next;
+                    return fn;
+                };
+                return fn;
+            })(),
+            isOrderIntentEnabled: true,
+            placeOrderIntent: function () {
+                placeOrderIntentCalls += 1;
+                return {
+                    always: function (fn) {
+                        resolveDeferred = fn;
+                        return this;
+                    },
+                    done: function () {
+                        return this;
+                    },
+                    fail: function () {
+                        return this;
+                    }
+                };
+            }
+        });
+
+        ctx.fillCompanyData({ companyName: 'Acme Widgets AS', companyId: '123' });
+        ctx.fillCompanyData({ companyName: 'Acme Widgets AS', companyId: '123' });
+
+        expect(placeOrderIntentCalls).toBe(1);
+
+        // Settling the first request re-arms the guard for a later, genuine
+        // re-selection of the same company.
+        resolveDeferred();
+        ctx.fillCompanyData({ companyName: 'Acme Widgets AS', companyId: '123' });
+
+        expect(placeOrderIntentCalls).toBe(2);
+    });
+});

--- a/Test/Js/gateway-method-intent-approved-notice.test.js
+++ b/Test/Js/gateway-method-intent-approved-notice.test.js
@@ -17,10 +17,17 @@ const { loadAmdModule, defaultMocks } = require('./amd-harness');
 const RENDERER = 'view/frontend/web/js/view/payment/method-renderer/gateway_method.js';
 
 const DEFAULT_COPY = {
-    withCompany:
-        'Your invoice with Two is likely to be accepted for {{companyName}}, subject to additional checks.',
-    withoutCompany: 'Your invoice with Two is likely to be accepted, subject to additional checks.',
-    companyNameToken: '{{companyName}}'
+    withCompany: 'This order by {{companyName}} ({{companyNumber}}) is likely to be accepted by Two',
+    withoutCompany: 'This order is likely to be accepted by Two',
+    companyNameToken: '{{companyName}}',
+    companyNumberToken: '{{companyNumber}}'
+};
+
+const DECLINED_COPY = {
+    withCompany: 'Two is not available for this order by {{companyName}} ({{companyNumber}})',
+    withoutCompany: 'Two is not available for this order',
+    companyNameToken: '{{companyName}}',
+    companyNumberToken: '{{companyNumber}}'
 };
 
 /**
@@ -31,7 +38,7 @@ const DEFAULT_COPY = {
  * whole of initialize(), which drags in company search, the address/quote
  * graph and select2 and would make these specs a mocking exercise.
  */
-function makeContext(noticeCopy) {
+function makeContext(noticeCopy, declinedCopy) {
     const component = loadAmdModule(RENDERER);
     const ko = defaultMocks().ko;
 
@@ -58,29 +65,33 @@ function makeContext(noticeCopy) {
 
     component.initOrderIntentApprovedNotice.call(ctx, {
         orderIntentApprovedNotice: noticeCopy,
-        orderIntentDeclinedMessage: 'Declined.'
+        // TWO-25326 §7.3: the "not approved" business outcome now renders
+        // via the SAME persistent-notice mechanism, with its own copy —
+        // undefined here defaults to '' if the individual test doesn't
+        // supply it, matching a caller that never wired the key.
+        orderIntentDeclinedNotice: declinedCopy
     });
-    ctx.orderIntentDeclinedMessage = 'Declined.';
 
     return ctx;
 }
 
 describe('gateway_method intent-approved notice', () => {
-    test('approval renders the company-name variant inline, never via the messages region', () => {
-        const ctx = makeContext(DEFAULT_COPY);
+    test('approval renders the company-name and -number variant inline, never via the messages region', () => {
+        const ctx = makeContext(DEFAULT_COPY, DECLINED_COPY);
         ctx.companyName('Acme Widgets AS');
+        ctx.companyId('123456789');
 
         ctx.processOrderIntentSuccessResponse.call(ctx, { approved: true });
 
         // addSuccessMessage throws in the stub: reaching here at all proves
         // the renderer no longer routes the notice through getRegion('messages').
         expect(ctx.orderIntentApprovedNotice()).toBe(
-            'Your invoice with Two is likely to be accepted for Acme Widgets AS, subject to additional checks.'
+            'This order by Acme Widgets AS (123456789) is likely to be accepted by Two'
         );
     });
 
     test('falls back to the no-company variant when the company name is blank', () => {
-        const ctx = makeContext(DEFAULT_COPY);
+        const ctx = makeContext(DEFAULT_COPY, DECLINED_COPY);
         ctx.companyName('   ');
 
         ctx.processOrderIntentSuccessResponse.call(ctx, { approved: true });
@@ -89,10 +100,11 @@ describe('gateway_method intent-approved notice', () => {
     });
 
     test('takes a company name containing $-sequences literally', () => {
-        const ctx = makeContext(DEFAULT_COPY);
+        const ctx = makeContext(DEFAULT_COPY, DECLINED_COPY);
         // String.replace treats $& / $1 in the *replacement* as patterns; the
         // renderer passes a replacer function to avoid that.
         ctx.companyName('A$& B$1 Ltd');
+        ctx.companyId('999');
 
         ctx.processOrderIntentSuccessResponse.call(ctx, { approved: true });
 
@@ -104,39 +116,50 @@ describe('gateway_method intent-approved notice', () => {
         // <intent_approved_notice_enabled>false</intent_approved_notice_enabled>.
         // The observable stays '' so the template's `ko if` never emits an
         // element.
-        const ctx = makeContext(null);
+        const ctx = makeContext(null, null);
         ctx.companyName('Acme Widgets AS');
+        ctx.companyId('123456789');
 
         ctx.processOrderIntentSuccessResponse.call(ctx, { approved: true });
 
         expect(ctx.orderIntentApprovedNotice()).toBe('');
     });
 
-    test('a decline clears the notice and still shows the decline message', () => {
-        const ctx = makeContext(DEFAULT_COPY);
+    test('a decline clears the approved notice and shows the persistent declined notice instead', () => {
+        const ctx = makeContext(DEFAULT_COPY, DECLINED_COPY);
         ctx.companyName('Acme Widgets AS');
+        ctx.companyId('123456789');
         ctx.processOrderIntentSuccessResponse.call(ctx, { approved: true });
         expect(ctx.orderIntentApprovedNotice()).not.toBe('');
 
         ctx.processOrderIntentSuccessResponse.call(ctx, { approved: false });
 
         expect(ctx.orderIntentApprovedNotice()).toBe('');
-        expect(ctx.errors).toEqual(['Declined.']);
+        expect(ctx.orderIntentDeclinedNotice()).toBe(
+            'Two is not available for this order by Acme Widgets AS (123456789)'
+        );
+        // No toast for a clean decline — the persistent tile notice is the
+        // only surface, matching the "tile shows ONLY the intent message"
+        // ruling.
+        expect(ctx.errors).toEqual([]);
     });
 
-    test('an intent error clears the notice', () => {
-        const ctx = makeContext(DEFAULT_COPY);
+    test('an intent error clears both notices', () => {
+        const ctx = makeContext(DEFAULT_COPY, DECLINED_COPY);
         ctx.companyName('Acme Widgets AS');
+        ctx.companyId('123456789');
         ctx.processOrderIntentSuccessResponse.call(ctx, { approved: true });
 
         ctx.processOrderIntentErrorResponse.call(ctx, {});
 
         expect(ctx.orderIntentApprovedNotice()).toBe('');
+        expect(ctx.orderIntentDeclinedNotice()).toBe('');
     });
 
-    test('changing the company clears the notice', () => {
-        const ctx = makeContext(DEFAULT_COPY);
+    test('changing the company clears both notices', () => {
+        const ctx = makeContext(DEFAULT_COPY, DECLINED_COPY);
         ctx.companyName('Acme Widgets AS');
+        ctx.companyId('123456789');
         ctx.processOrderIntentSuccessResponse.call(ctx, { approved: true });
         expect(ctx.orderIntentApprovedNotice()).not.toBe('');
 
@@ -145,16 +168,19 @@ describe('gateway_method intent-approved notice', () => {
         // The approval was for the previous company; keeping it would be a
         // buyer-facing lie.
         expect(ctx.orderIntentApprovedNotice()).toBe('');
+        expect(ctx.orderIntentDeclinedNotice()).toBe('');
     });
 
-    test('changing the company number clears the notice', () => {
-        const ctx = makeContext(DEFAULT_COPY);
+    test('changing the company number clears both notices', () => {
+        const ctx = makeContext(DEFAULT_COPY, DECLINED_COPY);
         ctx.companyName('Acme Widgets AS');
+        ctx.companyId('123456789');
         ctx.processOrderIntentSuccessResponse.call(ctx, { approved: true });
 
         ctx.companyId('999888777');
 
         expect(ctx.orderIntentApprovedNotice()).toBe('');
+        expect(ctx.orderIntentDeclinedNotice()).toBe('');
     });
 
     test('the notice survives a messageContainer clear (failed placeOrder validation)', () => {

--- a/Test/Js/gateway-method-place-order-latch.test.js
+++ b/Test/Js/gateway-method-place-order-latch.test.js
@@ -112,6 +112,15 @@ function makeContext(component, opts) {
         isPaymentTermsEnabled: 'termsEnabled' in opts ? opts.termsEnabled : true,
         isPaymentTermsAccepted: observable('termsAccepted' in opts ? opts.termsAccepted : true),
         isPlaceOrderActionAllowed: observable('allowed' in opts ? opts.allowed : true),
+        // TWO-25326 §6a: placeOrder() now blocks a manual (name-only, no
+        // organisation number) capture before it reaches this latch. These
+        // specs are about the latch, not the company gate, so a captured
+        // company is the default — pass `companyCaptured: false` to exercise
+        // the gate itself.
+        isCompanyCaptured: function () {
+            return 'companyCaptured' in opts ? opts.companyCaptured : true;
+        },
+        companyRequiredMessage: 'Please select your company before paying with Two.',
         isInvoiceEmailsEnabled: false,
         redirectAfterPlaceOrder: false,
         validate: function () {
@@ -138,6 +147,32 @@ function makeContext(component, opts) {
     };
     return ctx;
 }
+
+describe('gateway_method §6a company gate (TWO-25326, 2026-08-03 ruling)', () => {
+    test('blocks submit with a visible message when no company id has been captured', () => {
+        const component = loadComponent({});
+        const ctx = makeContext(component, { companyCaptured: false });
+
+        ctx.placeOrder.call(ctx);
+
+        expect(ctx.placeOrderCalls).toBe(0);
+        expect(ctx.errors).toEqual(['Please select your company before paying with Two.']);
+        // Blocked before the latch is even touched — matching WC/PS/Hyvä's
+        // "selectable, blocked at submit" pattern rather than disabling the
+        // method up front.
+        expect(ctx.isPlaceOrderActionAllowed()).toBe(true);
+    });
+
+    test('does not block submit once a company id has been captured', () => {
+        const component = loadComponent({});
+        const ctx = makeContext(component, { companyCaptured: true });
+
+        ctx.placeOrder.call(ctx);
+
+        expect(ctx.placeOrderCalls).toBe(1);
+        expect(ctx.errors).toEqual([]);
+    });
+});
 
 describe('gateway_method place-order latch (TWO-24843)', () => {
     test('refuses to post when a non-virtual quote has no shipping method', () => {

--- a/Test/Js/tile-company-readonly-fields.test.js
+++ b/Test/Js/tile-company-readonly-fields.test.js
@@ -197,13 +197,26 @@ function nameFieldVisible(renderer) {
             'expected exactly one company-name field wrapper, found ' + tags.length
         );
     }
-    if (!/visible:\s*!isCompanyCaptured\(\)/.test(tags[0])) {
+    // TWO-25326 §7.1/decline-recovery (2026-08-04 adversarial-review fix):
+    // the field also re-shows on a declined intent, even though
+    // isCompanyCaptured() is still true then — see the template's own
+    // comment. Pinned to the exact shape so a drift silently narrowing or
+    // widening the gate fails the string match, not just the behavioural
+    // cases below.
+    if (
+        !/visible:\s*\(!isCompanyCaptured\(\)\s*\|\|\s*isOrderIntentDeclinedNoticeVisible\(\)\)\s*&&\s*isTileCompanySearchActive\(\)/.test(
+            tags[0]
+        )
+    ) {
         throw new Error(
             "the company-name field's `visible:` binding is not the pinned "
-                + '`!isCompanyCaptured()` shape'
+                + '`(!isCompanyCaptured() || isOrderIntentDeclinedNoticeVisible()) && isTileCompanySearchActive()` shape'
         );
     }
-    return !renderer.isCompanyCaptured();
+    return (
+        (!renderer.isCompanyCaptured() || renderer.isOrderIntentDeclinedNoticeVisible()) &&
+        renderer.isTileCompanySearchActive()
+    );
 }
 
 /**
@@ -722,6 +735,43 @@ describe('the notices are gated on their own observables, not on capture', () =>
         expect(errors).toEqual([]);
     });
 
+    test('a decline re-opens the capture control instead of trapping the buyer (found in adversarial review, 2026-08-04)', () => {
+        // BLOCKER found reviewing this PR: isCompanyCaptured() stays true
+        // after a decline (only an approval's own company-change
+        // subscriptions clear the observables), so gating the field purely
+        // on isCompanyCaptured() left a declined buyer staring at a
+        // persistent "not available" notice with NO control anywhere on the
+        // tile to try a different company — a dead end without a page
+        // reload on a saved-address/virtual-cart/setting-off checkout,
+        // where the tile is the buyer's ONLY route to search.
+        const { renderer } = loadRendererOnly();
+
+        renderer.applyCompanyData(
+            { companyName: 'First Example Ltd', companyId: '12345678' },
+            { authoritative: true }
+        );
+        approveIntent(renderer);
+        expect(nameFieldVisible(renderer)).toBe(false);
+
+        renderer.processOrderIntentSuccessResponse({ approved: false });
+
+        expect(renderer.isCompanyCaptured()).toBe(true);
+        expect(declinedNoticeVisible(renderer)).toBe(true);
+        // The recovery path: the field is back, letting the buyer search
+        // again.
+        expect(nameFieldVisible(renderer)).toBe(true);
+
+        // Picking a different company clears the declined notice AND
+        // completes a new capture, so the field correctly hides again once
+        // there is something new to hide it for.
+        renderer.applyCompanyData(
+            { companyName: 'Second Example Ltd', companyId: '87654321' },
+            { authoritative: true }
+        );
+        expect(declinedNoticeVisible(renderer)).toBe(false);
+        expect(nameFieldVisible(renderer)).toBe(false);
+    });
+
     test('an errored intent shows neither notice', () => {
         // Distinct call site from the declined branch — a separate handler —
         // and it clears both notices for its own reason (an error says
@@ -1033,9 +1083,7 @@ function loadRendererOnly(extraMocks) {
         orderIntentDeclinedNotice: DECLINED_NOTICE_COPY
     });
     // showErrorMessage() routes through the payment block's messageContainer,
-    // which the renderer-only harness does not model. Needed by the
-    // intent-declined path below.
-    renderer.orderIntentDeclinedMessage = 'Declined.';
+    // which the renderer-only harness does not model.
     renderer.messageContainer = {
         addErrorMessage: function () {},
         errorMessages: { remove: function () {} }

--- a/Test/Js/tile-company-readonly-fields.test.js
+++ b/Test/Js/tile-company-readonly-fields.test.js
@@ -197,24 +197,27 @@ function nameFieldVisible(renderer) {
             'expected exactly one company-name field wrapper, found ' + tags.length
         );
     }
-    // TWO-25326 §7.1/decline-recovery (2026-08-04 adversarial-review fix):
-    // the field also re-shows on a declined intent, even though
-    // isCompanyCaptured() is still true then — see the template's own
-    // comment. Pinned to the exact shape so a drift silently narrowing or
-    // widening the gate fails the string match, not just the behavioural
-    // cases below.
+    // TWO-25326 §7.1/decline-recovery (2026-08-04 adversarial-review, round
+    // 1 then round 2): the field also re-shows on a declined intent, even
+    // though isCompanyCaptured() is still true then — see the template's
+    // own comment. Gated on isCompanyRecoveryNeeded(), NOT on the declined
+    // NOTICE's own visibility — round 2 found the notice-visibility gate
+    // reproduced the dead-end for a brand with order_intent enabled but the
+    // notice UI suppressed. Pinned to the exact shape so a drift silently
+    // narrowing or widening the gate fails the string match, not just the
+    // behavioural cases below.
     if (
-        !/visible:\s*\(!isCompanyCaptured\(\)\s*\|\|\s*isOrderIntentDeclinedNoticeVisible\(\)\)\s*&&\s*isTileCompanySearchActive\(\)/.test(
+        !/visible:\s*\(!isCompanyCaptured\(\)\s*\|\|\s*isCompanyRecoveryNeeded\(\)\)\s*&&\s*isTileCompanySearchActive\(\)/.test(
             tags[0]
         )
     ) {
         throw new Error(
             "the company-name field's `visible:` binding is not the pinned "
-                + '`(!isCompanyCaptured() || isOrderIntentDeclinedNoticeVisible()) && isTileCompanySearchActive()` shape'
+                + '`(!isCompanyCaptured() || isCompanyRecoveryNeeded()) && isTileCompanySearchActive()` shape'
         );
     }
     return (
-        (!renderer.isCompanyCaptured() || renderer.isOrderIntentDeclinedNoticeVisible()) &&
+        (!renderer.isCompanyCaptured() || renderer.isCompanyRecoveryNeeded()) &&
         renderer.isTileCompanySearchActive()
     );
 }
@@ -915,6 +918,16 @@ describe('the notices are gated on their own observables, not on capture', () =>
 
         declineIntent(renderer);
         expect(declinedNoticeVisible(renderer)).toBe(false);
+
+        // Round 2 of adversarial review, 2026-08-04: THIS is the case round
+        // 1's decline-recovery fix missed. `enable_order_intent` and
+        // `<intent_approved_notice_enabled>` are independent brand.xml
+        // switches — order_intent can fire for real (as it just did above)
+        // while the notice UI stays off. Gating the field's re-show on the
+        // declined NOTICE's own visibility (always false for this brand)
+        // would silently reproduce the original dead-end. It must re-show
+        // regardless.
+        expect(nameFieldVisible(renderer)).toBe(true);
     });
 
     test('an approved-notice override does not leak into the declined notice, or vice versa', () => {

--- a/Test/Js/tile-company-readonly-fields.test.js
+++ b/Test/Js/tile-company-readonly-fields.test.js
@@ -2,25 +2,22 @@
  * Copyright © Two.inc All rights reserved.
  * See COPYING.txt for license details.
  *
- * The payment tile's company display, as TWO-25326 §7 defines it: ONE line of
- * plain text, "Name (12345678)", between the term chips and the order-intent
- * notice.
- *
- * WHEN it shows is the 2026-08-03 ruling on TWO-25326, and it is NOT the same
- * as the one that hides the controls: the label is shown exactly when the
- * inline order-intent message is shown, and hidden exactly when that message
- * is hidden. The tile's own company controls remain gated on
- * isCompanyCaptured(), which is a separate and unchanged rule — so a company
- * captured with no approved intent on screen hides the controls and shows no
- * label. Both of those are pinned below.
+ * The payment tile's company display, as the 2026-08-03 ruling on TWO-25326
+ * (§7.3) now defines it: NO standalone label at all. The captured company
+ * name/number appear ONLY inside the order-intent notice sentence itself —
+ * `orderIntentApprovedNotice` / `orderIntentDeclinedNotice` — which has its
+ * own gate (whether an intent was placed and what it said), independent of
+ * the tile's company CONTROLS, which remain gated on isCompanyCaptured() —
+ * a separate and unchanged rule. A company captured with no intent outcome
+ * on screen hides the controls and shows neither notice.
  *
  * This supersedes three earlier shapes in turn. TWO-25288 first made the
  * captured number a read-only `<input>`; the ruling after that replaced the
  * input with a "Company Number" caption plus a separately-rendered value.
- * §7 removed that pair too — a caption and a number below an editable
- * company-name box is three renderings of one company in one tile — and gated
- * the resulting single line on isCompanyCaptured(). The 2026-08-03 ruling
- * replaces that gate with the intent message's own.
+ * §7 (pre-2026-08-03) replaced that pair with one `.two-company-label` line,
+ * gated on the intent message's own visibility. The 2026-08-03 ruling
+ * removes that label too — company display now lives ONLY in the notice
+ * text, not beside it.
  *
  * The control is HIDDEN, not deleted, and that distinction is pinned here
  * deliberately. The tile's picker is the only company-capture surface for a
@@ -124,24 +121,6 @@ function inputTag(id) {
 }
 
 /**
- * The `<div class="two-company-id-label">...</div>` block, comments already
- * stripped, INCLUDING its children (the caption span and the number span).
- * Non-greedy up to the first `</div>` — safe because this block's own
- * content is two flat `<span>` elements with no nested `<div>`. Throws
- * rather than returning null, same reasoning as inputTag() above.
- */
-function companyLabelTag() {
-    const markup = withoutComments(readTemplate());
-    const tags = markup.match(/<div\b[^>]*class="two-company-label"[^>]*>[\s\S]*?<\/div>/g) || [];
-    if (tags.length !== 1) {
-        throw new Error(
-            'expected exactly one <div class="two-company-label">, found ' + tags.length
-        );
-    }
-    return tags[0];
-}
-
-/**
  * What ko would paint into `id`'s value, derived rather than restated: read the
  * `value:` binding target out of the template, look that name up on a live
  * renderer, and evaluate it. A field bound to the wrong observable — or to none
@@ -162,97 +141,45 @@ function renderedValue(id, renderer) {
 }
 
 /**
- * What ko would paint as the tile's company label, derived the same way
- * renderedValue() does for an input — read the `text:` binding target out of
- * the template, look it up on the live renderer, evaluate it. A label rewired
- * to a different (or missing) method fails here rather than passing on a
- * restated string.
+ * Whether the approved / declined order-intent notice would currently
+ * render, and what it says — both derived from the live observable rather
+ * than restated, so a rewired binding fails here rather than passing on an
+ * assumed string. TWO-25326 §7.3 (2026-08-03 ruling): these observables are
+ * now the ONLY surface the captured company name/number appear on in the
+ * tile — there is no separate label to keep in sync with them.
  */
-function renderedLabelText(renderer) {
-    const bound = companyLabelTag().match(/text:\s*([A-Za-z_$][\w$]*)\(\)/);
-    if (!bound) {
-        throw new Error('the company label has no `text:` binding to a renderer method');
-    }
-    const target = renderer[bound[1]];
-    if (typeof target !== 'function') {
-        throw new Error(
-            'the company label is bound to `' + bound[1] + '`, which the renderer has not'
-        );
-    }
-    return target.call(renderer);
+function approvedNoticeVisible(renderer) {
+    return !!renderer.orderIntentApprovedNotice();
+}
+
+function approvedNoticeText(renderer) {
+    return renderer.orderIntentApprovedNotice();
+}
+
+function declinedNoticeVisible(renderer) {
+    return !!renderer.orderIntentDeclinedNotice();
+}
+
+function declinedNoticeText(renderer) {
+    return renderer.orderIntentDeclinedNotice();
 }
 
 /**
- * The `visible:` expression on the company label, verbatim and whitespace-
- * normalised, so it can be compared against the intent message's own gate as
- * a STRING rather than by two independent pattern matches.
- *
- * Anchored on `visible:` up to the next binding (`,` `text:` …) or the end of
- * the `data-bind` value.
+ * Confirms the template gates each notice `<div>` on its OWN observable
+ * (`orderIntentApprovedNotice()` / `orderIntentDeclinedNotice()`) via a
+ * `ko if`, rather than on some shared predicate that could drift from what
+ * the renderer actually resolved. Read from source rather than assumed.
  */
-function labelGateExpression() {
-    const bound = companyLabelTag().match(/visible:\s*([^,"]+)/);
-    if (!bound) {
-        throw new Error("the company label has no `visible:` binding");
-    }
-    return bound[1].trim();
-}
-
-/**
- * The `if:` expression on the inline order-intent message's ko virtual
- * element, same normalisation, so the two gates can be compared directly.
- */
-function intentMessageGateExpression() {
-    // The notice block is `<!-- ko if: X -->` immediately followed by the div
-    // carrying `two-order-intent-message`. Match that PAIR rather than
-    // guessing which of the template's several `ko if:` blocks it is — a
-    // positional match would silently retarget if a sibling block moved.
-    const pair = readTemplate().match(
-        /<!--\s*ko\s+if:\s*([^>]+?)\s*-->\s*<div[^>]*class="two-order-intent-message/
+function noticeGateExpression(cssClass) {
+    const pattern = new RegExp(
+        '<!--\\s*ko\\s+if:\\s*([^>]+?)\\s*-->\\s*<div[^>]*class="two-order-intent-message ' +
+            cssClass
     );
+    const pair = readTemplate().match(pattern);
     if (!pair) {
-        throw new Error(
-            'could not find the `<!-- ko if: … -->` guarding the order-intent message'
-        );
+        throw new Error('could not find the `ko if` guarding .' + cssClass + ' notice');
     }
     return pair[1].trim();
-}
-
-/**
- * Whether the tile's company label would currently render: read the
- * `visible:` expression out of the template, PIN it to the exact
- * `isOrderIntentMessageVisible()` shape (so a drift to some other predicate,
- * or to an always-true stub, fails the string match), then evaluate that
- * predicate against the live renderer for the actual truth value.
- *
- * The pinned shape is the intent message's gate, NOT a capture check. That is
- * the 2026-08-03 ruling: the label is shown exactly when the message is.
- */
-function labelVisible(renderer) {
-    if (labelGateExpression() !== 'isOrderIntentMessageVisible()') {
-        throw new Error(
-            "the company label's `visible:` binding is not the pinned "
-                + '`isOrderIntentMessageVisible()` shape, it is `'
-                + labelGateExpression() + '`'
-        );
-    }
-    return !!renderer.isOrderIntentMessageVisible();
-}
-
-/**
- * Whether the inline order-intent message would currently render, derived the
- * same way — so "the label shows exactly when the message shows" can be
- * asserted as two evaluated truth values and not only as matching source text.
- */
-function intentMessageVisible(renderer) {
-    const expression = intentMessageGateExpression();
-    if (expression !== 'isOrderIntentMessageVisible()') {
-        throw new Error(
-            'the order-intent message is not gated on the pinned '
-                + '`isOrderIntentMessageVisible()` shape, it is `' + expression + '`'
-        );
-    }
-    return !!renderer.isOrderIntentMessageVisible();
 }
 
 /**
@@ -324,56 +251,14 @@ describe('the payment tile shows the number as an uneditable label, not a field'
         expect(markup).not.toMatch(/<input\b[^>]*\bid\s*=\s*["']company_id["']/);
     });
 
-    test('the company label is a plain div, carries no name and no value binding to write to', () => {
-        const tag = companyLabelTag();
-
-        expect(tag).not.toMatch(/\sname\s*=/);
-        expect(tag).not.toMatch(/\svalue\s*=/);
-        // Not an input, not a button, not anything with default interactive
-        // semantics — a plain div reads unambiguously as non-editable.
-        expect(tag).toMatch(/^<div\b/);
-    });
-
-    test('the company label is one element bound to one builder', () => {
-        // TWO-25326 §7 asks for ONE line, "Name (number)". The superseded
-        // shape was a caption span plus a number span, i.e. two renderings of
-        // one company in one tile, which is the defect the ticket names.
-        const tag = companyLabelTag();
-
-        expect(tag).toMatch(/text:\s*companyDisplayLabel\(\)/);
-        // No inner elements: the whole string comes from one binding, so
-        // there is no caption/value split that can fall out of step.
-        expect(tag).not.toMatch(/<span\b/);
-    });
-
-    /**
-     * §7 names the position, not just the existence: "between the chips and
-     * the intent message (if rendered) or else the optional fields". Asserted
-     * on real source offsets rather than by eye, because the label is inert
-     * display text — nothing about it would break if it drifted to the bottom
-     * of the tile, so nothing but this test would notice.
-     */
-    test('the label sits between the term chips and the intent message', () => {
+    test('the standalone company label is gone — no class, no builder method', () => {
+        // TWO-25326 §7.3 (2026-08-03 ruling): the pre-ruling `.two-company-label`
+        // element and its companyDisplayLabel() builder are REMOVED, not
+        // relocated. Company display now lives only inside the notice text.
         const markup = withoutComments(readTemplate());
 
-        const lastChip = markup.lastIndexOf('two-term-chips__container');
-        const label = markup.indexOf('class="two-company-label"');
-        const intent = markup.indexOf('two-order-intent-message');
-        const invoiceEmail = markup.indexOf('id="invoice_emails"');
-
-        // Guard every anchor before comparing: indexOf returns -1 for a
-        // missing needle, and -1 compares "less than" everything, so a
-        // renamed anchor would make the ordering assertions pass on nonsense.
-        expect(lastChip).toBeGreaterThan(-1);
-        expect(label).toBeGreaterThan(-1);
-        expect(intent).toBeGreaterThan(-1);
-        expect(invoiceEmail).toBeGreaterThan(-1);
-
-        expect(label).toBeGreaterThan(lastChip);
-        expect(label).toBeLessThan(intent);
-        // And ahead of the optional fields, which is where §7 puts it when no
-        // intent message is rendered.
-        expect(label).toBeLessThan(invoiceEmail);
+        expect(markup).not.toContain('two-company-label');
+        expect(markup).not.toMatch(/companyDisplayLabel/);
     });
 
     test('the superseded caption and its separate number span are gone', () => {
@@ -384,9 +269,6 @@ describe('the payment tile shows the number as an uneditable label, not a field'
 
         expect(markup).not.toContain('two-company-id-label');
         expect(markup).not.toContain('two-company-id-label__caption');
-        // The old caption text is not simply relocated — the new label
-        // renders the bare `Name (number)` form with no caption at all.
-        expect(companyLabelTag()).not.toMatch(/Company Number/);
     });
 
     /**
@@ -434,7 +316,7 @@ describe('the payment tile shows the number as an uneditable label, not a field'
 
         expect(renderer.isCompanyCaptured()).toBe(false);
         expect(nameFieldVisible(renderer)).toBe(true);
-        expect(labelVisible(renderer)).toBe(false);
+        expect(approvedNoticeVisible(renderer)).toBe(false);
     });
 
     test('the name field is read-only only once a company has been captured', () => {
@@ -561,7 +443,7 @@ describe('the payment tile shows the number as an uneditable label, not a field'
 });
 
 describe('what each capture mode puts in front of the buyer', () => {
-    test('search mode: the tile shows one line, "Name (number)", and hides the control', () => {
+    test('search mode: an approved intent embeds "Name (number)" in the notice sentence, and hides the control', () => {
         const { renderer } = loadRendererOnly();
 
         renderer.applyCompanyData(
@@ -574,12 +456,12 @@ describe('what each capture mode puts in front of the buyer', () => {
         // hidden, so it is still bound and still the thing sole-trader mode
         // and the picker write to.
         expect(renderedValue('company_name', renderer)).toBe('First Example Ltd');
-        expect(renderedLabelText(renderer)).toBe('First Example Ltd (12345678)');
-        expect(labelVisible(renderer)).toBe(true);
+        expect(approvedNoticeText(renderer)).toBe('Approved for First Example Ltd (12345678).');
+        expect(approvedNoticeVisible(renderer)).toBe(true);
         expect(nameFieldVisible(renderer)).toBe(false);
     });
 
-    test('sole-trader mode: the minted name and synthetic number show as one line', () => {
+    test('sole-trader mode: the minted name and synthetic number are embedded the same way', () => {
         const { renderer } = loadRendererOnly();
 
         renderer.prefetched = {
@@ -594,8 +476,10 @@ describe('what each capture mode puts in front of the buyer', () => {
         approveIntent(renderer);
 
         expect(renderedValue('company_name', renderer)).toBe('Sole Trader Example');
-        expect(renderedLabelText(renderer)).toBe('Sole Trader Example (ST-SYNTH-004)');
-        expect(labelVisible(renderer)).toBe(true);
+        expect(approvedNoticeText(renderer)).toBe(
+            'Approved for Sole Trader Example (ST-SYNTH-004).'
+        );
+        expect(approvedNoticeVisible(renderer)).toBe(true);
         expect(nameFieldVisible(renderer)).toBe(false);
         // The field is hidden here, but its readonly binding must STILL read
         // locked. Hiding is a display decision and sole trader can be left
@@ -605,7 +489,7 @@ describe('what each capture mode puts in front of the buyer', () => {
         expect(isReadOnly('company_name', renderer)).toBe(true);
     });
 
-    test('manual-entry mode: the label disappears and the capture control comes back', () => {
+    test('manual-entry mode: the notice disappears and the capture control comes back', () => {
         // Driven through the real manual-entry path — clearCompany() is what the
         // sentinel row's handler calls — not by poking the observable, so this
         // fails if that path stops clearing the abandoned company's number.
@@ -616,12 +500,12 @@ describe('what each capture mode puts in front of the buyer', () => {
             { authoritative: true }
         );
         approveIntent(renderer);
-        expect(labelVisible(renderer)).toBe(true);
+        expect(approvedNoticeVisible(renderer)).toBe(true);
 
         renderer.clearCompany();
 
         expect(renderer.companyId()).toBe('');
-        expect(labelVisible(renderer)).toBe(false);
+        expect(approvedNoticeVisible(renderer)).toBe(false);
         // The control is back, and typeable — which is the whole point of the
         // mode, and the reason the swap is a visibility toggle rather than a
         // removal.
@@ -637,7 +521,7 @@ describe('what each capture mode puts in front of the buyer', () => {
      * the tile's control was always visible that was untidy but recoverable —
      * the buyer could just search, and the pick overwrote the stale identity.
      * Once the control HIDES on capture it is not recoverable: a buyer
-     * leaving sole-trader mode would face a sole-trader label, no search box,
+     * leaving sole-trader mode would face a sole-trader notice, no search box,
      * and no way back.
      */
     test('leaving sole-trader mode brings the capture control back', () => {
@@ -653,7 +537,7 @@ describe('what each capture mode puts in front of the buyer', () => {
         };
         renderer.soleTraderMode();
         approveIntent(renderer);
-        expect(labelVisible(renderer)).toBe(true);
+        expect(approvedNoticeVisible(renderer)).toBe(true);
         expect(nameFieldVisible(renderer)).toBe(false);
 
         // fillCustomerData() reaches into the quote's address objects
@@ -673,7 +557,7 @@ describe('what each capture mode puts in front of the buyer', () => {
         expect(renderer.isCompanyCaptured()).toBe(false);
         // ...so the buyer gets the search box back.
         expect(nameFieldVisible(renderer)).toBe(true);
-        expect(labelVisible(renderer)).toBe(false);
+        expect(approvedNoticeVisible(renderer)).toBe(false);
     });
 
     /**
@@ -708,12 +592,13 @@ describe('what each capture mode puts in front of the buyer', () => {
         expect(renderer.companyId()).toBe('12345678');
         expect(renderer.isCompanyCaptured()).toBe(true);
         expect(nameFieldVisible(renderer)).toBe(false);
-        // ...and once the intent for it is approved, the label appears. Ordered
-        // this way round on purpose: the notice's companyId subscription clears
-        // it whenever the company changes, so an approval taken BEFORE the
-        // init-path call would prove nothing about what survives the call.
+        // ...and once the intent for it is approved, the notice appears.
+        // Ordered this way round on purpose: the notice's companyId
+        // subscription clears it whenever the company changes, so an
+        // approval taken BEFORE the init-path call would prove nothing about
+        // what survives the call.
         approveIntent(renderer);
-        expect(labelVisible(renderer)).toBe(true);
+        expect(approvedNoticeVisible(renderer)).toBe(true);
     });
 
     /**
@@ -742,7 +627,7 @@ describe('what each capture mode puts in front of the buyer', () => {
         });
     });
 
-    test('an identifier-less pick keeps the control up, with no label', () => {
+    test('an identifier-less pick keeps the control up, with no notice', () => {
         // The other route to a blank number: the registry holds no identifier
         // for the picked company. Distinct from manual entry — a company IS
         // selected here.
@@ -758,54 +643,34 @@ describe('what each capture mode puts in front of the buyer', () => {
         );
 
         expect(renderedValue('company_name', renderer)).toBe('Second Example Ltd');
-        expect(labelVisible(renderer)).toBe(false);
+        expect(approvedNoticeVisible(renderer)).toBe(false);
+        expect(declinedNoticeVisible(renderer)).toBe(false);
         expect(nameFieldVisible(renderer)).toBe(true);
     });
 });
 
 /**
- * The 2026-08-03 ruling on TWO-25326, which supersedes §7's own gate: the label
- * is shown exactly when the inline order-intent message is shown, and hidden
- * exactly when it is hidden.
+ * TWO-25326 §7.3 (2026-08-03 ruling): each notice is gated on its OWN
+ * observable via a `ko if`, and each observable is set exactly once the
+ * corresponding order-intent outcome is known. There is no longer a shared
+ * "the label follows the message" predicate to pin, because there is no
+ * label — company display and intent outcome are now the SAME element.
  *
- * "Exactly when" is asserted two ways, because either alone is weak:
- *
- *  - as SOURCE: the two bindings must be the identical expression. Two
- *    different expressions that agree in the states a test happens to visit is
- *    the precise defect the ruling forbids, and no set of behavioural cases can
- *    rule it out.
- *  - as BEHAVIOUR: across every state that separates the new gate from the old
- *    one — captured-but-no-intent, declined, errored, brand-suppressed notice,
- *    order intent disabled, Dutch non-BV buyer — the label follows the message
- *    rather than capture.
- *
- * Be honest about the division of labour there. Because both bindings resolve
- * to the SAME predicate, the paired `intentMessageVisible()` /
- * `labelVisible()` assertions cannot disagree by construction — they are a
- * readability aid, not independent corroboration. The string-equality pin is
- * what actually forbids two expressions that merely agree; the behavioural
- * cases are what forbid the predicate being the wrong one.
- *
- * The behavioural cases are the mutation-sensitive half: each of them had the
- * label VISIBLE under the superseded `isCompanyCaptured()` gate, so reverting
- * the template one-liner fails them.
+ * The behavioural cases are the mutation-sensitive part: each of them
+ * exercises a state that a naive "captured ⇒ show something" gate would get
+ * wrong (captured-but-no-intent, declined, errored, brand-suppressed,
+ * order-intent-off, Dutch non-BV, edited company).
  */
-describe('the company label is shown exactly when the intent message is', () => {
-    test('both bindings are the same expression, not two that merely agree', () => {
-        expect(labelGateExpression()).toBe(intentMessageGateExpression());
-        // And that shared expression is the intent message's own gate, not a
-        // capture check that both were rewired to.
-        expect(labelGateExpression()).toBe('isOrderIntentMessageVisible()');
-        // The superseded gate is gone from the label specifically. Still
-        // present elsewhere in the template — it governs the capture controls —
-        // so this asserts on the label's tag, not on the whole file.
-        expect(companyLabelTag()).not.toMatch(/isCompanyCaptured/);
+describe('the notices are gated on their own observables, not on capture', () => {
+    test('each notice template block guards on its own observable expression', () => {
+        expect(noticeGateExpression('approved')).toBe('isOrderIntentApprovedNoticeVisible()');
+        expect(noticeGateExpression('declined')).toBe('isOrderIntentDeclinedNoticeVisible()');
     });
 
-    test('a captured company with no intent placed yet shows neither', () => {
-        // THE case the ruling changes, and the one the old gate got wrong: the
-        // company is fully captured, so `isCompanyCaptured()` is true and the
-        // old label showed. No intent has been placed, so there is no message.
+    test('a captured company with no intent placed yet shows neither notice', () => {
+        // THE case the ruling changes, and the one a capture-only gate would
+        // get wrong: the company is fully captured, so `isCompanyCaptured()`
+        // is true. No intent has been placed, so there is no message.
         const { renderer } = loadRendererOnly();
 
         renderer.applyCompanyData(
@@ -814,11 +679,11 @@ describe('the company label is shown exactly when the intent message is', () => 
         );
 
         expect(renderer.isCompanyCaptured()).toBe(true);
-        expect(intentMessageVisible(renderer)).toBe(false);
-        expect(labelVisible(renderer)).toBe(false);
+        expect(approvedNoticeVisible(renderer)).toBe(false);
+        expect(declinedNoticeVisible(renderer)).toBe(false);
     });
 
-    test('an approved intent shows both', () => {
+    test('an approved intent shows the approved notice only, with the company embedded', () => {
         const { renderer } = loadRendererOnly();
 
         renderer.applyCompanyData(
@@ -827,35 +692,41 @@ describe('the company label is shown exactly when the intent message is', () => 
         );
         approveIntent(renderer);
 
-        expect(intentMessageVisible(renderer)).toBe(true);
-        expect(labelVisible(renderer)).toBe(true);
-        // The label still renders the company, not the notice copy — tying the
-        // VISIBILITY together does not merge the two texts.
-        expect(renderedLabelText(renderer)).toBe('First Example Ltd (12345678)');
+        expect(approvedNoticeVisible(renderer)).toBe(true);
+        expect(declinedNoticeVisible(renderer)).toBe(false);
+        expect(approvedNoticeText(renderer)).toBe('Approved for First Example Ltd (12345678).');
     });
 
-    test('a declined intent shows neither, though the company is still captured', () => {
+    test('a declined intent shows the declined notice only, with the company embedded — not a toast', () => {
         const { renderer } = loadRendererOnly();
+        const errors = [];
+        renderer.showErrorMessage = function (message) {
+            errors.push(message);
+        };
 
         renderer.applyCompanyData(
             { companyName: 'First Example Ltd', companyId: '12345678' },
             { authoritative: true }
         );
         approveIntent(renderer);
-        expect(labelVisible(renderer)).toBe(true);
+        expect(approvedNoticeVisible(renderer)).toBe(true);
 
         renderer.processOrderIntentSuccessResponse({ approved: false });
 
         expect(renderer.isCompanyCaptured()).toBe(true);
-        expect(intentMessageVisible(renderer)).toBe(false);
-        expect(labelVisible(renderer)).toBe(false);
+        expect(approvedNoticeVisible(renderer)).toBe(false);
+        expect(declinedNoticeVisible(renderer)).toBe(true);
+        expect(declinedNoticeText(renderer)).toBe('Declined for First Example Ltd (12345678).');
+        // TWO-25326 §7.3 (2026-08-03 ruling): a clean decline is a persistent
+        // tile notice now, not a toast that a later checkout update wipes.
+        expect(errors).toEqual([]);
     });
 
-    test('an errored intent shows neither', () => {
+    test('an errored intent shows neither notice', () => {
         // Distinct call site from the declined branch — a separate handler —
-        // and it clears the notice for its own reason (an error says nothing
-        // about approval). Verified by mutation that the declined case above
-        // does not cover it.
+        // and it clears both notices for its own reason (an error says
+        // nothing about approval OR decline). Verified by mutation that the
+        // declined case above does not cover it.
         const { renderer } = loadRendererOnly();
 
         renderer.applyCompanyData(
@@ -863,20 +734,19 @@ describe('the company label is shown exactly when the intent message is', () => 
             { authoritative: true }
         );
         approveIntent(renderer);
-        expect(labelVisible(renderer)).toBe(true);
+        expect(approvedNoticeVisible(renderer)).toBe(true);
 
         renderer.processOrderIntentErrorResponse({});
 
         expect(renderer.isCompanyCaptured()).toBe(true);
-        expect(labelVisible(renderer)).toBe(false);
-        expect(intentMessageVisible(renderer)).toBe(false);
+        expect(approvedNoticeVisible(renderer)).toBe(false);
+        expect(declinedNoticeVisible(renderer)).toBe(false);
     });
 
-    test('editing the company after approval hides both again', () => {
+    test('editing the company after approval clears the notice', () => {
         // The notice is cleared by its own companyName / companyId
-        // subscriptions, because the approval it reports was for the previous
-        // company. The label must follow it down even though the replacement
-        // company is itself fully captured.
+        // subscriptions, because the approval it reports was for the
+        // previous company.
         const { renderer } = loadRendererOnly();
 
         renderer.applyCompanyData(
@@ -884,7 +754,7 @@ describe('the company label is shown exactly when the intent message is', () => 
             { authoritative: true }
         );
         approveIntent(renderer);
-        expect(labelVisible(renderer)).toBe(true);
+        expect(approvedNoticeVisible(renderer)).toBe(true);
 
         renderer.applyCompanyData(
             { companyName: 'Second Example Ltd', companyId: '87654321' },
@@ -892,11 +762,11 @@ describe('the company label is shown exactly when the intent message is', () => 
         );
 
         expect(renderer.isCompanyCaptured()).toBe(true);
-        expect(intentMessageVisible(renderer)).toBe(false);
-        expect(labelVisible(renderer)).toBe(false);
+        expect(approvedNoticeVisible(renderer)).toBe(false);
+        expect(declinedNoticeVisible(renderer)).toBe(false);
     });
 
-    test('editing only the NAME after approval hides both', () => {
+    test('editing only the NAME after approval clears the notice', () => {
         // The companyName subscription specifically. The test above changes the
         // company through applyCompanyData(), which writes BOTH observables, so
         // the companyId subscription alone satisfies it — verified by mutation:
@@ -910,22 +780,20 @@ describe('the company label is shown exactly when the intent message is', () => 
             { authoritative: true }
         );
         approveIntent(renderer);
-        expect(labelVisible(renderer)).toBe(true);
+        expect(approvedNoticeVisible(renderer)).toBe(true);
 
         // Only the name, as a buyer typing into the input would.
         renderer.companyName('First Example Limited');
 
         expect(renderer.companyId()).toBe('12345678');
-        expect(intentMessageVisible(renderer)).toBe(false);
-        expect(labelVisible(renderer)).toBe(false);
+        expect(approvedNoticeVisible(renderer)).toBe(false);
     });
 
-    test('order intent turned off means no notice and so no label, ever', () => {
+    test('order intent turned off means neither notice, ever', () => {
         // `enable_order_intent` off: fillCompanyData() never calls
-        // placeOrderIntent(), so nothing sets the notice and the §7 label is
-        // dead for that merchant's whole storefront. A consequence of "exactly
-        // when", not a defect — pinned so it reads as a decision rather than an
-        // oversight, and so widening the predicate cannot happen silently.
+        // placeOrderIntent(), so nothing sets either notice. Pinned so it
+        // reads as a decision rather than an oversight, and so widening
+        // either predicate cannot happen silently.
         const { renderer } = loadRendererOnly();
         const placeOrderIntent = jest.fn();
         renderer.placeOrderIntent = placeOrderIntent;
@@ -939,11 +807,11 @@ describe('the company label is shown exactly when the intent message is', () => 
         // Guard the premise: no intent was even attempted.
         expect(placeOrderIntent).not.toHaveBeenCalled();
         expect(renderer.isCompanyCaptured()).toBe(true);
-        expect(intentMessageVisible(renderer)).toBe(false);
-        expect(labelVisible(renderer)).toBe(false);
+        expect(approvedNoticeVisible(renderer)).toBe(false);
+        expect(declinedNoticeVisible(renderer)).toBe(false);
     });
 
-    test('a falsy intent response never sets the notice', () => {
+    test('a falsy intent response never sets either notice', () => {
         // The falsy branch of processOrderIntentSuccessResponse(). That branch is
         // how the Dutch non-BV route surfaces — placeOrderIntent() early-returns
         // a Deferred resolved with `null` — but be honest about the scope: this
@@ -959,13 +827,13 @@ describe('the company label is shown exactly when the intent message is', () => 
             { authoritative: true }
         );
         approveIntent(renderer);
-        expect(labelVisible(renderer)).toBe(true);
+        expect(approvedNoticeVisible(renderer)).toBe(true);
 
         renderer.processOrderIntentSuccessResponse(null);
 
         // Nothing was set OR cleared by the null response — but the company
         // write that precedes a real intent already cleared it, which is what
-        // makes the label absent on that path.
+        // makes the notice absent on that path.
         renderer.applyCompanyData(
             { companyName: 'Dutch Example VOF', companyId: '87654321' },
             { authoritative: true }
@@ -973,44 +841,70 @@ describe('the company label is shown exactly when the intent message is', () => 
         renderer.processOrderIntentSuccessResponse(null);
 
         expect(renderer.isCompanyCaptured()).toBe(true);
-        expect(intentMessageVisible(renderer)).toBe(false);
-        expect(labelVisible(renderer)).toBe(false);
+        expect(approvedNoticeVisible(renderer)).toBe(false);
+        expect(declinedNoticeVisible(renderer)).toBe(false);
     });
 
-    test('a brand that suppresses the notice shows no label either', () => {
+    test('a brand that suppresses the notice shows neither variant', () => {
         // <intent_approved_notice_enabled>false</intent_approved_notice_enabled>
-        // leaves orderIntentApprovedNoticeCopy null, so the notice text is
-        // always '' and the message never renders. Under the ruling the label
-        // does not render for that brand either. Flagged deliberately rather
-        // than worked around: it follows from "exactly when". A label wanted
-        // without the notice would be a different rule, and needs the ticket.
+        // leaves both notice-copy objects null, so neither notice text is
+        // ever non-empty — the SAME switch suppresses both (§7.4: they are
+        // one on/off unit).
         const { renderer } = loadRendererOnly();
 
         renderer.initOrderIntentApprovedNotice({});
         expect(renderer.orderIntentApprovedNoticeCopy).toBeNull();
+        expect(renderer.orderIntentDeclinedNoticeCopy).toBeNull();
 
         renderer.applyCompanyData(
             { companyName: 'First Example Ltd', companyId: '12345678' },
             { authoritative: true }
         );
         approveIntent(renderer);
+        expect(approvedNoticeVisible(renderer)).toBe(false);
 
-        expect(renderer.isCompanyCaptured()).toBe(true);
-        expect(intentMessageVisible(renderer)).toBe(false);
-        expect(labelVisible(renderer)).toBe(false);
+        declineIntent(renderer);
+        expect(declinedNoticeVisible(renderer)).toBe(false);
     });
 
-    test('the shared gate survives a renderer that was never initialised', () => {
-        // isOrderIntentMessageVisible() is read from a `visible:` AND an `if:`
-        // binding, and `orderIntentApprovedNotice` is created in
-        // initOrderIntentApprovedNotice() rather than in `defaults` — so on an
-        // uninitialised renderer it is absent. An unguarded read would throw
-        // inside a binding and take the whole payment tile down.
+    test('an approved-notice override does not leak into the declined notice, or vice versa', () => {
+        // TWO-25326 §7.4: the two overrides are independent knobs.
+        const { renderer } = loadRendererOnly();
+        renderer.initOrderIntentApprovedNotice({
+            orderIntentApprovedNotice: {
+                withCompany: 'Brand-specific approval for {company}.',
+                withoutCompany: 'Brand-specific approval.',
+                companyNameToken: '{company}',
+                companyNumberToken: '{number}'
+            },
+            orderIntentDeclinedNotice: DECLINED_NOTICE_COPY
+        });
+
+        renderer.applyCompanyData(
+            { companyName: 'First Example Ltd', companyId: '12345678' },
+            { authoritative: true }
+        );
+        declineIntent(renderer);
+
+        expect(declinedNoticeText(renderer)).not.toContain('Brand-specific approval');
+        expect(declinedNoticeText(renderer)).toBe('Declined for First Example Ltd (12345678).');
+    });
+
+    test('both notice observables survive a renderer that was never initialised', () => {
+        // Each notice is read from a `ko if` binding, and both observables are
+        // created in initOrderIntentApprovedNotice() rather than in
+        // `defaults` — so on an uninitialised renderer they are absent. An
+        // unguarded template read would throw and take the whole payment
+        // tile down; the template guards with `orderIntentApprovedNotice()`/
+        // `orderIntentDeclinedNotice()` directly, which is undefined-safe
+        // only because `ko if` treats a thrown binding as a hard failure —
+        // this pins that the observables exist post-init, not a defensive
+        // wrapper in the getters themselves.
         const dom = makeRecordingDom();
         const bare = loadAmdModule(RENDERER, { jquery: dom.$ });
 
         expect(bare.orderIntentApprovedNotice).toBeUndefined();
-        expect(bare.isOrderIntentMessageVisible()).toBe(false);
+        expect(bare.orderIntentDeclinedNotice).toBeUndefined();
     });
 });
 
@@ -1097,15 +991,23 @@ function makeRecordingDom() {
 }
 
 /**
- * The brand copy ConfigProvider ships for the intent-approved notice. Real
- * shape (both variants plus the token), because resolveOrderIntentApprovedNotice()
- * substitutes into it and the label tests depend on the notice actually being
- * non-empty.
+ * The brand copy ConfigProvider ships for the intent-approved / -declined
+ * notices. Real shape (both variants plus both tokens), because
+ * resolveCompanyNotice() substitutes into it and the tests below depend on
+ * each notice actually being non-empty when it should be.
  */
 const NOTICE_COPY = {
-    withCompany: 'Approved for {company}.',
+    withCompany: 'Approved for {company} ({number}).',
     withoutCompany: 'Approved.',
-    companyNameToken: '{company}'
+    companyNameToken: '{company}',
+    companyNumberToken: '{number}'
+};
+
+const DECLINED_NOTICE_COPY = {
+    withCompany: 'Declined for {company} ({number}).',
+    withoutCompany: 'Declined.',
+    companyNameToken: '{company}',
+    companyNumberToken: '{number}'
 };
 
 function loadRendererOnly(extraMocks) {
@@ -1119,14 +1021,17 @@ function loadRendererOnly(extraMocks) {
     renderer.getCode = function () {
         return 'two_payment';
     };
-    // The intent-approved notice observable is created in
+    // The intent-approved/-declined notice observables are created in
     // initOrderIntentApprovedNotice(), which initialize() calls — and this
     // harness deliberately does not boot the component. Called explicitly
-    // rather than faked, so the real observable AND its real companyName /
-    // companyId subscriptions (which clear the notice when the buyer's company
-    // changes) are what the label tests run against. Without this the notice
-    // is absent and the label could never show.
-    renderer.initOrderIntentApprovedNotice({ orderIntentApprovedNotice: NOTICE_COPY });
+    // rather than faked, so the real observables AND their real companyName /
+    // companyId subscriptions (which clear both notices when the buyer's
+    // company changes) are what the tests below run against. Without this
+    // the notices are absent and neither could ever show.
+    renderer.initOrderIntentApprovedNotice({
+        orderIntentApprovedNotice: NOTICE_COPY,
+        orderIntentDeclinedNotice: DECLINED_NOTICE_COPY
+    });
     // showErrorMessage() routes through the payment block's messageContainer,
     // which the renderer-only harness does not model. Needed by the
     // intent-declined path below.
@@ -1146,6 +1051,14 @@ function loadRendererOnly(extraMocks) {
  */
 function approveIntent(renderer) {
     renderer.processOrderIntentSuccessResponse({ approved: true });
+}
+
+/**
+ * Same, for the "not approved" business outcome (TWO-25326 §7.3, 2026-08-03
+ * ruling) — a clean response with `approved: false`.
+ */
+function declineIntent(renderer) {
+    renderer.processOrderIntentSuccessResponse({ approved: false });
 }
 
 describe('an accepted organisation number still reaches the order', () => {

--- a/Test/Unit/Model/Ui/ConfigProviderIntentDeclinedNoticeTest.php
+++ b/Test/Unit/Model/Ui/ConfigProviderIntentDeclinedNoticeTest.php
@@ -12,21 +12,14 @@ use Two\Gateway\Api\BrandRegistryInterface;
 use Two\Gateway\Model\Ui\ConfigProvider;
 
 /**
- * ConfigProvider's intent-approved-notice payload resolution (TWO-25218).
- *
- * The switch — not the copy override — decides whether a payload is
- * shipped to the storefront renderer at all. `null` is the renderer's
- * "emit no element" signal, so a regression that keys suppression off the
- * copy override again would re-introduce the superseded three-state
- * contract silently.
- *
- * ConfigProvider's constructor pulls in the full checkout collaborator
- * graph and getConfig() reaches most of it; the notice resolution touches
- * only $brandRegistry. Instantiating without the constructor and injecting
- * that one collaborator keeps this a unit test rather than a checkout
- * harness.
+ * ConfigProvider's intent-DECLINED-notice payload resolution (TWO-25326
+ * §7.3/§7.4, 2026-08-03 ruling). Mirrors
+ * ConfigProviderIntentApprovedNoticeTest — same suppression switch
+ * (isIntentApprovedNoticeEnabled), a SEPARATE copy override
+ * (getIntentDeclinedNotice), and a company-number substitution the
+ * approved notice also gained in the same ruling.
  */
-class ConfigProviderIntentApprovedNoticeTest extends TestCase
+class ConfigProviderIntentDeclinedNoticeTest extends TestCase
 {
     public function testReturnsNullWhenTheBrandDisabledTheNotice(): void
     {
@@ -37,9 +30,7 @@ class ConfigProviderIntentApprovedNoticeTest extends TestCase
 
     public function testReturnsNullWhenDisabledEvenWithACopyOverride(): void
     {
-        // The switch wins. A brand that declares copy and then turns the
-        // notice off must get no payload.
-        $payload = $this->resolveFor(false, 'Custom %1 line for %2.');
+        $payload = $this->resolveFor(false, 'Custom %1 decline for %2 (%3).');
 
         $this->assertNull($payload);
     }
@@ -50,15 +41,13 @@ class ConfigProviderIntentApprovedNoticeTest extends TestCase
 
         $this->assertIsArray($payload);
         $this->assertSame(
-            'This order by '
+            'Acme is not available for this order by '
             . ConfigProvider::COMPANY_NAME_TOKEN
-            . ' ('
-            . ConfigProvider::COMPANY_NUMBER_TOKEN
-            . ') is likely to be accepted by Acme',
+            . ' (' . ConfigProvider::COMPANY_NUMBER_TOKEN . ')',
             $payload['withCompany']
         );
         $this->assertSame(
-            'This order is likely to be accepted by Acme',
+            'Acme is not available for this order',
             $payload['withoutCompany']
         );
         $this->assertSame(ConfigProvider::COMPANY_NAME_TOKEN, $payload['companyNameToken']);
@@ -67,19 +56,39 @@ class ConfigProviderIntentApprovedNoticeTest extends TestCase
 
     public function testOverrideReplacesTheCompanyKnownVariantOnly(): void
     {
-        $payload = $this->resolveFor(true, 'Custom %1 line for %2 (%3).');
+        $payload = $this->resolveFor(true, 'Custom %1 decline for %2 (%3).');
 
         $this->assertIsArray($payload);
         $this->assertSame(
-            'Custom Acme line for '
+            'Custom Acme decline for '
             . ConfigProvider::COMPANY_NAME_TOKEN
             . ' (' . ConfigProvider::COMPANY_NUMBER_TOKEN . ').',
             $payload['withCompany']
         );
         $this->assertSame(
-            'This order is likely to be accepted by Acme',
+            'Acme is not available for this order',
             $payload['withoutCompany']
         );
+    }
+
+    public function testApprovedOverrideDoesNotLeakIntoTheDeclinedCopy(): void
+    {
+        // §7.4: a brand's approved wording must never be forced onto the
+        // declined variant, or vice versa — the two overrides are
+        // independent knobs.
+        $registry = $this->createMock(BrandRegistryInterface::class);
+        $registry->method('isIntentApprovedNoticeEnabled')->willReturn(true);
+        $registry->method('getIntentApprovedNotice')->willReturn('Approved copy for %2.');
+        $registry->method('getIntentDeclinedNotice')->willReturn(null);
+        $registry->method('getProductName')->willReturn('Acme');
+
+        $reflection = new \ReflectionClass(ConfigProvider::class);
+        $provider = $reflection->newInstanceWithoutConstructor();
+        $reflection->getProperty('brandRegistry')->setValue($provider, $registry);
+
+        $declined = $reflection->getMethod('getOrderIntentDeclinedNotice')->invoke($provider);
+
+        $this->assertStringNotContainsString('Approved copy', $declined['withCompany']);
     }
 
     /**
@@ -89,16 +98,14 @@ class ConfigProviderIntentApprovedNoticeTest extends TestCase
     {
         $registry = $this->createMock(BrandRegistryInterface::class);
         $registry->method('isIntentApprovedNoticeEnabled')->willReturn($enabled);
-        $registry->method('getIntentApprovedNotice')->willReturn($override);
+        $registry->method('getIntentDeclinedNotice')->willReturn($override);
         $registry->method('getProductName')->willReturn('Acme');
 
         $reflection = new \ReflectionClass(ConfigProvider::class);
         $provider = $reflection->newInstanceWithoutConstructor();
 
-        // No setAccessible() call: it has been a no-op since PHP 8.1
-        // (the plugin's floor) and is deprecated from 8.5.
         $reflection->getProperty('brandRegistry')->setValue($provider, $registry);
 
-        return $reflection->getMethod('getOrderIntentApprovedNotice')->invoke($provider);
+        return $reflection->getMethod('getOrderIntentDeclinedNotice')->invoke($provider);
     }
 }

--- a/docs/brand-overlay-guide.md
+++ b/docs/brand-overlay-guide.md
@@ -131,28 +131,33 @@ across modules). Elements may appear in any order (`xs:all`).
 | `extra_http_headers`             | no       | `<header name="…">` list  | Extra headers on API calls.                                                                                                                                     |
 | `suppressed_fields`              | no       | `<field path="…">` list   | Hides admin controls for this brand (below).                                                                                                                    |
 | `inline_term_fees`               | no       | boolean                   | Show per-term merchant fee beside Payment Terms checkboxes in admin (default true).                                                                             |
-| `intent_approved_notice_enabled` | no       | `true` \| `false`         | On/off switch for the buyer-facing "order intent approved" notice. Default `true`. **See below.**                                                               |
-| `intent_approved_notice`         | no       | string                    | Copy override for that notice — wording only, **not** an off switch. **See below.**                                                                             |
+| `intent_approved_notice_enabled` | no       | `true` \| `false`         | On/off switch for BOTH the "order intent approved" and "order intent declined" notices. Default `true`. **See below.**                                          |
+| `intent_approved_notice`         | no       | string                    | Copy override for the approved notice — wording only, **not** an off switch. **See below.**                                                                     |
+| `intent_declined_notice`         | no       | string                    | Copy override for the declined notice — a SEPARATE override from the approved one (added 2026-08-03, TWO-25326 §7.3/§7.4). **See below.**                       |
 
-### The intent-approved notice — two keys, one each for on/off and wording
+### The intent notices — one on/off switch, two independent wording overrides
 
-The notice is a buyer-facing "order intent approved" reassurance line
-rendered inline in the checkout payment tile. It is controlled by **two
-independent keys**: whether it shows, and what it says. **Do not
-overload one key with both meanings** — an off switch expressed as the
-absence of content is indistinguishable from an unfinished string, and
-any tidy-up that deletes the "empty, unused" declaration silently turns
-the notice back on.
+The notices are buyer-facing "order intent approved" / "order intent not
+approved" lines rendered inline in the checkout payment tile — as of the
+2026-08-03 ruling (TWO-25326 §7.3), this is the ONLY place the buyer's
+captured company name/number are displayed in the tile at all; the
+earlier standalone `.two-company-label` element is gone, not relocated.
+Both notices are controlled by **one shared on/off switch** and **two
+independent wording overrides**. **Do not overload the switch with
+wording meaning** — an off switch expressed as the absence of content is
+indistinguishable from an unfinished string, and any tidy-up that
+deletes the "empty, unused" declaration silently turns the notice back
+on.
 
-#### `intent_approved_notice_enabled` — the on/off switch
+#### `intent_approved_notice_enabled` — the on/off switch for BOTH notices
 
 Explicit boolean only:
 
 | brand.xml                                                                | Behaviour                                                                                  |
 | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
-| `<intent_approved_notice_enabled>true</intent_approved_notice_enabled>`  | Notice **ON**.                                                                             |
-| `<intent_approved_notice_enabled>false</intent_approved_notice_enabled>` | Notice **suppressed entirely** — no element is emitted into the DOM, not an empty wrapper. Since TWO-25326 this also suppresses the payment tile's captured-company label, whose visibility is tied to the notice's. |
-| element absent                                                           | Documented explicit default **`true`** (notice ON).                                        |
+| `<intent_approved_notice_enabled>true</intent_approved_notice_enabled>`  | Both notices **ON** (whichever one an order-intent outcome selects).                       |
+| `<intent_approved_notice_enabled>false</intent_approved_notice_enabled>` | Both notices **suppressed entirely** — no element is emitted into the DOM, not an empty wrapper. There is no separate `intent_declined_notice_enabled` element; the ruling treats "the intent message" as one on/off unit, approved or declined. |
+| element absent                                                           | Documented explicit default **`true`** (notices ON).                                        |
 | anything else (`1`, `0`, `yes`, empty, whitespace)                       | **Error.** Never a silent third behaviour.                                                 |
 
 Absent-means-`true` is deliberate: it keeps a third-party overlay that
@@ -171,18 +176,25 @@ runtime (see the validation warning below):
 Note `xs:boolean` is deliberately **not** used: it would also accept `1`
 and `0`, and this switch is meant to read as a decision.
 
-#### `intent_approved_notice` — the copy override
+#### `intent_approved_notice` / `intent_declined_notice` — the copy overrides
 
-| brand.xml                                            | Behaviour                                                                                                              |
-| ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| element absent                                       | Platform default translated copy.                                                                                      |
-| empty or whitespace-only                             | **Inert** — same as absent. It does **not** mean "off".                                                                |
-| `<intent_approved_notice>…</intent_approved_notice>` | The content is used verbatim as the company-known copy template. `%1` = brand product name, `%2` = buyer company name. |
+Two SEPARATE elements, one per notice — a brand with its own approved
+wording is not forced to also take the vanilla declined wording, or
+vice versa (§7.4):
 
-`Descriptor::getIntentApprovedNotice()` returns `null` for the first two
-rows and the template for the third; it never returns `''`. The switch
-above is what `Model\Ui\ConfigProvider` consults to decide whether to ship
-a payload to the renderer at all.
+| brand.xml                                            | Behaviour                                                                                                                                              |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| element absent                                       | Platform default translated copy for that notice.                                                                                                        |
+| empty or whitespace-only                             | **Inert** — same as absent. It does **not** mean "off".                                                                                                  |
+| `<intent_approved_notice>…</intent_approved_notice>` | Used verbatim as the approved-notice template. `%1` = brand product name, `%2` = buyer company name, `%3` = buyer organisation number (added 2026-08-03). |
+| `<intent_declined_notice>…</intent_declined_notice>` | Used verbatim as the declined-notice template. Same `%1`/`%2`/`%3` contract.                                                                              |
+
+`Descriptor::getIntentApprovedNotice()` / `getIntentDeclinedNotice()`
+each return `null` for the first two rows and their own template for the
+third; neither ever returns `''`. The switch above is what
+`Model\Ui\ConfigProvider` consults to decide whether to ship EITHER
+payload to the renderer at all — the resolution otherwise runs
+independently per notice.
 
 #### Deploy order
 
@@ -204,11 +216,15 @@ The company-unknown copy variant always stays on the platform default.
 In practice it is unreachable: an order intent is only ever placed once
 the buyer's company name **and** company number are known.
 
-Both Magento storefront renderers (Luma and Hyvä) emit the notice as a
-persistent inline element with class `two-order-intent-message approved`
-inside the payment-method tile, as does PrestaShop. WooCommerce uses
-`twoinc-intent-approved` instead, so grep for both when sweeping the four
-checkout surfaces.
+This parent plugin's storefront renderer (Luma/Amasty/Fire, one shared
+code path) emits each notice as a persistent inline element with class
+`two-order-intent-message approved` / `two-order-intent-message declined`
+inside the payment-method tile, as does PrestaShop (approved variant
+only, as of writing). WooCommerce uses `twoinc-intent-approved` instead,
+so grep for the platform-specific class names when sweeping the four
+checkout surfaces. The magento-hyva-extension repo is out of scope for
+the 2026-08-03 declined-notice addition described here — check that repo
+directly before assuming it has picked up the same shape.
 
 The two keys carry the same names and the same semantics on WooCommerce
 and PrestaShop, where they are real PHP booleans rather than an XSD

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -360,7 +360,7 @@
                 <field id="enable_company_search" translate="label comment" type="select" sortOrder="10"
                        showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Enable Company Search</label>
-                    <comment>Show company search in the shipping address field. Company search on the payment method step is always available and is not affected by this setting.</comment>
+                    <comment>Where the ONE company-search control lives, not whether it exists: Yes puts it in the shipping address field; No puts it in the payment method tile instead (TWO-25326 §7.1). A checkout with no address form to host it — a saved address, or a virtual cart — keeps it in the tile either way.</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <depends>
                         <field id="active">1</field>

--- a/etc/brand.xsd
+++ b/etc/brand.xsd
@@ -95,6 +95,23 @@
                 mitigation. Do not resurrect empty-means-off.
             -->
             <xs:element name="intent_approved_notice" type="xs:string" minOccurs="0"/>
+            <!--
+                COPY OVERRIDE ONLY for the "order intent NOT approved" tile
+                notice (TWO-25326 §7.3/§7.4, added 2026-08-03). Same
+                inert-when-absent/empty contract as
+                <intent_approved_notice> above, and gated by the SAME
+                <intent_approved_notice_enabled> switch — there is no
+                separate on/off element for the declined variant.
+
+                  absent / empty / whitespace-only
+                          ⇒ INERT: platform default translated copy
+                  non-empty
+                          ⇒ used verbatim as the company-known copy
+                            template (%1 = brand product name,
+                            %2 = buyer company name,
+                            %3 = buyer organisation number)
+            -->
+            <xs:element name="intent_declined_notice" type="xs:string" minOccurs="0"/>
             <xs:element name="csp_origins" type="cspOriginsType" minOccurs="0"/>
             <xs:element name="admin_resource" type="xs:string"/>
             <xs:element name="module_label_chain" type="moduleLabelChainType" minOccurs="0"/>

--- a/view/frontend/web/css/style.css
+++ b/view/frontend/web/css/style.css
@@ -645,6 +645,20 @@
 }
 
 /*
+ * TWO-25326 §7.3 (2026-08-03 ruling): the "not approved" counterpart to
+ * `.approved` above, added when the standalone company label was removed
+ * and its name/number folded into this sentence instead. A warm, muted
+ * red rather than the approved blue — a business decline is not an error
+ * the buyer caused, so it deliberately does not reuse `.message-error`'s
+ * louder styling.
+ */
+.two-order-intent-message.declined {
+    border-color: #e0b7b7;
+    background: #fdf4f4;
+    color: #8a3b3b;
+}
+
+/*
  * The company-NAME input's read-only affordance. `readonly` is bound and true
  * in sole-trader mode only (see gateway_method.html), and `readonly` alone
  * renders identically to a normal input in most themes — an input the buyer
@@ -661,35 +675,6 @@
     color: #666666;
     cursor: default;
 }
-
-/*
- * TWO-25326 §7. The captured company on the payment tile, as ONE line of
- * text — "Name (12345678)" — between the term chips and the order-intent
- * notice.
- *
- * This supersedes `.two-company-id-label` and its `__caption`, which
- * rendered a "Company Number" caption and the number as a second block
- * below the company-name input. That was two renderings of one company in
- * one tile, which is the defect the ticket names; one line replaces both.
- *
- * Sits in the tile's own vertical flow (block, full width) rather than
- * aligned against a field's edge, because it is no longer a caption hanging
- * off an input — it is a statement of what the buyer is paying as. Left to
- * the reading direction for the same reason: `text-align` is not set at all,
- * so it inherits, and RTL store views need no special case.
- *
- * Slightly muted and small, matching the tile's other secondary text, so it
- * reads as context for the payment rather than competing with the term
- * chips above it.
- */
-.two-company-label {
-    display: block;
-    margin: 8px 0;
-    color: #666666;
-    font-size: 13px;
-    word-break: break-word;
-}
-
 
 /*
  * TWO-25288. The address-step "Company Number" field (injected by

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -135,7 +135,6 @@ define([
             this.termsNotAcceptedMessage = config.termsNotAcceptedMessage;
             this.isPaymentTermsEnabled = config.isPaymentTermsEnabled;
             this.initOrderIntentApprovedNotice(config);
-            this.orderIntentDeclinedMessage = config.orderIntentDeclinedMessage;
             this.companyRequiredMessage = config.companyRequiredMessage;
             this.generalErrorMessage = config.generalErrorMessage;
             this.invalidEmailListMessage = config.invalidEmailListMessage;
@@ -380,10 +379,17 @@ define([
          *    above (removing it there would block those orders outright,
          *    and the same is true here).
          *
-         * Read live rather than cached: Luma/Amasty/Fire all re-render
-         * this payment renderer on shipping/address changes (see
-         * dispose()'s comment), which is exactly when a buyer could switch
-         * between a new and a saved address, so a stale answer would stick.
+         * Read live rather than cached: `updateShippingAddress()` /
+         * `updateBillingAddress()` call `refreshTileCompanySearchBinding()`
+         * on every quote address change specifically because a NEW vs SAVED
+         * address switch flips whether `#shipping-new-address-form` exists,
+         * which is exactly what this reads. DO NOT memoise this into a
+         * property or a `ko.computed` that only recomputes on
+         * companyName/companyId/quote.isVirtual() changes — an earlier
+         * version relied on incidental re-renders for reactivity and an
+         * address-type switch with no company field touched went stale
+         * (found in adversarial review, 2026-08-04; fixed by the explicit
+         * refresh call above, not by caching this differently).
          *
          * @returns {boolean}
          */
@@ -492,7 +498,27 @@ define([
                 this._orderIntentInFlightFor = companyId;
                 fullScreenLoader.startLoader();
                 const self = this;
-                this.placeOrderIntent()
+                let deferred;
+                try {
+                    // Found in adversarial review, 2026-08-04: placeOrderIntent()
+                    // can THROW synchronously rather than return a Deferred —
+                    // quote.billingAddress() can legitimately be null for a
+                    // transient window (see the comment on that observable
+                    // elsewhere in this file), and placeOrderIntent() reads
+                    // `billingAddress.countryId` unguarded. An unhandled throw
+                    // here would skip `.always()` entirely, and
+                    // `_orderIntentInFlightFor` would stay set to this
+                    // companyId FOREVER — every later pick of the SAME
+                    // company would silently no-op against the guard above,
+                    // with no recovery short of a page reload. Same rescue
+                    // shape as placeOrderBackend()'s own try/catch.
+                    deferred = self.placeOrderIntent();
+                } catch (error) {
+                    fullScreenLoader.stopLoader();
+                    self._orderIntentInFlightFor = null;
+                    throw error;
+                }
+                deferred
                     .always(function () {
                         fullScreenLoader.stopLoader();
                         if (self._orderIntentInFlightFor === companyId) {
@@ -500,10 +526,28 @@ define([
                         }
                     })
                     .done(function (response) {
-                        self.processOrderIntentSuccessResponse(response);
+                        // Found in adversarial review, 2026-08-04: a cross-
+                        // company race. The in-flight guard above only
+                        // dedupes a repeat request for the SAME company — it
+                        // does nothing if the buyer picks company A, then
+                        // (once A's request settles and re-arms the guard)
+                        // picks company B before A's response has actually
+                        // arrived back is not the risk; the risk is A's
+                        // response landing AFTER the buyer has already moved
+                        // on to B. resolveCompanyNotice() reads
+                        // companyName()/companyId() LIVE at settle time, so a
+                        // stale response for A would render A's verdict with
+                        // B's name/number substituted in. Guarded by
+                        // confirming the observables still match what THIS
+                        // request was for before writing either notice.
+                        if (self.companyId() === companyId && self.companyName() === companyName) {
+                            self.processOrderIntentSuccessResponse(response);
+                        }
                     })
                     .fail(function (response) {
-                        self.processOrderIntentErrorResponse(response);
+                        if (self.companyId() === companyId && self.companyName() === companyName) {
+                            self.processOrderIntentErrorResponse(response);
+                        }
                     });
             }
         },
@@ -765,10 +809,46 @@ define([
             if (shippingAddress.getCacheKey() == quote.billingAddress().getCacheKey()) {
                 this.updateAddress(shippingAddress);
             }
+            // Unconditional, unlike updateAddress() above: a SAVED address
+            // and a NEW address differ in whether #shipping-new-address-form
+            // exists at all, which is exactly what
+            // isTileCompanySearchActive() reads — so this has to re-run on
+            // every shipping-address change, not only the ones the cache-key
+            // check lets through.
+            this.refreshTileCompanySearchBinding();
         },
         updateBillingAddress: function (billingAddress) {
             console.debug({ logger: 'twoPayment.updateBillingAddress', billingAddress });
             this.updateAddress(billingAddress);
+            this.refreshTileCompanySearchBinding();
+        },
+        /**
+         * Found in adversarial review, 2026-08-04: enableCompanySearch() only
+         * runs from three call sites (initObservable() → registeredOrganisationMode(),
+         * the "Search for company" link, and the supported-company-types
+         * callback) — NONE of which fire when a buyer switches between a NEW
+         * and a SAVED shipping/billing address. `#shipping-new-address-form`
+         * appears and disappears exactly on that switch, which is the live
+         * DOM signal isTileCompanySearchActive() reads. Without this, a buyer
+         * who starts on a new address (tile inactive, address-area control
+         * live) and then picks a saved address (address-area control's host
+         * form disappears) would find the tile's search widget never bound —
+         * `isTileCompanySearchActive()` would newly return true, the FIELD
+         * would show again (template `visible:` binding does react to that),
+         * but the select2 WIDGET behind it was never initialised, leaving a
+         * plain text input with no dropdown.
+         *
+         * Idempotent both directions: enableCompanySearch() itself no-ops if
+         * the tile is not the active location (checked at its own top), and
+         * destroyCompanySearchWidget() is documented safe to call when
+         * nothing is bound.
+         */
+        refreshTileCompanySearchBinding: function () {
+            if (this.isTileCompanySearchActive()) {
+                this.enableCompanySearch();
+            } else {
+                this.destroyCompanySearchWidget();
+            }
         },
         /**
          * TWO-25347: an earlier version of this comment called the
@@ -1237,7 +1317,16 @@ define([
                 // AMOUNT above is already faithfully 0.00), so the guard
                 // resolves to '0.000000' rather than omitting the key or
                 // inventing a non-zero rate.
+                //
+                // Guarded on `!isFinite`, not `=== 0`, since adversarial
+                // review (2026-08-04) found the narrower check still let a
+                // literal "NaN" reach the wire: `shipping_amount` can arrive
+                // non-numeric/undefined mid totals-recalc (Amasty's async
+                // shipping-method changes), and `parseFloat(undefined) === 0`
+                // is false, so that case fell through to the division branch
+                // and produced `NaN / NaN` — same 400, different trigger.
                 tax_rate: (
+                    !isFinite(parseFloat(totals['shipping_amount'])) ||
                     parseFloat(totals['shipping_amount']) === 0
                         ? 0
                         : parseFloat(totals['shipping_tax_amount']) /

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -432,6 +432,26 @@ define([
         isOrderIntentDeclinedNoticeVisible: function () {
             return !!(this.orderIntentDeclinedNotice && this.orderIntentDeclinedNotice());
         },
+        /**
+         * Whether the tile's capture control should re-show for decline
+         * recovery, independent of whether the declined NOTICE TEXT is
+         * visible. Added in round 2 of adversarial review, 2026-08-04:
+         * gating the field's re-show directly on
+         * isOrderIntentDeclinedNoticeVisible() reproduced the original
+         * dead-end for any brand with order_intent enabled but the notice
+         * UI suppressed (`enable_order_intent` and
+         * `<intent_approved_notice_enabled>` are independent switches — see
+         * Model/Brand/Loader.php) — that brand's declined buyer would still
+         * see the field stay hidden, just silently instead of with a notice.
+         * `orderIntentDeclined` is set on every decline regardless of
+         * whether any notice text was produced, so this reads true whenever
+         * a decline needs recovering from, on every brand configuration.
+         *
+         * @returns {boolean}
+         */
+        isCompanyRecoveryNeeded: function () {
+            return !!(this.orderIntentDeclined && this.orderIntentDeclined());
+        },
         selectTerm: function (days) {
             surchargeModel.selectTerm(days);
         },
@@ -510,13 +530,31 @@ define([
                     // `_orderIntentInFlightFor` would stay set to this
                     // companyId FOREVER — every later pick of the SAME
                     // company would silently no-op against the guard above,
-                    // with no recovery short of a page reload. Same rescue
-                    // shape as placeOrderBackend()'s own try/catch.
+                    // with no recovery short of a page reload.
                     deferred = self.placeOrderIntent();
                 } catch (error) {
+                    // Round-2 adversarial review, 2026-08-04: an earlier
+                    // version of this catch rethrew, mirroring
+                    // placeOrderBackend()'s shape — but every caller of
+                    // fillCompanyData() is an unguarded synchronous context
+                    // with its OWN statements after the call (the
+                    // select2:select handler's addressLookup() call,
+                    // updateAddress()'s project/department writes,
+                    // updateShippingAddress()/updateBillingAddress()'s
+                    // refreshTileCompanySearchBinding() call). Rethrowing
+                    // aborted all of those too, on top of leaving the buyer
+                    // with no visible sign anything went wrong (loader
+                    // flashes and vanishes, nothing else happens). Logging +
+                    // a visible message + NOT rethrowing lets the caller's
+                    // remaining statements run and gives the buyer something
+                    // to act on, at the cost of this one attempt's order
+                    // intent — strictly better than either silent failure or
+                    // aborting unrelated sibling work.
+                    console.error({ logger: 'twoPayment.fillCompanyData.placeOrderIntent', error });
                     fullScreenLoader.stopLoader();
                     self._orderIntentInFlightFor = null;
-                    throw error;
+                    self.showErrorMessage(self.generalErrorMessage);
+                    return;
                 }
                 deferred
                     .always(function () {
@@ -1114,6 +1152,21 @@ define([
             this.orderIntentDeclinedNoticeCopy = config.orderIntentDeclinedNotice || null;
             this.orderIntentDeclinedNotice = ko.observable('');
 
+            // Round 2 adversarial review, 2026-08-04: `orderIntentDeclinedNotice`
+            // is NOT a reliable "was the last intent declined" signal on its
+            // own — `enable_order_intent` and
+            // `<intent_approved_notice_enabled>` are two INDEPENDENT brand
+            // switches (see Model/Brand/Loader.php), so a brand can have
+            // order_intent firing for real while the notice UI stays off.
+            // On that brand, orderIntentDeclinedNoticeCopy is permanently
+            // null, resolveCompanyNotice() always returns '', and gating the
+            // decline-recovery field re-show on the notice's OWN visibility
+            // would reproduce the exact dead-end that fix was written to
+            // close — just for a different brand config. Tracked separately
+            // so the recovery path does not depend on whether the notice UI
+            // happens to be on.
+            this.orderIntentDeclined = ko.observable(false);
+
             // The notice is *persistent* — unlike the message-region
             // treatment it replaces, it survives checkout updates and a
             // failed placeOrder validation (see the deliberate omission in
@@ -1129,10 +1182,12 @@ define([
             this.companyName.subscribe(function () {
                 self.orderIntentApprovedNotice('');
                 self.orderIntentDeclinedNotice('');
+                self.orderIntentDeclined(false);
             });
             this.companyId.subscribe(function () {
                 self.orderIntentApprovedNotice('');
                 self.orderIntentDeclinedNotice('');
+                self.orderIntentDeclined(false);
             });
         },
         /**
@@ -1192,6 +1247,7 @@ define([
                     // approval reassurance was effectively never seen.
                     this.orderIntentApprovedNotice(this.resolveOrderIntentApprovedNotice());
                     this.orderIntentDeclinedNotice('');
+                    this.orderIntentDeclined(false);
                 } else {
                     // TWO-25326 §7.3 (2026-08-03 ruling): a clean "not
                     // approved" response is a business outcome, not a
@@ -1201,6 +1257,11 @@ define([
                     // ONLY the intent message" the ruling asks for.
                     this.orderIntentApprovedNotice('');
                     this.orderIntentDeclinedNotice(this.resolveOrderIntentDeclinedNotice());
+                    // Set regardless of whether the notice text above is
+                    // empty (brand suppressed the notice UI) — this is the
+                    // signal the decline-recovery field re-show reads, and
+                    // it must fire on EVERY decline, notice or not.
+                    this.orderIntentDeclined(true);
                 }
             }
         },
@@ -1209,6 +1270,7 @@ define([
             // notice from a previous, successful intent.
             this.orderIntentApprovedNotice('');
             this.orderIntentDeclinedNotice('');
+            this.orderIntentDeclined(false);
 
             // `let`, not `const`: the SCHEMA_ERROR branch below reassigns
             // this to '' once it has pushed the field-level errors into

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -263,6 +263,14 @@ define([
             if (this.isTwoVisible && this.isTwoVisible.dispose) {
                 this.isTwoVisible.dispose();
             }
+            // TWO-25347: tear down fillCustomerData()'s subscriptions to the
+            // shared quote/customerData singletons — see that method's own
+            // comment for why an undisposed set there fired stacked
+            // concurrent order_intent POSTs on Fire Checkout specifically.
+            if (this._customerDataSubs) {
+                this._customerDataSubs.forEach((sub) => sub.dispose());
+                this._customerDataSubs = null;
+            }
             this._super();
         },
         /**
@@ -481,11 +489,28 @@ define([
             $('#select2-company_name-container')?.text(companyName);
             this.companyId(companyId);
             if (this.isOrderIntentEnabled) {
+                // TWO-25347 belt-and-braces: refuse a second concurrent
+                // order_intent POST for the SAME captured company. The root
+                // cause — fillCustomerData() stacking undisposed
+                // subscriptions on every re-render, each one independently
+                // reaching fillCompanyData() for an unchanged company pick
+                // — is fixed in dispose()/fillCustomerData() above; this
+                // guard is a second line of defence against any other path
+                // that could re-enter here before the first request settles
+                // (Fire Checkout re-renders this payment renderer on every
+                // totals/shipping change).
+                if (this._orderIntentInFlightFor === companyId) {
+                    return;
+                }
+                this._orderIntentInFlightFor = companyId;
                 fullScreenLoader.startLoader();
                 const self = this;
                 this.placeOrderIntent()
                     .always(function () {
                         fullScreenLoader.stopLoader();
+                        if (self._orderIntentInFlightFor === companyId) {
+                            self._orderIntentInFlightFor = null;
+                        }
                     })
                     .done(function (response) {
                         self.processOrderIntentSuccessResponse(response);
@@ -759,18 +784,30 @@ define([
             this.updateAddress(billingAddress);
         },
         /**
-         * PRE-EXISTING, not introduced here, flagged so it is not mistaken for
-         * new: none of the subscriptions below are disposed, and
-         * fillCustomerData() is re-callable (registeredOrganisationMode(),
-         * reached from applyPrefetch()). N calls therefore leave N stacked
-         * subscriptions on each section, so one notification runs
-         * applyCompanyData() N times. Idempotent today, so it is waste rather
-         * than a bug — out of scope for this change.
+         * TWO-25347: an earlier version of this comment called the
+         * undisposed subscriptions below "idempotent today... waste rather
+         * than a bug". That was wrong about the network side effect
+         * specifically — N stacked subscriptions run applyCompanyData() N
+         * times, and each of THOSE independently drives fillCompanyData() →
+         * placeOrderIntent(), so N stacked subscriptions fired N concurrent
+         * order_intent POSTs for a single company pick. Fire Checkout
+         * re-renders this payment renderer on every totals/shipping change
+         * (see payment-availability.js), so it hit this far more often than
+         * Luma/Amasty and was the one where it surfaced. Fixed below by
+         * disposing the previous set on every call and disposing the
+         * current set in dispose(), mirroring the `_twoVisibilitySub`
+         * pattern already in place for the minimum-order subscription.
          */
         fillCustomerData: function () {
             const self = this;
 
-            customerData
+            // See the docblock above for why this is here.
+            if (this._customerDataSubs) {
+                this._customerDataSubs.forEach((sub) => sub.dispose());
+            }
+            this._customerDataSubs = [];
+
+            this._customerDataSubs.push(customerData
                 .get('companyData')
                 // Authoritative: a change NOTIFICATION on this section is the
                 // shipping-step picker writing it, so an identifier-less
@@ -791,7 +828,7 @@ define([
                 // one-shot read below exists to prevent.
                 .subscribe((companyData) =>
                     self.applyCompanyData(companyData, { authoritative: true })
-                );
+                ));
             // NOT authoritative: this is a one-shot read of a localStorage
             // section that outlives page loads and previous orders, and
             // fillCustomerData() is re-callable (registeredOrganisationMode(),
@@ -799,20 +836,24 @@ define([
             // companyId: ''}` row must not overwrite a live payment-step pick.
             this.applyCompanyData(customerData.get('companyData')());
 
-            customerData
+            this._customerDataSubs.push(customerData
                 .get('shippingTelephone')
-                .subscribe((telephone) => self.fillTelephone(telephone));
+                .subscribe((telephone) => self.fillTelephone(telephone)));
             this.fillTelephone(customerData.get('shippingTelephone')());
 
-            customerData
+            this._customerDataSubs.push(customerData
                 .get('countryCode')
-                .subscribe((countryCode) => self.fillCountryCode(countryCode));
+                .subscribe((countryCode) => self.fillCountryCode(countryCode)));
             this.fillCountryCode(customerData.get('countryCode')());
 
-            quote.shippingAddress.subscribe((address) => self.updateShippingAddress(address));
+            this._customerDataSubs.push(
+                quote.shippingAddress.subscribe((address) => self.updateShippingAddress(address))
+            );
             this.updateShippingAddress(quote.shippingAddress());
 
-            quote.billingAddress.subscribe((address) => self.updateBillingAddress(address));
+            this._customerDataSubs.push(
+                quote.billingAddress.subscribe((address) => self.updateBillingAddress(address))
+            );
             this.updateBillingAddress(quote.billingAddress());
         },
         afterPlaceOrder: function () {

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -136,10 +136,18 @@ define([
             this.isPaymentTermsEnabled = config.isPaymentTermsEnabled;
             this.initOrderIntentApprovedNotice(config);
             this.orderIntentDeclinedMessage = config.orderIntentDeclinedMessage;
+            this.companyRequiredMessage = config.companyRequiredMessage;
             this.generalErrorMessage = config.generalErrorMessage;
             this.invalidEmailListMessage = config.invalidEmailListMessage;
             this.soleTraderErrorMessage = config.soleTraderErrorMessage;
             this.isOrderIntentEnabled = config.isOrderIntentEnabled;
+            // TWO-25326 §7.1: the ONE admin setting that decides where the
+            // shared company-search control renders. ON = address area
+            // (address-autocomplete.js's job); OFF = payment tile (this
+            // renderer's job) — see isTileCompanySearchActive() below,
+            // which is also where the saved-address/virtual-cart fallback
+            // is documented.
+            this.isAddressAreaCompanySearchEnabled = !!config.isCompanySearchEnabled;
             this.isInvoiceEmailsEnabled = config.isInvoiceEmailsEnabled;
             this.isDepartmentFieldEnabled = config.isDepartmentFieldEnabled;
             this.isProjectFieldEnabled = config.isProjectFieldEnabled;
@@ -311,12 +319,14 @@ define([
          * they stay visible and fully functional, because they are the buyer's
          * route to capturing a company in the first place.
          *
-         * It no longer governs the company LABEL. The label's visibility is
-         * tied to the order-intent message's — see
-         * isOrderIntentMessageVisible() — so this predicate and the label are
-         * NOT two directions of one switch any more. A captured company with
-         * no approved intent showing hides the controls and shows no label,
-         * and that is the ruling, not an oversight.
+         * It no longer governs any standalone company LABEL — the
+         * 2026-08-03 ruling (§7.3) removed that element outright. The
+         * captured company now appears ONLY inside the order-intent notice
+         * sentence itself (orderIntentApprovedNotice / orderIntentDeclinedNotice),
+         * which has its own gate (whether an intent was placed and what it
+         * said) that is independent of this one. A captured company with no
+         * intent outcome yet showing hides the controls and shows no
+         * notice, and that is the ruling, not an oversight.
          *
          * Keeping the controls rather than deleting them is deliberate and
          * load-bearing. The tile's picker is not a duplicate of the address
@@ -352,92 +362,69 @@ define([
             return !!(this.companyName() || '').trim() && !!(this.companyId() || '').trim();
         },
         /**
-         * The captured company as one line of display text for the payment
-         * tile (TWO-25326 §7): `Name (12345678)`.
+         * TWO-25326 §7.1: whether the payment tile is the buyer's ACTIVE
+         * route to the shared company-search control, as opposed to a
+         * display-only surface. One admin setting, `isCompanySearchEnabled`
+         * (address-area ON/OFF), decides WHERE the one shared control
+         * lives — never whether it exists twice:
          *
-         * Only ever rendered while isOrderIntentMessageVisible() is true, and
-         * that message only exists after an intent was approved for the
-         * company currently in the observables, so both parts are present by
-         * construction; the name-only guard below is a belt-and-braces
-         * against a future caller, not a state the template can reach.
-         * Returns '' rather than a bare parenthesised number if a number ever
-         * arrived without a name — nothing to attach it to reads worse than
-         * nothing at all.
+         *  - setting OFF (`!isAddressAreaCompanySearchEnabled`) → the tile
+         *    is always the control's home.
+         *  - setting ON → the address-area control
+         *    (address-autocomplete.js, bound to
+         *    `#shipping-new-address-form`) is the control's home, EXCEPT
+         *    when that form does not exist on this checkout at all — a
+         *    saved address and a virtual cart both render no such form —
+         *    in which case the tile remains the buyer's only route to
+         *    search, same reasoning as isCompanyCaptured()'s doc comment
+         *    above (removing it there would block those orders outright,
+         *    and the same is true here).
          *
-         * The parentheses are the format the ticket specifies literally, and
-         * they wrap a VALUE rather than a translated caption. That is why
-         * this does not repeat the locale hazard that kept the superseded
-         * "Company Number" caption and its number on separate lines: there is
-         * no caption here for punctuation to be glued to.
-         *
-         * READ-ONLY. Never writes either observable, and the element it feeds
-         * carries no `name`, so it submits nothing. getData() reads
-         * `companyName()`/`companyId()` directly and remains the only path to
-         * the order.
-         *
-         * @returns {string}
-         */
-        companyDisplayLabel: function () {
-            const companyName = (this.companyName() || '').trim();
-            if (!companyName) return '';
-            const companyId = (this.companyId() || '').trim();
-            return companyId ? companyName + ' (' + companyId + ')' : companyName;
-        },
-        /**
-         * The ONE gate for both the inline order-intent message and the
-         * company label beside it (TWO-25326, ruling of 2026-08-03: the
-         * company label is shown exactly when the intent message is shown and
-         * hidden exactly when it is hidden).
-         *
-         * Both template bindings call THIS, rather than each testing a
-         * condition of its own that happens to agree. That is the whole point
-         * of the method existing: a parallel "is a company captured" check
-         * would agree with the message most of the time and diverge exactly in
-         * the states the ruling asks about — a company captured with no intent
-         * placed yet, an intent that was declined or errored, and a brand that
-         * suppresses the notice altogether
-         * (<intent_approved_notice_enabled>false</intent_approved_notice_enabled>
-         * in brand.xml, which leaves orderIntentApprovedNoticeCopy null so the
-         * notice text is always '').
-         *
-         * READ THIS BEFORE ASSUMING THE LABEL IS ALWAYS AVAILABLE. Two further
-         * configurations mean the notice never appears at all, and therefore
-         * that the §7 company label never renders for those buyers either:
-         *
-         *  - `enable_order_intent` off (Model/Config/Repository.php
-         *    ::isOrderIntentEnabled) — fillCompanyData() skips
-         *    placeOrderIntent() entirely, so nothing ever sets the notice. The
-         *    label is dead for that merchant's whole storefront.
-         *  - a Dutch buyer whose company is not a BV — placeOrderIntent()
-         *    early-returns a Deferred resolved with `null`, so
-         *    processOrderIntentSuccessResponse() sees a falsy response and sets
-         *    nothing.
-         *
-         * Both follow literally from "shown exactly when the intent message is
-         * shown", so they are a consequence of the ruling rather than a defect
-         * here, and they are pinned by tests so they read as decisions. If the
-         * label is meant to survive order intent being off, that is a different
-         * rule and needs the ticket — do not quietly widen this predicate.
-         *
-         * `orderIntentApprovedNotice` is created in
-         * initOrderIntentApprovedNotice() rather than in `defaults` (see the
-         * shared-observable footgun documented there), so it is genuinely
-         * absent on a renderer that has not been initialised. Guarded rather
-         * than assumed: this is read from a `visible:` and an `if:` binding,
-         * and a throw inside either takes the whole tile down.
-         *
-         * Know what the guard trades for that. If a binding ever WERE evaluated
-         * before initOrderIntentApprovedNotice(), ko would register no
-         * dependency on the absent observable, so both the label and the notice
-         * would stay hidden for the life of the tile rather than failing loudly.
-         * Unreachable today — initialize() calls that wiring before bindings
-         * apply — but a future refactor that defers it would produce a silent
-         * permanent hide, not an error.
+         * Read live rather than cached: Luma/Amasty/Fire all re-render
+         * this payment renderer on shipping/address changes (see
+         * dispose()'s comment), which is exactly when a buyer could switch
+         * between a new and a saved address, so a stale answer would stick.
          *
          * @returns {boolean}
          */
-        isOrderIntentMessageVisible: function () {
+        isTileCompanySearchActive: function () {
+            if (!this.isAddressAreaCompanySearchEnabled) {
+                return true;
+            }
+            return (
+                quote.isVirtual() ||
+                $('#shipping-new-address-form input[name="company"]').length === 0
+            );
+        },
+        /**
+         * Guarded read of orderIntentApprovedNotice() for the template's
+         * `ko if`. The observable is created in
+         * initOrderIntentApprovedNotice() rather than in `defaults` (see the
+         * shared-observable footgun documented there), so it is genuinely
+         * absent on a renderer `ko if` is evaluated against before
+         * initialize() runs — unreachable in production (initialize() wires
+         * it before bindings apply) but a plain `orderIntentApprovedNotice()`
+         * call in the template would throw, not fail soft, if that ever
+         * changed. Guarded here rather than trusted; `text:` still binds the
+         * raw observable directly.
+         *
+         * @returns {boolean}
+         */
+        isOrderIntentApprovedNoticeVisible: function () {
             return !!(this.orderIntentApprovedNotice && this.orderIntentApprovedNotice());
+        },
+        /**
+         * Same guard, for the declined notice. Deliberately a SEPARATE
+         * function rather than one shared predicate — TWO-25326's
+         * 2026-08-03 ruling explicitly rejects one gate driving two
+         * different sentences (that was the standalone label's defect).
+         * Each notice is its own on/off decision; this only protects against
+         * reading an absent observable, it does not couple the two.
+         *
+         * @returns {boolean}
+         */
+        isOrderIntentDeclinedNoticeVisible: function () {
+            return !!(this.orderIntentDeclinedNotice && this.orderIntentDeclinedNotice());
         },
         selectTerm: function (days) {
             surchargeModel.selectTerm(days);
@@ -890,6 +877,21 @@ define([
             // processOrderIntent*Response().
             this.messageContainer.clear();
 
+            // TWO-25326 §6a (2026-08-03 ruling): a manual (name-only, no
+            // organisation number) capture must NOT make the method usable,
+            // but the method stays SELECTABLE — this is a blocked SUBMIT,
+            // matching WC/PS/Hyvä, not a disabled/unselectable radio button.
+            // Before this, Magento had no client-side check here at all: a
+            // manual capture went silently nowhere (see
+            // isCompanyCaptured()'s doc comment for why the method still
+            // has to accept name-only submissions rather than refuse them
+            // outright — validate() does not enforce it either, since
+            // company_name has no number companion field to require).
+            if (!this.isCompanyCaptured()) {
+                this.showErrorMessage(this.companyRequiredMessage);
+                return;
+            }
+
             // Recover a stale place-order latch.
             //
             // isPlaceOrderActionAllowed has only two writers: this renderer, which
@@ -1024,39 +1026,50 @@ define([
             // notice into the next.
             this.orderIntentApprovedNotice = ko.observable('');
 
+            // TWO-25326 §7.3 (2026-08-03 ruling) counterpart to the notice
+            // above: the persistent tile message for a clean "not approved"
+            // order-intent response. Same suppression source
+            // (orderIntentApprovedNoticeCopy === null means the brand
+            // turned the whole intent message off), separate copy.
+            this.orderIntentDeclinedNoticeCopy = config.orderIntentDeclinedNotice || null;
+            this.orderIntentDeclinedNotice = ko.observable('');
+
             // The notice is *persistent* — unlike the message-region
             // treatment it replaces, it survives checkout updates and a
             // failed placeOrder validation (see the deliberate omission in
             // placeOrder(), which clears messageContainer but not this). It
             // must NOT survive the buyer's company changing, because the
-            // approval it reports was for the previous company.
+            // approval/decline it reports was for the previous company.
             // fillCompanyData() writes companyName / companyId before firing
             // the intent, so these subscriptions clear first and
-            // processOrderIntentSuccessResponse re-sets afterwards; a company
-            // edited by hand in the input clears the notice and leaves it
-            // cleared, which is the correct fail-closed outcome.
+            // processOrderIntent*Response() re-sets afterwards; a company
+            // edited by hand in the input clears both notices and leaves
+            // them cleared, which is the correct fail-closed outcome.
             var self = this;
             this.companyName.subscribe(function () {
                 self.orderIntentApprovedNotice('');
+                self.orderIntentDeclinedNotice('');
             });
             this.companyId.subscribe(function () {
                 self.orderIntentApprovedNotice('');
+                self.orderIntentDeclinedNotice('');
             });
         },
         /**
-         * Resolve the intent-approved notice text for the current buyer.
+         * Substitute the buyer's company name/number into a
+         * ConfigProvider-shipped copy template. Shared by
+         * resolveOrderIntentApprovedNotice() and
+         * resolveOrderIntentDeclinedNotice() — the only difference between
+         * the two is which `copy` object and which fallback they pass in.
          *
-         * Returns '' when the active brand suppressed the notice, so callers
-         * can assign the result unconditionally.
+         * A replacer *function* is used rather than a plain string so `$&` /
+         * `$1` sequences in a company name or number are taken literally
+         * instead of as replacement patterns.
          *
-         * The company name is substituted client-side because it is only
-         * known here; ConfigProvider ships both resolved copy variants plus
-         * the token to replace. A replacer *function* is used rather than a
-         * plain string so `$&` / `$1` sequences in a company name are taken
-         * literally instead of as replacement patterns.
+         * @param {?object} copy {withCompany, withoutCompany, companyNameToken, companyNumberToken}|null
+         * @returns {string}
          */
-        resolveOrderIntentApprovedNotice: function () {
-            const copy = this.orderIntentApprovedNoticeCopy;
+        resolveCompanyNotice: function (copy) {
             if (!copy) {
                 return '';
             }
@@ -1064,9 +1077,30 @@ define([
             if (!companyName) {
                 return copy.withoutCompany;
             }
-            return copy.withCompany.replace(copy.companyNameToken, function () {
-                return companyName;
-            });
+            const companyId = (this.companyId() || '').trim();
+            return copy.withCompany
+                .replace(copy.companyNameToken, function () {
+                    return companyName;
+                })
+                .replace(copy.companyNumberToken, function () {
+                    return companyId;
+                });
+        },
+        /**
+         * Resolve the intent-approved notice text for the current buyer.
+         * Returns '' when the active brand suppressed the notice, so callers
+         * can assign the result unconditionally.
+         */
+        resolveOrderIntentApprovedNotice: function () {
+            return this.resolveCompanyNotice(this.orderIntentApprovedNoticeCopy);
+        },
+        /**
+         * Resolve the intent-DECLINED notice text for the current buyer
+         * (TWO-25326 §7.3, 2026-08-03 ruling). Returns '' when the active
+         * brand suppressed the intent message entirely.
+         */
+        resolveOrderIntentDeclinedNotice: function () {
+            return this.resolveCompanyNotice(this.orderIntentDeclinedNoticeCopy);
         },
         processOrderIntentSuccessResponse: function (response) {
             if (response) {
@@ -1077,9 +1111,16 @@ define([
                     // is cleared on every checkout update, so on Luma the
                     // approval reassurance was effectively never seen.
                     this.orderIntentApprovedNotice(this.resolveOrderIntentApprovedNotice());
+                    this.orderIntentDeclinedNotice('');
                 } else {
+                    // TWO-25326 §7.3 (2026-08-03 ruling): a clean "not
+                    // approved" response is a business outcome, not a
+                    // technical failure, so it gets the SAME persistent
+                    // tile-notice treatment as approval — a toast that a
+                    // later checkout update wipes is not "the tile shows
+                    // ONLY the intent message" the ruling asks for.
                     this.orderIntentApprovedNotice('');
-                    this.showErrorMessage(this.orderIntentDeclinedMessage);
+                    this.orderIntentDeclinedNotice(this.resolveOrderIntentDeclinedNotice());
                 }
             }
         },
@@ -1087,8 +1128,20 @@ define([
             // An intent that errored says nothing about approval; drop any
             // notice from a previous, successful intent.
             this.orderIntentApprovedNotice('');
+            this.orderIntentDeclinedNotice('');
 
-            const message = this.generalErrorMessage,
+            // `let`, not `const`: the SCHEMA_ERROR branch below reassigns
+            // this to '' once it has pushed the field-level errors into
+            // messageContainer itself. A `const` here made every
+            // SCHEMA_ERROR response throw
+            // "TypeError: Assignment to constant variable" the instant it
+            // arrived — silently, since this runs inside a jQuery Deferred
+            // `.fail()` handler with nothing upstream to surface a thrown
+            // error to the buyer. That is very likely why a manual-entry
+            // buyer saw no message at all before the §6a client-side gate
+            // was added: this path was the one meant to show it, and it was
+            // broken.
+            let message = this.generalErrorMessage,
                 self = this;
             if (response && response.responseJSON) {
                 const errorCode = response.responseJSON.error_code,
@@ -1176,9 +1229,19 @@ define([
                 quantity: 1,
                 unit_price: parseFloat(totals['shipping_amount']).toFixed(2),
                 tax_amount: parseFloat(totals['shipping_tax_amount']).toFixed(2),
+                // Free shipping makes shipping_amount 0, and 0/0 is NaN, not
+                // 0 — order_intent then 400s on every free-shipping cart
+                // (found investigating TWO-25326 §6a: it blocked testing
+                // the gating fix on a free-shipping cart). A zero-taxed
+                // shipping line rate is genuinely 0, not "no rate" (the tax
+                // AMOUNT above is already faithfully 0.00), so the guard
+                // resolves to '0.000000' rather than omitting the key or
+                // inventing a non-zero rate.
                 tax_rate: (
-                    parseFloat(totals['shipping_tax_amount']) /
-                    parseFloat(totals['shipping_amount'])
+                    parseFloat(totals['shipping_amount']) === 0
+                        ? 0
+                        : parseFloat(totals['shipping_tax_amount']) /
+                          parseFloat(totals['shipping_amount'])
                 ).toFixed(6),
                 tax_class_name: '',
                 quantity_unit: 'unit',
@@ -1272,6 +1335,14 @@ define([
          *        open unasked would steal focus from the payment form.
          */
         enableCompanySearch: function (options) {
+            // TWO-25326 §7.1: don't bind the tile's own live search widget
+            // when the address-area control is this checkout's active
+            // location for it — one shared control, not two simultaneous
+            // ones. See isTileCompanySearchActive() for the fallback carve-
+            // out (saved address / virtual cart).
+            if (!this.isTileCompanySearchActive()) {
+                return;
+            }
             let self = this;
             // One-shot, and deliberately a local rather than a property on the
             // renderer: `$.async` is a MutationObserver that fires again on

--- a/view/frontend/web/template/payment/gateway_method.html
+++ b/view/frontend/web/template/payment/gateway_method.html
@@ -69,62 +69,40 @@
         </div>
         <!-- /ko -->
         <!--
-            The captured company as one line of plain text — "Name (12345678)"
-            — between the term chips and the order-intent notice
-            (TWO-25326 §7). Canonical placement across all four platforms.
+            TWO-25326 §7.3 (2026-08-03 ruling): the standalone
+            `.two-company-label` text that used to sit here is REMOVED, not
+            supplemented. The captured company name/number are now shown
+            ONLY inside the order-intent notice sentence itself — see
+            ConfigProvider::getOrderIntentApprovedNotice() /
+            getOrderIntentDeclinedNotice() for the copy templates and
+            resolveCompanyNotice() in gateway_method.js for the substitution.
+            A company captured with no intent outcome yet showing renders
+            neither notice below and therefore displays the company nowhere
+            in the tile — that follows from "the notice is the only display
+            surface" and is the ruling, not an oversight.
 
-            Shown exactly when the order-intent message below is shown, and
-            hidden exactly when it is hidden (TWO-25326, 2026-08-03) — which is
-            why both bindings call the SAME predicate,
-            isOrderIntentMessageVisible(), rather than each testing its own
-            condition. This supersedes the earlier rule that gated the label on
-            a captured company number.
-
-            It is NOT a swap with the tile's company controls. Those are
-            hidden/shown on isCompanyCaptured() and that rule is unchanged, so
-            a company captured with no approved intent showing hides the
-            controls and shows no label. See isCompanyCaptured() in
-            gateway_method.js for why the controls are hidden rather than
-            removed — the tile is the ONLY company-capture surface for a buyer
-            on a saved address or a virtual cart, and deleting it would block
-            those orders outright.
-
-            `visible:`, not `if:`, deliberately. `if:` would tear the node out
-            of the DOM and rebuild it on every change; the node here is inert
-            display text, and keeping it stable costs nothing while avoiding
-            any interaction with the MutationObserver-based rebinding the
-            company picker relies on.
-
-            One element, one binding, so there is no caption/value split to
-            fall out of step and no punctuation glued outside a translated
-            string — companyDisplayLabel() builds the whole string in one
-            place. The element carries no `name` and no writable binding: it
-            displays companyName()/companyId() and never writes either.
-            getData() still reads those observables, never the DOM.
+            Persistent inline notices, inside the payment tile next to the
+            term chips. Each is emitted only when its own observable is
+            non-empty, so a brand that suppresses the intent message
+            entirely (<intent_approved_notice_enabled>false</…> in
+            brand.xml) yields no element at all rather than an empty
+            wrapper — both notices share that one suppression switch, see
+            ConfigProvider. Class names match the PrestaShop / WooCommerce
+            surfaces so the four platforms stay greppable; `declined` is a
+            new modifier alongside the existing `approved` one.
         -->
-        <div
-            class="two-company-label"
-            data-bind="visible: isOrderIntentMessageVisible(), text: companyDisplayLabel()"
-        ></div>
-        <!--
-            Persistent inline "order intent approved" notice, inside the
-            payment tile next to the term chips. Emitted only when non-empty,
-            so a brand that suppresses the notice
-            (<intent_approved_notice_enabled>false</intent_approved_notice_enabled>
-            in brand.xml) yields no element at all rather than an empty
-            wrapper. Class name matches the PrestaShop /
-            WooCommerce surfaces so the four platforms stay greppable.
-
-            Gated on isOrderIntentMessageVisible() rather than on the
-            observable directly — same truth value, but it makes the shared
-            gate literal: the company label above reads the identical
-            expression, so the two cannot drift apart.
-        -->
-        <!-- ko if: isOrderIntentMessageVisible() -->
+        <!-- ko if: isOrderIntentApprovedNoticeVisible() -->
         <div
             class="two-order-intent-message approved"
             role="status"
             data-bind="text: orderIntentApprovedNotice"
+        ></div>
+        <!-- /ko -->
+        <!-- ko if: isOrderIntentDeclinedNoticeVisible() -->
+        <div
+            class="two-order-intent-message declined"
+            role="status"
+            data-bind="text: orderIntentDeclinedNotice"
         ></div>
         <!-- /ko -->
         <!-- ko if: showModeTab -->
@@ -206,28 +184,43 @@
                 data-bind='attr: {id: "payment_form_" + getCode()}'
             >
                 <!--
-                    TWO-25326 §7. Hidden once a company is captured, because
-                    the captured company is then shown as a text label above
-                    (between the chips and the intent notice) and a second,
-                    editable copy of the same thing is exactly what the ticket
-                    calls out as the defect.
+                    TWO-25326 §7 / §7.1. Hidden once a company is captured,
+                    because the captured company is then shown inside the
+                    order-intent notice sentence (see the notices below) and
+                    a second, editable copy of the same thing is exactly what
+                    the ticket calls out as the defect.
+
+                    Also hidden whenever isTileCompanySearchActive() is
+                    false — i.e. the admin setting puts the shared
+                    company-search control in the address area AND that
+                    address-area control actually exists on this checkout.
+                    The tile is then a display-only surface; showing this
+                    editable field too would be the "two bespoke
+                    implementations" the 2026-08-03 ruling forbids. See
+                    isTileCompanySearchActive() in gateway_method.js for the
+                    saved-address/virtual-cart fallback that keeps it true
+                    (and this field visible) even with the setting on.
 
                     NOT removed, only hidden. This field and the picker bound
-                    to it are the only company-capture route for a buyer on a
-                    saved address or a virtual cart — see isCompanyCaptured()
-                    in gateway_method.js. `visible:` also keeps the node in
-                    the DOM so the select2 binding, its MutationObserver
-                    rebinding and the sole-trader write path all keep working
-                    untouched; `if:` would destroy and rebuild the node under
-                    them.
+                    to it are the buyer's company-capture route whenever the
+                    tile IS the active location — see isCompanyCaptured() and
+                    isTileCompanySearchActive() in gateway_method.js.
+                    `visible:` also keeps the node in the DOM so the select2
+                    binding, its MutationObserver rebinding and the
+                    sole-trader write path all keep working untouched; `if:`
+                    would destroy and rebuild the node under them.
 
                     Hiding also takes this `required` input out of jQuery
                     Validation's way, which only matters in the direction that
-                    helps: `elements()` skips hidden fields, and the only
-                    state where this is hidden is the one where a name has
-                    already been captured.
+                    helps: `elements()` skips hidden fields, and both states
+                    where this is hidden are states where the buyer either
+                    already captured a company here or has another control
+                    (the address-area one) to do it with.
                 -->
-                <div class="field field-text required" data-bind="visible: !isCompanyCaptured()">
+                <div
+                    class="field field-text required"
+                    data-bind="visible: !isCompanyCaptured() && isTileCompanySearchActive()"
+                >
                     <label for="company_name" class="label">
                         <span><!-- ko i18n: 'Company Name'--><!-- /ko --></span>
                     </label>
@@ -268,37 +261,32 @@
                             class="input-text"
                         />
                         <!--
-                            The organisation number is NO LONGER shown here.
-                            TWO-25326 §7 moved it into a single
-                            `Name (number)` text label higher up the tile,
-                            between the term chips and the intent notice — see
-                            `.two-company-label` above and
-                            companyDisplayLabel() in gateway_method.js.
+                            The organisation number is NOT shown here as its
+                            own element. Pre-2026-08-03, TWO-25326 §7 moved it
+                            into a standalone `.two-company-label` text line
+                            higher up the tile; the 2026-08-03 ruling (§7.3)
+                            removed THAT too — the number now appears only
+                            embedded inside the order-intent notice sentence
+                            (ConfigProvider::getOrderIntentApprovedNotice() /
+                            getOrderIntentDeclinedNotice(), rendered by the
+                            `two-order-intent-message` blocks above).
 
-                            "Moved", not "always replaced". Since the
-                            2026-08-03 ruling that label only renders while
-                            the intent message renders, so in every state
-                            where the notice is absent — no intent placed
-                            yet, declined, errored, a notice-suppressed
-                            brand, order intent off, a Dutch non-BV buyer —
+                            So in every state where NEITHER notice is showing
+                            — no intent placed yet, order intent off, a
+                            notice-suppressed brand, a Dutch non-BV buyer —
                             the captured organisation number is displayed
                             NOWHERE on the payment tile. The address step's
                             own Company Number field is visually hidden too
                             (TWO-25288, see style.css), so there is no second
                             surface picking it up. That is forfeited display,
-                            not a hidden bug: it follows from "exactly when",
-                            and giving the label a second capture-based route
-                            is a ticket decision rather than a tidy-up.
+                            not a hidden bug: it follows from "the notice is
+                            the only display surface", and giving the number
+                            a second capture-based display route is a ticket
+                            decision rather than a tidy-up.
 
-                            Removed rather than hidden, unlike the input
-                            above it: that input is a capture control and
-                            still has work to do while no company is
-                            captured, whereas this was only ever a DISPLAY of
-                            a number, and the new label is that display. Two
-                            renderings of one value is precisely the defect
-                            §7 names. The value itself is untouched —
-                            `companyId` is still the single carrier and
-                            getData() still reads it, never the DOM.
+                            The value itself is untouched — `companyId` is
+                            still the single carrier and getData() still
+                            reads it, never the DOM.
                         -->
                     </div>
                 </div>

--- a/view/frontend/web/template/payment/gateway_method.html
+++ b/view/frontend/web/template/payment/gateway_method.html
@@ -227,15 +227,23 @@
                     on the tile to pick a different company — a dead end
                     without a page reload on exactly the checkouts where the
                     tile is the buyer's ONLY route (saved address, virtual
-                    cart, or the setting off). isOrderIntentDeclinedNoticeVisible()
-                    re-opens the field for precisely that state; picking a new
-                    company clears the declined notice AND completes capture,
+                    cart, or the setting off).
+
+                    isCompanyRecoveryNeeded(), NOT isOrderIntentDeclinedNoticeVisible()
+                    — round 2 of the same review found gating this on the
+                    NOTICE's own visibility reproduced the dead-end for any
+                    brand with order_intent enabled but the notice UI
+                    suppressed (two independent brand.xml switches), since
+                    that brand's notice text is permanently empty even on a
+                    real decline. isCompanyRecoveryNeeded() is set on every
+                    decline regardless of whether any notice text exists.
+                    Picking a new company clears both AND completes capture,
                     so the field hides again once there is something new to
                     hide it for.
                 -->
                 <div
                     class="field field-text required"
-                    data-bind="visible: (!isCompanyCaptured() || isOrderIntentDeclinedNoticeVisible()) && isTileCompanySearchActive()"
+                    data-bind="visible: (!isCompanyCaptured() || isCompanyRecoveryNeeded()) && isTileCompanySearchActive()"
                 >
                     <label for="company_name" class="label">
                         <span><!-- ko i18n: 'Company Name'--><!-- /ko --></span>

--- a/view/frontend/web/template/payment/gateway_method.html
+++ b/view/frontend/web/template/payment/gateway_method.html
@@ -216,10 +216,26 @@
                     where this is hidden are states where the buyer either
                     already captured a company here or has another control
                     (the address-area one) to do it with.
+
+                    RE-SHOWN on a decline, even though isCompanyCaptured() is
+                    still true then (found in adversarial review, 2026-08-04):
+                    processOrderIntentSuccessResponse()'s declined branch does
+                    NOT clear companyName/companyId — only an approval's own
+                    company-change subscriptions do that. Gating on capture
+                    alone left a declined buyer looking at a persistent "not
+                    available for this order" notice with NO control anywhere
+                    on the tile to pick a different company — a dead end
+                    without a page reload on exactly the checkouts where the
+                    tile is the buyer's ONLY route (saved address, virtual
+                    cart, or the setting off). isOrderIntentDeclinedNoticeVisible()
+                    re-opens the field for precisely that state; picking a new
+                    company clears the declined notice AND completes capture,
+                    so the field hides again once there is something new to
+                    hide it for.
                 -->
                 <div
                     class="field field-text required"
-                    data-bind="visible: !isCompanyCaptured() && isTileCompanySearchActive()"
+                    data-bind="visible: (!isCompanyCaptured() || isOrderIntentDeclinedNoticeVisible()) && isTileCompanySearchActive()"
                 >
                     <label for="company_name" class="label">
                         <span><!-- ko i18n: 'Company Name'--><!-- /ko --></span>


### PR DESCRIPTION
## Summary

Implements Doug's 2026-08-03 design ruling on TWO-25326 for Magento (Luma/Amasty/Fire, one shared code path):

- **§6a — gating alignment.** The Two payment method stays selectable with a manual (name-only, no organisation number) capture, but submit is now blocked with a visible message, matching the WC/PS/Hyvä pattern. Previously: no block, no message, no order — a silent no-op.
- **Two bugs found along the way, both fixed:**
  - `gateway_method.js`'s `SCHEMA_ERROR` error-handling branch reassigned a `const message`, throwing and silently swallowing the message this exact path exists to show. `const` → `let`.
  - `order_intent` 400s on every free-shipping cart: the `SHIPPING_FEE` line divided `shipping_tax_amount` by a zero `shipping_amount`, sending `tax_rate: "NaN"`. Now resolves to `"0.000000"` when shipping is free.
- **§7.1 — one shared company-search control, location set by admin setting.** The existing `enable_company_search` setting already gated the address-area control; the payment tile's own instance of the same widget was previously unconditional. It now binds only when the tile is the active location (setting off, or no address-area host exists — saved address / virtual cart).
- **§7.2/§7.3 — text-only tile, standalone label removed.** The pre-ruling `.two-company-label` element is removed, not relocated: company name/number now appear only embedded inside the order-intent notice sentence itself:
  - Approved: `This order by <name> (<number>) is likely to be accepted by Two`
  - Not approved: `Two is not available for this order by <name> (<number>)`

  A clean "not approved" response now renders as a persistent tile notice (mirroring the approved notice) instead of a toast a later checkout update would wipe.
- **§7.4 — audited the private brand-overlay repo for this platform** (read-only reference, not modified): its brand config already suppresses the whole intent-message surface for that brand, so there's no vanilla-string override risk today. The new per-notice copy-override mechanism is independent per notice, ready for any future brand that re-enables the notice with its own wording.
- **Follow-up bundled in this PR (own commit):** TWO-25347 — `fillCustomerData()` stacked undisposed subscriptions on every re-render, firing N concurrent `order_intent` POSTs for a single company pick on Fire Checkout. Fixed with proper disposal + a belt-and-braces in-flight guard.

## Test plan

- [x] PHP: `make test` — 558/558 passing, including new/updated `ConfigProviderIntentApprovedNoticeTest` and `ConfigProviderIntentDeclinedNoticeTest`.
- [x] JS: `npx jest --config Test/Js/jest.config.js` — 333/333 passing across 26 suites, including new coverage for the §6a gate, the tile location gate, the customer-data subscription leak, and both notices' independent gating/wording/clearing.
- [x] Mutation-verified: temporarily broke the new declined-notice test assertions and confirmed they fail for the right reason before restoring.
- [ ] Real-browser/local Docker checkout verification of: §6a block message on manual entry, free-shipping order_intent no longer 400s, tile shows the merged notice text with name+number, tile search control moves per the admin setting.
