### PR TITLE
fix(checkout): declined intent notice must never be brand-overridable

### DIFF
--- a/Api/BrandRegistryInterface.php
+++ b/Api/BrandRegistryInterface.php
@@ -78,24 +78,13 @@ interface BrandRegistryInterface
     public function getIntentApprovedNotice(): ?string;
 
     /**
-     * Per-brand COPY override for the buyer-facing "order intent NOT
-     * approved" notice rendered inline in the checkout payment tile
-     * (TWO-25326 §7.3/§7.4, added 2026-08-03). Sourced from brand.xml
-     * <intent_declined_notice>. Wording only, and independent of the
-     * approved-notice override — a brand overlay with its own approved copy
-     * is not forced to also take the vanilla declined copy.
-     *
-     * Suppressed by the SAME switch as the approved notice —
-     * isIntentApprovedNoticeEnabled() — since the ruling treats "the intent
-     * message" as one on/off unit, approved or declined, not two.
-     *
-     *  - `null`  — no override (element absent, empty or whitespace-only):
-     *              platform default translated copy. Never ''.
-     *  - non-''  — used verbatim as the company-known copy template
-     *              (%1 = brand product name, %2 = buyer company name,
-     *              %3 = buyer organisation number).
+     * Deliberately absent: the buyer-facing "order intent NOT approved"
+     * notice is NEVER brand-overridable (2026-08-04 ruling, TWO-25326).
+     * Every brand renders the platform default declined/not-available
+     * copy. Do not add a getIntentDeclinedNotice()-style hook here; a
+     * brand overlay that wants different declined-notice wording is a
+     * ruling change, not a code change.
      */
