### PR TITLE
fix(checkout): tile company-search control stays visible; add org-number label

### DIFF
--- a/Model/Ui/ConfigProvider.php
+++ b/Model/Ui/ConfigProvider.php
@@ -278,11 +278,14 @@ class ConfigProvider implements ConfigProviderInterface
      * company-known variant, absent/empty leaves the platform default.
      * See BrandRegistryInterface for both contracts.
      *
-     * TWO-25326 2026-08-03 ruling, §7.3: this is now the ONLY place the
-     * captured company name/number are displayed in the payment tile — the
+     * TWO-25326 2026-08-03 ruling, §7.3: this is the ONLY place the
+     * captured company NAME is displayed in the payment tile — the
      * standalone `.two-company-label` text (§7, pre-ruling) is removed, not
      * supplemented. Default wording is the literal ticket copy, with the
      * company number substituted the same way the company name always was.
+     * The company NUMBER also renders separately, notice-independent, via
+     * the tile's `.two-company-id-text` label (TWO-25326 2026-08-04 ruling,
+     * §5/§7 follow-up) — see gateway_method.html.
      *
      * @return array{withCompany:string,withoutCompany:string,companyNameToken:string,companyNumberToken:string}|null
      */

--- a/Test/Js/tile-company-readonly-fields.test.js
+++ b/Test/Js/tile-company-readonly-fields.test.js
@@ -204,13 +204,32 @@ function nameFieldVisible(renderer) {
             'expected exactly one company-name field wrapper, found ' + tags.length
         );
     }
-    if (!/visible:\s*isTileCompanySearchActive\(\)/.test(tags[0])) {
+    const bind = tags[0].match(/data-bind="([^"]*)"/);
+    if (!bind) {
+        throw new Error("the company-name field's wrapper has no data-bind attribute");
+    }
+    const visibleMatch = bind[1].match(/visible:\s*([^,]+?)\s*(?:,|$)/);
+    if (!visibleMatch) {
+        throw new Error("the company-name field's `visible:` binding is missing");
+    }
+    if (visibleMatch[1].trim() !== 'isTileCompanySearchActive()') {
         throw new Error(
             "the company-name field's `visible:` binding is not the pinned "
-                + '`isTileCompanySearchActive()` shape'
+                + '`isTileCompanySearchActive()` shape — got `'
+                + visibleMatch[1].trim()
+                + '`'
         );
     }
