### PR TITLE
refactor(checkout): consolidate company-search select2 wiring into one class

### DIFF
--- a/Test/Js/all-js-modules.test.js
+++ b/Test/Js/all-js-modules.test.js
@@ -28,6 +28,7 @@ const JS_FILES = [
     'view/frontend/requirejs-config.js',
     'view/frontend/web/js/action/set-shipping-information-mixin.js',
     'view/frontend/web/js/model/brand-config.js',
+    'view/frontend/web/js/model/company-search-control.js',
     'view/frontend/web/js/model/new-customer-address-mixin.js',
     'view/frontend/web/js/model/surcharge.js',
     'view/frontend/web/js/view/address-autocomplete.js',

--- a/Test/Js/amd-harness.js
+++ b/Test/Js/amd-harness.js
@@ -153,6 +153,26 @@ function defaultMocks() {
             setSearching: function () {},
             setUnavailable: function () {}
         },
+        // Inert default, same convention as the company-search mock above:
+        // a constructor whose instances no-op every method. Tests that
+        // exercise the real select2 wiring load the real
+        // company-search-control.js module and pass it via extraMocks so
+        // they control the jQuery/select2 it closes over.
+        'Two_Gateway/js/model/company-search-control': (function () {
+            function CompanySearchControlMock() {
+                this._field = null;
+            }
+            CompanySearchControlMock.prototype.bind = function () {};
+            CompanySearchControlMock.prototype.destroy = function () { return false; };
+            CompanySearchControlMock.prototype.abortActiveRequest = function () { return false; };
+            CompanySearchControlMock.prototype.isBound = function () { return false; };
+            CompanySearchControlMock.prototype.getField = function () { return this._field || {}; };
+            CompanySearchControlMock.prototype.showSearchForCompanyLink = function () {};
+            CompanySearchControlMock.prototype.getSearchForCompanyLink = function () {
+                return { length: 0 };
+            };
+            return CompanySearchControlMock;
+        })(),
         'Two_Gateway/js/model/brand-config': (function () {
             function getBrandConfig(code) {
                 return ((typeof window !== 'undefined' && window.checkoutConfig && window.checkoutConfig.payment) || {})[code] || {};
@@ -465,4 +485,45 @@ function loadAmdModule(relPath, extraMocks, extraGlobals) {
     return captured;
 }
 
-module.exports = { loadAmdModule: loadAmdModule, defaultMocks: defaultMocks };
+/**
+ * Load the REAL `company-search-control.js` class, closed over the given
+ * jQuery (usually a test's own recording/spy double) and the given
+ * `company-search.js` mock/real-module.
+ *
+ * Every test that wants to observe the actual select2 wiring — the
+ * `.select2({...})` call, its `select2:open`/`select2:close`/`select2:select`
+ * handlers, the manual-entry button, the "Search for company" link — has to
+ * load this for real, exactly as it already has to load the real
+ * `company-search.js` for the same reason: TWO-25326's rebuild moved that
+ * wiring out of `address-autocomplete.js` / `gateway_method.js` and into
+ * this one shared class, so the default inert mock (a no-op stub, same
+ * convention as the `company-search` default) proves nothing about it.
+ *
+ * @param {object} $ jQuery (real or a test double)
+ * @param {object} [companySearchMock] `company-search.js` module/mock —
+ *        defaults to the harness's own inert mock, same as any other dep.
+ * @param {object} [extraGlobals] forwarded to `loadAmdModule` — pass
+ *        `{ document: document, window: window }` for any test that expects
+ *        the `select2:open` handler's real focus call (`document
+ *        .querySelector('.select2-search__field').focus()`) to land on the
+ *        REAL jsdom document, the same real-globals requirement this line
+ *        had before TWO-25326 moved it out of the two surface files.
+ * @returns {Function} the CompanySearchControl constructor
+ */
+function loadCompanySearchControl($, companySearchMock, extraGlobals) {
+    const extraMocks = { jquery: $ };
+    if (companySearchMock) {
+        extraMocks['Two_Gateway/js/model/company-search'] = companySearchMock;
+    }
+    return loadAmdModule(
+        'view/frontend/web/js/model/company-search-control.js',
+        extraMocks,
+        extraGlobals
+    );
+}
+
+module.exports = {
+    loadAmdModule: loadAmdModule,
+    defaultMocks: defaultMocks,
+    loadCompanySearchControl: loadCompanySearchControl
+};

--- a/Test/Js/company-search-address-lookup.test.js
+++ b/Test/Js/company-search-address-lookup.test.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const { loadAmdModule } = require('./amd-harness');
+const { loadAmdModule, loadCompanySearchControl } = require('./amd-harness');
 
 /**
  * jQuery test double that records $.ajax calls and the values written to
@@ -220,7 +220,11 @@ describe('payment-step company picker (gateway_method.js)', () => {
                 'view/frontend/web/js/view/payment/method-renderer/gateway_method.js',
                 {
                     jquery: $,
-                    'Two_Gateway/js/model/company-search': companySearch
+                    'Two_Gateway/js/model/company-search': companySearch,
+                    'Two_Gateway/js/model/company-search-control': loadCompanySearchControl(
+                        $,
+                        companySearch
+                    )
                 }
             ),
             companySearch: companySearch
@@ -319,7 +323,8 @@ describe('shipping-step company picker (address-autocomplete.js)', () => {
         const component = loadAmdModule('view/frontend/web/js/view/address-autocomplete.js', {
             jquery: $,
             'Two_Gateway/js/model/brand-config': brandConfig,
-            'Two_Gateway/js/model/company-search': companySearch
+            'Two_Gateway/js/model/company-search': companySearch,
+            'Two_Gateway/js/model/company-search-control': loadCompanySearchControl($, companySearch)
         });
 
         const ctx = Object.assign(Object.create(component.prototype || {}), {
@@ -366,7 +371,8 @@ describe('shipping-step company picker (address-autocomplete.js)', () => {
             jquery: $,
             'Magento_Customer/js/customer-data': { set: function () {}, get: function () { return function () {}; } },
             'Two_Gateway/js/model/brand-config': brandConfig,
-            'Two_Gateway/js/model/company-search': companySearch
+            'Two_Gateway/js/model/company-search': companySearch,
+            'Two_Gateway/js/model/company-search-control': loadCompanySearchControl($, companySearch)
         });
 
         const companyIdSelector =

--- a/Test/Js/company-search-country-switch.test.js
+++ b/Test/Js/company-search-country-switch.test.js
@@ -39,7 +39,7 @@
 
 'use strict';
 
-const { loadAmdModule } = require('./amd-harness');
+const { loadAmdModule, loadCompanySearchControl } = require('./amd-harness');
 
 const MODEL = 'view/frontend/web/js/model/company-search.js';
 const ADDRESS_STEP = 'view/frontend/web/js/view/address-autocomplete.js';
@@ -312,6 +312,7 @@ function loadAddressStep(options) {
         jquery: dom.$,
         'Magento_Customer/js/customer-data': cd.api,
         'Two_Gateway/js/model/company-search': companySearch,
+        'Two_Gateway/js/model/company-search-control': loadCompanySearchControl(dom.$, companySearch),
         'Two_Gateway/js/model/brand-config': {
             getActiveTwoBrandConfig: function () {
                 return {
@@ -467,9 +468,11 @@ describe('the address step on a country change', () => {
     test('a search still on the wire for the old country is cancelled', () => {
         // Up to 30s of window (REQUEST_TIMEOUT_MS) in which a GB response can
         // land and repaint a dropdown the buyer is now reading as ES results.
-        const ctx = loadAddressStep({ country: 'GB' });
-        const token = {};
-        ctx.component._bindToken = token;
+        // Search has to be ENABLED for a real control (and a real bind
+        // token) to exist at all — see the "no re-bind" test below for the
+        // token identity itself.
+        const ctx = loadAddressStep({ country: 'GB', searchEnabled: true });
+        const token = ctx.component._companySearchControl.getBindToken();
 
         switchCountryTo(ctx, 'ES');
 
@@ -481,10 +484,11 @@ describe('the address step on a country change', () => {
         // handler would be cancelling nothing, in a shape indistinguishable
         // from cancelling correctly.
         const ctx = loadAddressStep({ country: 'GB', searchEnabled: true });
+        const token = ctx.component._companySearchControl.getBindToken();
 
-        expect(typeof ctx.component._bindToken).toBe('object');
-        expect(ctx.component._bindToken).not.toBeNull();
-        expect(ctx.calls.ajaxOptions.token).toBe(ctx.component._bindToken);
+        expect(typeof token).toBe('object');
+        expect(token).not.toBeNull();
+        expect(ctx.calls.ajaxOptions.token).toBe(token);
     });
 
     test('the next search carries the new country, with no re-bind', () => {
@@ -493,12 +497,12 @@ describe('the address step on a country change', () => {
         // the bound widget already searches the new country — and a re-bind
         // would drag a buyer in manual-entry mode back into search mode.
         const ctx = loadAddressStep({ country: 'GB', searchEnabled: true });
-        const tokenBefore = ctx.component._bindToken;
+        const tokenBefore = ctx.component._companySearchControl.getBindToken();
 
         switchCountryTo(ctx, 'ES');
 
         expect(ctx.calls.ajaxOptions.getCountryCode()).toBe('ES');
-        expect(ctx.component._bindToken).toBe(tokenBefore);
+        expect(ctx.component._companySearchControl.getBindToken()).toBe(tokenBefore);
     });
 
     test('a change event that re-selects the same country discards nothing', () => {
@@ -507,8 +511,6 @@ describe('the address step on a country change', () => {
         // switch would blank a returning customer's prefilled company on load.
         const ctx = loadAddressStep({ country: 'GB' });
         ctx.component.setCompanyData('12345678', 'Example Ltd');
-        const token = {};
-        ctx.component._bindToken = token;
 
         switchCountryTo(ctx, 'GB');
 

--- a/Test/Js/company-search-input-hints.test.js
+++ b/Test/Js/company-search-input-hints.test.js
@@ -33,7 +33,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { loadAmdModule } = require('./amd-harness');
+const { loadAmdModule, loadCompanySearchControl } = require('./amd-harness');
 
 const BASE_CONFIG = {
     checkoutApiUrl: 'https://api.example.test',
@@ -124,7 +124,8 @@ function loadShippingSurface($, companySearch) {
     const component = loadAmdModule('view/frontend/web/js/view/address-autocomplete.js', {
         jquery: $,
         'Two_Gateway/js/model/brand-config': brandConfig,
-        'Two_Gateway/js/model/company-search': companySearch
+        'Two_Gateway/js/model/company-search': companySearch,
+        'Two_Gateway/js/model/company-search-control': loadCompanySearchControl($, companySearch)
     });
 
     const ctx = Object.assign(Object.create(component.prototype || {}), {
@@ -251,7 +252,14 @@ describe('threshold centralisation', () => {
 
         const component = loadAmdModule(
             'view/frontend/web/js/view/payment/method-renderer/gateway_method.js',
-            { jquery: $, 'Two_Gateway/js/model/company-search': companySearch }
+            {
+                jquery: $,
+                'Two_Gateway/js/model/company-search': companySearch,
+                'Two_Gateway/js/model/company-search-control': loadCompanySearchControl(
+                    $,
+                    companySearch
+                )
+            }
         );
         const ctx = Object.assign(Object.create(component.prototype || {}), {
             companyNameSelector: 'input#company_name',

--- a/Test/Js/company-search-manual-entry-payment-tile.test.js
+++ b/Test/Js/company-search-manual-entry-payment-tile.test.js
@@ -6,11 +6,17 @@
  * the manual-entry button (a real `<button>`, a sibling of the results list,
  * threshold-driven, staleness-checked) is pinned in
  * company-search-manual-entry.test.js — this file covers only what is
- * specific to the payment-tile surface (`gateway_method.js`): it must wire
- * the SAME shared helpers, with an activation callback that tears down this
- * picker's own widget (`self.clearCompany()`) and brings back the "Search
- * for company" link, rather than address-autocomplete.js's
- * `enterDetailsManually()`.
+ * specific to the payment-tile surface (`gateway_method.js`): it must
+ * construct the ONE shared control (company-search-control.js) with an
+ * `onManualEntryActivated` hook that tears down this picker's own widget
+ * (`self.clearCompany()`) and brings back the "Search for company" link,
+ * rather than address-autocomplete.js's `enterDetailsManually()`.
+ *
+ * TWO-25326 rebuild: the select2 wiring itself — including where
+ * `attachManualEntryButton`/`detachManualEntryButton` are actually called —
+ * moved out of this surface and into that one shared class. What is still
+ * specific to THIS surface, and still worth pinning here, is the glue: which
+ * hook it passes and what that hook does.
  *
  * Structural (source-grep) tests only: the surface's business logic here is
  * a couple of lines of glue around calls the shared-model suite already
@@ -26,6 +32,7 @@ const path = require('path');
 
 const MODEL_PATH = 'view/frontend/web/js/model/company-search.js';
 const SURFACE_PATH = 'view/frontend/web/js/view/payment/method-renderer/gateway_method.js';
+const CONTROL_PATH = 'view/frontend/web/js/model/company-search-control.js';
 
 function readSource(relPath) {
     return fs.readFileSync(path.resolve(__dirname, '..', '..', relPath), 'utf8');
@@ -33,9 +40,11 @@ function readSource(relPath) {
 
 describe('gateway_method.js payment-tile surface (structural fix, #30.x.15)', function () {
     let src;
+    let controlSrc;
 
     beforeAll(function () {
         src = readSource(SURFACE_PATH);
+        controlSrc = readSource(CONTROL_PATH);
     });
 
     test('no longer builds the manual-entry affordance as a select2 pseudo-option', () => {
@@ -43,40 +52,49 @@ describe('gateway_method.js payment-tile surface (structural fix, #30.x.15)', fu
         expect(src).not.toMatch(/isManualEntryOption/);
     });
 
-    test('wires the shared model button on select2:open', () => {
-        expect(src).toMatch(
-            /companySearch\.attachManualEntryButton\(\s*\$companyNameField,\s*bindToken,/
+    test('does not roll its own select2 wiring — constructs the shared control instead', () => {
+        expect(src).toContain('new CompanySearchControl(');
+        expect(src).not.toContain('.select2({');
+        expect(src).not.toMatch(/companySearch\.attachManualEntryButton\(/);
+        expect(src).not.toMatch(/companySearch\.detachManualEntryButton\(/);
+    });
+
+    test('the shared control wires the shared model button on select2:open, and detaches it on close/re-bind', () => {
+        expect(controlSrc).toMatch(
+            /companySearch\.attachManualEntryButton\(\s*\$field,\s*bindToken,/
         );
+        // Search from the `bind()` method itself, not from index 0 — the
+        // class's own doc comment mentions `.select2({…})` in prose, which
+        // would otherwise be found first and make every real call below it
+        // look like it came "before" the (real) select2 init.
+        const bindMethodIndex = controlSrc.indexOf('CompanySearchControl.prototype.bind =');
+        expect(bindMethodIndex).toBeGreaterThan(-1);
+        const reinitIndex = controlSrc.indexOf('.select2({', bindMethodIndex);
+        expect(reinitIndex).toBeGreaterThan(-1);
+        const beforeReinit = controlSrc.slice(bindMethodIndex, reinitIndex);
+        expect(beforeReinit).toMatch(/companySearch\.detachManualEntryButton\(\s*\$field\s*\)/);
+
+        const detachCalls = controlSrc.match(/companySearch\.detachManualEntryButton\(/g) || [];
+        // re-bind path (bind()) and select2:close.
+        expect(detachCalls.length).toBeGreaterThanOrEqual(2);
     });
 
     test("the activation callback tears down this picker's widget and restores the search link", () => {
-        const openIndex = src.indexOf("on('select2:open'");
-        expect(openIndex).toBeGreaterThan(-1);
-        const closeIndex = src.indexOf("on('select2:close'", openIndex);
-        expect(closeIndex).toBeGreaterThan(openIndex);
-        const block = src.slice(openIndex, closeIndex);
+        const hookIndex = src.indexOf('onManualEntryActivated:');
+        expect(hookIndex).toBeGreaterThan(-1);
+        const nextKeyIndex = src.indexOf('onBound:', hookIndex);
+        expect(nextKeyIndex).toBeGreaterThan(hookIndex);
+        const block = src.slice(hookIndex, nextKeyIndex);
 
-        expect(block).toMatch(/attachManualEntryButton\(/);
         expect(block).toMatch(/self\.clearCompany\(\)/);
-        expect(block).toMatch(/\.find\(\s*['"]\.search_for_company['"]\s*\)\s*\.show\(\)/);
+        expect(block).toMatch(/showSearchForCompanyLink\(\s*true\s*\)/);
 
-        // The activation callback, NOT a bare select2:selecting handler —
-        // clearCompany() must be reached through attachManualEntryButton's
-        // own callback argument, not a second independent listener.
-        const activateIndex = block.indexOf('attachManualEntryButton(');
+        // clearCompany() (the teardown) has to run BEFORE the link is shown,
+        // or the widget's own destroy() would tear down a link the buyer was
+        // just shown.
         const clearIndex = block.indexOf('self.clearCompany()');
-        expect(clearIndex).toBeGreaterThan(activateIndex);
-    });
-
-    test('detaches the button on close, and on the re-bind path before re-init', () => {
-        const reinitIndex = src.indexOf('.select2({');
-        expect(reinitIndex).toBeGreaterThan(-1);
-        const beforeReinit = src.slice(0, reinitIndex);
-        expect(beforeReinit).toMatch(/companySearch\.detachManualEntryButton\(\s*\$companyNameField\s*\)/);
-
-        const detachCalls = src.match(/companySearch\.detachManualEntryButton\(/g) || [];
-        // re-bind path, select2:close, and destroyCompanySearchWidget.
-        expect(detachCalls.length).toBeGreaterThanOrEqual(3);
+        const showIndex = block.indexOf('showSearchForCompanyLink(');
+        expect(showIndex).toBeGreaterThan(clearIndex);
     });
 
     test('the shared model exports the button helpers this surface depends on', () => {

--- a/Test/Js/company-search-manual-entry.test.js
+++ b/Test/Js/company-search-manual-entry.test.js
@@ -1031,9 +1031,14 @@ describe('dropdown geometry (resize nudge)', () => {
 
 describe('address-autocomplete.js surface (structural fix)', () => {
     let src;
+    let controlSrc;
 
     beforeAll(() => {
         src = readSource(SURFACE_PATH);
+        // TWO-25326 rebuild: the select2 wiring — including the manual-entry
+        // button's attach/detach calls — moved out of this surface and into
+        // the one shared class both mounts construct.
+        controlSrc = readSource('view/frontend/web/js/model/company-search-control.js');
     });
 
     test('no longer intercepts select2:selecting for a manual-entry sentinel', () => {
@@ -1041,17 +1046,25 @@ describe('address-autocomplete.js surface (structural fix)', () => {
         expect(src).not.toMatch(/isManualEntryOption/);
     });
 
-    test('wires the shared model button, activating enterDetailsManually directly', () => {
-        expect(src).toMatch(
-            /companySearch\.attachManualEntryButton\(\s*\$companyNameField,\s*bindToken,/
-        );
-        expect(src).toMatch(/self\.enterDetailsManually\(\s*\$companyNameField,\s*bindToken\s*\)/);
+    test('does not roll its own select2 wiring — constructs the shared control instead', () => {
+        expect(src).toContain('new CompanySearchControl(');
+        expect(src).not.toContain('.select2({');
+        expect(src).not.toMatch(/companySearch\.attachManualEntryButton\(/);
+        expect(src).not.toMatch(/companySearch\.detachManualEntryButton\(/);
     });
 
-    test('detaches the button on close, and on the re-bind path before re-init', () => {
-        expect(src).toMatch(/companySearch\.detachManualEntryButton\(\s*\$companyNameField\s*\)/);
-        const detachCalls = src.match(/companySearch\.detachManualEntryButton\(/g) || [];
-        // re-bind path (enterDetailsManually) and select2:close.
+    test('activates enterDetailsManually via the control\'s onManualEntryActivated hook', () => {
+        expect(src).toMatch(/onManualEntryActivated:\s*function\s*\(\$companyNameField\)/);
+        expect(src).toMatch(/self\.enterDetailsManually\(\s*\$companyNameField\s*\)/);
+    });
+
+    test('the shared control wires the shared model button, and detaches it on close and re-bind', () => {
+        expect(controlSrc).toMatch(
+            /companySearch\.attachManualEntryButton\(\s*\$field,\s*bindToken,/
+        );
+        expect(controlSrc).toMatch(/companySearch\.detachManualEntryButton\(\s*\$field\s*\)/);
+        const detachCalls = controlSrc.match(/companySearch\.detachManualEntryButton\(/g) || [];
+        // re-bind path (bind()) and select2:close.
         expect(detachCalls.length).toBeGreaterThanOrEqual(2);
     });
 

--- a/Test/Js/company-search-open-on-type.test.js
+++ b/Test/Js/company-search-open-on-type.test.js
@@ -30,6 +30,12 @@ const { loadAmdModule } = require('./amd-harness');
 const MODEL_PATH = 'view/frontend/web/js/model/company-search.js';
 const ADDRESS_PATH = 'view/frontend/web/js/view/address-autocomplete.js';
 const TILE_PATH = 'view/frontend/web/js/view/payment/method-renderer/gateway_method.js';
+// TWO-25326 rebuild: the select2 wiring itself (language block, open-on-type)
+// moved into ONE shared class, `company-search-control.js`, constructed by
+// each surface rather than each rolling its own `.select2({...})` call. The
+// wiring is pinned there now; the two surfaces are pinned below only to have
+// constructed the class and to no longer contain a parallel implementation.
+const CONTROL_PATH = 'view/frontend/web/js/model/company-search-control.js';
 
 function readRepoFile(relPath) {
     const contents = fs.readFileSync(path.join(__dirname, '..', '..', relPath), 'utf8');
@@ -313,9 +319,9 @@ describe('TWO-25326 §1: zero-result wording', () => {
     });
 });
 
-describe('both call sites are actually wired to the shared fixes', () => {
-    test('the address-step picker passes the shared language block and opens on type', () => {
-        const src = readRepoFile(ADDRESS_PATH);
+describe('the shared control is actually wired to the shared fixes', () => {
+    test('company-search-control.js passes the shared language block and opens on type', () => {
+        const src = readRepoFile(CONTROL_PATH);
 
         expect(src).toContain('language: companySearch.buildLanguageOptions()');
         expect(src).toContain('companySearch.attachOpenOnType(');
@@ -324,10 +330,16 @@ describe('both call sites are actually wired to the shared fixes', () => {
         expect(src).not.toContain('inputTooShort: function');
     });
 
-    test('the payment-tile picker does too', () => {
-        const src = readRepoFile(TILE_PATH);
+    test('both surfaces construct the shared control rather than rolling their own select2 wiring', () => {
+        [ADDRESS_PATH, TILE_PATH].forEach(function (relPath) {
+            const src = readRepoFile(relPath);
 
-        expect(src).toContain('language: companySearch.buildLanguageOptions()');
-        expect(src).toContain('companySearch.attachOpenOnType(');
+            expect(src).toContain('new CompanySearchControl(');
+            // A second, parallel select2 wiring would be exactly the defect
+            // TWO-25326 asked to close — one implementation, not two.
+            expect(src).not.toContain('.select2({');
+            expect(src).not.toContain('companySearch.buildLanguageOptions()');
+            expect(src).not.toContain('companySearch.attachOpenOnType(');
+        });
     });
 });

--- a/Test/Js/company-search-resilience.test.js
+++ b/Test/Js/company-search-resilience.test.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const { loadAmdModule } = require('./amd-harness');
+const { loadAmdModule, loadCompanySearchControl } = require('./amd-harness');
 
 const BASE_CONFIG = {
     checkoutApiUrl: 'https://api.example.test',
@@ -1088,7 +1088,14 @@ describe('re-render safety of the select2 binding', () => {
         const companySearch = loadCompanySearch($);
         const component = loadAmdModule(
             'view/frontend/web/js/view/payment/method-renderer/gateway_method.js',
-            { jquery: $, 'Two_Gateway/js/model/company-search': companySearch }
+            {
+                jquery: $,
+                'Two_Gateway/js/model/company-search': companySearch,
+                'Two_Gateway/js/model/company-search-control': loadCompanySearchControl(
+                    $,
+                    companySearch
+                )
+            }
         );
         return Object.assign(Object.create(component.prototype || {}), {
             companyNameSelector: SEARCH_FIELD,
@@ -1186,9 +1193,11 @@ describe('re-render safety of the select2 binding', () => {
 
     /**
      * The re-enable link is only visible on paths that have already destroyed
-     * the widget (manual entry → clearCompany → destroy), so resolving it from
-     * `_$companyNameField` found nothing and left the link up in sole-trader
-     * mode. It must resolve from the cached container instead.
+     * the widget (manual entry → clearCompany → destroy), so resolving it
+     * from the select2 field itself found nothing and left the link up in
+     * sole-trader mode. It must resolve through the shared control's own
+     * reference instead — the control does not clear that reference on
+     * destroy() (see its own doc comment), for exactly this reason.
      */
     test('the re-enable link stays resolvable after the widget is destroyed', () => {
         const { $ } = makeQueryDouble();
@@ -1196,10 +1205,11 @@ describe('re-render safety of the select2 binding', () => {
 
         ctx.enableCompanySearch();
         expect(ctx.searchForCompanyLink().length).toBe(1);
+        expect(ctx._companySearchControl.isBound()).toBe(true);
 
         ctx.destroyCompanySearchWidget();
 
-        expect(ctx._$companyNameField).toBeNull();
+        expect(ctx._companySearchControl.isBound()).toBe(false);
         expect(ctx.searchForCompanyLink().length).toBe(1);
     });
 
@@ -1303,7 +1313,8 @@ describe('re-render safety of the select2 binding', () => {
         const component = loadAmdModule('view/frontend/web/js/view/address-autocomplete.js', {
             jquery: $,
             'Two_Gateway/js/model/brand-config': brandConfig,
-            'Two_Gateway/js/model/company-search': companySearch
+            'Two_Gateway/js/model/company-search': companySearch,
+            'Two_Gateway/js/model/company-search-control': loadCompanySearchControl($, companySearch)
         });
         return Object.assign(Object.create(component.prototype || {}), {
             countrySelector: '#shipping-new-address-form select[name="country_id"]',

--- a/Test/Js/company-search-return-to-search.test.js
+++ b/Test/Js/company-search-return-to-search.test.js
@@ -37,7 +37,7 @@
 
 'use strict';
 
-const { loadAmdModule, defaultMocks } = require('./amd-harness');
+const { loadAmdModule, defaultMocks, loadCompanySearchControl } = require('./amd-harness');
 
 /**
  * BOTH surfaces reach manual entry through a row INSIDE the results list, so
@@ -345,7 +345,12 @@ function loadShipping($) {
         {
             jquery: $,
             'Two_Gateway/js/model/brand-config': brandConfig,
-            'Two_Gateway/js/model/company-search': companySearchMock
+            'Two_Gateway/js/model/company-search': companySearchMock,
+            'Two_Gateway/js/model/company-search-control': loadCompanySearchControl(
+                $,
+                companySearchMock,
+                { document: document, window: window }
+            )
         },
         { document: document, window: window }
     );
@@ -405,7 +410,12 @@ function loadPayment($) {
         'view/frontend/web/js/view/payment/method-renderer/gateway_method.js',
         {
             jquery: $,
-            'Two_Gateway/js/model/company-search': companySearchMock
+            'Two_Gateway/js/model/company-search': companySearchMock,
+            'Two_Gateway/js/model/company-search-control': loadCompanySearchControl(
+                $,
+                companySearchMock,
+                { document: document, window: window }
+            )
         },
         {
             document: document,
@@ -641,13 +651,19 @@ describe.each([
      */
     test('a synthetic click right behind the Enter keydown does not re-activate', () => {
         reachManualMode($, ctx, enterManual, searchLink);
-        ctx.enableCompanySearch = jest.fn(ctx.enableCompanySearch);
+        // The link's own activation now lives on the shared control
+        // (company-search-control.js), not on the surface's
+        // `enableCompanySearch()` — spy on the control's `bind()` instead;
+        // it is the re-activation entry point the guard has to gate.
+        ctx._companySearchControl.bind = jest.fn(ctx._companySearchControl.bind.bind(
+            ctx._companySearchControl
+        ));
 
         $(searchLink).first().trigger('keydown', { key: 'Enter', which: 13, preventDefault: function () {} });
-        expect(ctx.enableCompanySearch).toHaveBeenCalledTimes(1);
+        expect(ctx._companySearchControl.bind).toHaveBeenCalledTimes(1);
 
         click($, searchLink);
 
-        expect(ctx.enableCompanySearch).toHaveBeenCalledTimes(1);
+        expect(ctx._companySearchControl.bind).toHaveBeenCalledTimes(1);
     });
 });

--- a/Test/Js/company-search-spinner-surfaces.test.js
+++ b/Test/Js/company-search-spinner-surfaces.test.js
@@ -22,7 +22,7 @@
 
 'use strict';
 
-const { loadAmdModule } = require('./amd-harness');
+const { loadAmdModule, loadCompanySearchControl } = require('./amd-harness');
 
 const BASE_CONFIG = {
     checkoutApiUrl: 'https://api.example.test',
@@ -172,7 +172,8 @@ test('SHIPPING surface: searching state reaches visible spinner markup', () => {
     const component = loadAmdModule('view/frontend/web/js/view/address-autocomplete.js', {
         jquery: $,
         'Two_Gateway/js/model/brand-config': brandConfig,
-        'Two_Gateway/js/model/company-search': companySearch
+        'Two_Gateway/js/model/company-search': companySearch,
+        'Two_Gateway/js/model/company-search-control': loadCompanySearchControl($, companySearch)
     });
 
     const ctx = Object.assign(Object.create(component.prototype || {}), {
@@ -201,7 +202,11 @@ test('PAYMENT surface: searching state reaches visible spinner markup', () => {
         'view/frontend/web/js/view/payment/method-renderer/gateway_method.js',
         {
             jquery: $,
-            'Two_Gateway/js/model/company-search': companySearch
+            'Two_Gateway/js/model/company-search': companySearch,
+            'Two_Gateway/js/model/company-search-control': loadCompanySearchControl(
+                $,
+                companySearch
+            )
         }
     );
 

--- a/Test/Js/gateway-method-company-selection.test.js
+++ b/Test/Js/gateway-method-company-selection.test.js
@@ -46,7 +46,7 @@
 
 'use strict';
 
-const { loadAmdModule } = require('./amd-harness');
+const { loadAmdModule, loadCompanySearchControl } = require('./amd-harness');
 
 const RENDERER = 'view/frontend/web/js/view/payment/method-renderer/gateway_method.js';
 
@@ -181,7 +181,10 @@ function makeDom() {
  */
 function loadRenderer() {
     const dom = makeDom();
-    const renderer = loadAmdModule(RENDERER, { jquery: dom.$ });
+    const renderer = loadAmdModule(RENDERER, {
+        jquery: dom.$,
+        'Two_Gateway/js/model/company-search-control': loadCompanySearchControl(dom.$)
+    });
     return { renderer: renderer, node: dom.node, $: dom.$ };
 }
 
@@ -465,7 +468,10 @@ describe('order intent for a company with no registry identifier', () => {
      */
     function loadWithIntent() {
         const dom = makeDom();
-        const renderer = loadAmdModule(RENDERER, { jquery: dom.$ });
+        const renderer = loadAmdModule(RENDERER, {
+            jquery: dom.$,
+            'Two_Gateway/js/model/company-search-control': loadCompanySearchControl(dom.$)
+        });
         renderer.isOrderIntentEnabled = true;
         const chain = {
             always: () => chain,

--- a/Test/Js/tile-company-readonly-fields.test.js
+++ b/Test/Js/tile-company-readonly-fields.test.js
@@ -634,7 +634,13 @@ describe('what each capture mode puts in front of the buyer', () => {
      * real browser renders it.
      */
     test('the picker takes a percentage width, so a hidden init cannot freeze it at zero', () => {
-        const source = fs.readFileSync(path.join(__dirname, '..', '..', RENDERER), 'utf8');
+        // TWO-25326 rebuild: the `.select2({...})` call — and this `width`
+        // option — moved into the one shared class both mounts construct,
+        // company-search-control.js, rather than living in this renderer.
+        const source = fs.readFileSync(
+            path.join(__dirname, '..', '..', 'view/frontend/web/js/model/company-search-control.js'),
+            'utf8'
+        );
         const widths = source.match(/width:\s*'([^']*)'/g) || [];
 
         expect(widths.length).toBeGreaterThan(0);

--- a/view/frontend/web/js/model/company-search-control.js
+++ b/view/frontend/web/js/model/company-search-control.js
@@ -1,0 +1,376 @@
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+/**
+ * TWO-25326: the single class that owns the company-search picker's full
+ * lifecycle end to end — select2 construction, dropdown open/close wiring,
+ * the manual-entry button, the "Search for company" return link, and
+ * open-on-type — built on top of the shared, mount-agnostic primitives in
+ * `company-search.js` (the search request, result mapping, address
+ * write-back, and the in-field chrome helpers).
+ *
+ * Mirrors PrestaShop's `TwoCompanySearch` class: ONE implementation of the
+ * select2 wiring, configured entirely through the constructor options
+ * below, never duplicated per mount. `address-autocomplete.js` (shipping
+ * step) and `gateway_method.js` (payment tile) each construct exactly one
+ * instance of this class rather than each rolling their own `.select2({…})`
+ * call — see those two files' `enableCompanySearch()` for the call sites.
+ *
+ * Magento's checkout is more dynamic than PrestaShop's: a payment renderer
+ * is pushed once PER Two-family brand (so a checkout offering two brands has
+ * two independent tile widgets alive at once), and which mount — address
+ * area or tile — is the buyer's active route to search can flip at runtime
+ * (virtual cart, saved address) without a page reload. Those two facts are
+ * why this stays two call sites rather than PrestaShop's one
+ * `TwoCheckoutManager`-owned singleton: each call site is a different
+ * Knockout component with its own dispose() lifecycle already scoped to
+ * "the widget THIS component bound", and forcing a page-wide singleton would
+ * fight that existing multi-brand safety model rather than simplify it. The
+ * mutual-exclusion invariant PrestaShop gets from a single decision point,
+ * Magento gets from the existing `isCompanySearchEnabled` /
+ * `isTileCompanySearchActive()` guards each call site already checks before
+ * constructing or (re)binding its instance — at most one of the two mounts
+ * is ever actively bound to a live select2 widget for a given brand at a
+ * time.
+ */
+define(['jquery', 'Two_Gateway/js/model/company-search'], function ($, companySearch) {
+    'use strict';
+
+    /**
+     * @param {object} options
+     * @param {string} options.fieldSelector jQuery selector for the
+     *        company-name input this control binds to. Re-resolved via
+     *        `$.async` on every bind() call, so a node replaced by a
+     *        checkout re-render is picked up automatically.
+     * @param {object} options.config brand config subtree — needs
+     *        `checkoutApiUrl`, `companySearchLimit`, `isAddressSearchEnabled`.
+     * @param {function(): (string|undefined)} [options.getCountryCode]
+     *        returns the current ISO country code (any case), read fresh on
+     *        every search request.
+     * @param {function(object, object)} [options.onSelect] called with
+     *        (selectedItem, $field) when the buyer picks a company from the
+     *        dropdown. `selectedItem` is select2's result item
+     *        (`{id, text, html, companyId, lookupId}` — see
+     *        company-search.js's `processResults`).
+     * @param {function(object, object)} [options.onManualEntryActivated]
+     *        called with ($field, bindToken) once the buyer has actually
+     *        activated the "My company is not on the list" button. Owns
+     *        whatever "manual entry" means for this mount — the two call
+     *        sites deliberately differ here (address step: convert the
+     *        field to a plain typeable text input; payment tile: tear the
+     *        widget down entirely and show the "Search for company" link).
+     * @param {function(object)} [options.onBound] called with ($field) once
+     *        per bind(), after every handler is wired — the hook for
+     *        mount-specific paint that has to run after binding (placeholder
+     *        text, a pre-filled selection's rendered text, …).
+     * @param {function(): string} [options.templateSelectionFallback] text
+     *        shown in the closed combobox when select2 has no `text` to
+     *        render for the current selection.
+     * @param {string} [options.searchForCompanyText] label for the
+     *        "Search for company" return link.
+     * @param {string} [options.searchForCompanyId] `id` attribute to give
+     *        the "Search for company" link and to resolve it by. Omit when
+     *        multiple instances of this control can exist on one page (the
+     *        payment tile, pushed once per brand) — the link is then found
+     *        and scoped by CONTAINER instead, exactly as the class already
+     *        scopes every other per-bind lookup.
+     */
+    function CompanySearchControl(options) {
+        options = options || {};
+        this.fieldSelector = options.fieldSelector;
+        this.config = options.config;
+        this.getCountryCode = options.getCountryCode || function () { return ''; };
+        this.onSelect = options.onSelect || function () {};
+        this.onManualEntryActivated = options.onManualEntryActivated || function () {};
+        this.onBound = options.onBound || function () {};
+        this.templateSelectionFallback = options.templateSelectionFallback || function () { return ''; };
+        this.searchForCompanyText = options.searchForCompanyText || '';
+        this.searchForCompanyId = options.searchForCompanyId || null;
+
+        this._$field = null;
+        this._bindToken = null;
+        this._$searchForCompanyLink = null;
+    }
+
+    /**
+     * (Re-)bind the picker to whatever node `fieldSelector` currently
+     * matches. Safe to call repeatedly — select2 4.1's own constructor
+     * destroys any existing instance on the same node, so re-init is the
+     * correct way to re-point the widget (and its handlers' closures) at a
+     * re-rendered form, exactly as both original call sites relied on.
+     *
+     * @param {object} [bindOptions]
+     * @param {boolean} [bindOptions.openDropdown] open the picker as soon as
+     *        it is (re)bound. Set only by the "Search for company" link:
+     *        returning to search mode should land the buyer in the search
+     *        box, not on a closed picker they must click again. Leave off
+     *        for a checkout's initial bind, where popping a dropdown open
+     *        unasked would steal focus from the form.
+     */
+    CompanySearchControl.prototype.bind = function (bindOptions) {
+        const self = this;
+        // One-shot, and deliberately a local rather than an instance field:
+        // `$.async` is a MutationObserver that can fire again on every
+        // re-render (Fire Checkout re-renders a lot), so a flag that
+        // survived past the first fire would pop the dropdown open under a
+        // buyer who has moved on to another field.
+        let pendingOpen = !!(bindOptions && bindOptions.openDropdown);
+
+        require(['Two_Gateway/select2-4.1.0/js/select2.min'], function () {
+            $.async(self.fieldSelector, function (fieldNode) {
+                const $field = $(fieldNode);
+                self._$field = $field;
+
+                // Identity for this bind, so a previous widget's still-in-flight
+                // response cannot paint chrome onto the widget that replaced it.
+                const bindToken = {};
+                self._bindToken = bindToken;
+
+                // select2's destroy() only does `$element.off('.select2')` —
+                // our own handlers are not in that namespace and would
+                // otherwise survive every re-init, stacking one more copy per
+                // re-render.
+                $field.off(companySearch.EVENT_NS);
+                // select2's destroy() doesn't disconnect this either, and a
+                // re-render while the picker is open can replace the select2
+                // instance without emitting `select2:close` first — leaving a
+                // manual-entry button from the PREVIOUS bind wired to the
+                // widget this call is about to replace.
+                companySearch.detachManualEntryButton($field);
+
+                $field
+                    .select2({
+                        minimumInputLength: companySearch.MIN_INPUT_LENGTH,
+                        // Shared with the sibling mount so the two surfaces
+                        // cannot show different wording for the same state.
+                        language: companySearch.buildLanguageOptions(),
+                        // Shared stable hook for style.css's dropdown-row
+                        // fixes — drawn from the one constant so this and the
+                        // sibling mount's dropdown CSS can't drift apart on a
+                        // rename.
+                        dropdownCssClass: companySearch.DROPDOWN_CSS_CLASS,
+                        width: '100%',
+                        escapeMarkup: function (markup) {
+                            return markup;
+                        },
+                        templateResult: function (data) {
+                            return data.html;
+                        },
+                        templateSelection: function (data) {
+                            return data.text || self.templateSelectionFallback();
+                        },
+                        ajax: companySearch.buildSearchAjaxOptions({
+                            config: self.config,
+                            token: bindToken,
+                            getCountryCode: self.getCountryCode,
+                            // Bound to THIS node, not to the selector: a
+                            // search issued by a widget since destroyed finds
+                            // no instance on its own element and no-ops,
+                            // rather than painting a stale failure onto
+                            // whichever picker is live now.
+                            onSearching: function (isSearching) {
+                                companySearch.setSearching($field, isSearching, bindToken);
+                            },
+                            onUnavailable: function (isUnavailable) {
+                                companySearch.setUnavailable($field, isUnavailable, bindToken);
+                            }
+                        })
+                    })
+                    .on('select2:open' + companySearch.EVENT_NS, function () {
+                        // select2 only detaches the dropdown on close and only
+                        // clears the search input's value, so anything
+                        // appended into the search box survives a reopen —
+                        // clear it here or a reopened picker shows the
+                        // previous search's "unavailable" notice.
+                        companySearch.clearSearchChrome($field, bindToken);
+                        // A SIBLING of the results list (#30.x.15), not a row
+                        // inside it, so it stays visible outside select2's
+                        // own scroll/clip and needs no selection-cancelling
+                        // dance — its own click handler is the only thing
+                        // that activates it.
+                        companySearch.attachManualEntryButton($field, bindToken, function () {
+                            self.onManualEntryActivated($field, bindToken);
+                        });
+                        document.querySelector('.select2-search__field').focus();
+                    })
+                    .on('select2:close' + companySearch.EVENT_NS, function () {
+                        // Every open re-attaches, so nothing is lost by
+                        // dropping the button here — and a checkout that
+                        // re-renders the form while the picker is closed
+                        // would otherwise leave a button from this bind wired
+                        // to a disposed renderer for the life of the page.
+                        companySearch.detachManualEntryButton($field);
+                    })
+                    .on('select2:select' + companySearch.EVENT_NS, function (e) {
+                        self.onSelect(e.params.data, $field);
+                    });
+
+                companySearch.markSearchBinding($field, bindToken);
+                // TWO-25326 §1: any character opens the dropdown, not just
+                // the Space/Enter select2 4.1 handles on its own.
+                companySearch.attachOpenOnType($field, bindToken);
+
+                self._bindSearchForCompanyLink($field);
+                self.onBound($field);
+
+                // Last, so every handler above — including `select2:open`,
+                // which is what puts the caret in the search box — is
+                // already bound when the dropdown opens.
+                if (pendingOpen) {
+                    pendingOpen = false;
+                    $field.select2('open');
+                }
+            });
+        });
+    };
+
+    /**
+     * Build (if absent) and (re)wire the "Search for company" return link
+     * for the field this bind owns.
+     *
+     * @param {object} $field jQuery-wrapped picker input
+     */
+    CompanySearchControl.prototype._bindSearchForCompanyLink = function ($field) {
+        const self = this;
+        const $container = $field.closest('.field');
+        const resolve = function () {
+            return self.searchForCompanyId
+                ? $('#' + self.searchForCompanyId)
+                : $container.find('.search_for_company');
+        };
+
+        if (resolve().length === 0) {
+            const idAttr = self.searchForCompanyId ? ` id="${self.searchForCompanyId}"` : '';
+            $container.append(
+                `<div${idAttr} class="search_for_company" role="button" tabindex="0" ` +
+                    `title="${self.searchForCompanyText}">` +
+                    `<span>${self.searchForCompanyText}</span>` +
+                    '</div>'
+            );
+        }
+
+        const $link = resolve();
+        self._$searchForCompanyLink = $link;
+
+        const activate = function () {
+            // Guards against a double-activation: this is a `role="button"`
+            // on a plain div, not a native <button>, and some assistive-
+            // tech/browser combinations forward a synthetic `click` in
+            // addition to the Enter keydown for exactly that shape of
+            // widget. Once hidden, a second call is a no-op rather than
+            // re-opening a dropdown the buyer already opened.
+            const $el = $link.first();
+            if ($el.length && $el.get(0).style.display === 'none') return;
+            self.bind({ openDropdown: true });
+            $link.hide();
+        };
+
+        $link
+            .off('click' + companySearch.EVENT_NS)
+            .off('keydown' + companySearch.EVENT_NS)
+            .on('click' + companySearch.EVENT_NS, activate)
+            // Keyboard reachability: this div has no native semantics, so
+            // Enter/Space have to be wired up by hand to match the
+            // role="button" contract set on the markup above.
+            .on('keydown' + companySearch.EVENT_NS, function (e) {
+                if (e.key !== 'Enter' && e.key !== ' ' && e.which !== 13 && e.which !== 32) {
+                    return;
+                }
+                e.preventDefault();
+                activate();
+            });
+        $link.hide();
+    };
+
+    /**
+     * The "Search for company" link this bind owns, or an empty jQuery set
+     * before the first bind().
+     *
+     * @returns {object}
+     */
+    CompanySearchControl.prototype.getSearchForCompanyLink = function () {
+        return this._$searchForCompanyLink || $();
+    };
+
+    /**
+     * Show the "Search for company" return link — the call sites' own hook
+     * for "the buyer just left search mode" (manual entry, a company
+     * cleared, …).
+     *
+     * @param {boolean} [focus] also focus the link — the manual-entry
+     *        activation path needs this: destroying the widget removes the
+     *        button that had focus, and nothing else refocuses anything.
+     */
+    CompanySearchControl.prototype.showSearchForCompanyLink = function (focus) {
+        if (!this._$searchForCompanyLink) return;
+        this._$searchForCompanyLink.show();
+        if (focus) this._$searchForCompanyLink.trigger('focus');
+    };
+
+    /**
+     * Cancel the in-flight search for the current bind, if any.
+     *
+     * @returns {boolean} true when a request was actually aborted
+     */
+    CompanySearchControl.prototype.abortActiveRequest = function () {
+        return companySearch.abortActiveRequest(this._bindToken);
+    };
+
+    /**
+     * The identity token stamped on the current bind, or null before the
+     * first bind(). Exposed for tests that pin bind/rebind identity — see
+     * the "live bind token" tests in `company-search-country-switch.test.js`.
+     *
+     * @returns {object|null}
+     */
+    CompanySearchControl.prototype.getBindToken = function () {
+        return this._bindToken;
+    };
+
+    /**
+     * Whether this control currently owns a live select2 instance.
+     *
+     * @returns {boolean}
+     */
+    CompanySearchControl.prototype.isBound = function () {
+        const $field = this._$field;
+        return !!($field && $field.length && $field.data && $field.data('select2'));
+    };
+
+    /**
+     * The field node this control is currently bound to, or an empty jQuery
+     * set before the first bind().
+     *
+     * @returns {object}
+     */
+    CompanySearchControl.prototype.getField = function () {
+        return this._$field || $();
+    };
+
+    /**
+     * Tear down the widget this control owns — detach the manual-entry
+     * button, drop our own namespaced handlers, and destroy select2. Safe to
+     * call repeatedly; a no-op once already torn down.
+     *
+     * @returns {boolean} true when a widget was actually torn down, false
+     *          when this was already a no-op — callers that only need to
+     *          convert the field back to a plain text input on an ACTUAL
+     *          teardown (not on a repeat call) use this to gate that.
+     */
+    CompanySearchControl.prototype.destroy = function () {
+        const $field = this._$field;
+        if (!this.isBound()) return false;
+        // Belt-and-braces alongside the `select2:close` handler above:
+        // destroy() does not always route through a `close` event first, and
+        // an undetached button would stay wired to this disposed control for
+        // the life of the page.
+        companySearch.detachManualEntryButton($field);
+        $field.off(companySearch.EVENT_NS);
+        $field.select2('destroy');
+        return true;
+    };
+
+    return CompanySearchControl;
+});

--- a/view/frontend/web/js/view/address-autocomplete.js
+++ b/view/frontend/web/js/view/address-autocomplete.js
@@ -11,7 +11,8 @@ define([
     'Magento_Checkout/js/model/step-navigator',
     'uiRegistry',
     'Two_Gateway/js/model/brand-config',
-    'Two_Gateway/js/model/company-search'
+    'Two_Gateway/js/model/company-search',
+    'Two_Gateway/js/model/company-search-control'
 ], function (
     $,
     $t,
@@ -21,7 +22,8 @@ define([
     stepNavigator,
     uiRegistry,
     brandConfig,
-    companySearch
+    companySearch,
+    CompanySearchControl
 ) {
     'use strict';
 
@@ -126,7 +128,9 @@ define([
             // issued under the OLD country is still on the wire for up to 30s,
             // and its results would populate a dropdown the buyer reads as
             // results for the new one.
-            companySearch.abortActiveRequest(this._bindToken);
+            if (this._companySearchControl) {
+                this._companySearchControl.abortActiveRequest();
+            }
             companySearch.revertAutofilledAddress();
             // Clears the name input, the number field, and the published
             // `companyData` section the payment tile reads — every surviving
@@ -608,22 +612,21 @@ define([
          * @param {object} $companyNameField the node THIS bind owns — not the
          *        document-wide selector, so a re-rendered form's picker is
          *        never the one torn down
-         * @param {object} bindToken identity for this bind, so the search the
-         *        buyer has just given up on can be cancelled
          */
-        enterDetailsManually: function ($companyNameField, bindToken) {
+        enterDetailsManually: function ($companyNameField) {
             // First, before anything else touches the widget. Cancelling the
             // selection leaves the dropdown open, so a search still on the
             // wire would come back up to 30s later and run select2's
             // highlight and scroll bookkeeping over a torn-down picker.
-            companySearch.abortActiveRequest(bindToken);
+            this._companySearchControl.abortActiveRequest();
             this.setCompanyData();
-            companySearch.detachManualEntryButton($companyNameField);
-            $companyNameField.off(companySearch.EVENT_NS);
-            $companyNameField.select2('destroy');
+            // Tears down the widget (detach manual-entry button, drop our
+            // handlers, select2('destroy')) — the mechanics shared with the
+            // payment tile's own teardown, owned by the control now.
+            this._companySearchControl.destroy();
             $companyNameField.attr('type', 'text');
             $companyNameField.val('');
-            $(this.searchForCompanyButton).show();
+            this._companySearchControl.showSearchForCompanyLink();
             // After the destroy above, not before: renderCompanyIdText()
             // decides on isCompanySearchActive(), which only reports
             // manual-entry once select2 is actually gone from the node.
@@ -651,209 +654,57 @@ define([
         enableCompanySearch: function (options) {
             if (!config.isCompanySearchEnabled) return;
             const self = this;
-            // One-shot, and deliberately NOT a property on the component:
-            // `$.async` is a MutationObserver that fires again on every
-            // re-render, so a flag that survived the first bind would pop the
-            // dropdown open under a buyer who has moved on to another field.
-            let pendingOpen = !!(options && options.openDropdown);
-            require(['Two_Gateway/select2-4.1.0/js/select2.min'], function () {
-                $.async(self.companyNameSelector, function (companyNameField) {
-                    // Re-binding on every `$.async` fire is intentional:
-                    // select2 4.1's constructor destroys any existing
-                    // instance on the same node, so re-init re-points the
-                    // widget and its handlers at the current component. An
-                    // early-return guard here would both keep a stale widget
-                    // alive and skip the placeholder / manual-entry
-                    // housekeeping below.
-                    const $companyNameField = $(companyNameField);
-                    // Identity for this bind, so a previous widget's late
-                    // response cannot paint chrome on its replacement.
-                    const bindToken = {};
-                    // Also held on the component, so the country-change handler
-                    // — which is bound to the country select, not to this node,
-                    // and therefore closes over no bind of its own — can cancel
-                    // the search the CURRENT picker has in flight. Overwritten
-                    // on every re-bind, which is correct: only the live bind
-                    // can have a request worth cancelling.
-                    self._bindToken = bindToken;
-                    // select2's destroy() only clears its own `.select2`
-                    // namespace, so our handlers would stack one copy per
-                    // re-render and a single pick would fire N address
-                    // lookups. Clear ours before re-binding.
-                    $companyNameField.off(companySearch.EVENT_NS);
-                    $companyNameField
-                        .select2({
-                            minimumInputLength: companySearch.MIN_INPUT_LENGTH,
-                            // Displaces select2's own built-in English
-                            // "input too short" and "No results found" text,
-                            // both baked into the vendored bundle. Ours are
-                            // translatable, name the threshold outright, and
-                            // use the cross-platform "No matches found"
-                            // wording pinned by TWO-25326 §1. Shared with the
-                            // payment-tile picker so the two cannot drift.
-                            language: companySearch.buildLanguageOptions(),
-                            // A stable, non-generated hook for style.css's
-                            // dropdown-row CSS fixes (text-transform,
-                            // vertical alignment). select2 IDs its own
-                            // rendered/results elements off the backing
-                            // element's `id` attribute when present, or
-                            // `name + 2 random chars` when it isn't — this
-                            // company field carries no explicit `id`, so
-                            // that fallback is NOT a stable selector CSS
-                            // could target. `dropdownCssClass` is select2's
-                            // own supported hook for exactly this — the
-                            // literal class name lives once, on
-                            // companySearch.DROPDOWN_CSS_CLASS, same
-                            // convention as MIN_INPUT_LENGTH above, so this
-                            // and the payment-tile picker's init (and
-                            // style.css) can't drift apart on a rename.
-                            dropdownCssClass: companySearch.DROPDOWN_CSS_CLASS,
-                            width: '100%',
-                            escapeMarkup: function (markup) {
-                                return markup;
-                            },
-                            templateResult: function (data) {
-                                return data.html;
-                            },
-                            templateSelection: function (data) {
-                                return data.text || self.companyNamePlaceholder;
-                            },
-                            ajax: companySearch.buildSearchAjaxOptions({
-                                config: config,
-                                token: bindToken,
-                                getCountryCode: function () {
-                                    return $(self.countrySelector).val();
-                                },
-                                // Bound to THIS node, not to the selector, so
-                                // a destroyed widget's late response cannot
-                                // paint onto the live picker.
-                                onSearching: function (isSearching) {
-                                    companySearch.setSearching(
-                                        $companyNameField,
-                                        isSearching,
-                                        bindToken
-                                    );
-                                },
-                                onUnavailable: function (isUnavailable) {
-                                    companySearch.setUnavailable(
-                                        $companyNameField,
-                                        isUnavailable,
-                                        bindToken
-                                    );
-                                }
-                            })
-                        })
-                        .on('select2:open' + companySearch.EVENT_NS, function () {
-                            // Nothing else removes what we appended into the
-                            // search box, so a reopened picker would show the
-                            // previous search's "unavailable" notice.
-                            companySearch.clearSearchChrome($companyNameField, bindToken);
-                            // The manual-entry button is a SIBLING of the
-                            // results list (#30.x.15), not a row inside it,
-                            // so it stays visible outside select2's own
-                            // scroll/clip and needs no selection-cancelling
-                            // dance: its own click handler below is the only
-                            // thing that activates it.
-                            companySearch.attachManualEntryButton(
-                                $companyNameField,
-                                bindToken,
-                                function () {
-                                    self.enterDetailsManually($companyNameField, bindToken);
-                                }
-                            );
-                            document.querySelector('.select2-search__field').focus();
-                        })
-                        .on('select2:close' + companySearch.EVENT_NS, function () {
-                            // Every open re-attaches, so nothing is lost by
-                            // dropping the button here — and a checkout that
-                            // re-renders the form while the picker is closed
-                            // would otherwise leave a button from this bind
-                            // wired to a disposed renderer for the life of
-                            // the page.
-                            companySearch.detachManualEntryButton($companyNameField);
-                        })
-                        .on('select2:select' + companySearch.EVENT_NS, function (e) {
-                            const selectedItem = e.params.data;
-                            $('.select2-selection__rendered').text(selectedItem.id);
-                            self.setCompanyData(selectedItem.companyId, selectedItem.text);
-                            // Gate lives in companySearch.lookupCompanyAddress
-                            // (config.isAddressSearchEnabled = the single
-                            // `enable_address_search` setting), shared with the
-                            // payment-step picker.
-                            self.addressLookup(selectedItem);
-                        });
-                    companySearch.markSearchBinding($companyNameField, bindToken);
-                    // TWO-25326 §1: typing any character (not just Space or
-                    // Enter, which is all select2 4.1 handles) opens the
-                    // dropdown and starts the search.
-                    companySearch.attachOpenOnType($companyNameField, bindToken);
-                    // Re-derive on every bind: a re-render rebuilds the
-                    // `.control` this label lives in, so a label written on a
-                    // previous bind is gone by now.
-                    self.renderCompanyIdText();
-                    // Set initial placeholder text for the company search
-                    if (!$(self.companyNameSelector).val()) {
-                        $(self.companyNameSelector)
-                            .closest('.field')
-                            .find('.select2-selection__rendered')
-                            .text(self.companyNamePlaceholder);
-                    }
-                    if ($(self.companyNameSelector).val()) {
-                        // pre-fill on checkout render
-                        $('.select2-selection__rendered').text($(self.companyNameSelector).val());
-                    }
-                    if ($(self.searchForCompanyButton).length == 0) {
-                        $(self.companyNameSelector)
-                            .closest('.field')
-                            .append(
-                                `<div id="shipping_search_for_company" class="search_for_company" ` +
-                                    `role="button" tabindex="0" title="${self.searchForCompanyText}">` +
-                                    `<span>${self.searchForCompanyText}</span>` +
-                                    '</div>'
-                            );
-                    }
-                    // Re-bound unconditionally: the div survives a re-render,
-                    // so the append guard above was false and this handler kept
-                    // closing over the first, stale component.
-                    const activateSearchForCompany = function () {
-                        // Guards against a double-activation: this is a
-                        // `role="button"` on a plain div, not a native
-                        // <button>, and some assistive-tech/browser
-                        // combinations forward a synthetic `click` in
-                        // addition to the Enter keydown for exactly that
-                        // shape of widget. Once hidden, a second call is a
-                        // no-op rather than re-opening a dropdown the buyer
-                        // already opened.
-                        const $button = $(self.searchForCompanyButton).first();
-                        if ($button.length && $button.get(0).style.display === 'none') return;
-                        self.enableCompanySearch({ openDropdown: true });
-                        $(self.searchForCompanyButton).hide();
-                    };
-                    $(self.searchForCompanyButton)
-                        .off('click' + companySearch.EVENT_NS)
-                        .off('keydown' + companySearch.EVENT_NS)
-                        .on('click' + companySearch.EVENT_NS, activateSearchForCompany)
-                        // Keyboard reachability (TWO parity with WooCommerce /
-                        // Hyvä): this div has no native semantics, so Enter/
-                        // Space have to be wired up by hand to match the
-                        // role="button" contract set on the markup above.
-                        .on('keydown' + companySearch.EVENT_NS, function (e) {
-                            if (e.key !== 'Enter' && e.key !== ' ' && e.which !== 13 && e.which !== 32) {
-                                return;
-                            }
-                            e.preventDefault();
-                            activateSearchForCompany();
-                        });
-                    $(self.searchForCompanyButton).hide();
-                    // Last, so every handler above — including `select2:open`,
-                    // which is what puts the caret in the search box — is
-                    // already bound when the dropdown opens.
-                    if (pendingOpen) {
-                        pendingOpen = false;
-                        $companyNameField.select2('open');
+            // ONE instance for this component, mirroring PrestaShop's single
+            // `TwoCompanySearch` construction site: every subsequent call
+            // (re-render, "Search for company" reactivation) re-binds THIS
+            // instance rather than constructing a second one. `companyIdSelector`'s
+            // id is static per address form, so a single fixed `id` on the
+            // return link (rather than container-scoping, which the payment
+            // tile needs for its multi-brand case) is the right lookup here.
+            if (!this._companySearchControl) {
+                this._companySearchControl = new CompanySearchControl({
+                    fieldSelector: self.companyNameSelector,
+                    config: config,
+                    getCountryCode: function () {
+                        return $(self.countrySelector).val();
+                    },
+                    templateSelectionFallback: function () {
+                        return self.companyNamePlaceholder;
+                    },
+                    searchForCompanyId: self.searchForCompanyButton.replace('#', ''),
+                    searchForCompanyText: self.searchForCompanyText,
+                    onSelect: function (selectedItem, $companyNameField) {
+                        $('.select2-selection__rendered').text(selectedItem.id);
+                        self.setCompanyData(selectedItem.companyId, selectedItem.text);
+                        // Gate lives in companySearch.lookupCompanyAddress
+                        // (config.isAddressSearchEnabled = the single
+                        // `enable_address_search` setting), shared with the
+                        // payment-tile picker.
+                        self.addressLookup(selectedItem);
+                    },
+                    onManualEntryActivated: function ($companyNameField) {
+                        self.enterDetailsManually($companyNameField);
+                    },
+                    onBound: function ($companyNameField) {
+                        // Re-derive on every bind: a re-render rebuilds the
+                        // `.control` this label lives in, so a label written
+                        // on a previous bind is gone by now.
+                        self.renderCompanyIdText();
+                        // Set initial placeholder text for the company search
+                        if (!$companyNameField.val()) {
+                            $companyNameField
+                                .closest('.field')
+                                .find('.select2-selection__rendered')
+                                .text(self.companyNamePlaceholder);
+                        }
+                        if ($companyNameField.val()) {
+                            // pre-fill on checkout render
+                            $('.select2-selection__rendered').text($companyNameField.val());
+                        }
                     }
                 });
-            });
+            }
+            this._companySearchControl.bind(options);
         }
     });
 });

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -19,6 +19,7 @@ define([
     'Two_Gateway/js/model/surcharge',
     'Two_Gateway/js/model/brand-config',
     'Two_Gateway/js/model/company-search',
+    'Two_Gateway/js/model/company-search-control',
     'Two_Gateway/js/model/minimum-order-visibility',
     'Magento_Ui/js/lib/view/utils/async',
     'mage/validation',
@@ -39,6 +40,7 @@ define([
     surchargeModel,
     getBrandConfig,
     companySearch,
+    CompanySearchControl,
     isAboveMinimums
 ) {
     'use strict';
@@ -67,22 +69,20 @@ define([
         formSelector: 'form#two_gateway_form',
         companyNameSelector: 'input#company_name',
         searchForCompanyText: $t('Search for company'),
-        // No `searchForCompanyButton` id selector here on purpose. The append
-        // guard is per-field, so this renderer — pushed once per Two-family
-        // brand — would otherwise mint duplicate ids and a document-wide
-        // lookup would hand brand A's link to brand B. Use
-        // searchForCompanyLink() instead.
+        // No `searchForCompanyButton` id selector here on purpose. The
+        // shared control's own append guard is per-CONTAINER, so this
+        // renderer — pushed once per Two-family brand — would otherwise mint
+        // duplicate ids and a document-wide lookup would hand brand A's link
+        // to brand B. Use searchForCompanyLink() instead.
         searchForCompanyLink: function () {
-            // Resolved from the cached CONTAINER, not from
-            // `_$companyNameField`: the paths where this link is visible are
-            // exactly the paths that have already destroyed the widget and
-            // nulled that node (the manual-entry button → clearCompany() →
-            // destroyCompanySearchWidget()). Keying on the node meant
-            // enterSoleTraderUi() silently hid nothing and the link stayed up
-            // in sole-trader mode.
-            const $container = this._$companyFieldContainer;
-            if (!$container || !$container.find) return $();
-            return $container.find('.search_for_company');
+            // Resolved through the control, which keeps its own reference to
+            // the link it built — surviving the paths that have already
+            // destroyed the select2 widget (the manual-entry button →
+            // clearCompany() → destroyCompanySearchWidget()). Keying on the
+            // widget's own node meant enterSoleTraderUi() silently hid
+            // nothing and the link stayed up in sole-trader mode.
+            if (!this._companySearchControl) return $();
+            return this._companySearchControl.getSearchForCompanyLink();
         },
         delegationToken: '',
         autofillToken: '',
@@ -1494,262 +1494,57 @@ define([
             if (!this.isTileCompanySearchActive()) {
                 return;
             }
-            let self = this;
-            // One-shot, and deliberately a local rather than a property on the
-            // renderer: `$.async` is a MutationObserver that fires again on
-            // every re-render (Fire Checkout re-renders a lot), so a flag that
-            // survived the first bind would pop the dropdown open under a
-            // buyer who has moved on to another field.
-            let pendingOpen = !!(options && options.openDropdown);
-            require(['Two_Gateway/select2-4.1.0/js/select2.min'], function () {
-                // No `$.async('input#company_id')` block here. The tile does
-                // show a company-number input again (TWO-25288), but it is
-                // `readonly` in every mode and ko's `value: companyId` binding
-                // paints it — so there is no editable state to resolve the node
-                // for, derive, or subscribe the observables to. A
-                // hand-typeable organisation number is still not an accepted
-                // source; showing the captured one is not the same thing as
-                // offering to take a typed one.
-                $.async(self.companyNameSelector, function (companyNameField) {
-                    // `$.async` is a MutationObserver, and every call to
-                    // enableCompanySearch() adds another one, so on a
-                    // one-page checkout (Fire Checkout) this fires
-                    // repeatedly. Re-binding is deliberately NOT guarded
-                    // against: select2 4.1's own constructor destroys any
-                    // existing instance on the same node
-                    // (`GetData(el, 'select2').destroy()`), so re-init is the
-                    // correct way to re-point the widget — and its handlers'
-                    // `self` closure — at the current component. Skipping the
-                    // re-init would leave the previous widget alive with
-                    // closures over a DISPOSED renderer, so picking a company
-                    // would write to dead observables. What re-render safety
-                    // needs instead is the teardown in dispose() below.
-                    const $companyNameField = $(companyNameField);
-                    // Remember the node we bound, so dispose() can destroy
-                    // THIS widget rather than whatever a document-wide
-                    // selector happens to match.
-                    self._$companyNameField = $companyNameField;
-                    // Survives the widget teardown on purpose — see
-                    // searchForCompanyLink().
-                    self._$companyFieldContainer = $companyNameField.closest('.field');
-                    // Identity for this bind. Re-stamped below, so a previous
-                    // widget's still-in-flight response can't paint chrome on
-                    // the widget that replaced it.
-                    const bindToken = {};
-                    // select2's destroy() only does `$element.off('.select2')`
-                    // — our own handlers are not in that namespace and would
-                    // survive every re-init, stacking one more copy per
-                    // re-render. N stacked `select2:select` handlers means one
-                    // company pick fires N address lookups, N-1 of them closed
-                    // over disposed renderers. Clear ours first.
-                    $companyNameField.off(companySearch.EVENT_NS);
-                    // select2's destroy() doesn't disconnect it either (it
-                    // isn't select2's own state), and the same re-render that
-                    // makes the stale-handler comment above true can also
-                    // leave this the ONLY teardown point reached: a re-render
-                    // while the picker is open replaces the select2 instance
-                    // without necessarily emitting `select2:close` first, so
-                    // a manual-entry button from the PREVIOUS bind would
-                    // otherwise survive, still wired to a disposed renderer,
-                    // until this node's picker happens to be reopened again.
-                    companySearch.detachManualEntryButton($companyNameField);
-                    $companyNameField
-                        .select2({
-                            minimumInputLength: companySearch.MIN_INPUT_LENGTH,
-                            // Shared with the address-step picker so the two
-                            // surfaces cannot show different wording for the
-                            // same state. Before TWO-25326 this picker passed
-                            // no `language` at all and fell back to select2's
-                            // vendored English "No results found" / remaining-
-                            // character countdown.
-                            language: companySearch.buildLanguageOptions(),
-                            // Same stable dropdown-row hook as the
-                            // address-step picker (address-autocomplete.js)
-                            // — this field's `input#company_name` id DOES
-                            // give select2 a stable `select2-company_name-*`
-                            // id already (confirmed by the existing
-                            // `#select2-company_name-container` references
-                            // below), but using the same explicit class here
-                            // too keeps both pickers' dropdown CSS keyed off
-                            // one mechanism rather than two. Drawn from
-                            // companySearch.DROPDOWN_CSS_CLASS, same shared
-                            // constant address-autocomplete.js uses, so the
-                            // two call sites and style.css can't drift.
-                            dropdownCssClass: companySearch.DROPDOWN_CSS_CLASS,
-                            width: '100%',
-                            escapeMarkup: function (markup) {
-                                return markup;
-                            },
-                            templateResult: function (data) {
-                                return data.html;
-                            },
-                            templateSelection: function (data) {
-                                return data.text;
-                            },
-                            ajax: companySearch.buildSearchAjaxOptions({
-                                config: self._brandConfig,
-                                token: bindToken,
-                                getCountryCode: function () {
-                                    return self.countryCode();
-                                },
-                                // Bound to THIS node, not to the selector.
-                                // A search issued by a widget that has since
-                                // been destroyed then finds no instance on
-                                // its own element and no-ops, rather than
-                                // painting a stale failure onto whatever
-                                // picker is live now.
-                                onSearching: function (isSearching) {
-                                    companySearch.setSearching(
-                                        $companyNameField,
-                                        isSearching,
-                                        bindToken
-                                    );
-                                },
-                                onUnavailable: function (isUnavailable) {
-                                    companySearch.setUnavailable(
-                                        $companyNameField,
-                                        isUnavailable,
-                                        bindToken
-                                    );
-                                }
-                            })
-                        })
-                        .on('select2:open' + companySearch.EVENT_NS, function () {
-                            // select2 only detaches the dropdown on close and
-                            // only blanks the search input, so anything we
-                            // appended into the search box survives. Clear it
-                            // here or a reopened picker still shows the last
-                            // search's "unavailable" notice.
-                            companySearch.clearSearchChrome($companyNameField, bindToken);
-                            // The manual-entry button is a SIBLING of the
-                            // results list (#30.x.15), not a row inside it,
-                            // so it stays visible outside select2's own
-                            // scroll/clip and needs no selection-cancelling
-                            // dance: its own click handler below is the only
-                            // thing that activates it.
-                            companySearch.attachManualEntryButton(
-                                $companyNameField,
-                                bindToken,
-                                function () {
-                                    self.clearCompany();
-                                    // Resolved here, not earlier: a container
-                                    // captured before the widget teardown
-                                    // above could be replaced by the same
-                                    // checkout re-render the button's own
-                                    // staleness check guards against, and
-                                    // `.show()` on a detached node would
-                                    // silently no-op, leaving the real link
-                                    // hidden.
-                                    //
-                                    // Focused too, not just shown: clearCompany()
-                                    // tears the select2 widget down through
-                                    // destroyCompanySearchWidget(), which removes
-                                    // the manual-entry button — the element that
-                                    // had focus — from the document. Nothing
-                                    // else in that teardown path refocuses
-                                    // anything, so a buyer who reached the
-                                    // button by keyboard is otherwise dropped
-                                    // back to `<body>` with no visible focus at
-                                    // all.
-                                    $companyNameField
-                                        .closest('.field')
-                                        .find('.search_for_company')
-                                        .show()
-                                        .trigger('focus');
-                                }
-                            );
-                            document.querySelector('.select2-search__field').focus();
-                        })
-                        .on('select2:close' + companySearch.EVENT_NS, function () {
-                            // Every open re-attaches, so nothing is lost by
-                            // dropping the button here — and a checkout that
-                            // re-renders the form while the picker is closed
-                            // would otherwise leave a button from this bind
-                            // wired to a disposed renderer for the life of
-                            // the page.
-                            companySearch.detachManualEntryButton($companyNameField);
-                        })
-                        .on('select2:select' + companySearch.EVENT_NS, function (e) {
-                            const selectedItem = e.params.data;
-                            const companyId = selectedItem.companyId;
-                            const companyName = selectedItem.text;
-                            // applyCompanyData(), not fillCompanyData(): a pick
-                            // is authoritative and must overwrite the previous
-                            // company's identifier even when the new company
-                            // has none of its own.
-                            self.applyCompanyData(
-                                { companyId, companyName },
-                                { authoritative: true }
-                            );
-                            // TWO-25193: the payment-step picker used to stop
-                            // here, leaving the billing address blank. Gate is
-                            // config.isAddressSearchEnabled, applied inside
-                            // lookupCompanyAddress — same one the shipping-step
-                            // picker uses.
-                            self.addressLookup(selectedItem);
-                        });
-                    companySearch.markSearchBinding($companyNameField, bindToken);
-                    // TWO-25326 §1: any character opens the dropdown, not
-                    // just the Space/Enter select2 4.1 handles on its own.
-                    companySearch.attachOpenOnType($companyNameField, bindToken);
-                    $('#select2-company_name-container').text(self.companyName());
-                    // Scoped to the container of the node THIS bind owns.
-                    // With two Two-family renderers there is one
-                    // `#billing_search_for_company` id in the page, so a
-                    // document-wide lookup would hand the link in brand A's
-                    // field to whichever component bound last.
-                    const $field = $companyNameField.closest('.field');
-                    if ($field.find('.search_for_company').length == 0) {
-                        $field.append(
-                            `<div class="search_for_company" role="button" tabindex="0" ` +
-                                `title="${self.searchForCompanyText}">` +
-                                `<span>${self.searchForCompanyText}</span>` +
-                                '</div>'
-                        );
-                    }
-                    // Re-bound unconditionally (the div survives a re-render,
-                    // so an append guard would leave this closed over a stale
-                    // component) and scoped to this bind's own container.
-                    const $searchForCompany = $field.find('.search_for_company');
-                    const activateSearchForCompany = function () {
-                        // Guards against a double-activation: this is a
-                        // `role="button"` on a plain div, not a native
-                        // <button>, and some assistive-tech/browser
-                        // combinations forward a synthetic `click` in
-                        // addition to the Enter keydown for exactly that
-                        // shape of widget. Once hidden, a second call is a
-                        // no-op rather than re-opening a dropdown the buyer
-                        // already opened.
-                        const $el = $searchForCompany.first();
-                        if ($el.length && $el.get(0).style.display === 'none') return;
-                        self.enableCompanySearch({ openDropdown: true });
-                        $searchForCompany.hide();
-                    };
-                    $searchForCompany
-                        .off('click' + companySearch.EVENT_NS)
-                        .off('keydown' + companySearch.EVENT_NS)
-                        .on('click' + companySearch.EVENT_NS, activateSearchForCompany)
-                        // Keyboard reachability (TWO parity with WooCommerce /
-                        // Hyvä): this div has no native semantics, so Enter/
-                        // Space have to be wired up by hand to match the
-                        // role="button" contract set on the markup above.
-                        .on('keydown' + companySearch.EVENT_NS, function (e) {
-                            if (e.key !== 'Enter' && e.key !== ' ' && e.which !== 13 && e.which !== 32) {
-                                return;
-                            }
-                            e.preventDefault();
-                            activateSearchForCompany();
-                        });
-                    $searchForCompany.hide();
-                    // Last, so every handler above — including `select2:open`,
-                    // which is what puts the caret in the search box — is
-                    // already bound when the dropdown opens.
-                    if (pendingOpen) {
-                        pendingOpen = false;
-                        $companyNameField.select2('open');
+            const self = this;
+            // ONE instance per renderer — a renderer is pushed once per
+            // Two-family brand, so this is one instance per brand's tile,
+            // never a second parallel select2 wiring for the same tile. No
+            // `searchForCompanyId` here on purpose: the "Search for company"
+            // link's own append guard has to be scoped to THIS bind's
+            // container, not a document-wide id, or a checkout offering two
+            // Two-family brands would mint duplicate ids and hand brand A's
+            // link to brand B — see the class's own doc comment on
+            // `searchForCompanyId`.
+            if (!this._companySearchControl) {
+                this._companySearchControl = new CompanySearchControl({
+                    fieldSelector: self.companyNameSelector,
+                    config: self._brandConfig,
+                    getCountryCode: function () {
+                        return self.countryCode();
+                    },
+                    searchForCompanyText: self.searchForCompanyText,
+                    onSelect: function (selectedItem) {
+                        const companyId = selectedItem.companyId;
+                        const companyName = selectedItem.text;
+                        // applyCompanyData(), not fillCompanyData(): a pick is
+                        // authoritative and must overwrite the previous
+                        // company's identifier even when the new company has
+                        // none of its own.
+                        self.applyCompanyData({ companyId, companyName }, { authoritative: true });
+                        // TWO-25193: the payment-tile picker used to stop
+                        // here, leaving the billing address blank. Gate is
+                        // config.isAddressSearchEnabled, applied inside
+                        // lookupCompanyAddress — same one the shipping-step
+                        // picker uses.
+                        self.addressLookup(selectedItem);
+                    },
+                    onManualEntryActivated: function () {
+                        self.clearCompany();
+                        // Focused too, not just shown: clearCompany() tears
+                        // the select2 widget down through
+                        // destroyCompanySearchWidget(), which removes the
+                        // manual-entry button — the element that had focus —
+                        // from the document. Nothing else in that teardown
+                        // path refocuses anything, so a buyer who reached the
+                        // button by keyboard is otherwise dropped back to
+                        // `<body>` with no visible focus at all.
+                        self._companySearchControl.showSearchForCompanyLink(true);
+                    },
+                    onBound: function () {
+                        $('#select2-company_name-container').text(self.companyName());
                     }
                 });
-            });
+            }
+            this._companySearchControl.bind(options);
         },
         getTelephone: function () {
             const telephone = this.telephone();
@@ -1813,19 +1608,19 @@ define([
          * Destroy only the widget this component bound. Safe to call twice.
          */
         destroyCompanySearchWidget: function () {
-            const $field = this._$companyNameField;
-            // `_$companyFieldContainer` is deliberately NOT cleared here: the
-            // re-enable link lives in that container and has to stay
-            // resolvable after the widget is gone.
-            this._$companyNameField = null;
-            if (!$field || !$field.data || !$field.data('select2')) return;
-            // Belt-and-braces alongside the `select2:close` handler above:
-            // destroy() does not always route through a `close` event first,
-            // and an undetached button would stay wired to this disposed
-            // renderer for the life of the page.
-            companySearch.detachManualEntryButton($field);
-            $field.off(companySearch.EVENT_NS);
-            $field.select2('destroy');
+            if (!this._companySearchControl) return;
+            // The control's own reference to the "Search for company" link
+            // is deliberately NOT cleared by destroy(): the re-enable link
+            // has to stay resolvable after the widget is gone — see
+            // searchForCompanyLink().
+            const $field = this._companySearchControl.getField();
+            // isBound()/destroy() are the scoped, idempotent teardown of
+            // ONLY the widget this component bound — the same belt-and-
+            // braces need as the `select2:close` handler above: destroy()
+            // does not always route through a `close` event first, and an
+            // undetached button would stay wired to this disposed renderer
+            // for the life of the page.
+            if (!this._companySearchControl.destroy()) return;
             $field.attr('type', 'text');
         },
         /**


### PR DESCRIPTION
## Summary

TWO-25326: rebuild WC/Magento/Hyva's company search to follow PrestaShop's `TwoCompanySearch` class pattern — one implementation of the picker's select2 wiring, not one per checkout mount.

Before this PR, `address-autocomplete.js` (shipping step) and `gateway_method.js` (payment tile) each rolled their own `.select2({...})` construction, `select2:open`/`select2:close`/`select2:select` handlers, manual-entry button wiring, and "Search for company" return link — two parallel implementations of the same picker built on the same shared helpers in `company-search.js`, drifting further apart with every fix.

## What changed

- New `view/frontend/web/js/model/company-search-control.js`: a `CompanySearchControl` class that owns the picker's full lifecycle end to end (select2 construction, dropdown wiring, manual-entry button, return link, open-on-type), configured via a constructor options object — mirrors PrestaShop's `TwoCompanySearch`.
- `address-autocomplete.js` and `gateway_method.js` are now thin call sites: each constructs exactly one `CompanySearchControl` instance and supplies only the mount-specific glue (field selector, `onSelect`, what "manual entry" means for that mount).
- `company-search.js` (the search request / result mapping / address write-back / chrome primitives) is unchanged — the control is built on top of it, same as before.

### Why two call sites, not one (the deliberate deviation from PrestaShop)

PrestaShop has one `TwoCheckoutManager` singleton deciding which mount is active. Magento doesn't have an equivalent, for two structural reasons that predate this PR:

- a payment renderer is pushed once **per Two-family brand**, so a checkout offering two brands has two live tile widgets at once — there is no single page-wide instance even before this change;
- which mount is the buyer's active route to search can flip **at runtime** (virtual cart, saved address) without a page reload — `gateway_method.js`'s `isTileCompanySearchActive()` already re-evaluates this live.

Each surface is its own Knockout component with its own `dispose()` lifecycle already scoped to "the widget THIS component bound" (a deliberate multi-brand safety property). Forcing a page-wide singleton would fight that model rather than simplify it. The mutual-exclusion PrestaShop gets from one decision point, Magento keeps via the existing `isCompanySearchEnabled` / `isTileCompanySearchActive()` guards each call site already checks — at most one mount is ever actively bound to a live select2 widget per brand at a time.

## Test plan

- [x] `npm run test:js` — 341 tests, 26 suites, all green.
- [x] Added `company-search-control.js` to the module smoke-load list (`all-js-modules.test.js`).
- [x] Retargeted the two structural (source-grep) suites that used to assert the select2 wiring lived in the two surface files — they now assert the wiring lives in `company-search-control.js`, and that both surfaces construct it rather than rolling a second implementation.
- [x] No PHP files touched; PHPUnit not re-run.