-    public function getIntentDeclinedNotice(): ?string;
 
     /**
      * Short brand tag used to decorate non-production checkout URLs

--- a/Brand/DescriptorBackedBrandRegistry.php
+++ b/Brand/DescriptorBackedBrandRegistry.php
@@ -61,11 +61,6 @@ class DescriptorBackedBrandRegistry implements BrandRegistryInterface
         return $this->activeBrandResolver->resolve()->getIntentApprovedNotice();
     }
 
-    public function getIntentDeclinedNotice(): ?string
-    {
-        return $this->activeBrandResolver->resolve()->getIntentDeclinedNotice();
-    }
-
     public function getSignUpUrl(): string
     {
         return $this->activeBrandResolver->resolve()->getSignUpUrl();

--- a/Model/Brand.php
+++ b/Model/Brand.php
@@ -122,19 +122,6 @@ class Brand implements BrandRegistryInterface
         );
     }
 
-    /**
-     * @deprecated 2.0.0 See note on getCode().
-     */
-    public function getIntentDeclinedNotice(): ?string
-    {
-        throw new \LogicException(
-            'Two\\Gateway\\Model\\Brand is deprecated; consume '
-            . 'BrandRegistryInterface via DescriptorBackedBrandRegistry instead. '
-            . 'The intent-declined notice override now comes from brand.xml '
-            . '`<intent_declined_notice>` via ActiveBrandResolver.'
-        );
-    }
-
     public function getSignUpUrl(): string
     {
         return $this->signUpUrl;

--- a/Model/Brand/Descriptor.php
+++ b/Model/Brand/Descriptor.php
@@ -46,7 +46,6 @@ final class Descriptor
      * @param float[] $surchargeRoundingSteps Buyer-surcharge rounding steps offered in the admin Rounding Step dropdown, ascending.
      * @param string|null $intentApprovedNotice Copy override for the buyer-facing intent-approved notice; null = use the platform default copy. Never ''. See getIntentApprovedNotice().
      * @param bool $intentApprovedNoticeEnabled Whether the buyer-facing intent-approved notice is rendered at all. Default true. See isIntentApprovedNoticeEnabled().
-     * @param string|null $intentDeclinedNotice Copy override for the buyer-facing intent-NOT-approved notice; null = use the platform default copy. Never ''. See getIntentDeclinedNotice().
      */
     public function __construct(
         private readonly string $code,
@@ -73,8 +72,7 @@ final class Descriptor
         private readonly string $checkoutSubtitle = '',
         private readonly array $surchargeRoundingSteps = [],
         private readonly ?string $intentApprovedNotice = null,
-        private readonly bool $intentApprovedNoticeEnabled = true,
-        private readonly ?string $intentDeclinedNotice = null
+        private readonly bool $intentApprovedNoticeEnabled = true
     ) {
     }
 
@@ -118,18 +116,6 @@ final class Descriptor
     public function getIntentApprovedNotice(): ?string
     {
         return $this->intentApprovedNotice;
-    }
-
-    /**
-     * Per-brand COPY override for the buyer-facing "order intent NOT
-     * approved" notice (TWO-25326 §7.3/§7.4, 2026-08-03 ruling). Same
-     * null-means-default contract as getIntentApprovedNotice(), and gated
-     * by the SAME isIntentApprovedNoticeEnabled() switch — a brand that
-     * suppresses the notice gets neither variant.
-     */
-    public function getIntentDeclinedNotice(): ?string
-    {
-        return $this->intentDeclinedNotice;
     }
 
     /**

--- a/Model/Brand/Loader.php
+++ b/Model/Brand/Loader.php
@@ -208,14 +208,21 @@ class Loader
             $intentApprovedNotice = null;
         }
 
-        // Copy override ONLY, same contract as $intentApprovedNotice above
-        // — added by the 2026-08-03 ruling (TWO-25326 §7.3/§7.4). No
-        // separate enabled/disabled element: suppression is the approved
-        // notice's switch, since the ruling treats "the intent message" as
-        // one on/off unit.
-        $intentDeclinedNotice = trim((string)($brand->intent_declined_notice ?? ''));
-        if ($intentDeclinedNotice === '') {
-            $intentDeclinedNotice = null;
+        // The declined/not-available notice is NEVER brand-overridable
+        // (2026-08-04 ruling, TWO-25326): there is deliberately no copy
+        // override element for it. A brand.xml that declares
+        // <intent_declined_notice> anyway is almost certainly copying the
+        // approved-notice pattern by habit, so this fails loudly rather
+        // than silently ignoring the element and leaving the overlay
+        // author to wonder why their copy never renders.
+        if (isset($brand->intent_declined_notice)) {
+            throw new \DomainException(sprintf(
+                'brand.xml at %s declares <intent_declined_notice>, which is '
+                . 'not a supported override: the buyer-facing "order intent '
+                . 'NOT approved" notice is never brand-overridable. Remove '
+                . 'the element; the platform default copy always renders.',
+                $sourcePath
+            ));
         }
 
         $inlineTermFees = true;
@@ -252,8 +259,7 @@ class Loader
             (string)($brand->checkout_subtitle ?? ''),
             $roundingSteps,
             $intentApprovedNotice,
-            $intentApprovedNoticeEnabled,
-            $intentDeclinedNotice
+            $intentApprovedNoticeEnabled
         );
     }
 }

--- a/Model/Ui/ConfigProvider.php
+++ b/Model/Ui/ConfigProvider.php
@@ -338,6 +338,11 @@ class ConfigProvider implements ConfigProviderInterface
      * surface, `generalErrorMessage`, handled by
      * processOrderIntentErrorResponse() in gateway_method.js.
      *
+     * Deliberately NOT brand-overridable (2026-08-04 ruling, TWO-25326):
+     * unlike getOrderIntentApprovedNotice() above, there is no copy-override
+     * hook here and there must never be one — every brand renders this exact
+     * platform default copy. See BrandRegistryInterface for the contract.
+     *
      * @return array{withCompany:string,withoutCompany:string,companyNameToken:string,companyNumberToken:string}|null
      */
     private function getOrderIntentDeclinedNotice(): ?array
@@ -346,18 +351,14 @@ class ConfigProvider implements ConfigProviderInterface
             return null;
         }
 
-        $override = $this->brandRegistry->getIntentDeclinedNotice();
-
         $productName = $this->brandRegistry->getProductName();
 