-    return renderer.isTileCompanySearchActive();
+    // Evaluate the pinned expression against the renderer, same discipline as
+    // `companyIdLabel()` below — a drift back to the old
+    // `(!isCompanyCaptured() || isCompanyRecoveryNeeded()) && isTileCompanySearchActive()`
+    // gate (or any other suffix conjunction) fails both the exact-shape check
+    // above AND would fail here too, rather than passing on a restated value.
+    // eslint-disable-next-line no-new-func
+    return !!new Function(
+        'renderer',
+        'with (renderer) { return (' + visibleMatch[1] + '); }'
+    ).call(null, renderer);
 }
 
 /**
@@ -254,6 +273,17 @@ function companyIdLabel(renderer) {
     if (typeof target !== 'function') {
         throw new Error(
             '`.two-company-id-text` binds text to `' + textMatch[1] + '`, not on the renderer'
+        );
+    }
+    // A bare number with no accessible name is unreadable to a screen
+    // reader — the same reason address-autocomplete.js's
+    // renderCompanyIdText() carries an `aria-label`, not just visible text
+    // (see address-step-company-id-text.test.js's aria-label pin). Pinned
+    // here too so a drift that drops it fails the suite, not just review.
+    if (!/attr:\s*\{\s*'aria-label':\s*\$t\('Company Number'\)\s*\}/.test(bind[1])) {
+        throw new Error(
+            "`.two-company-id-text` is missing its pinned `aria-label: 'Company Number'` "
+                + 'accessible name binding'
         );
     }
     return { visible: visible, text: target.call(renderer) };

--- a/Test/Js/tile-company-readonly-fields.test.js
+++ b/Test/Js/tile-company-readonly-fields.test.js
@@ -144,8 +144,10 @@ function renderedValue(id, renderer) {
  * render, and what it says — both derived from the live observable rather
  * than restated, so a rewired binding fails here rather than passing on an
  * assumed string. TWO-25326 §7.3 (2026-08-03 ruling): these observables are
- * now the ONLY surface the captured company name/number appear on in the
- * tile — there is no separate label to keep in sync with them.
+ * the ONLY surface the captured company NAME appears on in the tile —
+ * there is no separate name label to keep in sync with them. The NUMBER
+ * also renders separately, notice-independent, via `.two-company-id-text`
+ * (2026-08-04 ruling, §5/§7 follow-up) — see companyIdLabel() below.
  */
 function approvedNoticeVisible(renderer) {
     return !!renderer.orderIntentApprovedNotice();

--- a/Test/Js/tile-company-readonly-fields.test.js
+++ b/Test/Js/tile-company-readonly-fields.test.js
@@ -2,28 +2,31 @@
  * Copyright © Two.inc All rights reserved.
  * See COPYING.txt for license details.
  *
- * The payment tile's company display, as the 2026-08-03 ruling on TWO-25326
- * (§7.3) now defines it: NO standalone label at all. The captured company
- * name/number appear ONLY inside the order-intent notice sentence itself —
- * `orderIntentApprovedNotice` / `orderIntentDeclinedNotice` — which has its
- * own gate (whether an intent was placed and what it said), independent of
- * the tile's company CONTROLS, which remain gated on isCompanyCaptured() —
- * a separate and unchanged rule. A company captured with no intent outcome
- * on screen hides the controls and shows neither notice.
+ * The payment tile's company display, as the TWO-25326 2026-08-04 ruling
+ * now defines it. Two things changed from the 2026-08-03 (§7.3) shape this
+ * file used to pin, and they are independent:
  *
- * This supersedes three earlier shapes in turn. TWO-25288 first made the
- * captured number a read-only `<input>`; the ruling after that replaced the
- * input with a "Company Number" caption plus a separately-rendered value.
- * §7 (pre-2026-08-03) replaced that pair with one `.two-company-label` line,
- * gated on the intent message's own visibility. The 2026-08-03 ruling
- * removes that label too — company display now lives ONLY in the notice
- * text, not beside it.
+ *  - Bug A: the capture CONTROL's (the field + picker) visibility is no
+ *    longer gated on isCompanyCaptured() or on any order-intent outcome at
+ *    all. Doug's exact words: it "is controlled ONLY by the state of the
+ *    'enable search in address' admin setting ... and search control
+ *    visibility is not changed for any other reason" — i.e.
+ *    isTileCompanySearchActive() alone. Previously it hid on capture (the
+ *    theory being that the notice sentence made a second, editable copy
+ *    redundant) and briefly grew a decline-recovery carve-out
+ *    (isCompanyRecoveryNeeded(), now deleted) to avoid trapping a declined
+ *    buyer — found in testing to still leave the control gone, permanently,
+ *    on the common approve path.
  *
- * The control is HIDDEN, not deleted, and that distinction is pinned here
- * deliberately. The tile's picker is the only company-capture surface for a
- * buyer on a saved address (no `#shipping-new-address-form` exists, and that
- * is the only selector address-autocomplete.js binds) or on a virtual cart
- * (no shipping step at all). Deleting it would block those orders outright.
+ *  - Bug B: a `.two-company-id-text` org-number LABEL now renders under the
+ *    control once a company is captured (gated on isCompanyCaptured() &&
+ *    isTileCompanySearchActive()), mirroring address-autocomplete.js's
+ *    renderCompanyIdText()/`.two-company-id-text` (§5). This is NOT a
+ *    reinstatement of the `.two-company-label` line §7 added and §7.3
+ *    removed — that was a combined name+number line gated on the notice's
+ *    own visibility, and it stays removed. The order-intent notice sentence
+ *    is unaffected and still carries its own embedded "Name (number)" text
+ *    independently of this label.
  *
  * Four groups, and they are NOT the same kind of test. Be honest about which
  * is which before trusting a green run:
@@ -33,16 +36,12 @@
  *     shape and against any future reinstatement of an editable NUMBER field,
  *     because there is no `<input id="company_id">` left to satisfy either.
  *
- *  2. GATE PINS — two separate gates, pinned separately. The label and the
- *     order-intent message read the IDENTICAL expression (asserted as string
- *     equality between the two bindings, not as two matches against one
- *     pattern, because two different expressions that both happen to be true
- *     is precisely the failure the ruling forbids). The capture controls read
- *     `!isCompanyCaptured()`, which is a different gate on purpose. Every
- *     expression is read out of the template and pinned to an exact shape
- *     before being evaluated, so a drift to some other predicate — or to an
- *     always-true stub — fails the string match rather than passing on a
- *     coincidence.
+ *  2. GATE PINS — the control's `visible:` binding
+ *     (`isTileCompanySearchActive()` alone, post-2026-08-04) and the
+ *     org-number label's (`isCompanyCaptured() && isTileCompanySearchActive()`)
+ *     are pinned separately, each to its exact shape, so a drift to some
+ *     other predicate — or to an always-true stub — fails the string match
+ *     rather than passing on a coincidence.
  *
  *  3. WHAT-THE-BUYER-SEES PINS — 'what each capture mode puts in front of the
  *     buyer'. These do not restate the markup: they read the `text:` binding
@@ -184,9 +183,17 @@ function noticeGateExpression(cssClass) {
 
 /**
  * Whether the tile's company-name FIELD (the capture control) would currently
- * render. Same derive-then-evaluate discipline. Pinned to
- * `!isCompanyCaptured()`, which is DELIBERATELY not the label's gate any more:
- * the controls swap on capture, the label swaps on the intent message.
+ * render. Same derive-then-evaluate discipline.
+ *
+ * TWO-25326, 2026-08-04 ruling: pinned to `isTileCompanySearchActive()`
+ * ALONE. Doug's exact words: the control "is controlled ONLY by the state
+ * of the 'enable search in address' admin setting ... and search control
+ * visibility is not changed for any other reason." This supersedes the
+ * earlier `!isCompanyCaptured() || isCompanyRecoveryNeeded()` gate this
+ * function used to also require — capture state and order-intent outcome
+ * (approved, declined, errored) no longer affect the control's visibility
+ * at all. Pinned to the exact shape so a drift reintroducing either gate
+ * fails the string match, not just the behavioural cases below.
  */
 function nameFieldVisible(renderer) {
     const markup = withoutComments(readTemplate());
@@ -197,29 +204,59 @@ function nameFieldVisible(renderer) {
             'expected exactly one company-name field wrapper, found ' + tags.length
         );
     }
-    // TWO-25326 §7.1/decline-recovery (2026-08-04 adversarial-review, round
-    // 1 then round 2): the field also re-shows on a declined intent, even
-    // though isCompanyCaptured() is still true then — see the template's
-    // own comment. Gated on isCompanyRecoveryNeeded(), NOT on the declined
-    // NOTICE's own visibility — round 2 found the notice-visibility gate
-    // reproduced the dead-end for a brand with order_intent enabled but the
-    // notice UI suppressed. Pinned to the exact shape so a drift silently
-    // narrowing or widening the gate fails the string match, not just the
-    // behavioural cases below.
-    if (
-        !/visible:\s*\(!isCompanyCaptured\(\)\s*\|\|\s*isCompanyRecoveryNeeded\(\)\)\s*&&\s*isTileCompanySearchActive\(\)/.test(
-            tags[0]
-        )
-    ) {
+    if (!/visible:\s*isTileCompanySearchActive\(\)/.test(tags[0])) {
         throw new Error(
             "the company-name field's `visible:` binding is not the pinned "
-                + '`(!isCompanyCaptured() || isCompanyRecoveryNeeded()) && isTileCompanySearchActive()` shape'
+                + '`isTileCompanySearchActive()` shape'
         );
     }
-    return (
-        (!renderer.isCompanyCaptured() || renderer.isCompanyRecoveryNeeded()) &&
-        renderer.isTileCompanySearchActive()
-    );
+    return renderer.isTileCompanySearchActive();
+}
+
+/**
+ * The tile's org-number label — `.two-company-id-text` — as it would
+ * currently render: whether it is visible, and what text it would show.
+ * TWO-25326, 2026-08-04 ruling, Bug B: the tile's equivalent of
+ * address-autocomplete.js's renderCompanyIdText()/`.two-company-id-text`
+ * (§5), NOT a reinstatement of the `.two-company-label` line §7.3 removed.
+ * Derived from the template's own binding, same discipline as the other
+ * helpers here — a drift in either the gate or the bound value fails here
+ * rather than passing on a restated expectation.
+ */
+function companyIdLabel(renderer) {
+    const markup = withoutComments(readTemplate());
+    const tags = markup.match(/<div\b[^>]*class="two-company-id-text"[^>]*>/g) || [];
+    if (tags.length !== 1) {
+        throw new Error(
+            'expected exactly one `.two-company-id-text` label, found ' + tags.length
+        );
+    }
+    const bind = tags[0].match(/data-bind="([^"]*)"/);
+    if (!bind) {
+        throw new Error('`.two-company-id-text` has no data-bind attribute');
+    }
+    const visibleMatch = bind[1].match(/visible:\s*([^,]+?)\s*,/);
+    const textMatch = bind[1].match(/text:\s*([A-Za-z_$][\w$]*)/);
+    if (!visibleMatch || !textMatch) {
+        throw new Error('`.two-company-id-text` is missing its `visible:`/`text:` binding');
+    }
+    // `with`, not a bare `return (expr)`: ko evaluates a `data-bind` string
+    // with the view model as its implicit scope, so `isCompanyCaptured()`
+    // in the markup means `renderer.isCompanyCaptured()`, not a free
+    // identifier — the same reason `renderedValue()` above resolves its
+    // bound name against `renderer` rather than eval-ing it bare.
+    // eslint-disable-next-line no-new-func
+    const visible = !!new Function(
+        'renderer',
+        'with (renderer) { return (' + visibleMatch[1] + '); }'
+    ).call(null, renderer);
+    const target = renderer[textMatch[1]];
+    if (typeof target !== 'function') {
+        throw new Error(
+            '`.two-company-id-text` binds text to `' + textMatch[1] + '`, not on the renderer'
+        );
+    }
+    return { visible: visible, text: target.call(renderer) };
 }
 
 /**
@@ -288,16 +325,19 @@ describe('the payment tile shows the number as an uneditable label, not a field'
     });
 
     /**
-     * The reason the field is HIDDEN rather than deleted, pinned so a future
-     * tidy-up cannot quietly delete it: the tile's picker is the only
-     * company-capture surface for a buyer on a saved address (no
-     * `#shipping-new-address-form` is rendered, and that is the only selector
-     * address-autocomplete.js binds) or on a virtual cart (no shipping step
-     * at all). Removing it blocks those orders outright, because
-     * Model/Two.php::authorize() refuses a company with no organisation
-     * number.
+     * TWO-25326, 2026-08-04 ruling: the field is retained AND stays visible
+     * once a company is captured — it no longer hides. Doug's exact words:
+     * the control's visibility "is controlled ONLY by the state of the
+     * 'enable search in address' admin setting ... and search control
+     * visibility is not changed for any other reason." This supersedes the
+     * earlier "hides once captured, because a second editable copy of the
+     * notice sentence is a defect" reasoning — that theory made the control
+     * disappear on the common approve path with nothing to bring it back.
+     * The saved-address / virtual-cart capture route this used to also
+     * protect is now covered directly by isTileCompanySearchActive() alone,
+     * with no capture-state carve-out needed.
      */
-    test('the capture control is retained and hides on capture', () => {
+    test('the capture control is retained and stays visible on capture', () => {
         const { renderer } = loadRendererOnly();
 
         // Still present in the template — not deleted.
@@ -308,21 +348,22 @@ describe('the payment tile shows the number as an uneditable label, not a field'
         // Nothing captured: the control is available.
         expect(nameFieldVisible(renderer)).toBe(true);
 
-        // Captured: it hides. This rule is unchanged by the 2026-08-03 label
-        // ruling and must stay that way — it is what preserves the
-        // saved-address / virtual-cart capture route described above.
+        // Captured: it stays up. Unlike the pre-2026-08-04 rule, this is
+        // unconditional — no order-intent outcome changes it.
         renderer.applyCompanyData(
             { companyName: 'First Example Ltd', companyId: '12345678' },
             { authoritative: true }
         );
-        expect(nameFieldVisible(renderer)).toBe(false);
+        expect(nameFieldVisible(renderer)).toBe(true);
     });
 
     test('a name with no number leaves the capture control up — name-only is not captured', () => {
         // §6: manual entry (name, no number) must not make the payment method
-        // usable, so capture is NOT complete and the buyer must keep the
-        // search box. This is the case most likely to be got wrong by gating
-        // the control on the name alone.
+        // usable, so capture is NOT complete. The control staying up here is
+        // now the SAME rule as the captured case above (visibility no longer
+        // depends on capture state at all), but this case is kept separate
+        // because isCompanyCaptured() still gates the org-number label below
+        // it, and a name-only capture must show neither.
         const { renderer } = loadRendererOnly();
 
         renderer.applyCompanyData(
@@ -333,6 +374,7 @@ describe('the payment tile shows the number as an uneditable label, not a field'
         expect(renderer.isCompanyCaptured()).toBe(false);
         expect(nameFieldVisible(renderer)).toBe(true);
         expect(approvedNoticeVisible(renderer)).toBe(false);
+        expect(companyIdLabel(renderer).visible).toBe(false);
     });
 
     test('the name field is read-only only once a company has been captured', () => {
@@ -459,7 +501,7 @@ describe('the payment tile shows the number as an uneditable label, not a field'
 });
 
 describe('what each capture mode puts in front of the buyer', () => {
-    test('search mode: an approved intent embeds "Name (number)" in the notice sentence, and hides the control', () => {
+    test('search mode: an approved intent embeds "Name (number)" in the notice sentence, and the control stays up', () => {
         const { renderer } = loadRendererOnly();
 
         renderer.applyCompanyData(
@@ -468,13 +510,17 @@ describe('what each capture mode puts in front of the buyer', () => {
         );
         approveIntent(renderer);
 
-        // The name observable still carries the name — the control is only
-        // hidden, so it is still bound and still the thing sole-trader mode
-        // and the picker write to.
+        // The name observable carries the name, and — TWO-25326, 2026-08-04
+        // ruling — the control is never hidden by an approval, so it is
+        // still bound and still the thing sole-trader mode and the picker
+        // write to.
         expect(renderedValue('company_name', renderer)).toBe('First Example Ltd');
         expect(approvedNoticeText(renderer)).toBe('Approved for First Example Ltd (12345678).');
         expect(approvedNoticeVisible(renderer)).toBe(true);
-        expect(nameFieldVisible(renderer)).toBe(false);
+        expect(nameFieldVisible(renderer)).toBe(true);
+        // The org-number label (Bug B) shows alongside both the control and
+        // the notice — a separate display route from the notice sentence.
+        expect(companyIdLabel(renderer)).toEqual({ visible: true, text: '12345678' });
     });
 
     test('sole-trader mode: the minted name and synthetic number are embedded the same way', () => {
@@ -496,16 +542,14 @@ describe('what each capture mode puts in front of the buyer', () => {
             'Approved for Sole Trader Example (ST-SYNTH-004).'
         );
         expect(approvedNoticeVisible(renderer)).toBe(true);
-        expect(nameFieldVisible(renderer)).toBe(false);
-        // The field is hidden here, but its readonly binding must STILL read
-        // locked. Hiding is a display decision and sole trader can be left
-        // (registeredOrganisationMode()) — if the binding had been allowed to
-        // relax on the assumption nobody can see the field, re-showing it
-        // would hand the buyer an editable copy of a name they must not edit.
+        // Visible throughout (2026-08-04 ruling) — but still LOCKED: a
+        // visible, editable copy of a sole-trader-minted name is exactly
+        // what isCompanyNameReadOnly() exists to prevent.
+        expect(nameFieldVisible(renderer)).toBe(true);
         expect(isReadOnly('company_name', renderer)).toBe(true);
     });
 
-    test('manual-entry mode: the notice disappears and the capture control comes back', () => {
+    test('manual-entry mode: the notice and the org-number label disappear, and the control is typeable again', () => {
         // Driven through the real manual-entry path — clearCompany() is what the
         // sentinel row's handler calls — not by poking the observable, so this
         // fails if that path stops clearing the abandoned company's number.
@@ -517,30 +561,32 @@ describe('what each capture mode puts in front of the buyer', () => {
         );
         approveIntent(renderer);
         expect(approvedNoticeVisible(renderer)).toBe(true);
+        expect(nameFieldVisible(renderer)).toBe(true);
+        expect(companyIdLabel(renderer).visible).toBe(true);
 
         renderer.clearCompany();
 
         expect(renderer.companyId()).toBe('');
         expect(approvedNoticeVisible(renderer)).toBe(false);
-        // The control is back, and typeable — which is the whole point of the
-        // mode, and the reason the swap is a visibility toggle rather than a
-        // removal.
+        expect(companyIdLabel(renderer).visible).toBe(false);
+        // The control was never hidden (2026-08-04 ruling) and is now
+        // typeable again — which is the whole point of the mode.
         expect(nameFieldVisible(renderer)).toBe(true);
         expect(isReadOnly('company_name', renderer)).toBe(false);
     });
 
     /**
-     * The regression §7's swap introduces if nothing is done about it, caught
-     * in adversarial review rather than by the original test set.
-     *
-     * registeredOrganisationMode() did not clear the captured company. While
-     * the tile's control was always visible that was untidy but recoverable —
-     * the buyer could just search, and the pick overwrote the stale identity.
-     * Once the control HIDES on capture it is not recoverable: a buyer
-     * leaving sole-trader mode would face a sole-trader notice, no search box,
-     * and no way back.
+     * Pre-2026-08-04, registeredOrganisationMode() not clearing the captured
+     * company was a regression only because the tile's control used to HIDE
+     * on capture — a buyer leaving sole-trader mode would otherwise face a
+     * sole-trader notice, no search box, and no way back. The control no
+     * longer hides for any capture-state reason, so that specific dead end
+     * is moot, but the underlying clear is still correct on its own terms
+     * (see registeredOrganisationMode()'s own comment): a sole-trader
+     * identity must not survive into registered-organisation mode. Pinned
+     * here as a visibility-independent behaviour.
      */
-    test('leaving sole-trader mode brings the capture control back', () => {
+    test('leaving sole-trader mode clears the sole-trader identity (the control was never hidden)', () => {
         const { renderer } = loadRendererOnly();
 
         renderer.prefetched = {
@@ -554,7 +600,7 @@ describe('what each capture mode puts in front of the buyer', () => {
         renderer.soleTraderMode();
         approveIntent(renderer);
         expect(approvedNoticeVisible(renderer)).toBe(true);
-        expect(nameFieldVisible(renderer)).toBe(false);
+        expect(nameFieldVisible(renderer)).toBe(true);
 
         // fillCustomerData() reaches into the quote's address objects
         // (getCacheKey()), which this file's renderer-only harness does not
@@ -571,8 +617,9 @@ describe('what each capture mode puts in front of the buyer', () => {
         // The sole-trader identity does not survive the mode switch...
         expect(renderer.companyId()).toBe('');
         expect(renderer.isCompanyCaptured()).toBe(false);
-        // ...so the buyer gets the search box back.
+        // ...and the control — visible the whole time — is typeable again.
         expect(nameFieldVisible(renderer)).toBe(true);
+        expect(isReadOnly('company_name', renderer)).toBe(false);
         expect(approvedNoticeVisible(renderer)).toBe(false);
     });
 
@@ -607,7 +654,8 @@ describe('what each capture mode puts in front of the buyer', () => {
 
         expect(renderer.companyId()).toBe('12345678');
         expect(renderer.isCompanyCaptured()).toBe(true);
-        expect(nameFieldVisible(renderer)).toBe(false);
+        expect(nameFieldVisible(renderer)).toBe(true);
+        expect(companyIdLabel(renderer)).toEqual({ visible: true, text: '12345678' });
         // ...and once the intent for it is approved, the notice appears.
         // Ordered this way round on purpose: the notice's companyId
         // subscription clears it whenever the company changes, so an
@@ -618,20 +666,22 @@ describe('what each capture mode puts in front of the buyer', () => {
     });
 
     /**
-     * Hiding rather than removing means select2 can be initialised against a
-     * node that is already `display: none` (a company captured on the address
-     * step before the tile rendered). select2 measures a width at init, and
-     * `_resolveWidth` returns anything that is not `resolve`/`element`/
-     * `style`/`computedstyle` VERBATIM — so the literal `'100%'` this picker
-     * passes is a CSS percentage that resolves whenever the node is shown,
-     * not a pixel count frozen at zero.
+     * `visible:` rather than `if:` means select2 can be initialised against
+     * a node that is already `display: none` — this field still hides
+     * whenever isTileCompanySearchActive() is false (the address-area
+     * setting is on and an address-area control actually exists on this
+     * checkout), even though capture state no longer hides it. select2
+     * measures a width at init, and `_resolveWidth` returns anything that is
+     * not `resolve`/`element`/`style`/`computedstyle` VERBATIM — so the
+     * literal `'100%'` this picker passes is a CSS percentage that resolves
+     * whenever the node is shown, not a pixel count frozen at zero.
      *
      * Switching that option to `'resolve'` or `'element'` would measure
      * `outerWidth()` at init instead, which is 0 on a hidden node, and the
-     * buyer who returns to manual entry would get a zero-width search box.
-     * Pinned as an option value because there is no way to observe the
-     * consequence in jsdom (no layout), and the failure is invisible until a
-     * real browser renders it.
+     * buyer who ends up on the tile after starting on a hidden init would
+     * get a zero-width search box. Pinned as an option value because there
+     * is no way to observe the consequence in jsdom (no layout), and the
+     * failure is invisible until a real browser renders it.
      */
     test('the picker takes a percentage width, so a hidden init cannot freeze it at zero', () => {
         // TWO-25326 rebuild: the `.select2({...})` call — and this `width`
@@ -744,15 +794,15 @@ describe('the notices are gated on their own observables, not on capture', () =>
         expect(errors).toEqual([]);
     });
 
-    test('a decline re-opens the capture control instead of trapping the buyer (found in adversarial review, 2026-08-04)', () => {
-        // BLOCKER found reviewing this PR: isCompanyCaptured() stays true
-        // after a decline (only an approval's own company-change
-        // subscriptions clear the observables), so gating the field purely
-        // on isCompanyCaptured() left a declined buyer staring at a
-        // persistent "not available" notice with NO control anywhere on the
-        // tile to try a different company — a dead end without a page
-        // reload on a saved-address/virtual-cart/setting-off checkout,
-        // where the tile is the buyer's ONLY route to search.
+    test('the capture control stays up through approve, decline, and a re-pick (TWO-25326, 2026-08-04 ruling)', () => {
+        // Supersedes the pre-2026-08-04 "decline re-opens the capture
+        // control" fix: that fix existed only because isCompanyCaptured()
+        // used to hide the field on approval and had no way to re-show it
+        // on decline without a dedicated carve-out
+        // (isCompanyRecoveryNeeded(), now removed). The 2026-08-04 ruling
+        // makes the control's visibility depend on isTileCompanySearchActive()
+        // alone, so there is nothing left to trap the buyer with — pinned
+        // here across all three states in one flow.
         const { renderer } = loadRendererOnly();
 
         renderer.applyCompanyData(
@@ -760,25 +810,21 @@ describe('the notices are gated on their own observables, not on capture', () =>
             { authoritative: true }
         );
         approveIntent(renderer);
-        expect(nameFieldVisible(renderer)).toBe(false);
+        expect(nameFieldVisible(renderer)).toBe(true);
 
         renderer.processOrderIntentSuccessResponse({ approved: false });
 
         expect(renderer.isCompanyCaptured()).toBe(true);
         expect(declinedNoticeVisible(renderer)).toBe(true);
-        // The recovery path: the field is back, letting the buyer search
-        // again.
         expect(nameFieldVisible(renderer)).toBe(true);
 
-        // Picking a different company clears the declined notice AND
-        // completes a new capture, so the field correctly hides again once
-        // there is something new to hide it for.
         renderer.applyCompanyData(
             { companyName: 'Second Example Ltd', companyId: '87654321' },
             { authoritative: true }
         );
         expect(declinedNoticeVisible(renderer)).toBe(false);
-        expect(nameFieldVisible(renderer)).toBe(false);
+        expect(nameFieldVisible(renderer)).toBe(true);
+        expect(companyIdLabel(renderer)).toEqual({ visible: true, text: '87654321' });
     });
 
     test('an errored intent shows neither notice', () => {
@@ -925,14 +971,12 @@ describe('the notices are gated on their own observables, not on capture', () =>
         declineIntent(renderer);
         expect(declinedNoticeVisible(renderer)).toBe(false);
 
-        // Round 2 of adversarial review, 2026-08-04: THIS is the case round
-        // 1's decline-recovery fix missed. `enable_order_intent` and
-        // `<intent_approved_notice_enabled>` are independent brand.xml
-        // switches — order_intent can fire for real (as it just did above)
-        // while the notice UI stays off. Gating the field's re-show on the
-        // declined NOTICE's own visibility (always false for this brand)
-        // would silently reproduce the original dead-end. It must re-show
-        // regardless.
+        // The 2026-08-04 ruling makes this trivial where it used to need a
+        // dedicated fix: the field's visibility no longer reads either
+        // notice observable, so a brand with the notice UI suppressed
+        // (`enable_order_intent` on, `<intent_approved_notice_enabled>`
+        // off — two independent brand.xml switches) can never produce a
+        // hidden-with-no-notice dead end in the first place.
         expect(nameFieldVisible(renderer)).toBe(true);
     });
 

--- a/Test/Js/tile-company-readonly-fields.test.js
+++ b/Test/Js/tile-company-readonly-fields.test.js
@@ -337,7 +337,9 @@ describe('the payment tile shows the number as an uneditable label, not a field'
     test('the standalone company label is gone — no class, no builder method', () => {
         // TWO-25326 §7.3 (2026-08-03 ruling): the pre-ruling `.two-company-label`
         // element and its companyDisplayLabel() builder are REMOVED, not
-        // relocated. Company display now lives only inside the notice text.
+        // relocated. The company NAME now lives only inside the notice text;
+        // the NUMBER also renders separately via `.two-company-id-text`
+        // (2026-08-04 ruling, §5/§7 follow-up) — see companyIdLabel() above.
         const markup = withoutComments(readTemplate());
 
         expect(markup).not.toContain('two-company-label');

--- a/docs/brand-overlay-guide.md
+++ b/docs/brand-overlay-guide.md
@@ -141,8 +141,11 @@ There is deliberately **no** `intent_declined_notice` element. See below.
 The notices are buyer-facing "order intent approved" / "order intent not
 approved" lines rendered inline in the checkout payment tile — as of the
 2026-08-03 ruling (TWO-25326 §7.3), this is the ONLY place the buyer's
-captured company name/number are displayed in the tile at all; the
-earlier standalone `.two-company-label` element is gone, not relocated.
+captured company NAME is displayed in the tile; the earlier standalone
+`.two-company-label` element is gone, not relocated. The company NUMBER
+also renders separately, independent of these notices, via the tile's
+`.two-company-id-text` label (2026-08-04 ruling, TWO-25326 §5/§7
+follow-up), mirroring the address step's equivalent label.
 Both notices are controlled by **one shared on/off switch**, but only the
 APPROVED notice has a wording override. **This is deliberate, not an
 oversight** (2026-08-04 ruling, TWO-25326): the declined/not-available

--- a/view/frontend/web/css/style.css
+++ b/view/frontend/web/css/style.css
@@ -691,18 +691,24 @@
 }
 
 /*
- * The address-step company number, rendered as a plain text label (TWO-25326
- * §5) rather than the input above — which is hidden outright.
+ * The captured company number, rendered as a plain text label rather than
+ * an editable input, under EITHER of the two mounts the shared
+ * company-search control can live on:
  *
- * Appended into the company field's `.control` by
- * view/frontend/web/js/view/address-autocomplete.js only once a search result
- * has actually been selected, so it is absent before selection and absent in
- * manual-entry mode (name-only capture). `text-align: end` rather than
- * `right` so it follows the writing direction on RTL store views instead of
- * pinning to the physical right edge.
+ *  - the address step (TWO-25326 §5) — appended into the company field's
+ *    `.control` by address-autocomplete.js's renderCompanyIdText(), only
+ *    once a search result has actually been selected;
+ *  - the payment tile (TWO-25326, 2026-08-04 ruling, Bug B) — a KO `<div>`
+ *    in gateway_method.html, `visible`-bound to
+ *    `isCompanyCaptured() && isTileCompanySearchActive()`.
  *
- * `.control` is the input's own containing box, so aligning to its end edge
- * lines the number up with the input's end edge exactly.
+ * Both are absent before selection and absent in manual-entry mode
+ * (name-only capture). `text-align: end` rather than `right` so it follows
+ * the writing direction on RTL store views instead of pinning to the
+ * physical right edge.
+ *
+ * `.control` is the input's own containing box on both mounts, so aligning
+ * to its end edge lines the number up with the input's end edge exactly.
  */
 .two-company-id-text {
     display: block;

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -312,42 +312,35 @@ define([
          * Has a company actually been CAPTURED — name plus organisation
          * number — as opposed to merely named?
          *
-         * This is the switch that hides the tile's own company CONTROLS. When
-         * it is true the controls are hidden, because capture is complete and
-         * there is nothing left for the buyer to do here; when it is false
-         * they stay visible and fully functional, because they are the buyer's
-         * route to capturing a company in the first place.
+         * TWO-25326, 2026-08-04 ruling: this NO LONGER hides the tile's
+         * company-capture controls (the field + picker). Doug's exact
+         * words on the control's visibility: it "is controlled ONLY by the
+         * state of the 'enable search in address' admin setting ... and
+         * search control visibility is not changed for any other reason" —
+         * see isTileCompanySearchActive() and the `visible:` binding on the
+         * field wrapper in gateway_method.html, which no longer reads this
+         * method at all. Superseded here is the earlier design where
+         * capture (and, briefly, a decline-recovery carve-out on top of it)
+         * hid and re-showed that field — found in live testing to leave the
+         * control gone with no way back on the common approve path.
          *
-         * It no longer governs any standalone company LABEL — the
-         * 2026-08-03 ruling (§7.3) removed that element outright. The
-         * captured company now appears ONLY inside the order-intent notice
-         * sentence itself (orderIntentApprovedNotice / orderIntentDeclinedNotice),
-         * which has its own gate (whether an intent was placed and what it
-         * said) that is independent of this one. A captured company with no
-         * intent outcome yet showing hides the controls and shows no
-         * notice, and that is the ruling, not an oversight.
+         * What THIS method still gates, post-ruling:
          *
-         * Keeping the controls rather than deleting them is deliberate and
-         * load-bearing. The tile's picker is not a duplicate of the address
-         * step's: address-autocomplete.js binds only
-         * `#shipping-new-address-form`, so a buyer who selects a SAVED
-         * address (no new-address form is rendered) or checks out a VIRTUAL
-         * cart (no shipping step exists at all) has no company search
-         * anywhere else. Removing this surface outright would leave those two
-         * flows with no way to supply a company, and
-         * Model/Two.php::authorize() then refuses the order server-side — an
-         * order-blocking regression, not a cosmetic one.
+         *  - the org-number label underneath the field in
+         *    gateway_method.html (`.two-company-id-text`) — shown once
+         *    capture is complete, same "name AND number" rule as below,
+         *    mirroring address-autocomplete.js's renderCompanyIdText();
+         *  - placeOrder()'s client-side submit gate (§6a) — a manual,
+         *    name-only capture must not let the buyer submit.
          *
          * Gated on the NUMBER, not on the name alone, and that is the whole
          * distinction:
          *
-         *  - a registry pick and sole-trader autofill both yield a number, so
-         *    capture is complete and the controls can go;
-         *  - manual entry yields a name and no number. §6 says name-only must
-         *    NOT make the payment method usable, so capture is precisely NOT
-         *    complete, and hiding the controls at that point would take away
-         *    the search box while telling the buyer they were finished. The
-         *    controls stay.
+         *  - a registry pick and sole-trader autofill both yield a number,
+         *    so capture is complete;
+         *  - manual entry yields a name and no number. §6 says name-only
+         *    must NOT make the payment method usable, so capture is
+         *    precisely NOT complete.
          *
          * A plain function, not a computed — same reasoning as
          * isCompanyNameReadOnly() above: the template reads it inside `visible`
@@ -375,9 +368,12 @@ define([
          *    when that form does not exist on this checkout at all — a
          *    saved address and a virtual cart both render no such form —
          *    in which case the tile remains the buyer's only route to
-         *    search, same reasoning as isCompanyCaptured()'s doc comment
-         *    above (removing it there would block those orders outright,
-         *    and the same is true here).
+         *    search: a saved address and a virtual cart both mean no
+         *    address-area control exists on this checkout at all, so
+         *    removing the tile's own route too would leave those two flows
+         *    with no way to supply a company, and Model/Two.php::authorize()
+         *    then refuses the order server-side — an order-blocking
+         *    regression, not a cosmetic one.
          *
          * Read live rather than cached: `updateShippingAddress()` /
          * `updateBillingAddress()` call `refreshTileCompanySearchBinding()`
@@ -431,26 +427,6 @@ define([
          */
         isOrderIntentDeclinedNoticeVisible: function () {
             return !!(this.orderIntentDeclinedNotice && this.orderIntentDeclinedNotice());
-        },
-        /**
-         * Whether the tile's capture control should re-show for decline
-         * recovery, independent of whether the declined NOTICE TEXT is
-         * visible. Added in round 2 of adversarial review, 2026-08-04:
-         * gating the field's re-show directly on
-         * isOrderIntentDeclinedNoticeVisible() reproduced the original
-         * dead-end for any brand with order_intent enabled but the notice
-         * UI suppressed (`enable_order_intent` and
-         * `<intent_approved_notice_enabled>` are independent switches — see
-         * Model/Brand/Loader.php) — that brand's declined buyer would still
-         * see the field stay hidden, just silently instead of with a notice.
-         * `orderIntentDeclined` is set on every decline regardless of
-         * whether any notice text was produced, so this reads true whenever
-         * a decline needs recovering from, on every brand configuration.
-         *
-         * @returns {boolean}
-         */
-        isCompanyRecoveryNeeded: function () {
-            return !!(this.orderIntentDeclined && this.orderIntentDeclined());
         },
         selectTerm: function (days) {
             surchargeModel.selectTerm(days);
@@ -1152,21 +1128,6 @@ define([
             this.orderIntentDeclinedNoticeCopy = config.orderIntentDeclinedNotice || null;
             this.orderIntentDeclinedNotice = ko.observable('');
 
-            // Round 2 adversarial review, 2026-08-04: `orderIntentDeclinedNotice`
-            // is NOT a reliable "was the last intent declined" signal on its
-            // own — `enable_order_intent` and
-            // `<intent_approved_notice_enabled>` are two INDEPENDENT brand
-            // switches (see Model/Brand/Loader.php), so a brand can have
-            // order_intent firing for real while the notice UI stays off.
-            // On that brand, orderIntentDeclinedNoticeCopy is permanently
-            // null, resolveCompanyNotice() always returns '', and gating the
-            // decline-recovery field re-show on the notice's OWN visibility
-            // would reproduce the exact dead-end that fix was written to
-            // close — just for a different brand config. Tracked separately
-            // so the recovery path does not depend on whether the notice UI
-            // happens to be on.
-            this.orderIntentDeclined = ko.observable(false);
-
             // The notice is *persistent* — unlike the message-region
             // treatment it replaces, it survives checkout updates and a
             // failed placeOrder validation (see the deliberate omission in
@@ -1182,12 +1143,10 @@ define([
             this.companyName.subscribe(function () {
                 self.orderIntentApprovedNotice('');
                 self.orderIntentDeclinedNotice('');
-                self.orderIntentDeclined(false);
             });
             this.companyId.subscribe(function () {
                 self.orderIntentApprovedNotice('');
                 self.orderIntentDeclinedNotice('');
-                self.orderIntentDeclined(false);
             });
         },
         /**
@@ -1247,7 +1206,6 @@ define([
                     // approval reassurance was effectively never seen.
                     this.orderIntentApprovedNotice(this.resolveOrderIntentApprovedNotice());
                     this.orderIntentDeclinedNotice('');
-                    this.orderIntentDeclined(false);
                 } else {
                     // TWO-25326 §7.3 (2026-08-03 ruling): a clean "not
                     // approved" response is a business outcome, not a
@@ -1257,11 +1215,6 @@ define([
                     // ONLY the intent message" the ruling asks for.
                     this.orderIntentApprovedNotice('');
                     this.orderIntentDeclinedNotice(this.resolveOrderIntentDeclinedNotice());
-                    // Set regardless of whether the notice text above is
-                    // empty (brand suppressed the notice UI) — this is the
-                    // signal the decline-recovery field re-show reads, and
-                    // it must fire on EVERY decline, notice or not.
-                    this.orderIntentDeclined(true);
                 }
             }
         },
@@ -1270,7 +1223,6 @@ define([
             // notice from a previous, successful intent.
             this.orderIntentApprovedNotice('');
             this.orderIntentDeclinedNotice('');
-            this.orderIntentDeclined(false);
 
             // `let`, not `const`: the SCHEMA_ERROR branch below reassigns
             // this to '' once it has pushed the field-level errors into
@@ -1712,16 +1664,9 @@ define([
                 // mirror of enterSoleTraderUi() clearing on the way in. A
                 // sole trader's minted name and synthetic number are not a
                 // registered organisation, so carrying them across the mode
-                // switch would submit one identity under the other's mode.
-                //
-                // Load-bearing since TWO-25326 §7 made the tile's company
-                // control HIDE once a company is captured. Before that the
-                // stale identity was untidy but recoverable — the search box
-                // was still on screen, and picking a company overwrote it.
-                // Now it is not: isCompanyCaptured() would still be true, so
-                // the control would stay hidden and the buyer would be
-                // stranded in registered-organisation mode looking at a
-                // sole-trader label with no way to search.
+                // switch would submit one identity under the other's mode —
+                // getData() would otherwise post the sole trader's number
+                // under whatever name the buyer then searches for.
                 //
                 // Before enableCompanySearch(), not after: clearCompany()
                 // ends in destroyCompanySearchWidget(), which would otherwise

--- a/view/frontend/web/template/payment/gateway_method.html
+++ b/view/frontend/web/template/payment/gateway_method.html
@@ -71,15 +71,19 @@
         <!--
             TWO-25326 §7.3 (2026-08-03 ruling): the standalone
             `.two-company-label` text that used to sit here is REMOVED, not
-            supplemented. The captured company name/number are now shown
-            ONLY inside the order-intent notice sentence itself — see
+            supplemented. The captured company NAME is now shown ONLY
+            inside the order-intent notice sentence itself — see
             ConfigProvider::getOrderIntentApprovedNotice() /
             getOrderIntentDeclinedNotice() for the copy templates and
             resolveCompanyNotice() in gateway_method.js for the substitution.
             A company captured with no intent outcome yet showing renders
-            neither notice below and therefore displays the company nowhere
-            in the tile — that follows from "the notice is the only display
-            surface" and is the ruling, not an oversight.
+            neither notice below and therefore displays the company NAME
+            nowhere in the tile — that follows from "the notice is the
+            only display surface for the name" and is the ruling, not an
+            oversight. The company NUMBER is a separate surface (2026-08-04
+            ruling, §5/§7 follow-up): see the `.two-company-id-text` label
+            further down this template, which renders independently of
+            these notices.
 
             Persistent inline notices, inside the payment tile next to the
             term chips. Each is emitted only when its own observable is

--- a/view/frontend/web/template/payment/gateway_method.html
+++ b/view/frontend/web/template/payment/gateway_method.html
@@ -184,66 +184,56 @@
                 data-bind='attr: {id: "payment_form_" + getCode()}'
             >
                 <!--
-                    TWO-25326 §7 / §7.1. Hidden once a company is captured,
-                    because the captured company is then shown inside the
-                    order-intent notice sentence (see the notices below) and
-                    a second, editable copy of the same thing is exactly what
-                    the ticket calls out as the defect.
+                    TWO-25326, 2026-08-04 ruling (supersedes the §7/§7.1
+                    capture-state and decline-recovery gating that used to
+                    live in this comment — Doug's exact words: "the search
+                    control ... is controlled ONLY by the state of the
+                    'enable search in address' admin setting: if true,
+                    search control is rendered inside the address block,
+                    otherwise is rendered inside the payment tile — and
+                    search control visibility is not changed for any other
+                    reason").
 
-                    Also hidden whenever isTileCompanySearchActive() is
-                    false — i.e. the admin setting puts the shared
-                    company-search control in the address area AND that
-                    address-area control actually exists on this checkout.
-                    The tile is then a display-only surface; showing this
-                    editable field too would be the "two bespoke
-                    implementations" the 2026-08-03 ruling forbids. See
-                    isTileCompanySearchActive() in gateway_method.js for the
-                    saved-address/virtual-cart fallback that keeps it true
-                    (and this field visible) even with the setting on.
+                    So this field's visibility depends on ONE thing —
+                    isTileCompanySearchActive(), the live read of that single
+                    admin setting (plus the saved-address/virtual-cart
+                    fallback documented on that method in gateway_method.js,
+                    which is the SAME condition, not a second one). It no
+                    longer depends on isCompanyCaptured() or on any
+                    order-intent outcome: the control stays visible after a
+                    company is picked, whether the subsequent order-intent
+                    call approves, declines, or errors. The org-number label
+                    below (not the notice sentence) is now the one thing that
+                    changes on capture.
 
-                    NOT removed, only hidden. This field and the picker bound
-                    to it are the buyer's company-capture route whenever the
-                    tile IS the active location — see isCompanyCaptured() and
-                    isTileCompanySearchActive() in gateway_method.js.
-                    `visible:` also keeps the node in the DOM so the select2
-                    binding, its MutationObserver rebinding and the
-                    sole-trader write path all keep working untouched; `if:`
-                    would destroy and rebuild the node under them.
+                    The previous behaviour hid this field once
+                    isCompanyCaptured() went true, on the theory that the
+                    order-intent notice sentence made an editable, visible
+                    control redundant — and only re-showed it on a decline,
+                    via isCompanyRecoveryNeeded(), to avoid a dead end for a
+                    buyer with no other route to pick a different company.
+                    Doug found this INCORRECT in live testing on 2026-08-04:
+                    the control was disappearing when a company was picked
+                    and, on the common path (order intent approves), never
+                    coming back — with nothing marking that as intentional
+                    from the buyer's side. This ruling removes that coupling
+                    entirely rather than patching it again.
 
-                    Hiding also takes this `required` input out of jQuery
-                    Validation's way, which only matters in the direction that
-                    helps: `elements()` skips hidden fields, and both states
-                    where this is hidden are states where the buyer either
-                    already captured a company here or has another control
-                    (the address-area one) to do it with.
+                    `visible:`, not `if:`, for the same reason as before:
+                    it keeps the node in the DOM so the select2 binding, its
+                    MutationObserver rebinding and the sole-trader write path
+                    all keep working untouched; `if:` would destroy and
+                    rebuild the node under them.
 
-                    RE-SHOWN on a decline, even though isCompanyCaptured() is
-                    still true then (found in adversarial review, 2026-08-04):
-                    processOrderIntentSuccessResponse()'s declined branch does
-                    NOT clear companyName/companyId — only an approval's own
-                    company-change subscriptions do that. Gating on capture
-                    alone left a declined buyer looking at a persistent "not
-                    available for this order" notice with NO control anywhere
-                    on the tile to pick a different company — a dead end
-                    without a page reload on exactly the checkouts where the
-                    tile is the buyer's ONLY route (saved address, virtual
-                    cart, or the setting off).
-
-                    isCompanyRecoveryNeeded(), NOT isOrderIntentDeclinedNoticeVisible()
-                    — round 2 of the same review found gating this on the
-                    NOTICE's own visibility reproduced the dead-end for any
-                    brand with order_intent enabled but the notice UI
-                    suppressed (two independent brand.xml switches), since
-                    that brand's notice text is permanently empty even on a
-                    real decline. isCompanyRecoveryNeeded() is set on every
-                    decline regardless of whether any notice text exists.
-                    Picking a new company clears both AND completes capture,
-                    so the field hides again once there is something new to
-                    hide it for.
+                    Hiding (when isTileCompanySearchActive() is false) also
+                    takes this `required` input out of jQuery Validation's
+                    way — `elements()` skips hidden fields, and that state is
+                    exactly the one where the buyer has the address-area
+                    control instead.
                 -->
                 <div
                     class="field field-text required"
-                    data-bind="visible: (!isCompanyCaptured() || isCompanyRecoveryNeeded()) && isTileCompanySearchActive()"
+                    data-bind="visible: isTileCompanySearchActive()"
                 >
                     <label for="company_name" class="label">
                         <span><!-- ko i18n: 'Company Name'--><!-- /ko --></span>
@@ -285,33 +275,41 @@
                             class="input-text"
                         />
                         <!--
-                            The organisation number is NOT shown here as its
-                            own element. Pre-2026-08-03, TWO-25326 §7 moved it
-                            into a standalone `.two-company-label` text line
-                            higher up the tile; the 2026-08-03 ruling (§7.3)
-                            removed THAT too — the number now appears only
-                            embedded inside the order-intent notice sentence
-                            (ConfigProvider::getOrderIntentApprovedNotice() /
-                            getOrderIntentDeclinedNotice(), rendered by the
-                            `two-order-intent-message` blocks above).
+                            The captured organisation number, as plain text
+                            underneath the field — TWO-25326, 2026-08-04
+                            ruling. This is NOT a reinstatement of the
+                            `.two-company-label` line §7 added and the
+                            2026-08-03 ruling (§7.3) removed: that was a
+                            single line combining name AND number, gated on
+                            the order-intent notice's own visibility, and it
+                            stays removed. This is the tile's equivalent of
+                            the address-step's own `.two-company-id-text`
+                            label (see renderCompanyIdText() in
+                            address-autocomplete.js and TWO-25326 §5) —
+                            NUMBER only, gated on capture rather than on any
+                            notice, so the two mount points behave the same
+                            way once a result is picked, independent of
+                            whether order intent is even enabled.
 
-                            So in every state where NEITHER notice is showing
-                            — no intent placed yet, order intent off, a
-                            notice-suppressed brand, a Dutch non-BV buyer —
-                            the captured organisation number is displayed
-                            NOWHERE on the payment tile. The address step's
-                            own Company Number field is visually hidden too
-                            (TWO-25288, see style.css), so there is no second
-                            surface picking it up. That is forfeited display,
-                            not a hidden bug: it follows from "the notice is
-                            the only display surface", and giving the number
-                            a second capture-based display route is a ticket
-                            decision rather than a tidy-up.
+                            Reuses `.two-company-id-text`'s styling (see
+                            style.css) for the same reason the address step
+                            has it: right/end-aligned under the field it
+                            annotates. Absent before a result is selected and
+                            absent again in manual-entry mode, because
+                            isCompanyCaptured() requires a name AND a number
+                            and manual entry clears the number
+                            (clearCompany()) — matching
+                            renderCompanyIdText()'s own "not visible before
+                            selection, never in manual entry" rule.
 
-                            The value itself is untouched — `companyId` is
-                            still the single carrier and getData() still
-                            reads it, never the DOM.
+                            The value itself is untouched either way —
+                            `companyId` is still the single carrier and
+                            getData() still reads it, never the DOM.
                         -->
+                        <div
+                            class="two-company-id-text"
+                            data-bind="visible: isCompanyCaptured() && isTileCompanySearchActive(), text: companyId"
+                        ></div>
                     </div>
                 </div>
                 <!--

--- a/view/frontend/web/template/payment/gateway_method.html
+++ b/view/frontend/web/template/payment/gateway_method.html
@@ -308,7 +308,7 @@
                         -->
                         <div
                             class="two-company-id-text"
-                            data-bind="visible: isCompanyCaptured() && isTileCompanySearchActive(), text: companyId"
+                            data-bind="visible: isCompanyCaptured() && isTileCompanySearchActive(), text: companyId, attr: {'aria-label': $t('Company Number')}"
                         ></div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary

TWO-25326, 2026-08-04 ruling — two fixes to the payment tile's company-search control, both deliberately superseding the 2026-08-03 (§7.3) capture-state/decline-recovery gating.

- **Bug A**: the tile's company-search control (field + picker) disappeared once a company was captured, and only came back on a *declined* order-intent response — leaving it permanently hidden on the common *approved* path. Its `visible:` binding no longer reads `isCompanyCaptured()`/`isCompanyRecoveryNeeded()` (the latter deleted, along with the now-dead `orderIntentDeclined` observable). Visibility now depends on `isTileCompanySearchActive()` alone — i.e. only the "enable search in address" admin setting decides whether the control lives in the address block or the payment tile, and nothing else changes it.
- **Bug B**: after picking a company in the tile, no label showed the captured org/registration number. Added a `.two-company-id-text` label under the control, gated on `isCompanyCaptured() && isTileCompanySearchActive()`, mirroring the address-step's existing `renderCompanyIdText()` pattern (`address-autocomplete.js`, §5) — the two mount points now behave consistently. This is a different element from the `.two-company-label` line §7.3 removed (a combined name+number line gated on notice visibility); that stays removed, and the order-intent notice sentence is unaffected.

## Test plan

- [x] `npm run test:js` — 26 suites / 341 tests, all green
- [x] `Test/Js/tile-company-readonly-fields.test.js` rewritten: the GATE PINS group now pins the control's `visible:` binding and the new label's gate separately (each to its exact shape), and every capture-mode test that previously asserted the control disappears now asserts it stays visible throughout approve/decline/re-pick
- [x] Diff/branch/commit messages leak-gated before push

🤖 Generated with [Claude Code](https://claude.com/claude-code)
