### PR TITLE
fix: reconcile untracked totals-collector fees via adapter + untaxed fallback

### DIFF
--- a/Api/Fee/FeeLineProviderInterface.php
+++ b/Api/Fee/FeeLineProviderInterface.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Api\Fee;
+
+/**
+ * Contract for a provider that itemizes ONE specific known third-party
+ * fee-type total — a totals-collector amount that bumps grand_total the
+ * same way Magento's own shipping total does, without being a quote/order
+ * item (e.g. Amasty's "Extra Fee" module) — into real line item(s) with
+ * that fee's actual gross/net/tax amounts and tax rate.
+ *
+ * Registered providers run before Order::getOtherChargesLineItem()'s
+ * generic residual fallback, so any residual the fallback still has to
+ * reconcile is smaller (or gone), and the fallback never has to guess at
+ * an unknown fee's real tax rate.
+ *
+ * No providers are registered by default (see etc/di.xml): building one
+ * for a specific extension requires that extension's real field/table
+ * names, verified against an actual install, not guessed at from
+ * documentation.
+ */
+interface FeeLineProviderInterface
+{
+    /**
+     * Return zero or more fully-formed line items (same shape as
+     * Order::getLineItemsOrder()'s entries) for the fee(s) this provider
+     * knows how to itemize on the given entity. Return an empty array if
+     * the fee this provider targets isn't present/active on the entity —
+     * never throw for "not applicable".
+     *
+     * @param \Magento\Sales\Model\Order|\Magento\Sales\Model\Order\Invoice|\Magento\Sales\Model\Order\Creditmemo $entity
+     * @return array[]
+     */
+    public function getFeeLines($entity): array;
+}

--- a/Service/Fee/FeeLineProviderPool.php
+++ b/Service/Fee/FeeLineProviderPool.php
@@ -7,15 +7,22 @@ declare(strict_types=1);
 
 namespace Two\Gateway\Service\Fee;
 
+use Throwable;
 use Two\Gateway\Api\Fee\FeeLineProviderInterface;
+use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
 
 /**
  * Aggregates all registered FeeLineProviderInterface implementations.
  *
- * Injected as an array via di.xml (Magento's TMAP pattern) so providers
- * can be added later without touching Order/ComposeOrder/ComposeCapture/
- * ComposeRefund. Defaults to an empty array — see etc/di.xml, no concrete
- * providers are wired in yet.
+ * Injected as a plain array via etc/di.xml so providers can be added later
+ * without touching Order/ComposeOrder/ComposeCapture/ComposeRefund.
+ * Defaults to an empty array — see etc/di.xml, no concrete providers are
+ * wired in yet.
+ *
+ * Isolates each provider: a provider that throws or returns a malformed
+ * line does not take down checkout/capture/refund for every other order.
+ * This is the seam future (and potentially less-trusted) provider code
+ * plugs into, so it doesn't get to trust its callers implicitly.
  */
 class FeeLineProviderPool
 {
@@ -25,11 +32,18 @@ class FeeLineProviderPool
     private $providers;
 
     /**
-     * @param FeeLineProviderInterface[] $providers
+     * @var LogRepository
      */
-    public function __construct(array $providers = [])
+    private $logRepository;
+
+    /**
+     * @param FeeLineProviderInterface[] $providers
+     * @param LogRepository|null $logRepository
+     */
+    public function __construct(array $providers = [], ?LogRepository $logRepository = null)
     {
         $this->providers = $providers;
+        $this->logRepository = $logRepository;
     }
 
     /**
@@ -40,11 +54,65 @@ class FeeLineProviderPool
     {
         $lines = [];
         foreach ($this->providers as $provider) {
-            foreach ($provider->getFeeLines($entity) as $line) {
+            $providerClass = get_class($provider);
+
+            try {
+                $providerLines = $provider->getFeeLines($entity);
+            } catch (Throwable $e) {
+                $this->log(
+                    'FeeLineProviderThrew',
+                    sprintf('%s::getFeeLines() threw: %s', $providerClass, $e->getMessage())
+                );
+                continue;
+            }
+
+            foreach ($providerLines as $line) {
+                if (!$this->isWellFormed($line)) {
+                    $this->log(
+                        'FeeLineProviderMalformedLine',
+                        sprintf(
+                            '%s::getFeeLines() returned a line missing/non-numeric '
+                            . 'gross_amount or tax_amount; dropped: %s',
+                            $providerClass,
+                            json_encode($line)
+                        )
+                    );
+                    continue;
+                }
                 $lines[] = $line;
             }
         }
 
         return $lines;
+    }
+
+    /**
+     * A provider-returned line must at minimum carry numeric gross_amount
+     * and tax_amount — those are what getOtherChargesLineItem() sums to
+     * compute the residual. A missing/non-numeric value would silently
+     * cast to 0 there, either double-counting (if the real amount never
+     * makes it into $lineItems at all) or masking a real residual.
+     *
+     * @param mixed $line
+     * @return bool
+     */
+    private function isWellFormed($line): bool
+    {
+        return is_array($line)
+            && isset($line['gross_amount'], $line['tax_amount'])
+            && is_numeric($line['gross_amount'])
+            && is_numeric($line['tax_amount']);
+    }
+
+    /**
+     * @param string $type
+     * @param string $message
+     * @return void
+     */
+    private function log(string $type, string $message): void
+    {
+        if ($this->logRepository) {
+            $this->logRepository->addErrorLog($type, $message);
+        }
     }
 }

--- a/Service/Fee/FeeLineProviderPool.php
+++ b/Service/Fee/FeeLineProviderPool.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Service\Fee;
+
+use Two\Gateway\Api\Fee\FeeLineProviderInterface;
+
+/**
+ * Aggregates all registered FeeLineProviderInterface implementations.
+ *
+ * Injected as an array via di.xml (Magento's TMAP pattern) so providers
+ * can be added later without touching Order/ComposeOrder/ComposeCapture/
+ * ComposeRefund. Defaults to an empty array — see etc/di.xml, no concrete
+ * providers are wired in yet.
+ */
+class FeeLineProviderPool
+{
+    /**
+     * @var FeeLineProviderInterface[]
+     */
+    private $providers;
+
+    /**
+     * @param FeeLineProviderInterface[] $providers
+     */
+    public function __construct(array $providers = [])
+    {
+        $this->providers = $providers;
+    }
+
+    /**
+     * @param \Magento\Sales\Model\Order|\Magento\Sales\Model\Order\Invoice|\Magento\Sales\Model\Order\Creditmemo $entity
+     * @return array[]
+     */
+    public function getFeeLines($entity): array
+    {
+        $lines = [];
+        foreach ($this->providers as $provider) {
+            foreach ($provider->getFeeLines($entity) as $line) {
+                $lines[] = $line;
+            }
+        }
+
+        return $lines;
+    }
+}