-        $withCompany = $override === null
-            ? __(
-                '%1 is not available for this order by %2 (%3)',
-                $productName,
-                self::COMPANY_NAME_TOKEN,
-                self::COMPANY_NUMBER_TOKEN
-            )
-            : __($override, $productName, self::COMPANY_NAME_TOKEN, self::COMPANY_NUMBER_TOKEN);
+        $withCompany = __(
+            '%1 is not available for this order by %2 (%3)',
+            $productName,
+            self::COMPANY_NAME_TOKEN,
+            self::COMPANY_NUMBER_TOKEN
+        );
 
         return [
             'withCompany' => (string)$withCompany,

--- a/Test/Unit/Model/Ui/ConfigProviderIntentDeclinedNoticeTest.php
+++ b/Test/Unit/Model/Ui/ConfigProviderIntentDeclinedNoticeTest.php
@@ -12,32 +12,26 @@ use Two\Gateway\Api\BrandRegistryInterface;
 use Two\Gateway\Model\Ui\ConfigProvider;
 
 /**
- * ConfigProvider's intent-DECLINED-notice payload resolution (TWO-25326
- * §7.3/§7.4, 2026-08-03 ruling). Mirrors
- * ConfigProviderIntentApprovedNoticeTest — same suppression switch
- * (isIntentApprovedNoticeEnabled), a SEPARATE copy override
- * (getIntentDeclinedNotice), and a company-number substitution the
- * approved notice also gained in the same ruling.
+ * ConfigProvider's intent-DECLINED-notice payload resolution. Same
+ * suppression switch as the approved notice (isIntentApprovedNoticeEnabled),
+ * but — unlike the approved notice — deliberately NO brand copy override
+ * (2026-08-04 ruling, TWO-25326): every brand renders the exact same
+ * platform default copy for this outcome. BrandRegistryInterface has no
+ * getIntentDeclinedNotice() method; do not reintroduce one, and do not add
+ * a call to it here.
  */
 class ConfigProviderIntentDeclinedNoticeTest extends TestCase
 {
     public function testReturnsNullWhenTheBrandDisabledTheNotice(): void
     {
-        $payload = $this->resolveFor(false, null);
+        $payload = $this->resolveFor(false);
 
         $this->assertNull($payload);
     }
 
-    public function testReturnsNullWhenDisabledEvenWithACopyOverride(): void
+    public function testReturnsPlatformDefaultCopyWhenEnabled(): void
     {
-        $payload = $this->resolveFor(false, 'Custom %1 decline for %2 (%3).');
-
-        $this->assertNull($payload);
-    }
-
-    public function testReturnsDefaultCopyWhenEnabledWithNoOverride(): void
-    {
-        $payload = $this->resolveFor(true, null);
+        $payload = $this->resolveFor(true);
 
         $this->assertIsArray($payload);
         $this->assertSame(
@@ -54,32 +48,13 @@ class ConfigProviderIntentDeclinedNoticeTest extends TestCase
         $this->assertSame(ConfigProvider::COMPANY_NUMBER_TOKEN, $payload['companyNumberToken']);
     }
 
-    public function testOverrideReplacesTheCompanyKnownVariantOnly(): void
-    {
-        $payload = $this->resolveFor(true, 'Custom %1 decline for %2 (%3).');
-
-        $this->assertIsArray($payload);
-        $this->assertSame(
-            'Custom Acme decline for '
-            . ConfigProvider::COMPANY_NAME_TOKEN
-            . ' (' . ConfigProvider::COMPANY_NUMBER_TOKEN . ').',
-            $payload['withCompany']
-        );
-        $this->assertSame(
-            'Acme is not available for this order',
-            $payload['withoutCompany']
-        );
-    }
-
     public function testApprovedOverrideDoesNotLeakIntoTheDeclinedCopy(): void
     {
-        // §7.4: a brand's approved wording must never be forced onto the
-        // declined variant, or vice versa — the two overrides are
-        // independent knobs.
+        // A brand's approved wording must never bleed into the declined
+        // variant — the declined variant has no override input at all.
         $registry = $this->createMock(BrandRegistryInterface::class);
         $registry->method('isIntentApprovedNoticeEnabled')->willReturn(true);
         $registry->method('getIntentApprovedNotice')->willReturn('Approved copy for %2.');
-        $registry->method('getIntentDeclinedNotice')->willReturn(null);
         $registry->method('getProductName')->willReturn('Acme');
 
         $reflection = new \ReflectionClass(ConfigProvider::class);
@@ -91,14 +66,27 @@ class ConfigProviderIntentDeclinedNoticeTest extends TestCase
         $this->assertStringNotContainsString('Approved copy', $declined['withCompany']);
     }
 
+    public function testBrandRegistryInterfaceHasNoDeclinedNoticeOverrideHook(): void
+    {
+        // Locks in the 2026-08-04 ruling at the type level: a brand overlay
+        // must never be able to override this copy. If this assertion ever
+        // fails, someone re-added the hook — revert it, don't update this
+        // test.
+        $this->assertFalse(
+            method_exists(BrandRegistryInterface::class, 'getIntentDeclinedNotice'),
+            'BrandRegistryInterface must not declare a declined-notice copy '
+            . 'override; the "order intent NOT approved" message is never '
+            . 'brand-overridable.'
+        );
+    }
+
     /**
      * @return array{withCompany:string,withoutCompany:string,companyNameToken:string,companyNumberToken:string}|null
      */
-    private function resolveFor(bool $enabled, ?string $override): ?array
+    private function resolveFor(bool $enabled): ?array
     {
         $registry = $this->createMock(BrandRegistryInterface::class);
         $registry->method('isIntentApprovedNoticeEnabled')->willReturn($enabled);
-        $registry->method('getIntentDeclinedNotice')->willReturn($override);
         $registry->method('getProductName')->willReturn('Acme');
 
         $reflection = new \ReflectionClass(ConfigProvider::class);

--- a/docs/brand-overlay-guide.md
+++ b/docs/brand-overlay-guide.md
@@ -133,21 +133,29 @@ across modules). Elements may appear in any order (`xs:all`).
 | `inline_term_fees`               | no       | boolean                   | Show per-term merchant fee beside Payment Terms checkboxes in admin (default true).                                                                             |
 | `intent_approved_notice_enabled` | no       | `true` \| `false`         | On/off switch for BOTH the "order intent approved" and "order intent declined" notices. Default `true`. **See below.**                                          |
 | `intent_approved_notice`         | no       | string                    | Copy override for the approved notice — wording only, **not** an off switch. **See below.**                                                                     |
-| `intent_declined_notice`         | no       | string                    | Copy override for the declined notice — a SEPARATE override from the approved one (added 2026-08-03, TWO-25326 §7.3/§7.4). **See below.**                       |
 
-### The intent notices — one on/off switch, two independent wording overrides
+There is deliberately **no** `intent_declined_notice` element. See below.
+
+### The intent notices — one on/off switch, one wording override
 
 The notices are buyer-facing "order intent approved" / "order intent not
 approved" lines rendered inline in the checkout payment tile — as of the
 2026-08-03 ruling (TWO-25326 §7.3), this is the ONLY place the buyer's
 captured company name/number are displayed in the tile at all; the
 earlier standalone `.two-company-label` element is gone, not relocated.
-Both notices are controlled by **one shared on/off switch** and **two
-independent wording overrides**. **Do not overload the switch with
-wording meaning** — an off switch expressed as the absence of content is
-indistinguishable from an unfinished string, and any tidy-up that
-deletes the "empty, unused" declaration silently turns the notice back
-on.
+Both notices are controlled by **one shared on/off switch**, but only the
+APPROVED notice has a wording override. **This is deliberate, not an
+oversight** (2026-08-04 ruling, TWO-25326): the declined/not-available
+notice must render identical platform-default copy for every brand,
+approved-only overrides are how each ABN-style overlay puts its own
+branding on the reassurance message while the "not available" wording
+stays neutral. Do not add an `intent_declined_notice` copy-override
+element — `Model\Brand\Loader` hard-fails if a brand.xml declares one.
+
+**Do not overload the switch with wording meaning** — an off switch
+expressed as the absence of content is indistinguishable from an
+unfinished string, and any tidy-up that deletes the "empty, unused"
+declaration silently turns the notice back on.
 
 #### `intent_approved_notice_enabled` — the on/off switch for BOTH notices
 
@@ -176,25 +184,25 @@ runtime (see the validation warning below):
 Note `xs:boolean` is deliberately **not** used: it would also accept `1`
 and `0`, and this switch is meant to read as a decision.
 
-#### `intent_approved_notice` / `intent_declined_notice` — the copy overrides
-
-Two SEPARATE elements, one per notice — a brand with its own approved
-wording is not forced to also take the vanilla declined wording, or
-vice versa (§7.4):
+#### `intent_approved_notice` — the copy override (approved only)
 
 | brand.xml                                            | Behaviour                                                                                                                                              |
 | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| element absent                                       | Platform default translated copy for that notice.                                                                                                        |
+| element absent                                       | Platform default translated copy.                                                                                                        |
 | empty or whitespace-only                             | **Inert** — same as absent. It does **not** mean "off".                                                                                                  |
 | `<intent_approved_notice>…</intent_approved_notice>` | Used verbatim as the approved-notice template. `%1` = brand product name, `%2` = buyer company name, `%3` = buyer organisation number (added 2026-08-03). |
-| `<intent_declined_notice>…</intent_declined_notice>` | Used verbatim as the declined-notice template. Same `%1`/`%2`/`%3` contract.                                                                              |
 
-`Descriptor::getIntentApprovedNotice()` / `getIntentDeclinedNotice()`
-each return `null` for the first two rows and their own template for the
-third; neither ever returns `''`. The switch above is what
-`Model\Ui\ConfigProvider` consults to decide whether to ship EITHER
-payload to the renderer at all — the resolution otherwise runs
-independently per notice.
+`Descriptor::getIntentApprovedNotice()` returns `null` for the first two
+rows and the template for the third; it never returns `''`. The declined
+notice has no equivalent override — `Model\Ui\ConfigProvider` always
+renders its own literal default copy for that outcome, and only consults
+the switch above to decide whether to ship EITHER payload to the
+renderer at all.
+
+**Every ABN-style brand overlay is expected to declare
+`intent_approved_notice`** with brand-specific copy (2026-08-04 ruling) —
+falling through to the platform default here for a live overlay is a
+bug, not a valid "no opinion" state.
 
 #### Deploy order
 
@@ -222,17 +230,19 @@ code path) emits each notice as a persistent inline element with class
 inside the payment-method tile, as does PrestaShop (approved variant
 only, as of writing). WooCommerce uses `twoinc-intent-approved` instead,
 so grep for the platform-specific class names when sweeping the four
-checkout surfaces. The magento-hyva-extension repo is out of scope for
-the 2026-08-03 declined-notice addition described here — check that repo
-directly before assuming it has picked up the same shape.
+checkout surfaces. `magento-hyva-extension` shares this parent's
+`BrandRegistryInterface`/brand.xml, so a brand's `intent_approved_notice`
+override applies to Hyvä too without any Hyvä-side declaration.
 
-The two keys carry the same names and the same semantics on WooCommerce
-and PrestaShop, where they are real PHP booleans rather than an XSD
-enumeration. **The failure mode differs:** an invalid value throws here
-and is a logged error plus the default `true` there, because those
-resolvers run while rendering a buyer-facing checkout, where a white
-screen is worse than a notice that stays on. Don't assume Magento's
-throw when working across platforms.
+The `intent_approved_notice_enabled` key carries the same name and
+semantics on WooCommerce and PrestaShop, where it is a real PHP boolean
+rather than an XSD enumeration. **The failure mode differs:** an invalid
+value throws here and is a logged error plus the default `true` there,
+because those resolvers run while rendering a buyer-facing checkout,
+where a white screen is worse than a notice that stays on. Don't assume
+Magento's throw when working across platforms. None of the four
+platforms has (or should ever grow) a copy-override element for the
+declined/not-available notice.
 
 ### A warning about validation
 

--- a/docs/brand-overlay-guide.md
+++ b/docs/brand-overlay-guide.md
@@ -147,7 +147,7 @@ Both notices are controlled by **one shared on/off switch**, but only the
 APPROVED notice has a wording override. **This is deliberate, not an
 oversight** (2026-08-04 ruling, TWO-25326): the declined/not-available
 notice must render identical platform-default copy for every brand,
-approved-only overrides are how each ABN-style overlay puts its own
+approved-only overrides are how each brand overlay puts its own
 branding on the reassurance message while the "not available" wording
 stays neutral. Do not add an `intent_declined_notice` copy-override
 element — `Model\Brand\Loader` hard-fails if a brand.xml declares one.
@@ -199,7 +199,7 @@ renders its own literal default copy for that outcome, and only consults
 the switch above to decide whether to ship EITHER payload to the
 renderer at all.
 
-**Every ABN-style brand overlay is expected to declare
+**Every white-label brand overlay is expected to declare
 `intent_approved_notice`** with brand-specific copy (2026-08-04 ruling) —
 falling through to the platform default here for a live overlay is a
 bug, not a valid "no opinion" state.

--- a/etc/brand.xsd
+++ b/etc/brand.xsd
@@ -96,22 +96,13 @@
             -->
             <xs:element name="intent_approved_notice" type="xs:string" minOccurs="0"/>
             <!--
-                COPY OVERRIDE ONLY for the "order intent NOT approved" tile
-                notice (TWO-25326 §7.3/§7.4, added 2026-08-03). Same
-                inert-when-absent/empty contract as
-                <intent_approved_notice> above, and gated by the SAME
-                <intent_approved_notice_enabled> switch — there is no
-                separate on/off element for the declined variant.
-
-                  absent / empty / whitespace-only
-                          ⇒ INERT: platform default translated copy
-                  non-empty
-                          ⇒ used verbatim as the company-known copy
-                            template (%1 = brand product name,
-                            %2 = buyer company name,
-                            %3 = buyer organisation number)
+                Deliberately no <intent_declined_notice> element here
+                (removed 2026-08-04 ruling, TWO-25326): the "order intent
+                NOT approved" tile notice is never brand-overridable. Do
+                not re-add this element; Model\Brand\Loader also hard-fails
+                if a brand.xml declares it, as a backstop for an overlay on
+                an older copy of this schema.
             -->
-            <xs:element name="intent_declined_notice" type="xs:string" minOccurs="0"/>
             <xs:element name="csp_origins" type="cspOriginsType" minOccurs="0"/>
             <xs:element name="admin_resource" type="xs:string"/>
             <xs:element name="module_label_chain" type="moduleLabelChainType" minOccurs="0"/>


### PR DESCRIPTION
## Summary
- Reverts the part of #321 that added a fully-wired brand-override hook (`getIntentDeclinedNotice()`, `<intent_declined_notice>`) for the "order intent NOT approved" checkout tile notice. Per the 2026-08-04 TWO-25326 ruling, that message must render identical platform-default copy for every brand — only the approved/success notice is meant to be brand-overridable.
- `BrandRegistryInterface::getIntentDeclinedNotice()` and every implementation (registry, deprecated legacy `Brand`, `Descriptor`) removed.
- `Model\Brand\Loader` now hard-fails with a `DomainException` if a `brand.xml` declares `<intent_declined_notice>`, instead of silently parsing it.
- `etc/brand.xsd` no longer declares the element.
- `ConfigProvider::getOrderIntentDeclinedNotice()` always returns the literal platform-default copy.
- `docs/brand-overlay-guide.md` and the unit test suite updated to document/lock in "approved is overridable, declined never is".

The approved-notice override (`getIntentApprovedNotice()`) is untouched — brand overlays still use it, and per the same ruling every ABN-style brand overlay is now expected to actually use it (tracked/fixed separately in the brand-overlay repos, not this PR).

## Test plan
- [x] `make test` — full PHPUnit suite, 557 tests / 1006 assertions, all green.
- [x] `php -l` on every touched file.
- [x] Grepped diff for stray brand names before pushing (this is the public base repo).