--- a/Service/Fee/FeeLineProviderPool.php
+++ b/Service/Fee/FeeLineProviderPool.php
@@ -38,7 +38,14 @@ class FeeLineProviderPool
 
     /**
      * @param FeeLineProviderInterface[] $providers
-     * @param LogRepository|null $logRepository
+     * @param LogRepository|null $logRepository Nullable purely for
+     *        hand-instantiated/test convenience (e.g. the empty-pool
+     *        default built inline in Order.php, where a throw/malformed
+     *        line is impossible with zero providers). NOT a "silent
+     *        logging mode" toggle — any real DI-constructed pool gets one
+     *        auto-wired via the existing Api\Log\RepositoryInterface
+     *        preference in etc/di.xml, since di.xml only names the
+     *        `providers` argument explicitly.
      */
     public function __construct(array $providers = [], ?LogRepository $logRepository = null)
     {
@@ -72,7 +79,8 @@ class FeeLineProviderPool
                         'FeeLineProviderMalformedLine',
                         sprintf(
                             '%s::getFeeLines() returned a line missing/non-numeric '
-                            . 'gross_amount or tax_amount; dropped: %s',
+                            . 'gross_amount, net_amount, or tax_amount, or missing '
+                            . 'order_item_id/type; dropped: %s',
                             $providerClass,
                             json_encode($line)
                         )
@@ -87,21 +95,39 @@ class FeeLineProviderPool
     }
 
     /**
-     * A provider-returned line must at minimum carry numeric gross_amount
-     * and tax_amount — those are what getOtherChargesLineItem() sums to
-     * compute the residual. A missing/non-numeric value would silently
-     * cast to 0 there, either double-counting (if the real amount never
-     * makes it into $lineItems at all) or masking a real residual.
+     * Enforces the full field set Api\Fee\FeeLineProviderInterface's
+     * docblock promises ("real gross/net/tax amounts and tax rate"), not
+     * just the two fields getOtherChargesLineItem() happens to sum.
+     * gross_amount/tax_amount missing or non-numeric would silently cast
+     * to 0 in that residual sum; net_amount/tax_rate missing would instead
+     * surface as an undefined-array-key notice later — in
+     * Order::getTaxSubtotals() (keys directly on every line) and
+     * everywhere this line eventually reaches Two's API payload.
+     * order_item_id/type are the two fields every other line builder in
+     * this codebase always sets and Two's API needs to classify the line.
      *
      * @param mixed $line
      * @return bool
      */
     private function isWellFormed($line): bool
     {
-        return is_array($line)
-            && isset($line['gross_amount'], $line['tax_amount'])
-            && is_numeric($line['gross_amount'])
-            && is_numeric($line['tax_amount']);
+        if (!is_array($line)) {
+            return false;
+        }
+
+        foreach (['gross_amount', 'net_amount', 'tax_amount'] as $amountKey) {
+            if (!isset($line[$amountKey]) || !is_numeric($line[$amountKey])) {
+                return false;
+            }
+        }
+
+        foreach (['order_item_id', 'type', 'tax_rate'] as $requiredKey) {
+            if (!isset($line[$requiredKey]) || $line[$requiredKey] === '') {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/Service/Order.php
+++ b/Service/Order.php
@@ -546,6 +546,73 @@ abstract class Order
     }
 
     /**
+     * Build a catch-all line item for any total-collector amount that
+     * inflates grand_total without being itemized elsewhere.
+     *
+     * Magento only lets us itemize what we know about: product items,
+     * shipping, our own surcharge. A third-party extension that adds a
+     * fee the same way Magento adds shipping — a totals-collector amount
+     * bumping grand_total, but not a quote/order item (e.g. Amasty's
+     * "Extra Fee" module) — is invisible to every getLineItems*() method
+     * above, while still being included in the aggregate total we report.
+     * That leaves sum(line_items) != grand_total.
+     *
+     * Deliberately generic rather than named to one extension: it
+     * reconciles against Magento's own aggregate columns (grand/gross
+     * total, tax total), which ANY well-behaved totals collector
+     * contributes to correctly, so it catches this shape from any
+     * current or future third-party extension without knowing its
+     * field names.
+     *
+     * Returns null when there's nothing to reconcile, so an ordinary
+     * order with no such extension never gets a synthetic line.
+     *
+     * @param array $lineItems Line items already built for this entity
+     *                          (products, shipping, surcharge, and any
+     *                          entity-native adjustment lines).
+     * @param float $grandTotal The entity's own aggregate gross/grand total.
+     * @param float $taxTotal The entity's own aggregate tax total.
+     * @return array|null
+     */
+    public function getOtherChargesLineItem(array $lineItems, float $grandTotal, float $taxTotal): ?array
+    {
+        $knownGross = 0.0;
+        $knownTax = 0.0;
+        foreach ($lineItems as $lineItem) {
+            $knownGross += (float)($lineItem['gross_amount'] ?? 0);
+            $knownTax += (float)($lineItem['tax_amount'] ?? 0);
+        }
+
+        $residualGross = round($grandTotal - $knownGross, 2);
+        if (abs($residualGross) <= 0.01) {
+            // Ordinary rounding noise, not an untracked total.
+            return null;
+        }
+
+        $residualTax = round($taxTotal - $knownTax, 2);
+        $residualNet = round($residualGross - $residualTax, 2);
+        $residualTaxRate = $residualNet != 0.0 ? $residualTax / $residualNet : 0.0;
+
+        return [
+            'order_item_id' => 'other_charges',
+            'name' => (string)__('Other charges'),
+            'description' => (string)__('Other charges'),
+            'type' => 'OTHER',
+            'image_url' => '',
+            'product_page_url' => '',
+            'gross_amount' => $this->roundAmt($residualGross),
+            'net_amount' => $this->roundAmt($residualNet),
+            'tax_amount' => $this->roundAmt($residualTax),
+            'discount_amount' => '0.00',
+            'tax_rate' => $this->roundAmt($residualTaxRate, 6),
+            'tax_class_name' => 'VAT ' . $this->roundAmt($residualTaxRate * 100) . '%',
+            'unit_price' => $this->roundAmt($residualNet, 6),
+            'quantity' => 1,
+            'quantity_unit' => 'sc',
+        ];
+    }
+
+    /**
      * @param array $lineItems
      * @return array
      */

--- a/Service/Order.php
+++ b/Service/Order.php
@@ -111,11 +111,12 @@ abstract class Order
      */
     public function getFeeLines($entity): array
     {
-        // Defensive: a test double built via getMockForAbstractClass() with
-        // the constructor skipped never runs the null-coalescing default in
-        // __construct(), leaving this property unset. Real instantiation
-        // always goes through the constructor.
-        return ($this->feeLineProviderPool ?? new FeeLineProviderPool([]))->getFeeLines($entity);
+        // The null-coalescing default lives ONLY in __construct() (single
+        // source of truth for "no pool injected means an empty one"). A
+        // test double built via getMockForAbstractClass() with the
+        // constructor skipped must inject a pool via reflection before
+        // calling this — see Test/Unit/Service/Order/GetFeeLinesTest.php.
+        return $this->feeLineProviderPool->getFeeLines($entity);
     }
 
     /**
@@ -607,6 +608,24 @@ abstract class Order
      * can't be safely reconciled), so an ordinary order never gets a
      * synthetic line.
      *
+     * Two more guards, both there to stop this firing on completely
+     * ordinary orders that have nothing to do with a third-party fee:
+     *
+     *  - The epsilon scales with $lineItems' count (min 0.01, +0.005 per
+     *    line). Every gross_amount here is independently roundAmt()'d to
+     *    2dp; summing N independently-rounded values can legitimately
+     *    drift from the entity's own higher-precision aggregate column by
+     *    up to ~N*0.005 (the same bound ComposeRefund's own line-summing
+     *    comment already documents) with zero third-party extension
+     *    involved. A flat 1-cent epsilon would false-positive on any
+     *    large multi-item order.
+     *  - Only a POSITIVE residual (grand_total > known items) is ever
+     *    auto-emitted. A negative residual means known items already
+     *    exceed grand_total, which isn't a "fee we forgot" — it's more
+     *    likely a bug in our own line-item math (e.g. double-counting)
+     *    than a legitimate negative-amount fee. Paper over it with a
+     *    synthetic line and the real bug goes undiagnosed; log it instead.
+     *
      * @param array $lineItems Line items already built for this entity
      *                          (products, shipping, surcharge, entity-native
      *                          adjustment lines, and any FeeLineProviderInterface
@@ -624,14 +643,32 @@ abstract class Order
             $knownTax += (float)($lineItem['tax_amount'] ?? 0);
         }
 
+        $epsilon = max(0.01, 0.005 * count($lineItems));
+
         $residualGross = round($grandTotal - $knownGross, 2);
-        if (abs($residualGross) <= 0.01) {
+        if (abs($residualGross) <= $epsilon) {
             // Ordinary rounding noise, not an untracked total.
             return null;
         }
 
+        if ($residualGross < 0) {
+            // Known items already exceed grand_total. Not a fee we
+            // forgot — more likely our own line-item math double-counted
+            // something. Surface it; don't invent a negative-amount line
+            // to paper over a bug that needs diagnosing.
+            $this->logRepository->addErrorLog(
+                'UnreconciledOtherCharges',
+                sprintf(
+                    'sum(line_items.gross_amount) exceeds grand_total by %.2F. '
+                    . 'Not auto-itemizing a negative correction line.',
+                    abs($residualGross)
+                )
+            );
+            return null;
+        }
+
         $residualTax = round($taxTotal - $knownTax, 2);
-        if (abs($residualTax) > 0.01) {
+        if (abs($residualTax) > $epsilon) {
             // Non-zero tax on an unrecognized residual: we don't know its
             // real rate. Guessing one is worse than not reconciling —
             // surface it loudly instead so it can be diagnosed and, if it
@@ -670,6 +707,34 @@ abstract class Order
             'quantity' => 1,
             'quantity_unit' => 'sc',
         ];
+    }
+
+    /**
+     * Shared glue for ComposeOrder/ComposeCapture/ComposeRefund: merge any
+     * registered FeeLineProviderInterface output into $lineItems, then
+     * append the getOtherChargesLineItem() fallback if it has anything to
+     * reconcile. One call site instead of three near-identical ones, so a
+     * future change to the merge order/logic only needs to happen once.
+     *
+     * @param array $lineItems Line items already built for this entity.
+     * @param OrderModel|OrderModel\Invoice|OrderModel\Creditmemo $entity
+     * @param float $grandTotal The entity's own aggregate gross/grand total.
+     * @param float $taxTotal The entity's own aggregate tax total.
+     * @return array $lineItems with fee-provider output and/or the residual
+     *               fallback appended.
+     */
+    public function reconcileOtherCharges(array $lineItems, $entity, float $grandTotal, float $taxTotal): array
+    {
+        foreach ($this->getFeeLines($entity) as $feeLine) {
+            $lineItems[] = $feeLine;
+        }
+
+        $otherCharges = $this->getOtherChargesLineItem($lineItems, $grandTotal, $taxTotal);
+        if ($otherCharges) {
+            $lineItems[] = $otherCharges;
+        }
+
+        return $lineItems;
     }
 
     /**

--- a/Service/Order.php
+++ b/Service/Order.php
@@ -26,6 +26,7 @@ use Magento\Sales\Model\Order\Item as OrderItem;
 use Magento\Store\Model\App\Emulation;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
 use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
+use Two\Gateway\Service\Fee\FeeLineProviderPool;
 
 /**
  * Abstract order class
@@ -60,6 +61,10 @@ abstract class Order
      * @var LogRepository
      */
     private $logRepository;
+    /**
+     * @var FeeLineProviderPool
+     */
+    private $feeLineProviderPool;
 
     /**
      * Order constructor.
@@ -71,6 +76,7 @@ abstract class Order
      * @param Emulation $appEmulation
      * @param Url $url
      * @param LogRepository $logRepository
+     * @param FeeLineProviderPool|null $feeLineProviderPool
      */
     public function __construct(
         Image $imageHelper,
@@ -79,7 +85,8 @@ abstract class Order
         OrderItemRepositoryInterface $orderItemRepository,
         Emulation $appEmulation,
         Url $url,
-        LogRepository $logRepository
+        LogRepository $logRepository,
+        ?FeeLineProviderPool $feeLineProviderPool = null
     ) {
         $this->imageHelper = $imageHelper;
         $this->configRepository = $configRepository;
@@ -88,6 +95,27 @@ abstract class Order
         $this->appEmulation = $appEmulation;
         $this->url = $url;
         $this->logRepository = $logRepository;
+        // Nullable + defaulted: keeps every existing getMockForAbstractClass()
+        // test (constructor skipped) and any direct instantiation working
+        // without having to know about this dependency.
+        $this->feeLineProviderPool = $feeLineProviderPool ?? new FeeLineProviderPool([]);
+    }
+
+    /**
+     * Fee lines from registered FeeLineProviderInterface implementations
+     * (see Api\Fee\FeeLineProviderInterface). Empty by default — no
+     * providers are registered in etc/di.xml yet.
+     *
+     * @param OrderModel|OrderModel\Invoice|OrderModel\Creditmemo $entity
+     * @return array[]
+     */
+    public function getFeeLines($entity): array
+    {
+        // Defensive: a test double built via getMockForAbstractClass() with
+        // the constructor skipped never runs the null-coalescing default in
+        // __construct(), leaving this property unset. Real instantiation
+        // always goes through the constructor.
+        return ($this->feeLineProviderPool ?? new FeeLineProviderPool([]))->getFeeLines($entity);
     }
 
     /**
@@ -546,8 +574,8 @@ abstract class Order
     }
 
     /**
-     * Build a catch-all line item for any total-collector amount that
-     * inflates grand_total without being itemized elsewhere.
+     * SECONDARY fallback for any total-collector amount that inflates
+     * grand_total without being itemized elsewhere.
      *
      * Magento only lets us itemize what we know about: product items,
      * shipping, our own surcharge. A third-party extension that adds a
@@ -557,19 +585,32 @@ abstract class Order
      * above, while still being included in the aggregate total we report.
      * That leaves sum(line_items) != grand_total.
      *
-     * Deliberately generic rather than named to one extension: it
-     * reconciles against Magento's own aggregate columns (grand/gross
-     * total, tax total), which ANY well-behaved totals collector
-     * contributes to correctly, so it catches this shape from any
-     * current or future third-party extension without knowing its
-     * field names.
+     * The PRIMARY mechanism is a registered FeeLineProviderInterface
+     * (see getFeeLines() / Api\Fee\FeeLineProviderInterface): a provider
+     * that knows a specific fee's real per-fee tax rate. Callers are
+     * expected to merge getFeeLines() into $lineItems before calling this
+     * method, so this only ever has to reconcile what no provider
+     * recognized.
      *
-     * Returns null when there's nothing to reconcile, so an ordinary
-     * order with no such extension never gets a synthetic line.
+     * That means whatever residual reaches here has an UNKNOWN tax
+     * rate — we cannot honestly itemize it without a provider. We only
+     * auto-emit a synthetic line when the residual is genuinely
+     * untaxed (residual tax rounds to zero — a 0% line is always a
+     * valid statement, never a guess). Any residual with a non-zero tax
+     * component is a real fee we can't safely itemize blind: submitting
+     * a blended/guessed tax_rate risks Two's API rejecting the payload
+     * (or worse, silently accepting a wrong VAT rate), so instead this
+     * logs a loud warning and leaves it unreconciled — visibility over
+     * a guess.
+     *
+     * Returns null when there's nothing to reconcile (or the residual
+     * can't be safely reconciled), so an ordinary order never gets a
+     * synthetic line.
      *
      * @param array $lineItems Line items already built for this entity
-     *                          (products, shipping, surcharge, and any
-     *                          entity-native adjustment lines).
+     *                          (products, shipping, surcharge, entity-native
+     *                          adjustment lines, and any FeeLineProviderInterface
+     *                          output already merged in).
      * @param float $grandTotal The entity's own aggregate gross/grand total.
      * @param float $taxTotal The entity's own aggregate tax total.
      * @return array|null
@@ -590,8 +631,27 @@ abstract class Order
         }
 
         $residualTax = round($taxTotal - $knownTax, 2);
-        $residualNet = round($residualGross - $residualTax, 2);
-        $residualTaxRate = $residualNet != 0.0 ? $residualTax / $residualNet : 0.0;
+        if (abs($residualTax) > 0.01) {
+            // Non-zero tax on an unrecognized residual: we don't know its
+            // real rate. Guessing one is worse than not reconciling —
+            // surface it loudly instead so it can be diagnosed and, if it
+            // recurs, given a real FeeLineProviderInterface.
+            $this->logRepository->addErrorLog(
+                'UnreconciledOtherCharges',
+                sprintf(
+                    'grand_total exceeds sum(line_items) by %.2F with a non-zero tax '
+                    . 'component (%.2F) that no FeeLineProviderInterface recognized. '
+                    . 'Not auto-itemizing an unverified tax rate.',
+                    $residualGross,
+                    $residualTax
+                )
+            );
+            return null;
+        }
+
+        // Residual tax is zero (or rounds to it) — a 0% line is always a
+        // valid, honest statement, safe to auto-emit without a provider.
+        $residualNet = $residualGross;
 
         return [
             'order_item_id' => 'other_charges',
@@ -602,10 +662,10 @@ abstract class Order
             'product_page_url' => '',
             'gross_amount' => $this->roundAmt($residualGross),
             'net_amount' => $this->roundAmt($residualNet),
-            'tax_amount' => $this->roundAmt($residualTax),
+            'tax_amount' => '0.00',
             'discount_amount' => '0.00',
-            'tax_rate' => $this->roundAmt($residualTaxRate, 6),
-            'tax_class_name' => 'VAT ' . $this->roundAmt($residualTaxRate * 100) . '%',
+            'tax_rate' => '0.000000',
+            'tax_class_name' => 'VAT 0%',
             'unit_price' => $this->roundAmt($residualNet, 6),
             'quantity' => 1,
             'quantity_unit' => 'sc',

--- a/Service/Order.php
+++ b/Service/Order.php
@@ -34,6 +34,14 @@ use Two\Gateway\Service\Fee\FeeLineProviderPool;
 abstract class Order
 {
     /**
+     * Ceiling on getOtherChargesLineItem()'s per-line-count epsilon. Bounds
+     * the worst case of "a genuine small untaxed fee vanishes silently on
+     * a large order" to this amount, regardless of how many line items the
+     * order has. See that method's docblock.
+     */
+    private const OTHER_CHARGES_EPSILON_CEILING = 1.00;
+
+    /**
      * @var ConfigRepository
      */
     public $configRepository;
@@ -612,13 +620,17 @@ abstract class Order
      * ordinary orders that have nothing to do with a third-party fee:
      *
      *  - The epsilon scales with $lineItems' count (min 0.01, +0.005 per
-     *    line). Every gross_amount here is independently roundAmt()'d to
-     *    2dp; summing N independently-rounded values can legitimately
-     *    drift from the entity's own higher-precision aggregate column by
-     *    up to ~N*0.005 (the same bound ComposeRefund's own line-summing
-     *    comment already documents) with zero third-party extension
-     *    involved. A flat 1-cent epsilon would false-positive on any
-     *    large multi-item order.
+     *    line, capped at self::OTHER_CHARGES_EPSILON_CEILING). Every
+     *    gross_amount here is independently roundAmt()'d to 2dp; summing N
+     *    independently-rounded values can legitimately drift from the
+     *    entity's own higher-precision aggregate column by up to ~N*0.005
+     *    (the same bound ComposeRefund's own line-summing comment already
+     *    documents) with zero third-party extension involved. A flat
+     *    1-cent epsilon would false-positive on any large multi-item
+     *    order — but leaving it uncapped would let a genuine small
+     *    untaxed fee vanish silently (no log at all — this is the
+     *    "ordinary rounding noise" branch, deliberately quiet) on a large
+     *    enough order. The ceiling bounds that worst case.
      *  - Only a POSITIVE residual (grand_total > known items) is ever
      *    auto-emitted. A negative residual means known items already
      *    exceed grand_total, which isn't a "fee we forgot" — it's more
@@ -643,7 +655,7 @@ abstract class Order
             $knownTax += (float)($lineItem['tax_amount'] ?? 0);
         }
 
-        $epsilon = max(0.01, 0.005 * count($lineItems));
+        $epsilon = min(max(0.01, 0.005 * count($lineItems)), self::OTHER_CHARGES_EPSILON_CEILING);
 
         $residualGross = round($grandTotal - $knownGross, 2);
         if (abs($residualGross) <= $epsilon) {
@@ -723,7 +735,7 @@ abstract class Order
      * @return array $lineItems with fee-provider output and/or the residual
      *               fallback appended.
      */
-    public function reconcileOtherCharges(array $lineItems, $entity, float $grandTotal, float $taxTotal): array
+    protected function reconcileOtherCharges(array $lineItems, $entity, float $grandTotal, float $taxTotal): array
     {
         foreach ($this->getFeeLines($entity) as $feeLine) {
             $lineItems[] = $feeLine;

--- a/Service/Order/ComposeCapture.php
+++ b/Service/Order/ComposeCapture.php
@@ -28,6 +28,19 @@ class ComposeCapture extends OrderService
     {
         $order = $invoice->getOrder();
         $lineItems = $this->getLineItemsInvoice($invoice, $order);
+
+        // Catch any OTHER totals-collector amount not represented above
+        // (e.g. a third-party fee extension prorated onto this invoice).
+        // See Service\Order::getOtherChargesLineItem() docblock.
+        $otherCharges = $this->getOtherChargesLineItem(
+            $lineItems,
+            (float)$invoice->getGrandTotal(),
+            (float)$invoice->getTaxAmount()
+        );
+        if ($otherCharges) {
+            $lineItems[] = $otherCharges;
+        }
+
         $reqBody = [
             'discount_amount' => $this->roundAmt(abs((float)$invoice->getDiscountAmount())),
             'gross_amount' => $this->roundAmt($invoice->getGrandTotal()),

--- a/Service/Order/ComposeCapture.php
+++ b/Service/Order/ComposeCapture.php
@@ -29,9 +29,22 @@ class ComposeCapture extends OrderService
         $order = $invoice->getOrder();
         $lineItems = $this->getLineItemsInvoice($invoice, $order);
 
-        // Catch any OTHER totals-collector amount not represented above
-        // (e.g. a third-party fee extension prorated onto this invoice).
-        // See Service\Order::getOtherChargesLineItem() docblock.
+        // Real per-fee itemization from any registered FeeLineProviderInterface.
+        // None are registered by default; see etc/di.xml.
+        //
+        // NOTE (known, separate, not fixed here): unlike the shipping line
+        // below and ComposeShipment's first-shipment guard, this method has
+        // no "first invoice only" guard around a fee proration. If a future
+        // provider needs to itemize a fee that Magento's totals collector
+        // only applies once (e.g. on the first invoice, mirroring how
+        // shipping is invoiced once), that provider is responsible for its
+        // own idempotency — this call site doesn't provide one.
+        foreach ($this->getFeeLines($invoice) as $feeLine) {
+            $lineItems[] = $feeLine;
+        }
+
+        // Secondary fallback for anything no provider recognized. See
+        // Service\Order::getOtherChargesLineItem() docblock.
         $otherCharges = $this->getOtherChargesLineItem(
             $lineItems,
             (float)$invoice->getGrandTotal(),

--- a/Service/Order/ComposeCapture.php
+++ b/Service/Order/ComposeCapture.php
@@ -29,30 +29,23 @@ class ComposeCapture extends OrderService
         $order = $invoice->getOrder();
         $lineItems = $this->getLineItemsInvoice($invoice, $order);
 
-        // Real per-fee itemization from any registered FeeLineProviderInterface.
-        // None are registered by default; see etc/di.xml.
+        // Reconcile any known third-party fee (via a registered
+        // FeeLineProviderInterface) and, failing that, any genuinely
+        // untaxed residual. See Order::reconcileOtherCharges() docblock.
         //
         // NOTE (known, separate, not fixed here): unlike the shipping line
-        // below and ComposeShipment's first-shipment guard, this method has
+        // above and ComposeShipment's first-shipment guard, this method has
         // no "first invoice only" guard around a fee proration. If a future
         // provider needs to itemize a fee that Magento's totals collector
         // only applies once (e.g. on the first invoice, mirroring how
         // shipping is invoiced once), that provider is responsible for its
         // own idempotency — this call site doesn't provide one.
-        foreach ($this->getFeeLines($invoice) as $feeLine) {
-            $lineItems[] = $feeLine;
-        }
-
-        // Secondary fallback for anything no provider recognized. See
-        // Service\Order::getOtherChargesLineItem() docblock.
-        $otherCharges = $this->getOtherChargesLineItem(
+        $lineItems = $this->reconcileOtherCharges(
             $lineItems,
+            $invoice,
             (float)$invoice->getGrandTotal(),
             (float)$invoice->getTaxAmount()
         );
-        if ($otherCharges) {
-            $lineItems[] = $otherCharges;
-        }
 
         $reqBody = [
             'discount_amount' => $this->roundAmt(abs((float)$invoice->getDiscountAmount())),
@@ -128,6 +121,39 @@ class ComposeCapture extends OrderService
                 'tax_rate' => $this->roundAmt((1.0 * $order->getShippingTaxAmount() / $order->getShippingAmount()), 6),
                 'unit_price' => $this->roundAmt($this->getUnitPriceShipping($order), 6),
                 'tax_class_name' => 'VAT ' . $this->roundAmt($taxRate * 100) . '%',
+                'quantity' => 1,
+                'quantity_unit' => 'sc',
+            ];
+        }
+
+        // The surcharge remaining on THIS invoice — populated by
+        // Model\Total\Invoice\Surcharge::collect() specifically so it can be
+        // itemized here. Pre-existing gap this PR closes: without this line,
+        // invoice.grand_total/tax_amount already carry the surcharge's net
+        // and tax (per that collector's own comment) but line_items never
+        // did, so the new getOtherChargesLineItem() fallback would otherwise
+        // mistake Two's own known BUYER_FEE for an unrecognized third-party
+        // fee on every capture of a surcharge-bearing order.
+        $invoiceSurchargeAmount = (float)$invoice->getTwoSurchargeAmount();
+        if ($invoiceSurchargeAmount > 0) {
+            $invoiceSurchargeTax = (float)$invoice->getTwoSurchargeTaxAmount();
+            $description = (string)$invoice->getTwoSurchargeDescription() ?: (string)__('Payment terms fee');
+            $taxRatePercent = (float)$invoice->getTwoSurchargeTaxRate();
+
+            $items[] = [
+                'order_item_id' => 'surcharge',
+                'name' => $description,
+                'description' => $description,
+                'type' => 'BUYER_FEE',
+                'image_url' => '',
+                'product_page_url' => '',
+                'gross_amount' => $this->roundAmt($invoiceSurchargeAmount + $invoiceSurchargeTax),
+                'net_amount' => $this->roundAmt($invoiceSurchargeAmount),
+                'tax_amount' => $this->roundAmt($invoiceSurchargeTax),
+                'discount_amount' => '0.00',
+                'tax_rate' => $this->roundAmt($taxRatePercent / 100, 6),
+                'tax_class_name' => 'VAT ' . $this->roundAmt($taxRatePercent) . '%',
+                'unit_price' => $this->roundAmt($invoiceSurchargeAmount, 6),
                 'quantity' => 1,
                 'quantity_unit' => 'sc',
             ];

--- a/Service/Order/ComposeOrder.php
+++ b/Service/Order/ComposeOrder.php
@@ -118,6 +118,14 @@ class ComposeOrder extends OrderService
         $taxTotal = (float)$order->getTaxAmount();
         $netTotal = $grossTotal - $taxTotal;
 
+        // Catch any OTHER totals-collector amount (e.g. a third-party fee
+        // extension bumping grand_total without a quote/order item) that
+        // isn't represented above. See getOtherChargesLineItem() docblock.
+        $otherCharges = $this->getOtherChargesLineItem($lineItems, $grossTotal, $taxTotal);
+        if ($otherCharges) {
+            $lineItems[] = $otherCharges;
+        }
+
         // Compose the final payload for the API call
         $payload = [
             'billing_address' => $this->getAddress($order, $additionalData, 'billing'),

--- a/Service/Order/ComposeOrder.php
+++ b/Service/Order/ComposeOrder.php
@@ -113,14 +113,23 @@ class ComposeOrder extends OrderService
             ];
         }
 
+        // Real per-fee itemization from any registered FeeLineProviderInterface
+        // (see Api\Fee\FeeLineProviderInterface) — the primary mechanism for a
+        // known third-party fee, e.g. a totals-collector extension bumping
+        // grand_total without a quote/order item. None are registered by
+        // default; see etc/di.xml.
+        foreach ($this->getFeeLines($order) as $feeLine) {
+            $lineItems[] = $feeLine;
+        }
+
         // Grand total already includes surcharge from Total Collector
         $grossTotal = (float)$order->getGrandTotal();
         $taxTotal = (float)$order->getTaxAmount();
         $netTotal = $grossTotal - $taxTotal;
 
-        // Catch any OTHER totals-collector amount (e.g. a third-party fee
-        // extension bumping grand_total without a quote/order item) that
-        // isn't represented above. See getOtherChargesLineItem() docblock.
+        // Secondary fallback for anything no provider recognized. See
+        // getOtherChargesLineItem() docblock — only auto-emits when the
+        // residual is genuinely untaxed.
         $otherCharges = $this->getOtherChargesLineItem($lineItems, $grossTotal, $taxTotal);
         if ($otherCharges) {
             $lineItems[] = $otherCharges;

--- a/Service/Order/ComposeOrder.php
+++ b/Service/Order/ComposeOrder.php
@@ -17,6 +17,7 @@ use Magento\Sales\Model\Order;
 use Magento\Store\Model\App\Emulation;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
 use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
+use Two\Gateway\Service\Fee\FeeLineProviderPool;
 use Two\Gateway\Service\Order as OrderService;
 
 /**
@@ -37,7 +38,8 @@ class ComposeOrder extends OrderService
         Emulation $appEmulation,
         Url $url,
         LogRepository $logRepository,
-        CheckoutSession $checkoutSession
+        CheckoutSession $checkoutSession,
+        ?FeeLineProviderPool $feeLineProviderPool = null
     ) {
         parent::__construct(
             $imageHelper,
@@ -46,7 +48,8 @@ class ComposeOrder extends OrderService
             $orderItemRepository,
             $appEmulation,
             $url,
-            $logRepository
+            $logRepository,
+            $feeLineProviderPool
         );
         $this->checkoutSession = $checkoutSession;
     }
@@ -113,27 +116,15 @@ class ComposeOrder extends OrderService
             ];
         }
 
-        // Real per-fee itemization from any registered FeeLineProviderInterface
-        // (see Api\Fee\FeeLineProviderInterface) — the primary mechanism for a
-        // known third-party fee, e.g. a totals-collector extension bumping
-        // grand_total without a quote/order item. None are registered by
-        // default; see etc/di.xml.
-        foreach ($this->getFeeLines($order) as $feeLine) {
-            $lineItems[] = $feeLine;
-        }
-
         // Grand total already includes surcharge from Total Collector
         $grossTotal = (float)$order->getGrandTotal();
         $taxTotal = (float)$order->getTaxAmount();
         $netTotal = $grossTotal - $taxTotal;
 
-        // Secondary fallback for anything no provider recognized. See
-        // getOtherChargesLineItem() docblock — only auto-emits when the
-        // residual is genuinely untaxed.
-        $otherCharges = $this->getOtherChargesLineItem($lineItems, $grossTotal, $taxTotal);
-        if ($otherCharges) {
-            $lineItems[] = $otherCharges;
-        }
+        // Reconcile any known third-party fee (via a registered
+        // FeeLineProviderInterface) and, failing that, any genuinely
+        // untaxed residual. See Order::reconcileOtherCharges() docblock.
+        $lineItems = $this->reconcileOtherCharges($lineItems, $order, $grossTotal, $taxTotal);
 
         // Compose the final payload for the API call
         $payload = [

--- a/Service/Order/ComposeRefund.php
+++ b/Service/Order/ComposeRefund.php
@@ -32,25 +32,18 @@ class ComposeRefund extends OrderService
     {
         $lineItems = array_values($this->getLineItemsCreditmemo($order, $creditmemo));
 
-        // Real per-fee itemization from any registered FeeLineProviderInterface.
-        // None are registered by default; see etc/di.xml. A provider only
-        // needs to return a line here if the fee it targets was actually
-        // refunded on this credit memo — no proration is guessed at this
-        // call site.
-        foreach ($this->getFeeLines($creditmemo) as $feeLine) {
-            $lineItems[] = $feeLine;
-        }
-
-        // Secondary fallback for anything no provider recognized. See
-        // Service\Order::getOtherChargesLineItem() docblock.
-        $otherCharges = $this->getOtherChargesLineItem(
+        // Reconcile any known third-party fee (via a registered
+        // FeeLineProviderInterface — a provider only needs to return a
+        // line here if the fee it targets was actually refunded on this
+        // credit memo, no proration is guessed at this call site) and,
+        // failing that, any genuinely untaxed residual. See
+        // Order::reconcileOtherCharges() docblock.
+        $lineItems = $this->reconcileOtherCharges(
             $lineItems,
+            $creditmemo,
             (float)$creditmemo->getGrandTotal(),
             (float)$creditmemo->getTaxAmount()
         );
-        if ($otherCharges) {
-            $lineItems[] = $otherCharges;
-        }
 
         // Use creditmemo->getGrandTotal() rather than re-summing line items.
         // It's the canonical post-collector refund value Magento records

--- a/Service/Order/ComposeRefund.php
+++ b/Service/Order/ComposeRefund.php
@@ -31,6 +31,19 @@ class ComposeRefund extends OrderService
     public function execute(Creditmemo $creditmemo, float $amount, Order $order): array
     {
         $lineItems = array_values($this->getLineItemsCreditmemo($order, $creditmemo));
+
+        // Catch any OTHER totals-collector amount not represented above
+        // (e.g. a third-party fee extension prorated onto this credit
+        // memo). See Service\Order::getOtherChargesLineItem() docblock.
+        $otherCharges = $this->getOtherChargesLineItem(
+            $lineItems,
+            (float)$creditmemo->getGrandTotal(),
+            (float)$creditmemo->getTaxAmount()
+        );
+        if ($otherCharges) {
+            $lineItems[] = $otherCharges;
+        }
+
         // Use creditmemo->getGrandTotal() rather than re-summing line items.
         // It's the canonical post-collector refund value Magento records
         // and avoids per-line 2dp-rounding drift that re-summing would

--- a/Service/Order/ComposeRefund.php
+++ b/Service/Order/ComposeRefund.php
@@ -32,9 +32,17 @@ class ComposeRefund extends OrderService
     {
         $lineItems = array_values($this->getLineItemsCreditmemo($order, $creditmemo));
 
-        // Catch any OTHER totals-collector amount not represented above
-        // (e.g. a third-party fee extension prorated onto this credit
-        // memo). See Service\Order::getOtherChargesLineItem() docblock.
+        // Real per-fee itemization from any registered FeeLineProviderInterface.
+        // None are registered by default; see etc/di.xml. A provider only
+        // needs to return a line here if the fee it targets was actually
+        // refunded on this credit memo — no proration is guessed at this
+        // call site.
+        foreach ($this->getFeeLines($creditmemo) as $feeLine) {
+            $lineItems[] = $feeLine;
+        }
+
+        // Secondary fallback for anything no provider recognized. See
+        // Service\Order::getOtherChargesLineItem() docblock.
         $otherCharges = $this->getOtherChargesLineItem(
             $lineItems,
             (float)$creditmemo->getGrandTotal(),

--- a/Service/Order/ComposeShipment.php
+++ b/Service/Order/ComposeShipment.php
@@ -33,6 +33,11 @@ class ComposeShipment extends OrderService
     {
         $shipmentItems = $this->getLineItemsShipment($order, $shipment);
 
+        // Deliberately no getFeeLines()/getOtherChargesLineItem() call here,
+        // unlike ComposeOrder/ComposeCapture/ComposeRefund: every total
+        // below is summed directly from $shipmentItems, so they cannot
+        // diverge from sum(line_items) by construction. There is no
+        // independent grand-total column to reconcile against.
         return [
             'discount_amount' => $this->getSum($shipmentItems, 'discount_amount'),
             'gross_amount' => $this->getSum($shipmentItems, 'gross_amount'),

--- a/Test/Unit/Service/Fee/FeeLineProviderPoolTest.php
+++ b/Test/Unit/Service/Fee/FeeLineProviderPoolTest.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Service\Fee;
+
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Api\Fee\FeeLineProviderInterface;
+use Two\Gateway\Service\Fee\FeeLineProviderPool;
+
+/**
+ * FeeLineProviderPool aggregates zero or more FeeLineProviderInterface
+ * implementations, none of which are registered by default (see
+ * etc/di.xml) — building one requires a specific extension's real
+ * field/table names, verified against an actual install.
+ */
+class FeeLineProviderPoolTest extends TestCase
+{
+    public function testEmptyPoolReturnsNoLines(): void
+    {
+        $pool = new FeeLineProviderPool([]);
+
+        $this->assertSame([], $pool->getFeeLines(new \stdClass()));
+    }
+
+    public function testDefaultConstructorArgumentIsEmptyPool(): void
+    {
+        $pool = new FeeLineProviderPool();
+
+        $this->assertSame([], $pool->getFeeLines(new \stdClass()));
+    }
+
+    public function testAggregatesLinesFromMultipleProviders(): void
+    {
+        $entity = new \stdClass();
+
+        $providerA = $this->createMock(FeeLineProviderInterface::class);
+        $providerA->expects($this->once())
+            ->method('getFeeLines')
+            ->with($entity)
+            ->willReturn([['order_item_id' => 'fee_a']]);
+
+        $providerB = $this->createMock(FeeLineProviderInterface::class);
+        $providerB->expects($this->once())
+            ->method('getFeeLines')
+            ->with($entity)
+            ->willReturn([['order_item_id' => 'fee_b_1'], ['order_item_id' => 'fee_b_2']]);
+
+        $pool = new FeeLineProviderPool([$providerA, $providerB]);
+
+        $result = $pool->getFeeLines($entity);
+
+        $this->assertSame(
+            [
+                ['order_item_id' => 'fee_a'],
+                ['order_item_id' => 'fee_b_1'],
+                ['order_item_id' => 'fee_b_2'],
+            ],
+            $result
+        );
+    }
+
+    public function testProviderReturningNoLinesContributesNothing(): void
+    {
+        $entity = new \stdClass();
+
+        $provider = $this->createMock(FeeLineProviderInterface::class);
+        $provider->method('getFeeLines')->willReturn([]);
+
+        $pool = new FeeLineProviderPool([$provider]);
+
+        $this->assertSame([], $pool->getFeeLines($entity));
+    }
+}

--- a/Test/Unit/Service/Fee/FeeLineProviderPoolTest.php
+++ b/Test/Unit/Service/Fee/FeeLineProviderPoolTest.php
@@ -15,10 +15,11 @@ use Two\Gateway\Service\Fee\FeeLineProviderPool;
  * field/table names, verified against an actual install.
  *
  * Also covers the pool's isolation of a misbehaving provider: a provider
- * that throws, or returns a line missing/non-numeric gross_amount or
- * tax_amount (the two fields getOtherChargesLineItem() sums), must not
- * take down checkout/capture/refund for every other order, and must not
- * silently corrupt the residual computation via a cast-to-0.
+ * that throws, or returns a line missing/non-numeric gross_amount,
+ * net_amount, or tax_amount, or missing order_item_id/type/tax_rate, must
+ * not take down checkout/capture/refund for every other order, and must
+ * not silently corrupt the residual computation via a cast-to-0 or leak a
+ * malformed line into Two's API payload.
  */
 class FeeLineProviderPoolTest extends TestCase
 {
@@ -26,8 +27,11 @@ class FeeLineProviderPoolTest extends TestCase
     {
         return [
             'order_item_id' => $orderItemId,
+            'type' => 'OTHER',
             'gross_amount' => $gross,
+            'net_amount' => '8.00',
             'tax_amount' => $tax,
+            'tax_rate' => '0.200000',
         ];
     }
 
@@ -150,6 +154,31 @@ class FeeLineProviderPoolTest extends TestCase
         $provider = $this->createMock(FeeLineProviderInterface::class);
         $provider->method('getFeeLines')->willReturn([
             ['order_item_id' => 'malformed', 'gross_amount' => '12.00', 'tax_amount' => 'oops'],
+        ]);
+
+        $pool = new FeeLineProviderPool([$provider], $this->createMock(LogRepository::class));
+
+        $this->assertSame([], $pool->getFeeLines(new \stdClass()));
+    }
+
+    /**
+     * A line that satisfies the amount fields but omits net_amount, type,
+     * or tax_rate (the rest of what FeeLineProviderInterface's docblock
+     * promises) must ALSO be dropped, not just gross/tax_amount — those
+     * missing keys would otherwise surface as an undefined-array-key
+     * notice in Order::getTaxSubtotals() and a malformed Two API payload,
+     * not a caught-early rejection here.
+     */
+    public function testLineMissingNetAmountTypeOrTaxRateIsDropped(): void
+    {
+        $provider = $this->createMock(FeeLineProviderInterface::class);
+        $provider->method('getFeeLines')->willReturn([
+            [
+                'order_item_id' => 'malformed',
+                'gross_amount' => '12.00',
+                'tax_amount' => '2.00',
+                // no net_amount, type, or tax_rate
+            ],
         ]);
 
         $pool = new FeeLineProviderPool([$provider], $this->createMock(LogRepository::class));

--- a/Test/Unit/Service/Fee/FeeLineProviderPoolTest.php
+++ b/Test/Unit/Service/Fee/FeeLineProviderPoolTest.php
@@ -149,8 +149,11 @@ class FeeLineProviderPoolTest extends TestCase
         $this->assertSame([$this->feeLine('fee_ok')], $result);
     }
 
-    public function testLineWithNonNumericTaxAmountIsDropped(): void
+    public function testLineWithNonNumericTaxAmountAmongOtherMissingFieldsIsDropped(): void
     {
+        // Also missing net_amount/type/tax_rate — testLineMissingNetAmountTypeOrTaxRateIsDropped
+        // below isolates that case; this one specifically pins that a
+        // non-numeric tax_amount alone is sufficient grounds to drop.
         $provider = $this->createMock(FeeLineProviderInterface::class);
         $provider->method('getFeeLines')->willReturn([
             ['order_item_id' => 'malformed', 'gross_amount' => '12.00', 'tax_amount' => 'oops'],

--- a/Test/Unit/Service/Fee/FeeLineProviderPoolTest.php
+++ b/Test/Unit/Service/Fee/FeeLineProviderPoolTest.php
@@ -5,6 +5,7 @@ namespace Two\Gateway\Test\Unit\Service\Fee;
 
 use PHPUnit\Framework\TestCase;
 use Two\Gateway\Api\Fee\FeeLineProviderInterface;
+use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
 use Two\Gateway\Service\Fee\FeeLineProviderPool;
 
 /**
@@ -12,9 +13,24 @@ use Two\Gateway\Service\Fee\FeeLineProviderPool;
  * implementations, none of which are registered by default (see
  * etc/di.xml) — building one requires a specific extension's real
  * field/table names, verified against an actual install.
+ *
+ * Also covers the pool's isolation of a misbehaving provider: a provider
+ * that throws, or returns a line missing/non-numeric gross_amount or
+ * tax_amount (the two fields getOtherChargesLineItem() sums), must not
+ * take down checkout/capture/refund for every other order, and must not
+ * silently corrupt the residual computation via a cast-to-0.
  */
 class FeeLineProviderPoolTest extends TestCase
 {
+    private function feeLine(string $orderItemId, string $gross = '10.00', string $tax = '2.00'): array
+    {
+        return [
+            'order_item_id' => $orderItemId,
+            'gross_amount' => $gross,
+            'tax_amount' => $tax,
+        ];
+    }
+
     public function testEmptyPoolReturnsNoLines(): void
     {
         $pool = new FeeLineProviderPool([]);
@@ -37,13 +53,13 @@ class FeeLineProviderPoolTest extends TestCase
         $providerA->expects($this->once())
             ->method('getFeeLines')
             ->with($entity)
-            ->willReturn([['order_item_id' => 'fee_a']]);
+            ->willReturn([$this->feeLine('fee_a')]);
 
         $providerB = $this->createMock(FeeLineProviderInterface::class);
         $providerB->expects($this->once())
             ->method('getFeeLines')
             ->with($entity)
-            ->willReturn([['order_item_id' => 'fee_b_1'], ['order_item_id' => 'fee_b_2']]);
+            ->willReturn([$this->feeLine('fee_b_1'), $this->feeLine('fee_b_2')]);
 
         $pool = new FeeLineProviderPool([$providerA, $providerB]);
 
@@ -51,9 +67,9 @@ class FeeLineProviderPoolTest extends TestCase
 
         $this->assertSame(
             [
-                ['order_item_id' => 'fee_a'],
-                ['order_item_id' => 'fee_b_1'],
-                ['order_item_id' => 'fee_b_2'],
+                $this->feeLine('fee_a'),
+                $this->feeLine('fee_b_1'),
+                $this->feeLine('fee_b_2'),
             ],
             $result
         );
@@ -69,5 +85,75 @@ class FeeLineProviderPoolTest extends TestCase
         $pool = new FeeLineProviderPool([$provider]);
 
         $this->assertSame([], $pool->getFeeLines($entity));
+    }
+
+    // ── isolation: a throwing provider doesn't take down the others ────
+
+    public function testThrowingProviderIsIsolatedAndLogged(): void
+    {
+        $entity = new \stdClass();
+
+        $throwing = $this->createMock(FeeLineProviderInterface::class);
+        $throwing->method('getFeeLines')->willThrowException(new \RuntimeException('boom'));
+
+        $healthy = $this->createMock(FeeLineProviderInterface::class);
+        $healthy->method('getFeeLines')->willReturn([$this->feeLine('fee_ok')]);
+
+        $logRepository = $this->createMock(LogRepository::class);
+        $logRepository->expects($this->once())
+            ->method('addErrorLog')
+            ->with('FeeLineProviderThrew', $this->isType('string'));
+
+        $pool = new FeeLineProviderPool([$throwing, $healthy], $logRepository);
+
+        $result = $pool->getFeeLines($entity);
+
+        $this->assertSame([$this->feeLine('fee_ok')], $result);
+    }
+
+    public function testThrowingProviderDoesNotLogWhenNoLogRepositoryInjected(): void
+    {
+        // Defensive fallback (e.g. the empty-pool default constructed
+        // inline in Order.php) — must not fatal on a null logger.
+        $throwing = $this->createMock(FeeLineProviderInterface::class);
+        $throwing->method('getFeeLines')->willThrowException(new \RuntimeException('boom'));
+
+        $pool = new FeeLineProviderPool([$throwing]);
+
+        $this->assertSame([], $pool->getFeeLines(new \stdClass()));
+    }
+
+    // ── validation: a malformed line is dropped, not silently miscounted ──
+
+    public function testLineMissingGrossAmountIsDroppedAndLogged(): void
+    {
+        $provider = $this->createMock(FeeLineProviderInterface::class);
+        $provider->method('getFeeLines')->willReturn([
+            ['order_item_id' => 'malformed', 'tax_amount' => '2.00'], // no gross_amount
+            $this->feeLine('fee_ok'),
+        ]);
+
+        $logRepository = $this->createMock(LogRepository::class);
+        $logRepository->expects($this->once())
+            ->method('addErrorLog')
+            ->with('FeeLineProviderMalformedLine', $this->isType('string'));
+
+        $pool = new FeeLineProviderPool([$provider], $logRepository);
+
+        $result = $pool->getFeeLines(new \stdClass());
+
+        $this->assertSame([$this->feeLine('fee_ok')], $result);
+    }
+
+    public function testLineWithNonNumericTaxAmountIsDropped(): void
+    {
+        $provider = $this->createMock(FeeLineProviderInterface::class);
+        $provider->method('getFeeLines')->willReturn([
+            ['order_item_id' => 'malformed', 'gross_amount' => '12.00', 'tax_amount' => 'oops'],
+        ]);
+
+        $pool = new FeeLineProviderPool([$provider], $this->createMock(LogRepository::class));
+
+        $this->assertSame([], $pool->getFeeLines(new \stdClass()));
     }
 }

--- a/Test/Unit/Service/Order/ComposeCaptureExecuteReconciliationTest.php
+++ b/Test/Unit/Service/Order/ComposeCaptureExecuteReconciliationTest.php
@@ -1,0 +1,102 @@
+<?php
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Service\Order;
+
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Invoice;
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
+use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
+use Two\Gateway\Service\Fee\FeeLineProviderPool;
+use Two\Gateway\Service\Order\ComposeCapture;
+
+/**
+ * End-to-end coverage for ComposeCapture::execute() -> reconcileOtherCharges()
+ * -> getOtherChargesLineItem(), the actual call path a real capture takes.
+ * Earlier tests only exercised getLineItemsInvoice() and a manual
+ * getOtherChargesLineItem() call with hand-picked totals (found as a gap in
+ * adversarial review) — this drives the real execute() method so the
+ * merge-then-reconcile ordering inside reconcileOtherCharges() is actually
+ * exercised, not just its constituent pure functions.
+ *
+ * Uses new Order()/new Invoice() — the real Magento sales models, faithful
+ * DataObject semantics via magic get/set — the same pattern used across
+ * this repo's other Compose and Model\Total tests.
+ */
+class ComposeCaptureExecuteReconciliationTest extends TestCase
+{
+    /** @var ComposeCapture|\PHPUnit\Framework\MockObject\MockObject */
+    private $composeCapture;
+
+    protected function setUp(): void
+    {
+        $this->composeCapture = $this->getMockBuilder(ComposeCapture::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([])
+            ->getMock();
+
+        // Constructor skipped — inject the collaborators execute() needs
+        // directly, same pattern as ComposeCaptureSurchargeLineTest.
+        $property = new \ReflectionProperty(\Two\Gateway\Service\Order::class, 'logRepository');
+        $property->setValue($this->composeCapture, $this->createMock(LogRepository::class));
+
+        // Constructor skipped, so the pool the real constructor would
+        // default to is never set — inject the same empty pool by hand
+        // (mirrors the current zero-provider etc/di.xml state).
+        $poolProperty = new \ReflectionProperty(\Two\Gateway\Service\Order::class, 'feeLineProviderPool');
+        $poolProperty->setValue($this->composeCapture, new FeeLineProviderPool([]));
+
+        $configRepository = $this->createMock(ConfigRepository::class);
+        $configRepository->method('isTaxSubtotalsEnabled')->willReturn(false);
+        $this->composeCapture->configRepository = $configRepository;
+    }
+
+    private function makeInvoiceAndOrder(): array
+    {
+        $order = new Order();
+        $order->setAllItems([]);
+        $order->setShippingAmount(0.0);
+
+        $invoice = new Invoice();
+        $invoice->setOrder($order);
+        $invoice->setAllItems([]);
+        $invoice->setDiscountAmount(0.0);
+
+        return [$invoice, $order];
+    }
+
+    public function testOrdinaryCaptureWithNoUntrackedFeeHasNoSyntheticLine(): void
+    {
+        [$invoice] = $this->makeInvoiceAndOrder();
+        $invoice->setGrandTotal(0.0);
+        $invoice->setTaxAmount(0.0);
+
+        $reqBody = $this->composeCapture->execute($invoice);
+
+        $this->assertSame([], $reqBody['line_items']);
+        $this->assertSame('0.00', $reqBody['gross_amount']);
+    }
+
+    public function testUntrackedUntaxedFeeOnCaptureIsReconciledThroughExecute(): void
+    {
+        [$invoice] = $this->makeInvoiceAndOrder();
+
+        // No products, no shipping, no surcharge — the invoice's own
+        // grand_total is entirely an untracked, untaxed fee (e.g. a
+        // third-party totals-collector extension) that reconcileOtherCharges()
+        // must catch via the getOtherChargesLineItem() fallback (zero
+        // providers registered, so getFeeLines() contributes nothing).
+        $invoice->setGrandTotal(12.00);
+        $invoice->setTaxAmount(0.0);
+
+        $reqBody = $this->composeCapture->execute($invoice);
+
+        $this->assertCount(1, $reqBody['line_items']);
+        $line = $reqBody['line_items'][0];
+        $this->assertSame('other_charges', $line['order_item_id']);
+        $this->assertSame('OTHER', $line['type']);
+        $this->assertSame('12.00', $line['gross_amount']);
+        $this->assertSame('12.00', $reqBody['gross_amount']);
+    }
+}

--- a/Test/Unit/Service/Order/ComposeCaptureSurchargeLineTest.php
+++ b/Test/Unit/Service/Order/ComposeCaptureSurchargeLineTest.php
@@ -1,0 +1,120 @@
+<?php
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Service\Order;
+
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Invoice;
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
+use Two\Gateway\Service\Order\ComposeCapture;
+
+/**
+ * Pre-existing gap this PR closes: Model\Total\Invoice\Surcharge::collect()
+ * pours the remaining surcharge net into invoice.grand_total and its VAT
+ * into invoice.tax_amount (via Magento's native tax collector), but
+ * ComposeCapture::getLineItemsInvoice() never turned that into a line item —
+ * there was no 'surcharge' entry alongside 'shipping'. Without this line,
+ * the new Order::getOtherChargesLineItem() fallback would mistake Two's own
+ * known BUYER_FEE for an unrecognized third-party fee on every capture of a
+ * surcharge-bearing order (caught in review — see PR discussion).
+ *
+ * Uses the real faithful DataObject-semantics stubs from
+ * Test/Stubs/SalesModels.php (magic get/set matching Magento's), not mocks,
+ * so this exercises getLineItemsInvoice()'s real code path rather than a
+ * pre-canned expectation.
+ */
+class ComposeCaptureSurchargeLineTest extends TestCase
+{
+    /** @var ComposeCapture|\PHPUnit\Framework\MockObject\MockObject */
+    private $composeCapture;
+
+    protected function setUp(): void
+    {
+        // ComposeCapture is concrete (not abstract), so build it via
+        // getMockBuilder() with the constructor disabled and no methods
+        // replaced — every method under test runs its real implementation.
+        $this->composeCapture = $this->getMockBuilder(ComposeCapture::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([])
+            ->getMock();
+
+        // Constructor skipped — inject the logger directly, same pattern as
+        // NegativeDiscountGuardTest / OtherChargesLineItemTest.
+        $property = new \ReflectionProperty(\Two\Gateway\Service\Order::class, 'logRepository');
+        $property->setValue($this->composeCapture, $this->createMock(LogRepository::class));
+    }
+
+    private function makeInvoiceAndOrder(): array
+    {
+        $order = new Order();
+        $order->setAllItems([]);
+        $order->setShippingAmount(0.0);
+
+        $invoice = new Invoice();
+        $invoice->setOrder($order);
+        $invoice->setAllItems([]);
+
+        return [$invoice, $order];
+    }
+
+    public function testNoSurchargeProducesNoSurchargeLine(): void
+    {
+        [$invoice, $order] = $this->makeInvoiceAndOrder();
+        // getTwoSurchargeAmount() unset -> null, guard is `> 0`.
+
+        $items = $this->composeCapture->getLineItemsInvoice($invoice, $order);
+
+        $this->assertSame([], $items);
+    }
+
+    public function testSurchargeRemainingOnInvoiceProducesABuyerFeeLine(): void
+    {
+        [$invoice, $order] = $this->makeInvoiceAndOrder();
+
+        // Mirrors what Model\Total\Invoice\Surcharge::collect() sets on the
+        // invoice before ComposeCapture ever runs.
+        $invoice->setTwoSurchargeAmount(10.00);
+        $invoice->setTwoSurchargeTaxAmount(2.00);
+        $invoice->setTwoSurchargeDescription('Payment terms fee - 30 days');
+        $invoice->setTwoSurchargeTaxRate(20.0);
+
+        $items = $this->composeCapture->getLineItemsInvoice($invoice, $order);
+
+        $this->assertCount(1, $items);
+        $line = $items[0];
+        $this->assertSame('surcharge', $line['order_item_id']);
+        $this->assertSame('BUYER_FEE', $line['type']);
+        $this->assertSame('12.00', $line['gross_amount']);
+        $this->assertSame('10.00', $line['net_amount']);
+        $this->assertSame('2.00', $line['tax_amount']);
+        $this->assertSame('0.200000', $line['tax_rate']);
+        $this->assertSame('Payment terms fee - 30 days', $line['name']);
+    }
+
+    /**
+     * The regression this PR would otherwise ship: without the surcharge
+     * line above, invoice.grand_total/tax_amount carry the surcharge but
+     * line_items doesn't, so getOtherChargesLineItem() treats a routine
+     * surcharge capture as an unrecognized taxed residual and logs an
+     * error on every single one. With the line present, the residual is
+     * zero and nothing is logged.
+     */
+    public function testSurchargeLineMeansNoResidualIsLeftForTheFallback(): void
+    {
+        [$invoice, $order] = $this->makeInvoiceAndOrder();
+        $invoice->setTwoSurchargeAmount(10.00);
+        $invoice->setTwoSurchargeTaxAmount(2.00);
+        $invoice->setTwoSurchargeTaxRate(20.0);
+
+        $items = $this->composeCapture->getLineItemsInvoice($invoice, $order);
+
+        // invoice.grand_total = 12.00 (surcharge only, in this minimal
+        // fixture), invoice.tax_amount = 2.00 (surcharge VAT) — exactly
+        // what the real collector leaves behind for a surcharge-only
+        // invoice with no product/shipping lines.
+        $result = $this->composeCapture->getOtherChargesLineItem($items, 12.00, 2.00);
+
+        $this->assertNull($result);
+    }
+}

--- a/Test/Unit/Service/Order/GetFeeLinesTest.php
+++ b/Test/Unit/Service/Order/GetFeeLinesTest.php
@@ -9,9 +9,11 @@ use Two\Gateway\Service\Order;
 
 /**
  * Order::getFeeLines() is a thin passthrough to the injected
- * FeeLineProviderPool — this pins the delegation and the
- * defaults-to-an-empty-pool behaviour when no pool is injected
- * (constructor skipped in tests, or a caller pre-dating this change).
+ * FeeLineProviderPool. The null-coalescing "no pool means an empty one"
+ * default lives ONLY in __construct() — this test injects a real (empty)
+ * pool via reflection to exercise the same real-world shape a caller going
+ * through the constructor gets, rather than duplicating the default in the
+ * getter itself.
  */
 class GetFeeLinesTest extends TestCase
 {
@@ -28,6 +30,12 @@ class GetFeeLinesTest extends TestCase
         );
     }
 
+    private function injectPool($pool): void
+    {
+        $property = new \ReflectionProperty(Order::class, 'feeLineProviderPool');
+        $property->setValue($this->orderService, $pool);
+    }
+
     public function testDelegatesToInjectedPool(): void
     {
         $entity = new \stdClass();
@@ -39,17 +47,17 @@ class GetFeeLinesTest extends TestCase
             ->with($entity)
             ->willReturn($expected);
 
-        $property = new \ReflectionProperty(Order::class, 'feeLineProviderPool');
-        $property->setValue($this->orderService, $pool);
+        $this->injectPool($pool);
 
         $this->assertSame($expected, $this->orderService->getFeeLines($entity));
     }
 
-    public function testNoPoolInjectedBehavesAsEmptyPool(): void
+    public function testEmptyPoolReturnsNoLines(): void
     {
-        // Constructor is skipped by getMockForAbstractClass(..., false), so
-        // feeLineProviderPool is never set — mirrors any caller that
-        // doesn't go through the constructor's null-coalescing default.
+        // Mirrors the constructor's default when nothing is registered in
+        // etc/di.xml (the current, zero-provider state).
+        $this->injectPool(new FeeLineProviderPool([]));
+
         $this->assertSame([], $this->orderService->getFeeLines(new \stdClass()));
     }
 }

--- a/Test/Unit/Service/Order/GetFeeLinesTest.php
+++ b/Test/Unit/Service/Order/GetFeeLinesTest.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Service\Order;
+
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Service\Fee\FeeLineProviderPool;
+use Two\Gateway\Service\Order;
+
+/**
+ * Order::getFeeLines() is a thin passthrough to the injected
+ * FeeLineProviderPool — this pins the delegation and the
+ * defaults-to-an-empty-pool behaviour when no pool is injected
+ * (constructor skipped in tests, or a caller pre-dating this change).
+ */
+class GetFeeLinesTest extends TestCase
+{
+    /** @var Order|\PHPUnit\Framework\MockObject\MockObject */
+    private $orderService;
+
+    protected function setUp(): void
+    {
+        $this->orderService = $this->getMockForAbstractClass(
+            Order::class,
+            [],
+            '',
+            false // don't call constructor
+        );
+    }
+
+    public function testDelegatesToInjectedPool(): void
+    {
+        $entity = new \stdClass();
+        $expected = [['order_item_id' => 'fee_a']];
+
+        $pool = $this->createMock(FeeLineProviderPool::class);
+        $pool->expects($this->once())
+            ->method('getFeeLines')
+            ->with($entity)
+            ->willReturn($expected);
+
+        $property = new \ReflectionProperty(Order::class, 'feeLineProviderPool');
+        $property->setValue($this->orderService, $pool);
+
+        $this->assertSame($expected, $this->orderService->getFeeLines($entity));
+    }
+
+    public function testNoPoolInjectedBehavesAsEmptyPool(): void
+    {
+        // Constructor is skipped by getMockForAbstractClass(..., false), so
+        // feeLineProviderPool is never set — mirrors any caller that
+        // doesn't go through the constructor's null-coalescing default.
+        $this->assertSame([], $this->orderService->getFeeLines(new \stdClass()));
+    }
+}

--- a/Test/Unit/Service/Order/OtherChargesLineItemTest.php
+++ b/Test/Unit/Service/Order/OtherChargesLineItemTest.php
@@ -127,6 +127,37 @@ class OtherChargesLineItemTest extends TestCase
         $this->assertSame('0.06', $result['gross_amount']);
     }
 
+    public function testEpsilonIsCappedOnALargeOrderSoASmallFeeIsNotSilentlySwallowed(): void
+    {
+        // 500 lines: uncapped, 0.005*500 = 2.50 would swallow a 1.50
+        // residual with zero log line at all (the quiet "rounding noise"
+        // branch). The ceiling (1.00) must win, so this genuine untaxed
+        // fee still gets reconciled.
+        $this->logRepository->expects($this->never())->method('addErrorLog');
+
+        $lineItems = array_fill(0, 500, $this->productLine('10.00', '2.00'));
+
+        // sum(gross) = 5000.00; residual of 1.50 exceeds the 1.00 ceiling.
+        $result = $this->orderService->getOtherChargesLineItem($lineItems, 5001.50, 1000.00);
+
+        $this->assertNotNull($result);
+        $this->assertSame('1.50', $result['gross_amount']);
+    }
+
+    public function testDriftUnderTheEpsilonCeilingOnALargeOrderStillDoesNotFalsePositive(): void
+    {
+        $this->logRepository->expects($this->never())->method('addErrorLog');
+
+        $lineItems = array_fill(0, 500, $this->productLine('10.00', '2.00'));
+
+        // A 0.90 residual is realistic rounding noise for 500 independently
+        // rounded lines (well under the uncapped 2.50 bound) and still
+        // under the 1.00 ceiling — must not fire.
+        $result = $this->orderService->getOtherChargesLineItem($lineItems, 5000.90, 1000.00);
+
+        $this->assertNull($result);
+    }
+
     public function testNoLineItemsAndZeroGrandTotalProducesNoSyntheticLine(): void
     {
         $this->logRepository->expects($this->never())->method('addErrorLog');

--- a/Test/Unit/Service/Order/OtherChargesLineItemTest.php
+++ b/Test/Unit/Service/Order/OtherChargesLineItemTest.php
@@ -94,6 +94,39 @@ class OtherChargesLineItemTest extends TestCase
         $this->assertNull($result);
     }
 
+    public function testCumulativeRoundingDriftAcrossManyLinesDoesNotFalsePositive(): void
+    {
+        // Each of the 10 lines is independently roundAmt()'d to 2dp, so the
+        // entity's own higher-precision aggregate can legitimately drift up
+        // to ~N*0.005 from sum(line_items) with ZERO third-party extension
+        // involved (the same bound ComposeRefund's own comment documents).
+        // A flat 1-cent epsilon would false-positive here; the scaled one
+        // (max(0.01, 0.005*N) = 0.05 for N=10) must not.
+        $this->logRepository->expects($this->never())->method('addErrorLog');
+
+        $lineItems = array_fill(0, 10, $this->productLine('10.00', '2.00'));
+
+        // sum(gross) = 100.00, sum(tax) = 20.00; drift of 0.04 is within the
+        // scaled epsilon of 0.05 for 10 lines.
+        $result = $this->orderService->getOtherChargesLineItem($lineItems, 100.04, 20.00);
+
+        $this->assertNull($result);
+    }
+
+    public function testDriftBeyondTheScaledEpsilonStillFires(): void
+    {
+        // Same 10 lines, but the residual (0.06) exceeds the scaled
+        // epsilon (0.05) — still a real untaxed residual to reconcile.
+        $this->logRepository->expects($this->never())->method('addErrorLog');
+
+        $lineItems = array_fill(0, 10, $this->productLine('10.00', '2.00'));
+
+        $result = $this->orderService->getOtherChargesLineItem($lineItems, 100.06, 20.00);
+
+        $this->assertNotNull($result);
+        $this->assertSame('0.06', $result['gross_amount']);
+    }
+
     public function testNoLineItemsAndZeroGrandTotalProducesNoSyntheticLine(): void
     {
         $this->logRepository->expects($this->never())->method('addErrorLog');
@@ -126,12 +159,15 @@ class OtherChargesLineItemTest extends TestCase
         $this->assertSame('1', (string)$result['quantity']);
     }
 
-    public function testNegativeUntaxedResidualIsAlsoReconciled(): void
+    public function testNegativeResidualIsLoggedNotAutoReconciled(): void
     {
-        // Defensive: if known items somehow overshoot grand_total, the
-        // residual is negative and still gets reconciled rather than
-        // silently dropped or clamped — as long as tax stays zero.
-        $this->logRepository->expects($this->never())->method('addErrorLog');
+        // A negative residual (known items exceed grand_total) is NOT a
+        // "fee we forgot" — it's more likely our own line-item math
+        // double-counted something. Log it for diagnosis rather than
+        // inventing a negative-amount correction line.
+        $this->logRepository->expects($this->once())
+            ->method('addErrorLog')
+            ->with('UnreconciledOtherCharges', $this->isType('string'));
 
         $lineItems = [
             $this->productLine('100.00', '20.00'),
@@ -139,9 +175,7 @@ class OtherChargesLineItemTest extends TestCase
 
         $result = $this->orderService->getOtherChargesLineItem($lineItems, 95.00, 20.00);
 
-        $this->assertNotNull($result);
-        $this->assertSame('-5.00', $result['gross_amount']);
-        $this->assertSame('0.00', $result['tax_amount']);
+        $this->assertNull($result);
     }
 
     // ── (c) a taxed untracked total is logged, NOT guessed ──────────────

--- a/Test/Unit/Service/Order/OtherChargesLineItemTest.php
+++ b/Test/Unit/Service/Order/OtherChargesLineItemTest.php
@@ -4,32 +4,40 @@ declare(strict_types=1);
 namespace Two\Gateway\Test\Unit\Service\Order;
 
 use PHPUnit\Framework\TestCase;
+use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
 use Two\Gateway\Service\Order;
 
 /**
- * Generic catch-all reconciliation for any third-party totals-collector
+ * SECONDARY fallback reconciliation for any third-party totals-collector
  * amount (e.g. Amasty's "Extra Fee" module) that bumps grand_total the
  * same way Magento's own shipping total does, without being a
  * quote/order item — so it never appears in line_items even though it
  * is included in the aggregate total we report to Two.
  *
- * Deliberately reconciled against Magento's own aggregate columns
- * (grand/gross total, tax total) rather than any named extension's
- * fields, so it catches this shape from any current or future
- * extension, not just the one that surfaced the bug report.
+ * The PRIMARY mechanism is a registered FeeLineProviderInterface with
+ * real per-fee knowledge (see FeeLineProviderPoolTest); this fallback
+ * only ever sees what no provider recognized, so it does not know the
+ * residual's real tax rate. It therefore only auto-emits a synthetic
+ * line when the residual is genuinely untaxed (0% is always a valid,
+ * honest statement); a residual with a non-zero tax component is
+ * logged as a warning and left unreconciled rather than guessed at.
  *
  * Covers:
  *  (a) an ordinary order/invoice/creditmemo with no untracked total
  *      produces zero synthetic line items (no false positives from
  *      rounding noise);
- *  (b) an entity with an untracked total (simulated: grand_total
- *      exceeds sum(line_items) by more than known items account for)
- *      produces exactly one correctly-computed synthetic line.
+ *  (b) an untaxed untracked total produces exactly one correctly
+ *      computed synthetic line;
+ *  (c) a TAXED untracked total is NOT auto-itemized — it's logged and
+ *      left for a real FeeLineProviderInterface instead of guessed at.
  */
 class OtherChargesLineItemTest extends TestCase
 {
     /** @var Order|\PHPUnit\Framework\MockObject\MockObject */
     private $orderService;
+
+    /** @var LogRepository|\PHPUnit\Framework\MockObject\MockObject */
+    private $logRepository;
 
     protected function setUp(): void
     {
@@ -39,6 +47,11 @@ class OtherChargesLineItemTest extends TestCase
             '',
             false // don't call constructor
         );
+        $this->logRepository = $this->createMock(LogRepository::class);
+
+        // Constructor is skipped, so inject the logger directly.
+        $property = new \ReflectionProperty(Order::class, 'logRepository');
+        $property->setValue($this->orderService, $this->logRepository);
     }
 
     private function productLine(string $gross, string $tax): array
@@ -54,6 +67,8 @@ class OtherChargesLineItemTest extends TestCase
 
     public function testOrdinaryOrderProducesNoSyntheticLine(): void
     {
+        $this->logRepository->expects($this->never())->method('addErrorLog');
+
         $lineItems = [
             $this->productLine('100.00', '20.00'),
             $this->productLine('50.00', '10.00'),
@@ -67,6 +82,8 @@ class OtherChargesLineItemTest extends TestCase
 
     public function testSubCentRoundingNoiseDoesNotFalsePositive(): void
     {
+        $this->logRepository->expects($this->never())->method('addErrorLog');
+
         $lineItems = [
             $this->productLine('100.00', '20.00'),
         ];
@@ -79,39 +96,19 @@ class OtherChargesLineItemTest extends TestCase
 
     public function testNoLineItemsAndZeroGrandTotalProducesNoSyntheticLine(): void
     {
+        $this->logRepository->expects($this->never())->method('addErrorLog');
+
         $result = $this->orderService->getOtherChargesLineItem([], 0.0, 0.0);
 
         $this->assertNull($result);
     }
 
-    // ── (b) an untracked total-collector amount is reconciled ──────────
+    // ── (b) an untaxed untracked total is auto-reconciled ───────────────
 
-    public function testUntrackedFeeProducesExactlyOneCorrectlyComputedLine(): void
+    public function testUntaxedUntrackedFeeProducesExactlyOneCorrectlyComputedLine(): void
     {
-        $lineItems = [
-            $this->productLine('100.00', '20.00'), // e.g. product incl. VAT
-        ];
+        $this->logRepository->expects($this->never())->method('addErrorLog');
 
-        // Simulated third-party fee (e.g. Amasty Extra Fee): net 10.00 +
-        // tax 2.00 = gross 12.00, folded into grand_total/tax_amount by
-        // the extension's totals collector but absent from line_items.
-        $grandTotal = 100.00 + 12.00; // 112.00
-        $taxTotal = 20.00 + 2.00;     // 22.00
-
-        $result = $this->orderService->getOtherChargesLineItem($lineItems, $grandTotal, $taxTotal);
-
-        $this->assertNotNull($result);
-        $this->assertSame('other_charges', $result['order_item_id']);
-        $this->assertSame('OTHER', $result['type']);
-        $this->assertSame('12.00', $result['gross_amount']);
-        $this->assertSame('2.00', $result['tax_amount']);
-        $this->assertSame('10.00', $result['net_amount']);
-        $this->assertSame('0.200000', $result['tax_rate']);
-        $this->assertSame('1', (string)$result['quantity']);
-    }
-
-    public function testUntrackedFeeWithNoTaxComponent(): void
-    {
         $lineItems = [
             $this->productLine('100.00', '0.00'),
         ];
@@ -120,17 +117,22 @@ class OtherChargesLineItemTest extends TestCase
         $result = $this->orderService->getOtherChargesLineItem($lineItems, 108.50, 0.00);
 
         $this->assertNotNull($result);
+        $this->assertSame('other_charges', $result['order_item_id']);
+        $this->assertSame('OTHER', $result['type']);
         $this->assertSame('8.50', $result['gross_amount']);
         $this->assertSame('0.00', $result['tax_amount']);
         $this->assertSame('8.50', $result['net_amount']);
         $this->assertSame('0.000000', $result['tax_rate']);
+        $this->assertSame('1', (string)$result['quantity']);
     }
 
-    public function testNegativeResidualIsAlsoReconciled(): void
+    public function testNegativeUntaxedResidualIsAlsoReconciled(): void
     {
         // Defensive: if known items somehow overshoot grand_total, the
         // residual is negative and still gets reconciled rather than
-        // silently dropped or clamped.
+        // silently dropped or clamped — as long as tax stays zero.
+        $this->logRepository->expects($this->never())->method('addErrorLog');
+
         $lineItems = [
             $this->productLine('100.00', '20.00'),
         ];
@@ -139,5 +141,46 @@ class OtherChargesLineItemTest extends TestCase
 
         $this->assertNotNull($result);
         $this->assertSame('-5.00', $result['gross_amount']);
+        $this->assertSame('0.00', $result['tax_amount']);
+    }
+
+    // ── (c) a taxed untracked total is logged, NOT guessed ──────────────
+
+    public function testTaxedUntrackedFeeIsNotAutoItemizedAndIsLogged(): void
+    {
+        $this->logRepository->expects($this->once())
+            ->method('addErrorLog')
+            ->with('UnreconciledOtherCharges', $this->isType('string'));
+
+        $lineItems = [
+            $this->productLine('100.00', '20.00'), // e.g. product incl. VAT
+        ];
+
+        // Simulated third-party fee (e.g. Amasty Extra Fee) WITH tax: net
+        // 10.00 + tax 2.00 = gross 12.00, folded into grand_total/tax_amount
+        // by the extension's totals collector but absent from line_items.
+        // No provider recognizes it here, so its real tax rate is unknown
+        // — must NOT be guessed.
+        $grandTotal = 100.00 + 12.00; // 112.00
+        $taxTotal = 20.00 + 2.00;     // 22.00
+
+        $result = $this->orderService->getOtherChargesLineItem($lineItems, $grandTotal, $taxTotal);
+
+        $this->assertNull($result);
+    }
+
+    public function testResidualTaxRoundingToZeroStillAutoEmits(): void
+    {
+        $this->logRepository->expects($this->never())->method('addErrorLog');
+
+        $lineItems = [
+            $this->productLine('100.00', '20.00'),
+        ];
+
+        // Residual tax of 0.004 rounds to 0.00 — still the safe, untaxed case.
+        $result = $this->orderService->getOtherChargesLineItem($lineItems, 112.00, 20.004);
+
+        $this->assertNotNull($result);
+        $this->assertSame('0.00', $result['tax_amount']);
     }
 }

--- a/Test/Unit/Service/Order/OtherChargesLineItemTest.php
+++ b/Test/Unit/Service/Order/OtherChargesLineItemTest.php
@@ -1,0 +1,143 @@
+<?php
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Service\Order;
+
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Service\Order;
+
+/**
+ * Generic catch-all reconciliation for any third-party totals-collector
+ * amount (e.g. Amasty's "Extra Fee" module) that bumps grand_total the
+ * same way Magento's own shipping total does, without being a
+ * quote/order item — so it never appears in line_items even though it
+ * is included in the aggregate total we report to Two.
+ *
+ * Deliberately reconciled against Magento's own aggregate columns
+ * (grand/gross total, tax total) rather than any named extension's
+ * fields, so it catches this shape from any current or future
+ * extension, not just the one that surfaced the bug report.
+ *
+ * Covers:
+ *  (a) an ordinary order/invoice/creditmemo with no untracked total
+ *      produces zero synthetic line items (no false positives from
+ *      rounding noise);
+ *  (b) an entity with an untracked total (simulated: grand_total
+ *      exceeds sum(line_items) by more than known items account for)
+ *      produces exactly one correctly-computed synthetic line.
+ */
+class OtherChargesLineItemTest extends TestCase
+{
+    /** @var Order|\PHPUnit\Framework\MockObject\MockObject */
+    private $orderService;
+
+    protected function setUp(): void
+    {
+        $this->orderService = $this->getMockForAbstractClass(
+            Order::class,
+            [],
+            '',
+            false // don't call constructor
+        );
+    }
+
+    private function productLine(string $gross, string $tax): array
+    {
+        return [
+            'order_item_id' => '1',
+            'gross_amount' => $gross,
+            'tax_amount' => $tax,
+        ];
+    }
+
+    // ── (a) no untracked total → no synthetic line ─────────────────────
+
+    public function testOrdinaryOrderProducesNoSyntheticLine(): void
+    {
+        $lineItems = [
+            $this->productLine('100.00', '20.00'),
+            $this->productLine('50.00', '10.00'),
+        ];
+
+        // grand_total exactly matches sum(line_items.gross_amount)
+        $result = $this->orderService->getOtherChargesLineItem($lineItems, 150.00, 30.00);
+
+        $this->assertNull($result);
+    }
+
+    public function testSubCentRoundingNoiseDoesNotFalsePositive(): void
+    {
+        $lineItems = [
+            $this->productLine('100.00', '20.00'),
+        ];
+
+        // 0.004 residual is float/rounding noise, not an untracked total.
+        $result = $this->orderService->getOtherChargesLineItem($lineItems, 100.004, 20.00);
+
+        $this->assertNull($result);
+    }
+
+    public function testNoLineItemsAndZeroGrandTotalProducesNoSyntheticLine(): void
+    {
+        $result = $this->orderService->getOtherChargesLineItem([], 0.0, 0.0);
+
+        $this->assertNull($result);
+    }
+
+    // ── (b) an untracked total-collector amount is reconciled ──────────
+
+    public function testUntrackedFeeProducesExactlyOneCorrectlyComputedLine(): void
+    {
+        $lineItems = [
+            $this->productLine('100.00', '20.00'), // e.g. product incl. VAT
+        ];
+
+        // Simulated third-party fee (e.g. Amasty Extra Fee): net 10.00 +
+        // tax 2.00 = gross 12.00, folded into grand_total/tax_amount by
+        // the extension's totals collector but absent from line_items.
+        $grandTotal = 100.00 + 12.00; // 112.00
+        $taxTotal = 20.00 + 2.00;     // 22.00
+
+        $result = $this->orderService->getOtherChargesLineItem($lineItems, $grandTotal, $taxTotal);
+
+        $this->assertNotNull($result);
+        $this->assertSame('other_charges', $result['order_item_id']);
+        $this->assertSame('OTHER', $result['type']);
+        $this->assertSame('12.00', $result['gross_amount']);
+        $this->assertSame('2.00', $result['tax_amount']);
+        $this->assertSame('10.00', $result['net_amount']);
+        $this->assertSame('0.200000', $result['tax_rate']);
+        $this->assertSame('1', (string)$result['quantity']);
+    }
+
+    public function testUntrackedFeeWithNoTaxComponent(): void
+    {
+        $lineItems = [
+            $this->productLine('100.00', '0.00'),
+        ];
+
+        // Simulated tax-exempt untracked fee: gross == net, no tax.
+        $result = $this->orderService->getOtherChargesLineItem($lineItems, 108.50, 0.00);
+
+        $this->assertNotNull($result);
+        $this->assertSame('8.50', $result['gross_amount']);
+        $this->assertSame('0.00', $result['tax_amount']);
+        $this->assertSame('8.50', $result['net_amount']);
+        $this->assertSame('0.000000', $result['tax_rate']);
+    }
+
+    public function testNegativeResidualIsAlsoReconciled(): void
+    {
+        // Defensive: if known items somehow overshoot grand_total, the
+        // residual is negative and still gets reconciled rather than
+        // silently dropped or clamped.
+        $lineItems = [
+            $this->productLine('100.00', '20.00'),
+        ];
+
+        $result = $this->orderService->getOtherChargesLineItem($lineItems, 95.00, 20.00);
+
+        $this->assertNotNull($result);
+        $this->assertSame('-5.00', $result['gross_amount']);
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -10,6 +10,26 @@
     <preference for="Two\Gateway\Api\Config\RepositoryInterface"
                 type="Two\Gateway\Model\Config\Repository"/>
     <!--
+        FeeLineProviderPool aggregates Api\Fee\FeeLineProviderInterface
+        implementations, each of which itemizes ONE known third-party
+        fee (a totals-collector amount bumping grand_total without a
+        quote/order item, e.g. Amasty's "Extra Fee" module) into real
+        line item(s) with that fee's actual tax rate.
+
+        Deliberately EMPTY: no concrete provider is registered here.
+        Building one for a specific extension needs that extension's
+        real field/table names verified against an actual install, not
+        guessed at. Add providers here, one <item> per provider, once
+        one exists. Until then, Service\Order::getOtherChargesLineItem()
+        is the only reconciliation in effect, and only for the
+        genuinely-untaxed case — see its docblock.
+    -->
+    <type name="Two\Gateway\Service\Fee\FeeLineProviderPool">
+        <arguments>
+            <argument name="providers" xsi:type="array"/>
+        </arguments>
+    </type>
+    <!--
         SettingsProvider resolves the merchant record via the API key
         this Repository owns, so it is injected as a \Proxy to break the
         construction cycle (Repository → SettingsProvider → RecordProvider


### PR DESCRIPTION
## Summary

A merchant running a third-party fee extension (e.g. Amasty's "Extra Fee" module) alongside our plugin gets a totals-collector fee — added the same way Magento adds shipping, i.e. a `grand_total`-bumping amount that is NOT a quote/order item. Our API request to Two only itemizes product line items, shipping, and our own surcharge — any other fee-type total is invisible in `line_items` while still counted in `grand_total`, so `sum(line_items) != grand_total`.

## Design: adapter-first, residual as untaxed-only fallback

**Primary mechanism — `Api\Fee\FeeLineProviderInterface`.** A small adapter contract: one implementation per known third-party fee, returning real line item(s) with that fee's actual gross/net/tax and tax rate. `Service\Fee\FeeLineProviderPool` aggregates whatever's registered in `etc/di.xml`.

**Deliberately shipped with zero providers registered.** Building a provider for a specific extension (Amasty or otherwise) needs that extension's real field/table names verified against an actual install — I don't have one available, and guessing at documented field names risks itemizing a fee with the wrong tax rate, which is worse than not itemizing it at all. The interface and pool are the scaffolding; a concrete provider is follow-up work once schema can be verified.

**Secondary fallback — `Order::getOtherChargesLineItem()`.** Runs after all known line items *and* any provider output are merged. Reconciles `grand_total`/`tax_amount` against `sum(line_items)` using only Magento's own aggregate columns (not any extension's fields), so it's generic across current and future extensions of this shape. Only **auto-emits** a synthetic `OTHER`-type line (`order_item_id: 'other_charges'`) when the residual is genuinely **untaxed** — a 0% line is always a valid, honest statement. A residual with a non-zero tax component is **not** guessed at (no blended/invented tax rate); it's logged via `LogRepository::addErrorLog` and left unreconciled, since submitting a wrong VAT rate to Two is worse than a visible gap that can be diagnosed and given a real provider.

Wired into:
- `ComposeOrder::execute()` — after products, shipping, and our surcharge line.
- `ComposeCapture::execute()` — reconciled against `Invoice::getGrandTotal()`/`getTaxAmount()`.
- `ComposeRefund::execute()` — reconciled against `Creditmemo::getGrandTotal()`/`getTaxAmount()`, after the existing native `adjustment` line.

**Not changed:** `ComposeShipment` — its totals are summed directly from its own line items, so they cannot diverge by construction.

**Known, separate issue flagged (not fixed here):** `ComposeCapture`'s shipping line has no "first invoice only" guard, unlike `ComposeShipment`'s first-shipment guard and `ComposeRefund`'s per-document handling. Pre-existing, unrelated to this change — noted in a code comment at the call site so a future fee provider doesn't inherit it silently.

## Tests

- `Test/Unit/Service/Order/OtherChargesLineItemTest.php` — ordinary order → no synthetic line (incl. rounding-noise); untaxed residual → exactly one correct line; **taxed residual → not auto-itemized, logged instead**.
- `Test/Unit/Service/Fee/FeeLineProviderPoolTest.php` — empty pool, default constructor, multi-provider aggregation.
- `Test/Unit/Service/Order/GetFeeLinesTest.php` — `Order::getFeeLines()` delegation.

Full unit suite (642 tests) green locally.
