### PR TITLE
fix(checkout): tile search country sourcing, tile-local order-intent spinner, hide internal company numbers (TWO-25326)

### DIFF
--- a/Test/Js/amd-harness.js
+++ b/Test/Js/amd-harness.js
@@ -149,6 +149,32 @@ function defaultMocks() {
             syncManualEntryButton: function () { return null; },
             buildManualEntryButton: function () { return null; },
             markSearchBinding: function () {},
+            // TWO-25326 display/country helpers. Mirrored (not stubbed inert)
+            // because call sites READ their return value to decide whether to
+            // render a label at all, and an inert '' would make every such
+            // assertion pass vacuously.
+            HIDDEN_COMPANY_NUMBER_PREFIX: 'TWO:',
+            formatCompanyNumber: function (value) {
+                if (value === null || value === undefined) return '';
+                const text = String(value).trim();
+                if (!text) return '';
+                if (text.toUpperCase().indexOf(this.HIDDEN_COMPANY_NUMBER_PREFIX) === 0) return '';
+                return text;
+            },
+            stripBracketedToken: function (text, token) {
+                if (!text) return '';
+                if (!token) return String(text);
+                const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+                return String(text)
+                    .replace(new RegExp('[ \\t]*[([]\\s*' + escaped + '\\s*[)\\]]', 'g'), '')
+                    .replace(new RegExp(escaped, 'g'), '')
+                    .replace(/[ \t]{2,}/g, ' ')
+                    .trim();
+            },
+            // No DOM in the inert default: a spec that wants the live
+            // address-form country read has to supply the real module (or its
+            // own double) the same way it already does for the search itself.
+            currentAddressFormCountry: function () { return ''; },
             clearSearchChrome: function () {},
             setSearching: function () {},
             setUnavailable: function () {}

--- a/Test/Js/amd-harness.js
+++ b/Test/Js/amd-harness.js
@@ -30,6 +30,30 @@ const vm = require('vm');
  * override individual entries via the `extraMocks` parameter of
  * `loadAmdModule()`.
  */
+/**
+ * Lazily-loaded REAL `company-search.js`, for the default mock's pure display
+ * helpers to delegate to (see the `formatCompanyNumber` entry below).
+ *
+ * Lazy and memoised: `defaultMocks()` runs for every `loadAmdModule()` call, and
+ * this must not load the module — nor recurse into `defaultMocks()` — unless one
+ * of those helpers is actually reached. Given its own jQuery double rather than
+ * the caller's: the delegated members are pure string functions that touch no
+ * DOM, so the double is never used, and closing over the caller's would make the
+ * memoised copy depend on whichever test loaded first.
+ *
+ * @returns {object} the real company-search module
+ */
+let realCompanySearchModule = null;
+function realCompanySearch() {
+    if (!realCompanySearchModule) {
+        realCompanySearchModule = loadAmdModule(
+            'view/frontend/web/js/model/company-search.js',
+            { jquery: makeJQueryMock(), 'mage/translate': function (s) { return s; } }
+        );
+    }
+    return realCompanySearchModule;
+}
+
 function defaultMocks() {
     const ko = makeKnockoutMock();
     const $ = makeJQueryMock();
@@ -149,27 +173,21 @@ function defaultMocks() {
             syncManualEntryButton: function () { return null; },
             buildManualEntryButton: function () { return null; },
             markSearchBinding: function () {},
-            // TWO-25326 display/country helpers. Mirrored (not stubbed inert)
-            // because call sites READ their return value to decide whether to
-            // render a label at all, and an inert '' would make every such
-            // assertion pass vacuously.
-            HIDDEN_COMPANY_NUMBER_PREFIX: 'TWO:',
+            // TWO-25326 display helpers. DELEGATED to the real module, not
+            // reimplemented: call sites READ their return value to decide
+            // whether to render a label or brackets at all, so an inert '' would
+            // make those assertions pass vacuously — and a hand-copied
+            // reimplementation would leave every suite that reaches them (e.g.
+            // gateway-method-intent-approved-notice) green against stale logic
+            // the moment the production rule changes.
+            get HIDDEN_COMPANY_NUMBER_PREFIX() {
+                return realCompanySearch().HIDDEN_COMPANY_NUMBER_PREFIX;
+            },
             formatCompanyNumber: function (value) {
-                if (value === null || value === undefined) return '';
-                const text = String(value).trim();
-                if (!text) return '';
-                if (text.toUpperCase().indexOf(this.HIDDEN_COMPANY_NUMBER_PREFIX) === 0) return '';
-                return text;
+                return realCompanySearch().formatCompanyNumber(value);
             },
             stripBracketedToken: function (text, token) {
-                if (!text) return '';
-                if (!token) return String(text);
-                const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-                return String(text)
-                    .replace(new RegExp('[ \\t]*[([]\\s*' + escaped + '\\s*[)\\]]', 'g'), '')
-                    .replace(new RegExp(escaped, 'g'), '')
-                    .replace(/[ \t]{2,}/g, ' ')
-                    .trim();
+                return realCompanySearch().stripBracketedToken(text, token);
             },
             // No DOM in the inert default: a spec that wants the live
             // address-form country read has to supply the real module (or its

--- a/Test/Js/company-number-display-filter.test.js
+++ b/Test/Js/company-number-display-filter.test.js
@@ -1,0 +1,381 @@
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ *
+ * TWO-25326: an organisation-number value carrying the literal `TWO:` prefix
+ * is an internal reference minted on our side, not a registry number the buyer
+ * would recognise, and it must NEVER be displayed — anywhere in the plugin.
+ *
+ * Three surfaces, one shared formatter
+ * (`companySearch.formatCompanyNumber()`), because a per-site patch is a rule
+ * the next surface silently opts out of:
+ *
+ *   (a) the label under the company-name field on the address step
+ *       (renderCompanyIdText() in address-autocomplete.js) and its payment-tile
+ *       twin (`.two-company-id-text`, bound to displayCompanyId());
+ *   (b) the search-results dropdown rows (processResults());
+ *   (c) the order-intent status sentence (resolveCompanyNotice()) — where the
+ *       BRACKETS the number normally sits in have to go with it, so the
+ *       sentence reads "Company Name", never "Company Name ()".
+ *
+ * The raw value stays intact on every SUBMITTING path: it is the identifier
+ * the API is asked about. Hiding it from the buyer is not the same as not
+ * having it, and the specs below pin that distinction rather than only the
+ * hiding.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { loadAmdModule } = require('./amd-harness');
+
+const RENDERER = 'view/frontend/web/js/view/payment/method-renderer/gateway_method.js';
+const SEARCH = 'view/frontend/web/js/model/company-search.js';
+const ADDRESS = 'view/frontend/web/js/view/address-autocomplete.js';
+
+/** Plain (non-ko) observable factory, matching the sibling specs. */
+function plainObservable(initial) {
+    let v = initial;
+    const fn = function (next) {
+        if (!arguments.length) return v;
+        v = next;
+        return fn;
+    };
+    return fn;
+}
+
+/**
+ * The real company-search module. No jQuery double needed: nothing exercised
+ * here touches the DOM.
+ *
+ * @returns {object}
+ */
+function loadCompanySearch() {
+    return loadAmdModule(SEARCH);
+}
+
+describe('formatCompanyNumber — the one shared display filter (TWO-25326)', () => {
+    const companySearch = loadCompanySearch();
+
+    test('hides a TWO:-prefixed value', () => {
+        expect(companySearch.formatCompanyNumber('TWO:abc-123')).toBe('');
+    });
+
+    test('hides it whatever the case, and through surrounding whitespace', () => {
+        expect(companySearch.formatCompanyNumber('two:abc-123')).toBe('');
+        expect(companySearch.formatCompanyNumber('Two:abc-123')).toBe('');
+        expect(companySearch.formatCompanyNumber('  TWO:abc-123  ')).toBe('');
+    });
+
+    test('shows a genuine registry number unchanged', () => {
+        expect(companySearch.formatCompanyNumber('923609016')).toBe('923609016');
+        expect(companySearch.formatCompanyNumber('GB123456789')).toBe('GB123456789');
+    });
+
+    test('does not hide a number that merely CONTAINS the prefix later on', () => {
+        // Anchored at position 0 — "begins with", not "contains". A value like
+        // this is not an internal reference and hiding it would lose a real
+        // number.
+        expect(companySearch.formatCompanyNumber('123TWO:456')).toBe('123TWO:456');
+    });
+
+    test('treats absent / empty / non-string values as nothing to show', () => {
+        expect(companySearch.formatCompanyNumber(null)).toBe('');
+        expect(companySearch.formatCompanyNumber(undefined)).toBe('');
+        expect(companySearch.formatCompanyNumber('')).toBe('');
+        expect(companySearch.formatCompanyNumber('   ')).toBe('');
+        // Numeric ids are a real shape off `national_identifier.id`.
+        expect(companySearch.formatCompanyNumber(123456)).toBe('123456');
+    });
+});
+
+describe('(b) the search-results dropdown never renders a TWO: number', () => {
+    const companySearch = loadCompanySearch();
+
+    /**
+     * Build the select2 ajax block and run a response through its
+     * processResults, the way the picker does.
+     *
+     * @param {object[]} items search-response items
+     * @returns {object[]} mapped select2 results
+     */
+    function results(items) {
+        const ajax = companySearch.buildSearchAjaxOptions({
+            config: { checkoutApiUrl: 'https://api.example.test', companySearchLimit: 10 },
+            token: {},
+            getCountryCode: function () {
+                return 'gb';
+            }
+        });
+        return ajax.processResults({ items: items }).results;
+    }
+
+    test('a TWO:-prefixed identifier renders the name alone, with no empty brackets', () => {
+        const mapped = results([
+            {
+                name: 'Acme Widgets Ltd',
+                highlight: '<b>Acme</b> Widgets Ltd',
+                lookup_id: 'lookup-1',
+                national_identifier: { id: 'TWO:internal-ref' }
+            }
+        ]);
+        expect(mapped[0].html).toBe('<b>Acme</b> Widgets Ltd');
+        expect(mapped[0].html).not.toContain('TWO:');
+        expect(mapped[0].html).not.toContain('()');
+        // …but the value is still carried, because selecting the row still has
+        // to submit the identifier the registry gave us.
+        expect(mapped[0].companyId).toBe('TWO:internal-ref');
+        expect(mapped[0].lookupId).toBe('lookup-1');
+    });
+
+    test('a genuine identifier still renders in brackets', () => {
+        const mapped = results([
+            {
+                name: 'Acme Widgets Ltd',
+                highlight: '<b>Acme</b> Widgets Ltd',
+                lookup_id: 'lookup-1',
+                national_identifier: { id: '923609016' }
+            }
+        ]);
+        expect(mapped[0].html).toBe('<b>Acme</b> Widgets Ltd (923609016)');
+        expect(mapped[0].companyId).toBe('923609016');
+    });
+});
+
+describe('(c) the order-intent notice drops the number AND its brackets', () => {
+    const companySearch = loadCompanySearch();
+    const component = loadAmdModule(RENDERER, {
+        'Two_Gateway/js/model/company-search': companySearch
+    });
+
+    const COPY = {
+        // The literal default from ConfigProvider::getOrderIntentApprovedNotice().
+        withCompany: 'This order by {{companyName}} ({{companyNumber}}) is likely to be accepted by Two',
+        withoutCompany: 'This order is likely to be accepted by Two',
+        companyNameToken: '{{companyName}}',
+        companyNumberToken: '{{companyNumber}}'
+    };
+
+    /**
+     * @param {string} name companyName() value
+     * @param {string} id companyId() value
+     * @returns {string} resolved notice
+     */
+    function notice(name, id) {
+        const ctx = Object.assign({}, component, {
+            companyName: plainObservable(name),
+            companyId: plainObservable(id)
+        });
+        return ctx.resolveCompanyNotice(COPY);
+    }
+
+    test('a TWO: number yields no brackets at all', () => {
+        expect(notice('Acme Widgets Ltd', 'TWO:internal-ref')).toBe(
+            'This order by Acme Widgets Ltd is likely to be accepted by Two'
+        );
+    });
+
+    test('an EMPTY number yields no brackets either — the pre-existing "Company Name ()" case', () => {
+        expect(notice('Acme Widgets Ltd', '')).toBe(
+            'This order by Acme Widgets Ltd is likely to be accepted by Two'
+        );
+    });
+
+    test('no notice ever contains an empty bracket pair or the hidden prefix', () => {
+        ['TWO:internal-ref', '', '   ', 'two:x'].forEach(function (id) {
+            const text = notice('Acme Widgets Ltd', id);
+            expect(text).not.toContain('()');
+            expect(text).not.toContain('( )');
+            expect(text.toUpperCase()).not.toContain('TWO:');
+        });
+    });
+
+    test('a genuine number still renders in brackets', () => {
+        expect(notice('Acme Widgets Ltd', '923609016')).toBe(
+            'This order by Acme Widgets Ltd (923609016) is likely to be accepted by Two'
+        );
+    });
+
+    test('a brand copy override that places the token OUTSIDE brackets is handled too', () => {
+        const ctx = Object.assign({}, component, {
+            companyName: plainObservable('Acme Widgets Ltd'),
+            companyId: plainObservable('TWO:internal-ref')
+        });
+        expect(
+            ctx.resolveCompanyNotice(
+                Object.assign({}, COPY, {
+                    withCompany: 'Approved for {{companyName}} no {{companyNumber}} today'
+                })
+            )
+        ).toBe('Approved for Acme Widgets Ltd no today');
+    });
+
+    test('a company NAME containing brackets is not mistaken for the number\'s brackets', () => {
+        expect(notice('Acme (Holdings) Ltd', '923609016')).toBe(
+            'This order by Acme (Holdings) Ltd (923609016) is likely to be accepted by Two'
+        );
+        expect(notice('Acme (Holdings) Ltd', 'TWO:internal-ref')).toBe(
+            'This order by Acme (Holdings) Ltd is likely to be accepted by Two'
+        );
+    });
+});
+
+describe('(a) the tile label goes through the same filter', () => {
+    const companySearch = loadCompanySearch();
+    const component = loadAmdModule(RENDERER, {
+        'Two_Gateway/js/model/company-search': companySearch
+    });
+
+    /**
+     * @param {string} id companyId() value
+     * @returns {object} renderer context
+     */
+    function ctxWith(id) {
+        return Object.assign({}, component, {
+            companyName: plainObservable('Acme Widgets Ltd'),
+            companyId: plainObservable(id)
+        });
+    }
+
+    test('displayCompanyId() hides a TWO: number and shows a real one', () => {
+        expect(ctxWith('TWO:internal-ref').displayCompanyId()).toBe('');
+        expect(ctxWith('923609016').displayCompanyId()).toBe('923609016');
+    });
+
+    test('getData() still submits the RAW number the label refuses to show', () => {
+        const ctx = Object.assign({}, ctxWith('TWO:internal-ref'), {
+            getCode: function () {
+                return 'two_payment';
+            },
+            project: plainObservable(''),
+            department: plainObservable(''),
+            orderNote: plainObservable(''),
+            poNumber: plainObservable(''),
+            invoiceEmails: plainObservable(''),
+            selectedTerm: plainObservable(null)
+        });
+        expect(ctx.getData().additional_data.companyId).toBe('TWO:internal-ref');
+    });
+
+    test('the template binds the label to displayCompanyId and hides it when that is empty', () => {
+        const markup = fs
+            .readFileSync(
+                path.resolve(
+                    __dirname,
+                    '..',
+                    '..',
+                    'view/frontend/web/template/payment/gateway_method.html'
+                ),
+                'utf8'
+            )
+            .replace(/<!--[\s\S]*?-->/g, '');
+        const tag = markup.match(/<div\b[^>]*class="two-company-id-text"[^>]*>/);
+        expect(tag).not.toBeNull();
+        const bind = tag[0].match(/data-bind="([^"]*)"/)[1];
+        expect(bind).toMatch(/text:\s*displayCompanyId\b/);
+        // The gate, evaluated for real against both states rather than
+        // asserted as a string only.
+        const visible = bind.match(/visible:\s*(.+?)\s*,\s*text:/)[1];
+        // eslint-disable-next-line no-new-func
+        const evaluate = new Function(
+            'renderer',
+            'with (renderer) { return !!(' + visible + '); }'
+        );
+        expect(evaluate.call(null, ctxWith('923609016'))).toBe(true);
+        expect(evaluate.call(null, ctxWith('TWO:internal-ref'))).toBe(false);
+    });
+});
+
+describe('(a) the address-step label goes through the same filter', () => {
+    test('renderCompanyIdText() renders no label for a TWO: number, and one for a real number', () => {
+        const companySearch = loadCompanySearch();
+
+        // A recording jQuery double: enough of the chain
+        // renderCompanyIdText() walks (`$(field)` → `.closest('.control')` →
+        // `.find().remove()` → `.append()`) to observe WHETHER a label was
+        // appended and with what text.
+        const appended = [];
+        function node(length) {
+            const obj = {
+                length: length,
+                closest: function () {
+                    return node(length);
+                },
+                find: function () {
+                    return node(length);
+                },
+                remove: function () {
+                    return obj;
+                },
+                append: function (child) {
+                    appended.push(child);
+                    return obj;
+                },
+                addClass: function () {
+                    return obj;
+                },
+                attr: function () {
+                    return obj;
+                },
+                text: function (value) {
+                    obj._text = value;
+                    return obj;
+                },
+                val: function () {
+                    return '';
+                },
+                data: function () {
+                    return { select2: true };
+                },
+                on: function () {
+                    return obj;
+                },
+                off: function () {
+                    return obj;
+                }
+            };
+            return obj;
+        }
+        function $() {
+            return node(1);
+        }
+        $.async = function () {};
+        $.ajax = function () {
+            return {
+                done: function () { return this; },
+                fail: function () { return this; },
+                always: function () { return this; }
+            };
+        };
+
+        const Component = loadAmdModule(ADDRESS, {
+            jquery: $,
+            'Two_Gateway/js/model/company-search': companySearch
+        });
+
+        /**
+         * @param {string} id captured organisation number
+         * @returns {object[]} whatever the render appended
+         */
+        function render(id) {
+            appended.length = 0;
+            const ctx = Object.assign({}, Component, {
+                isCompanySearchActive: function () {
+                    return true;
+                },
+                capturedCompanyId: function () {
+                    return id;
+                }
+            });
+            ctx.renderCompanyIdText();
+            return appended;
+        }
+
+        expect(render('923609016')).toHaveLength(1);
+        expect(render('923609016')[0]._text).toBe('923609016');
+        // The whole label is absent, not merely blank.
+        expect(render('TWO:internal-ref')).toHaveLength(0);
+        expect(render('two:internal-ref')).toHaveLength(0);
+    });
+});

--- a/Test/Js/company-number-display-filter.test.js
+++ b/Test/Js/company-number-display-filter.test.js
@@ -273,17 +273,33 @@ describe('(a) the tile label goes through the same filter', () => {
         const tag = markup.match(/<div\b[^>]*class="two-company-id-text"[^>]*>/);
         expect(tag).not.toBeNull();
         const bind = tag[0].match(/data-bind="([^"]*)"/)[1];
-        expect(bind).toMatch(/text:\s*displayCompanyId\b/);
-        // The gate, evaluated for real against both states rather than
-        // asserted as a string only.
+
+        /**
+         * Evaluate a `data-bind` sub-expression the way ko does — with the view
+         * model as implicit scope. Both halves are EVALUATED, not string-matched:
+         * `text: displayCompanyId` (no parens) satisfies a string match but
+         * makes ko render the function's own source into the tile, which is
+         * exactly the defect this evaluation catches.
+         *
+         * @param {string} expr binding expression
+         * @param {object} renderer view model
+         * @returns {*}
+         */
+        function evaluate(expr, renderer) {
+            // eslint-disable-next-line no-new-func
+            return new Function('renderer', 'with (renderer) { return (' + expr + '); }').call(
+                null,
+                renderer
+            );
+        }
+
         const visible = bind.match(/visible:\s*(.+?)\s*,\s*text:/)[1];
-        // eslint-disable-next-line no-new-func
-        const evaluate = new Function(
-            'renderer',
-            'with (renderer) { return !!(' + visible + '); }'
-        );
-        expect(evaluate.call(null, ctxWith('923609016'))).toBe(true);
-        expect(evaluate.call(null, ctxWith('TWO:internal-ref'))).toBe(false);
+        const text = bind.match(/text:\s*(.+?)\s*,\s*attr:/)[1];
+
+        expect(!!evaluate(visible, ctxWith('923609016'))).toBe(true);
+        expect(evaluate(text, ctxWith('923609016'))).toBe('923609016');
+        expect(!!evaluate(visible, ctxWith('TWO:internal-ref'))).toBe(false);
+        expect(evaluate(text, ctxWith('TWO:internal-ref'))).toBe('');
     });
 });
 

--- a/Test/Js/company-search-tile-country-sourcing.test.js
+++ b/Test/Js/company-search-tile-country-sourcing.test.js
@@ -55,6 +55,12 @@ const SEARCH = 'view/frontend/web/js/model/company-search.js';
  * @returns {Function} jQuery-shaped selector function
  */
 function makeDollar() {
+    // Delegated handlers registered through `$(document).on(events, sel, fn)`,
+    // recorded rather than really delegated — the spec fires them by hand, so
+    // what is under test is the renderer's wiring and effect rather than a
+    // reimplementation of jQuery's delegation.
+    const delegated = [];
+
     function wrap(nodes) {
         return {
             length: nodes.length,
@@ -63,6 +69,16 @@ function makeDollar() {
             },
             val: function () {
                 return nodes.length ? nodes[0].value : undefined;
+            },
+            on: function (events, selector, handler) {
+                delegated.push({ events: events, selector: selector, handler: handler });
+                return this;
+            },
+            off: function (events) {
+                for (let i = delegated.length - 1; i >= 0; i--) {
+                    if (delegated[i].events.indexOf(events) !== -1) delegated.splice(i, 1);
+                }
+                return this;
             }
         };
     }
@@ -70,6 +86,7 @@ function makeDollar() {
         if (typeof selector !== 'string') return wrap([]);
         return wrap(Array.prototype.slice.call(document.querySelectorAll(selector)));
     }
+    $.delegated = delegated;
     $.async = function (selector, cb) {
         cb($(selector));
     };
@@ -123,12 +140,22 @@ function makeCtx(companySearch, observableCountry) {
         'Two_Gateway/js/model/company-search': companySearch
     });
     return Object.assign({}, component, {
-        countryCode: plainObservable(observableCountry || '')
+        countryCode: plainObservable(observableCountry || ''),
+        // fillCountryCode()'s downstream work, stubbed so the specs below can
+        // observe the country landing without also driving the
+        // supported-company-types fetch and the sole-trader tab.
+        getSupportedCompanyTypes: function () {
+            return { then: function () {} };
+        },
+        clearCompanyForCountryChange: function () {
+            this._cleared = true;
+        }
     });
 }
 
 afterEach(() => {
     document.body.innerHTML = '';
+    $.delegated.length = 0;
 });
 
 describe('payment-tile company search sources the country the buyer selected (TWO-25326)', () => {
@@ -150,7 +177,7 @@ describe('payment-tile company search sources the country the buyer selected (TW
         // The observable — the ONLY source before this fix — is empty, which
         // is exactly the state that produced an empty `country=` on the wire.
         expect(ctx.countryCode()).toBe('');
-        expect(ctx.currentCountryCode()).toBe('no');
+        expect(ctx.searchCountryCode()).toBe('no');
     });
 
     test('the country reaching the search URL is the selected one, not an empty default', () => {
@@ -169,7 +196,7 @@ describe('payment-tile company search sources the country the buyer selected (TW
             config: { checkoutApiUrl: 'https://api.example.test', companySearchLimit: 10 },
             token: {},
             getCountryCode: function () {
-                return ctx.currentCountryCode();
+                return ctx.searchCountryCode();
             }
         });
         const url = ajax.url({ term: 'acme', page: 1 });
@@ -177,25 +204,40 @@ describe('payment-tile company search sources the country the buyer selected (TW
         expect(url).not.toContain('country=&');
     });
 
-    test('Luma/Amasty are unchanged: the core form\'s select is the highest-priority source', () => {
+    test('the core form\'s select is the highest-priority DOM source', () => {
         document.body.innerHTML =
             '<form id="shipping-new-address-form">' +
             '  <select name="country_id"><option value="SE" selected>SE</option></select>' +
             '</form>' +
-            // A second, lower-priority select carrying a different country —
-            // a billing form the buyer has not touched. The shipping form must
-            // win, or a store with "my billing address is different" open
-            // would search the wrong country.
+            // A second select carrying a different country — a per-payment-method
+            // billing form the buyer has not touched. The core shipping form must
+            // win, or an untouched form's store default decides the search.
             '<form id="billing-new-address-form">' +
             '  <select name="country_id"><option value="US" selected>US</option></select>' +
             '</form>';
 
-        const companySearch = loadCompanySearch();
-        expect(companySearch.currentAddressFormCountry()).toBe('se');
-        expect(makeCtx(companySearch, 'se').currentCountryCode()).toBe('se');
+        expect(loadCompanySearch().currentAddressFormCountry()).toBe('se');
     });
 
-    test('a live selection change is picked up on the NEXT search, with no rebind', () => {
+    test('an UNTOUCHED DOM select can never beat a resolved country — the Luma/Amasty non-regression', () => {
+        // Core renders `#shipping-new-address-form` inside the HIDDEN
+        // new-address modal for a customer who has saved addresses: the select
+        // exists, holds the store default, and the buyer has never seen it. The
+        // quote-derived country must win, or this fix reintroduces the very bug
+        // it exists to close on the platforms that already worked.
+        document.body.innerHTML =
+            '<div id="opc-new-shipping-address" style="display:none">' +
+            '  <form id="shipping-new-address-form">' +
+            '    <select name="country_id"><option value="US" selected>US</option></select>' +
+            '  </form>' +
+            '</div>';
+
+        const companySearch = loadCompanySearch();
+        expect(companySearch.currentAddressFormCountry()).toBe('us');
+        expect(makeCtx(companySearch, 'no').searchCountryCode()).toBe('no');
+    });
+
+    test('a live selection change reaches countryCode() through the delegated watcher', () => {
         document.body.innerHTML =
             '<form id="shipping-new-address-form">' +
             '  <select name="country_id">' +
@@ -205,27 +247,72 @@ describe('payment-tile company search sources the country the buyer selected (TW
 
         const companySearch = loadCompanySearch();
         const ctx = makeCtx(companySearch, 'gb');
-        expect(ctx.currentCountryCode()).toBe('gb');
+        ctx.watchAddressFormCountry();
 
-        // The buyer switches country. Nothing re-binds the picker (see
-        // clearCompanyForCountryChange()'s docblock) — the read is per
-        // request, so the next search has to carry the new country.
+        // Delegated off the document, on the country select, so a re-rendered
+        // address form needs no re-binding.
+        expect($.delegated).toHaveLength(1);
+        expect($.delegated[0].events).toMatch(/^change\./);
+        expect($.delegated[0].selector).toBe('select[name="country_id"]');
+
+        // The buyer switches country; the handler fires.
         document.querySelector('select[name="country_id"]').value = 'NO';
-        expect(ctx.currentCountryCode()).toBe('no');
+        $.delegated[0].handler();
+
+        expect(ctx.countryCode()).toBe('no');
+        expect(ctx.searchCountryCode()).toBe('no');
+        // A country change must also retract the company captured under the
+        // previous one (TWO-24867) — silently absent on this checkout before.
+        expect(ctx._cleared).toBe(true);
     });
 
-    test('falls back to the quote-derived observable where there is NO address-form select at all', () => {
-        // The two carve-outs isTileCompanySearchActive() documents: a saved
-        // address and a virtual cart both render no address form, so the
+    test('each instance gets its own watcher namespace, and dispose() detaches only its own', () => {
+        const companySearch = loadCompanySearch();
+        // ONE module load, two instances built from it — the real shape (one
+        // RequireJS module, a renderer pushed per Two-family brand). Two
+        // separate loads would each get their own module-scope sequence and the
+        // namespaces would collide at 1, testing the harness rather than the
+        // renderer.
+        const component = loadAmdModule(RENDERER, {
+            jquery: $,
+            'Two_Gateway/js/model/company-search': companySearch
+        });
+        const instance = function () {
+            return Object.assign({}, component, {
+                countryCode: plainObservable(''),
+                getSupportedCompanyTypes: function () {
+                    return { then: function () {} };
+                }
+            });
+        };
+        const a = instance();
+        const b = instance();
+        a.watchAddressFormCountry();
+        b.watchAddressFormCountry();
+
+        expect($.delegated).toHaveLength(2);
+        expect(a._countryWatcherNs).not.toBe(b._countryWatcherNs);
+
+        Object.assign(a, { _super: function () {}, destroyCompanySearchWidget: function () {} });
+        a.dispose();
+        expect($.delegated).toHaveLength(1);
+        expect($.delegated[0].events).toContain(b._countryWatcherNs);
+    });
+
+    test('falls back to the DOM where there is NO resolved country yet, and to the observable where there is no select', () => {
+        // The two carve-outs isTileCompanySearchActive() documents — a saved
+        // address and a virtual cart — render no address form at all, so the
         // quote-derived country is the only country there is.
         document.body.innerHTML = '<div class="payment-method"></div>';
-
         const companySearch = loadCompanySearch();
         expect(companySearch.currentAddressFormCountry()).toBe('');
-        expect(makeCtx(companySearch, 'nl').currentCountryCode()).toBe('nl');
+        expect(makeCtx(companySearch, 'nl').searchCountryCode()).toBe('nl');
+
+        // Neither source has anything: no country, rather than a wrong one.
+        expect(makeCtx(companySearch, '').searchCountryCode()).toBe('');
     });
 
-    test('an address-form select with no value chosen falls back rather than sending an empty country', () => {
+    test('an address-form select with no value chosen contributes nothing', () => {
         document.body.innerHTML =
             '<form id="shipping-new-address-form">' +
             '  <select name="country_id"><option value="" selected></option></select>' +
@@ -233,13 +320,14 @@ describe('payment-tile company search sources the country the buyer selected (TW
 
         const companySearch = loadCompanySearch();
         expect(companySearch.currentAddressFormCountry()).toBe('');
-        expect(makeCtx(companySearch, 'dk').currentCountryCode()).toBe('dk');
+        expect(makeCtx(companySearch, 'dk').searchCountryCode()).toBe('dk');
+        expect(makeCtx(companySearch, '').searchCountryCode()).toBe('');
     });
 
     test('the getCountryCode the CONTROL is actually constructed with resolves the selected country', () => {
         // End to end through enableCompanySearch(), not a direct call to the
         // getter: the wiring is the part that regressed, and a spec that only
-        // calls currentCountryCode() itself would pass against a control still
+        // calls searchCountryCode() itself would pass against a control still
         // constructed with the raw observable.
         document.body.innerHTML =
             '<div id="firecheckout-address">' +
@@ -272,7 +360,7 @@ describe('payment-tile company search sources the country the buyer selected (TW
         expect(captured.getCountryCode()).toBe('no');
     });
 
-    test('the renderer wires currentCountryCode() into the control, not the raw observable', () => {
+    test('the renderer wires searchCountryCode() into the control, not the raw observable', () => {
         const fs = require('fs');
         const path = require('path');
         const src = fs.readFileSync(path.resolve(__dirname, '..', '..', RENDERER), 'utf8');
@@ -281,6 +369,14 @@ describe('payment-tile company search sources the country the buyer selected (TW
         // as a wrong country on one checkout variant nobody re-tests.
         const getter = src.match(/getCountryCode:\s*function\s*\(\)\s*\{\s*return\s+([^;]+);/);
         expect(getter).not.toBeNull();
-        expect(getter[1].trim()).toBe('self.currentCountryCode()');
+        expect(getter[1].trim()).toBe('self.searchCountryCode()');
+
+        // …and the watcher is actually armed on init. Every behavioural spec
+        // above calls watchAddressFormCountry() itself, so without this a drop
+        // of the initialize() call would leave the whole suite green while
+        // nothing on a real checkout ever attached the handler.
+        const initialize = src.match(/initialize:\s*function\s*\(\)\s*\{[\s\S]*?\n {8}\},/);
+        expect(initialize).not.toBeNull();
+        expect(initialize[0]).toMatch(/this\.watchAddressFormCountry\(\);/);
     });
 });

--- a/Test/Js/company-search-tile-country-sourcing.test.js
+++ b/Test/Js/company-search-tile-country-sourcing.test.js
@@ -1,0 +1,286 @@
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ *
+ * TWO-25326, Fire Checkout: the payment tile's company search ran against the
+ * search API's own default country (US) whatever the buyer had actually
+ * selected in the address form — on Fire Checkout only, never on Luma or
+ * Amasty.
+ *
+ * Mechanism, and it is a SOURCING gap rather than a hardcoded country
+ * anywhere: the tile's picker asked `countryCode()`, a ko observable with
+ * exactly two feeds —
+ *
+ *   1. the `countryCode` customer-data section, written ONLY by
+ *      address-autocomplete.js, and only once
+ *      `$.async('#shipping-new-address-form select[name="country_id"]')`
+ *      resolves;
+ *   2. updateAddress(), reading the country off the quote's PERSISTED
+ *      billing/shipping address.
+ *
+ * Luma and Amasty render the core `#shipping-new-address-form` markup, so
+ * feed 1 fires on every country change and the observable is current before
+ * the buyer can search. A one-page checkout that supplies its own address
+ * markup matches neither that selector, nor — until the address is saved —
+ * has a persisted quote address to read; `fillCountryCode()` early-returns on
+ * an empty value, so the observable stayed at its `''` default and
+ * buildSearchAjaxOptions() put an EMPTY `country=` on the search URL.
+ *
+ * Fixed by sourcing the tile's search country from the buyer's actual
+ * `<select>` first (companySearch.currentAddressFormCountry(), a priority list
+ * of address-form selectors ending in a catch-all), with the observable kept
+ * as the fallback for the checkouts that genuinely have no address-form select
+ * — a saved address and a virtual cart.
+ */
+
+'use strict';
+
+const { loadAmdModule } = require('./amd-harness');
+
+const RENDERER = 'view/frontend/web/js/view/payment/method-renderer/gateway_method.js';
+const SEARCH = 'view/frontend/web/js/model/company-search.js';
+
+/**
+ * Minimal jQuery double backed by the REAL jsdom document.
+ *
+ * Hand-rolled rather than `require('jquery')` because jQuery is not a
+ * devDependency of this module's JS test manifest (package.json declares jest
+ * and jsdom only) — the existing specs all supply their own doubles for the
+ * same reason. It implements exactly the three things
+ * currentAddressFormCountry() uses — `$(selector)`, `.first()`, `.length`,
+ * `.val()` — over `document.querySelectorAll`, so the selector list under test
+ * is genuinely evaluated against real markup rather than against a recorder
+ * that would answer whatever it was told to.
+ *
+ * @returns {Function} jQuery-shaped selector function
+ */
+function makeDollar() {
+    function wrap(nodes) {
+        return {
+            length: nodes.length,
+            first: function () {
+                return wrap(nodes.slice(0, 1));
+            },
+            val: function () {
+                return nodes.length ? nodes[0].value : undefined;
+            }
+        };
+    }
+    function $(selector) {
+        if (typeof selector !== 'string') return wrap([]);
+        return wrap(Array.prototype.slice.call(document.querySelectorAll(selector)));
+    }
+    $.async = function (selector, cb) {
+        cb($(selector));
+    };
+    $.ajax = function () {
+        return {
+            done: function () { return this; },
+            fail: function () { return this; },
+            always: function () { return this; }
+        };
+    };
+    return $;
+}
+
+const $ = makeDollar();
+
+/** Plain (non-ko) observable factory, matching the sibling specs. */
+function plainObservable(initial) {
+    let v = initial;
+    const fn = function (next) {
+        if (!arguments.length) return v;
+        v = next;
+        return fn;
+    };
+    return fn;
+}
+
+/**
+ * The REAL company-search module, closed over the real jQuery so its DOM
+ * reads hit the jsdom document this spec builds. Loading the real module is
+ * the point: the harness's inert double returns '' from
+ * currentAddressFormCountry(), which would make every assertion below pass
+ * without the production selector list existing at all.
+ *
+ * @returns {object} company-search module
+ */
+function loadCompanySearch() {
+    return loadAmdModule(SEARCH, { jquery: $ });
+}
+
+/**
+ * A renderer context whose only country state is the (empty, as on a
+ * pre-persistence one-page checkout) `countryCode` observable.
+ *
+ * @param {object} companySearch real company-search module
+ * @param {string} observableCountry value for `countryCode()`
+ * @returns {object}
+ */
+function makeCtx(companySearch, observableCountry) {
+    const component = loadAmdModule(RENDERER, {
+        jquery: $,
+        'Two_Gateway/js/model/company-search': companySearch
+    });
+    return Object.assign({}, component, {
+        countryCode: plainObservable(observableCountry || '')
+    });
+}
+
+afterEach(() => {
+    document.body.innerHTML = '';
+});
+
+describe('payment-tile company search sources the country the buyer selected (TWO-25326)', () => {
+    test('reads a one-page checkout\'s own address-form country select, which no `#shipping-new-address-form` selector matches', () => {
+        // Deliberately NOT `#shipping-new-address-form`: this is the shape of
+        // checkout the bug was reported on — the core form id is absent, so
+        // the address-area component never mounts against it and never
+        // publishes the `countryCode` section.
+        document.body.innerHTML =
+            '<div id="firecheckout-address">' +
+            '  <select name="country_id"><option value="US">US</option>' +
+            '    <option value="NO" selected>NO</option></select>' +
+            '</div>';
+
+        const companySearch = loadCompanySearch();
+        expect(companySearch.currentAddressFormCountry()).toBe('no');
+
+        const ctx = makeCtx(companySearch, '');
+        // The observable — the ONLY source before this fix — is empty, which
+        // is exactly the state that produced an empty `country=` on the wire.
+        expect(ctx.countryCode()).toBe('');
+        expect(ctx.currentCountryCode()).toBe('no');
+    });
+
+    test('the country reaching the search URL is the selected one, not an empty default', () => {
+        document.body.innerHTML =
+            '<div id="firecheckout-address">' +
+            '  <select name="country_id"><option value="GB" selected>GB</option></select>' +
+            '</div>';
+
+        const companySearch = loadCompanySearch();
+        const ctx = makeCtx(companySearch, '');
+
+        // Built the way the control builds it, so the assertion covers the
+        // whole path from the renderer's getCountryCode through to the URL —
+        // not just the getter in isolation.
+        const ajax = companySearch.buildSearchAjaxOptions({
+            config: { checkoutApiUrl: 'https://api.example.test', companySearchLimit: 10 },
+            token: {},
+            getCountryCode: function () {
+                return ctx.currentCountryCode();
+            }
+        });
+        const url = ajax.url({ term: 'acme', page: 1 });
+        expect(url).toContain('country=GB');
+        expect(url).not.toContain('country=&');
+    });
+
+    test('Luma/Amasty are unchanged: the core form\'s select is the highest-priority source', () => {
+        document.body.innerHTML =
+            '<form id="shipping-new-address-form">' +
+            '  <select name="country_id"><option value="SE" selected>SE</option></select>' +
+            '</form>' +
+            // A second, lower-priority select carrying a different country —
+            // a billing form the buyer has not touched. The shipping form must
+            // win, or a store with "my billing address is different" open
+            // would search the wrong country.
+            '<form id="billing-new-address-form">' +
+            '  <select name="country_id"><option value="US" selected>US</option></select>' +
+            '</form>';
+
+        const companySearch = loadCompanySearch();
+        expect(companySearch.currentAddressFormCountry()).toBe('se');
+        expect(makeCtx(companySearch, 'se').currentCountryCode()).toBe('se');
+    });
+
+    test('a live selection change is picked up on the NEXT search, with no rebind', () => {
+        document.body.innerHTML =
+            '<form id="shipping-new-address-form">' +
+            '  <select name="country_id">' +
+            '    <option value="GB" selected>GB</option><option value="NO">NO</option>' +
+            '  </select>' +
+            '</form>';
+
+        const companySearch = loadCompanySearch();
+        const ctx = makeCtx(companySearch, 'gb');
+        expect(ctx.currentCountryCode()).toBe('gb');
+
+        // The buyer switches country. Nothing re-binds the picker (see
+        // clearCompanyForCountryChange()'s docblock) — the read is per
+        // request, so the next search has to carry the new country.
+        document.querySelector('select[name="country_id"]').value = 'NO';
+        expect(ctx.currentCountryCode()).toBe('no');
+    });
+
+    test('falls back to the quote-derived observable where there is NO address-form select at all', () => {
+        // The two carve-outs isTileCompanySearchActive() documents: a saved
+        // address and a virtual cart both render no address form, so the
+        // quote-derived country is the only country there is.
+        document.body.innerHTML = '<div class="payment-method"></div>';
+
+        const companySearch = loadCompanySearch();
+        expect(companySearch.currentAddressFormCountry()).toBe('');
+        expect(makeCtx(companySearch, 'nl').currentCountryCode()).toBe('nl');
+    });
+
+    test('an address-form select with no value chosen falls back rather than sending an empty country', () => {
+        document.body.innerHTML =
+            '<form id="shipping-new-address-form">' +
+            '  <select name="country_id"><option value="" selected></option></select>' +
+            '</form>';
+
+        const companySearch = loadCompanySearch();
+        expect(companySearch.currentAddressFormCountry()).toBe('');
+        expect(makeCtx(companySearch, 'dk').currentCountryCode()).toBe('dk');
+    });
+
+    test('the getCountryCode the CONTROL is actually constructed with resolves the selected country', () => {
+        // End to end through enableCompanySearch(), not a direct call to the
+        // getter: the wiring is the part that regressed, and a spec that only
+        // calls currentCountryCode() itself would pass against a control still
+        // constructed with the raw observable.
+        document.body.innerHTML =
+            '<div id="firecheckout-address">' +
+            '  <select name="country_id"><option value="NO" selected>NO</option></select>' +
+            '</div>';
+
+        const companySearch = loadCompanySearch();
+        let captured = null;
+        function RecordingControl(options) {
+            captured = options;
+        }
+        RecordingControl.prototype.bind = function () {};
+
+        const component = loadAmdModule(RENDERER, {
+            jquery: $,
+            'Two_Gateway/js/model/company-search': companySearch,
+            'Two_Gateway/js/model/company-search-control': RecordingControl
+        });
+        const ctx = Object.assign({}, component, {
+            countryCode: plainObservable(''),
+            _brandConfig: { checkoutApiUrl: 'https://api.example.test', companySearchLimit: 10 },
+            isTileCompanySearchActive: function () {
+                return true;
+            }
+        });
+
+        ctx.enableCompanySearch();
+        expect(captured).not.toBeNull();
+        expect(typeof captured.getCountryCode).toBe('function');
+        expect(captured.getCountryCode()).toBe('no');
+    });
+
+    test('the renderer wires currentCountryCode() into the control, not the raw observable', () => {
+        const fs = require('fs');
+        const path = require('path');
+        const src = fs.readFileSync(path.resolve(__dirname, '..', '..', RENDERER), 'utf8');
+        // The tile's CompanySearchControl construction — pinned so a drift
+        // back to `self.countryCode()` fails here rather than only showing up
+        // as a wrong country on one checkout variant nobody re-tests.
+        const getter = src.match(/getCountryCode:\s*function\s*\(\)\s*\{\s*return\s+([^;]+);/);
+        expect(getter).not.toBeNull();
+        expect(getter[1].trim()).toBe('self.currentCountryCode()');
+    });
+});

--- a/Test/Js/gateway-method-order-intent-loader-refcount.test.js
+++ b/Test/Js/gateway-method-order-intent-loader-refcount.test.js
@@ -231,11 +231,17 @@ describe('order-intent spinner is tile-local and refcounted (TWO-25326)', () => 
 
         const tag = withoutComments.match(/<div\b[^>]*class="two-order-intent-spinner"[^>]*>/);
         expect(tag).not.toBeNull();
-        expect(tag[0]).toMatch(/visible:\s*orderIntentInProgress/);
         expect(tag[0]).toMatch(/role="status"/);
         // Accessible name, and translated — the figure itself is a background
         // image with no text of its own.
         expect(tag[0]).toMatch(/\$t\('Checking company'\)/);
+        // Gated by `ko if:` on the flag, so the `role="status"` node is
+        // INSERTED rather than un-hidden — see the template comment. Matched
+        // against the RAW markup: ko's virtual bindings are themselves HTML
+        // comments, so the comment-stripped copy above cannot see them.
+        expect(markup).toMatch(
+            /<!--\s*ko if:\s*orderIntentInProgress\(\)\s*-->\s*<div\b[^>]*class="two-order-intent-spinner"/
+        );
 
         // The tile must not reach for Magento's page-covering loader markup.
         expect(withoutComments).not.toMatch(/loading-mask/);
@@ -253,5 +259,24 @@ describe('order-intent spinner is tile-local and refcounted (TWO-25326)', () => 
         // cover, so exactly one call site is expected, not zero.
         const loaderCalls = renderer.match(/fullScreenLoader\.\w+\(/g) || [];
         expect(loaderCalls).toEqual(['fullScreenLoader.startLoader(']);
+    });
+
+    test('the order-intent request opts out of jQuery\'s GLOBAL ajax events, which raise the body overlay', () => {
+        // Found in adversarial review: Magento's `loaderAjax` widget is bound on
+        // `<body>` and listens for `ajaxSend`/`ajaxComplete`, raising the same
+        // body-wide overlay `fullScreenLoader` does. With `global: true` the
+        // page-covering overlay came up for the whole order-intent round trip no
+        // matter what this renderer did with its own loader — so "the spinner is
+        // tile-local" is only true with this flag off, and nothing in the
+        // behavioural specs above can see it.
+        const fs = require('fs');
+        const path = require('path');
+        const src = fs.readFileSync(path.resolve(__dirname, '..', '..', RENDERER), 'utf8');
+
+        const call = src.match(/\/v1\/order_intent[\s\S]{0,1200}?\}\);/);
+        expect(call).not.toBeNull();
+        const options = call[0].replace(/\/\/[^\n]*/g, '');
+        expect(options).toMatch(/global:\s*false/);
+        expect(options).not.toMatch(/global:\s*true/);
     });
 });

--- a/Test/Js/gateway-method-order-intent-loader-refcount.test.js
+++ b/Test/Js/gateway-method-order-intent-loader-refcount.test.js
@@ -2,12 +2,23 @@
  * Copyright © Two.inc All rights reserved.
  * See COPYING.txt for license details.
  *
- * TWO-25326: on Amasty OneStepCheckout and Fire Checkout, the full-screen
- * loader shown while an order_intent request is in flight was dismissed
- * BEFORE that request actually resolved — unlike Luma, where it correctly
- * stays up for the whole round trip.
+ * TWO-25326, two rules pinned together because the second one is what makes
+ * the first one non-obvious.
  *
- * Root cause: fillCustomerData() re-runs on every fresh instance's init
+ * RULE 1 — the order-intent spinner is TILE-LOCAL, never a page overlay.
+ * An order-intent check is one payment method deciding whether it can offer
+ * itself; covering and blocking the whole checkout for it is wrong. The
+ * spinner is now a `visible:`-bound element inside the payment tile
+ * (`.two-order-intent-spinner` in gateway_method.html) driven by
+ * `orderIntentInProgress`, and `fullScreenLoader` must not be touched by
+ * this path at all. `afterPlaceOrder()`'s loader is a DIFFERENT surface —
+ * it covers the gap before a redirect to the hosted checkout, after the
+ * order is placed — and is deliberately untouched.
+ *
+ * RULE 2 — that spinner's start/stop pairing is REFERENCE-COUNTED at module
+ * scope, and it has to stay that way now the spinner is local.
+ *
+ * fillCustomerData() re-runs on every fresh instance's init
  * (registeredOrganisationMode() → initObservable()) and re-applies the
  * customer-data section's already-captured company via applyCompanyData()
  * → fillCompanyData(). Amasty rebuilds the payment method list, and Fire
@@ -16,21 +27,15 @@
  * renderer instance whose own `_orderIntentInFlightFor` guard is unset,
  * and it independently fires its OWN order_intent POST for the SAME
  * company while the orphaned previous instance's request is still
- * outstanding. With a plain per-instance startLoader()/stopLoader() pair,
- * whichever request settles FIRST (typically the orphaned one, since it
- * started earlier) hid the shared full-screen loader while the surviving
- * instance's own request — the one whose resolution actually updates the
- * currently-rendered notice text — was still pending.
+ * outstanding. With a plain per-instance start/stop pair, whichever request
+ * settles FIRST (typically the orphaned one, since it started earlier) hid
+ * the spinner while the surviving instance's request — the one whose
+ * resolution actually updates the currently-rendered notice text — was
+ * still pending.
  *
  * Luma never re-renders this component on totals/shipping changes, so it
  * only ever has one order-intent request in flight at a time and never
  * hit this.
- *
- * Fixed by moving the loader start/stop pairing to a module-scope
- * reference count (mirroring the existing `placeOrderInFlight`
- * module-scope pattern in this same file), so the loader only hides once
- * EVERY outstanding order-intent request — across every instance sharing
- * this module — has settled.
  */
 
 'use strict';
@@ -50,24 +55,36 @@ function plainObservable(initial) {
     return fn;
 }
 
-describe('order-intent full-screen loader survives a mid-flight re-render (TWO-25326)', () => {
-    test('the loader stays up until BOTH a re-render\'s new request AND the orphaned old one settle', () => {
-        const seq = [];
-        const loader = {
+/**
+ * Load the renderer with a `fullScreenLoader` double that RECORDS every call,
+ * so "the order-intent path raises no page overlay" is asserted against real
+ * calls rather than assumed.
+ *
+ * @returns {{component: object, fullScreenCalls: string[]}}
+ */
+function loadRenderer() {
+    const fullScreenCalls = [];
+    const component = loadAmdModule(RENDERER, {
+        'Magento_Checkout/js/model/full-screen-loader': {
             startLoader: function () {
-                seq.push('startLoader');
+                fullScreenCalls.push('startLoader');
             },
             stopLoader: function () {
-                seq.push('stopLoader');
+                fullScreenCalls.push('stopLoader');
             }
-        };
+        }
+    });
+    return { component: component, fullScreenCalls: fullScreenCalls };
+}
 
+describe('order-intent spinner is tile-local and refcounted (TWO-25326)', () => {
+    test('the spinner stays up until BOTH a re-render\'s new request AND the orphaned old one settle', () => {
         // A single require of the module — exactly one page load, one
-        // RequireJS module instance, one module-scope refcount shared by
-        // every renderer instance built from it, matching real behaviour.
-        const component = loadAmdModule(RENDERER, {
-            'Magento_Checkout/js/model/full-screen-loader': loader
-        });
+        // RequireJS module instance, one module-scope refcount and one
+        // module-scope spinner observable shared by every renderer instance
+        // built from it, matching real behaviour.
+        const { component, fullScreenCalls } = loadRenderer();
+        const spinner = component.orderIntentInProgress;
 
         const deferreds = [];
         function makeDeferred() {
@@ -107,11 +124,13 @@ describe('order-intent full-screen loader survives a mid-flight re-render (TWO-2
             });
         }
 
+        expect(spinner()).toBe(false);
+
         // Instance A (e.g. the pre-re-render renderer) captures a company
         // and fires its order-intent request.
         const instanceA = makeCtx();
         instanceA.fillCompanyData({ companyName: 'Acme Widgets AS', companyId: '123' });
-        expect(seq).toEqual(['startLoader']);
+        expect(spinner()).toBe(true);
 
         // Amasty/Fire re-render mid-flight: a FRESH instance B is created
         // and its own init re-applies the SAME captured company, firing a
@@ -119,36 +138,29 @@ describe('order-intent full-screen loader survives a mid-flight re-render (TWO-2
         // outstanding.
         const instanceB = makeCtx();
         instanceB.fillCompanyData({ companyName: 'Acme Widgets AS', companyId: '123' });
-        expect(seq).toEqual(['startLoader', 'startLoader']);
+        expect(spinner()).toBe(true);
 
         // A's orphaned request settles first — this must NOT hide the
-        // loader while B's (the currently-rendered instance's) request is
+        // spinner while B's (the currently-rendered instance's) request is
         // still pending.
         deferreds[0]._always();
         deferreds[0]._done({ approved: true });
-        expect(seq).toEqual(['startLoader', 'startLoader']);
+        expect(spinner()).toBe(true);
 
         // B's request — the one that actually matters, since B is the
         // live rendered instance — finally settles. Only now must the
-        // loader come down.
+        // spinner come down.
         deferreds[1]._always();
         deferreds[1]._done({ approved: true });
-        expect(seq).toEqual(['startLoader', 'startLoader', 'stopLoader']);
+        expect(spinner()).toBe(false);
+
+        // RULE 1: nothing in any of that raised the page-covering loader.
+        expect(fullScreenCalls).toEqual([]);
     });
 
-    test('Luma\'s single-instance case is unaffected: one request, one start, one stop', () => {
-        const seq = [];
-        const loader = {
-            startLoader: function () {
-                seq.push('startLoader');
-            },
-            stopLoader: function () {
-                seq.push('stopLoader');
-            }
-        };
-        const component = loadAmdModule(RENDERER, {
-            'Magento_Checkout/js/model/full-screen-loader': loader
-        });
+    test('Luma\'s single-instance case is unaffected: one request, spinner up then down', () => {
+        const { component, fullScreenCalls } = loadRenderer();
+        const spinner = component.orderIntentInProgress;
 
         let resolveDeferred;
         const ctx = Object.assign({}, component, {
@@ -172,25 +184,16 @@ describe('order-intent full-screen loader survives a mid-flight re-render (TWO-2
         });
 
         ctx.fillCompanyData({ companyName: 'Acme Widgets AS', companyId: '123' });
-        expect(seq).toEqual(['startLoader']);
+        expect(spinner()).toBe(true);
 
         resolveDeferred();
-        expect(seq).toEqual(['startLoader', 'stopLoader']);
+        expect(spinner()).toBe(false);
+        expect(fullScreenCalls).toEqual([]);
     });
 
-    test('a synchronous throw from placeOrderIntent() still decrements the shared refcount (does not leak it stuck-open)', () => {
-        const seq = [];
-        const loader = {
-            startLoader: function () {
-                seq.push('startLoader');
-            },
-            stopLoader: function () {
-                seq.push('stopLoader');
-            }
-        };
-        const component = loadAmdModule(RENDERER, {
-            'Magento_Checkout/js/model/full-screen-loader': loader
-        });
+    test('a synchronous throw from placeOrderIntent() still decrements the shared refcount (does not leak the spinner stuck-on)', () => {
+        const { component, fullScreenCalls } = loadRenderer();
+        const spinner = component.orderIntentInProgress;
 
         const ctx = Object.assign({}, component, {
             companyName: plainObservable(''),
@@ -205,6 +208,50 @@ describe('order-intent full-screen loader survives a mid-flight re-render (TWO-2
 
         ctx.fillCompanyData({ companyName: 'Acme Widgets AS', companyId: '123' });
 
-        expect(seq).toEqual(['startLoader', 'stopLoader']);
+        expect(spinner()).toBe(false);
+        expect(fullScreenCalls).toEqual([]);
+    });
+
+    test('the tile template scopes the spinner locally — no page-overlay element, bound to orderIntentInProgress', () => {
+        const fs = require('fs');
+        const path = require('path');
+        const markup = fs.readFileSync(
+            path.resolve(
+                __dirname,
+                '..',
+                '..',
+                'view/frontend/web/template/payment/gateway_method.html'
+            ),
+            'utf8'
+        );
+        // Comments stripped: the rationale prose mentions `fullScreenLoader`
+        // and `loading-mask` by name, and a check that matched those would
+        // pass or fail on documentation rather than on markup.
+        const withoutComments = markup.replace(/<!--[\s\S]*?-->/g, '');
+
+        const tag = withoutComments.match(/<div\b[^>]*class="two-order-intent-spinner"[^>]*>/);
+        expect(tag).not.toBeNull();
+        expect(tag[0]).toMatch(/visible:\s*orderIntentInProgress/);
+        expect(tag[0]).toMatch(/role="status"/);
+        // Accessible name, and translated — the figure itself is a background
+        // image with no text of its own.
+        expect(tag[0]).toMatch(/\$t\('Checking company'\)/);
+
+        // The tile must not reach for Magento's page-covering loader markup.
+        expect(withoutComments).not.toMatch(/loading-mask/);
+        // …and the spinner must live INSIDE the tile's own subtree, not be
+        // appended to the document. This template IS the tile, so any element
+        // declared here is scoped to it; what would break that is a JS
+        // `document.body` append, pinned in the renderer source below.
+        const renderer = fs.readFileSync(
+            path.resolve(__dirname, '..', '..', RENDERER),
+            'utf8'
+        );
+        expect(renderer).not.toMatch(/document\.body/);
+        // The order-intent path must not raise the full-screen loader. Its
+        // ONE remaining legitimate use is afterPlaceOrder()'s pre-redirect
+        // cover, so exactly one call site is expected, not zero.
+        const loaderCalls = renderer.match(/fullScreenLoader\.\w+\(/g) || [];
+        expect(loaderCalls).toEqual(['fullScreenLoader.startLoader(']);
     });
 });

--- a/docs/brand-overlay-guide.md
+++ b/docs/brand-overlay-guide.md
@@ -227,6 +227,15 @@ The company-unknown copy variant always stays on the platform default.
 In practice it is unreachable: an order intent is only ever placed once
 the buyer's company name **and** company number are known.
 
+A company number is not always DISPLAYABLE, though, even when it is
+known. A value beginning with the literal prefix `TWO:` is an internal
+reference rather than a registry number and is never shown to the buyer
+on any surface. In the notice sentence the renderer then removes the
+company-number token **together with the brackets around it**, so the
+copy reads `… by Acme Ltd …`, never `… by Acme Ltd () …`. An override
+that places `%3` outside brackets is handled the same way. If you are
+writing override copy, do not assume the number will be present.
+
 This parent plugin's storefront renderer (Luma/Amasty/Fire, one shared
 code path) emits each notice as a persistent inline element with class
 `two-order-intent-message approved` / `two-order-intent-message declined`

--- a/docs/brand-overlay-guide.md
+++ b/docs/brand-overlay-guide.md
@@ -236,6 +236,12 @@ copy reads `… by Acme Ltd …`, never `… by Acme Ltd () …`. An override
 that places `%3` outside brackets is handled the same way. If you are
 writing override copy, do not assume the number will be present.
 
+**Keep `%3` inside round or square brackets in override copy.** The
+renderer removes the token together with a bracket pair around it; it
+does not know about other separators, so copy shaped `%2 – %3` or
+`%2, %3` leaves the dangling separator behind when the number is
+withheld.
+
 This parent plugin's storefront renderer (Luma/Amasty/Fire, one shared
 code path) emits each notice as a persistent inline element with class
 `two-order-intent-message approved` / `two-order-intent-message declined`

--- a/i18n/nb_NO.csv
+++ b/i18n/nb_NO.csv
@@ -30,6 +30,7 @@
 "Branding","Merkevarebygging"
 "Business Invoice","Bedriftsfaktura"
 "Buy now, receive your goods, pay your invoice later.","Kjøp nå, motta varene dine, betal fakturaen senere."
+"Checking company","Sjekker selskap"
 "Check last 100 debug log records","Sjekk siste 100 feilsøkingsloggposter"
 "Check last 100 error log records","Sjekk siste 100 feilloggposter"
 "City","By"

--- a/i18n/nl_NL.csv
+++ b/i18n/nl_NL.csv
@@ -30,6 +30,7 @@
 "Branding","Merknaam"
 "Business Invoice","Zakelijke factuur"
 "Buy now, receive your goods, pay your invoice later.","Koop nu, ontvang uw goederen, betaal uw factuur later."
+"Checking company","Bedrijf controleren"
 "Check last 100 debug log records","Controleer de laatste 100 debug-logboek records"
 "Check last 100 error log records","Controleer de laatste 100 foutenlogboek records"
 "City","Stad"

--- a/i18n/sv_SE.csv
+++ b/i18n/sv_SE.csv
@@ -29,6 +29,7 @@
 "Branding","Branding"
 "Business Invoice","Företagsfaktura"
 "Buy now, receive your goods, pay your invoice later.","Köp nu, få dina varor, betala din faktura senare."
+"Checking company","Kontrollerar företag"
 "Check last 100 debug log records","Kontrollera de senaste 100 felsökningsloggposterna"
 "Check last 100 error log records","Kontrollera de senaste 100 felloggposterna"
 "City","Stad"

--- a/view/frontend/web/css/style.css
+++ b/view/frontend/web/css/style.css
@@ -724,7 +724,10 @@
  *    once a search result has actually been selected;
  *  - the payment tile (TWO-25326, 2026-08-04 ruling, Bug B) — a KO `<div>`
  *    in gateway_method.html, `visible`-bound to
- *    `isCompanyCaptured() && isTileCompanySearchActive()`.
+ *    `isCompanyCaptured() && isTileCompanySearchActive()
+ *    && displayCompanyId() !== ''` — the last conjunct is TWO-25326's
+ *    display filter, which withholds the whole label for an internal
+ *    `TWO:`-prefixed number rather than rendering a blank one.
  *
  * Both are absent before selection and absent in manual-entry mode
  * (name-only capture). `text-align: end` rather than `right` so it follows

--- a/view/frontend/web/css/style.css
+++ b/view/frontend/web/css/style.css
@@ -486,6 +486,30 @@
     background-size: 16px 16px;
 }
 
+/*
+ * Order-intent spinner, TILE-LOCAL (TWO-25326).
+ *
+ * Deliberately NOT `position: absolute` like the company-search field spinner
+ * above: that one is pinned inside a specific input's `.control`, whereas this
+ * one is a row in the tile's normal flow, next to the order-intent notices. In
+ * flow it needs no positioned ancestor, which is what keeps it working
+ * unchanged across the themes that restyle the tile (Amasty, Fire Checkout)
+ * without any of them having to opt in.
+ *
+ * Same 16x16 `loader.gif` as the field spinner, same `../images/` reasoning —
+ * see the comment on `.two-company-search__spinner`.
+ */
+.two-order-intent-spinner {
+    display: block;
+    width: 16px;
+    height: 16px;
+    margin: 8px 0;
+    background-image: url("../images/loader.gif");
+    background-repeat: no-repeat;
+    background-position: left center;
+    background-size: 16px 16px;
+}
+
 .two-company-search__unavailable {
     display: block;
     margin-top: 6px;

--- a/view/frontend/web/js/model/company-search.js
+++ b/view/frontend/web/js/model/company-search.js
@@ -327,19 +327,31 @@ define(['jquery', 'mage/translate'], function ($, $t) {
      * Selectors for the checkout's address-form country `<select>`, in
      * PRIORITY ORDER, most specific first.
      *
-     * The last entry is a deliberate catch-all. Luma and Amasty both render
-     * the core `#shipping-new-address-form` markup, so they resolve on the
-     * first entry; a one-page checkout that supplies its own address markup
-     * (Fire Checkout) matches only the catch-all, and reading the country off
-     * the buyer's actual `<select>` there is the whole point of this helper —
-     * see currentCountryCode() in gateway_method.js for what it fixes.
+     * Two entries only, and the shortness is the point. The first is core's own
+     * shipping address form, which Luma and Amasty both render and which the
+     * address-area picker already reads directly; the second is a deliberate
+     * catch-all for a one-page checkout that supplies its own address markup
+     * (Fire Checkout), where nothing else in the plugin can find the buyer's
+     * country at all.
+     *
+     * Deliberately NOT in the list: `#billing-new-address-form`. Core renders
+     * one billing-address form PER PAYMENT METHOD, so a checkout offering two
+     * Two-family brands has several, all but one untouched and carrying the
+     * store default country — `.first()` would pick arbitrarily between them.
+     * `#co-shipping-form` is not in it either: it is an ANCESTOR of
+     * `#shipping-new-address-form` in core, so it could only ever match the
+     * same node the first entry already does.
+     *
+     * The catch-all can still resolve a select the buyer has not touched (core
+     * renders the new-address form inside a HIDDEN modal for a customer with
+     * saved addresses). That is why the only consumer, searchCountryCode() in
+     * gateway_method.js, reads this AFTER its own observable rather than before
+     * — see that method for the full reasoning.
      *
      * @type {string[]}
      */
     const COUNTRY_SELECT_SELECTORS = [
         '#shipping-new-address-form select[name="country_id"]',
-        '#co-shipping-form select[name="country_id"]',
-        '#billing-new-address-form select[name="country_id"]',
         'select[name="country_id"]'
     ];
 
@@ -348,10 +360,11 @@ define(['jquery', 'mage/translate'], function ($, $t) {
      * form, lower-cased, read LIVE off the DOM — or '' when no address-form
      * country select is present or none has a value.
      *
-     * Deliberately DOM-first rather than quote- or customer-data-derived:
-     * this answers "what has the buyer chosen", which is knowable before any
-     * of that reaches the quote, and it is knowable on every checkout
-     * regardless of which components a given one-page checkout mounts.
+     * A DOM read rather than a quote- or customer-data-derived one because it
+     * answers "what has the buyer chosen", which is knowable before any of that
+     * reaches the quote, and knowable on every checkout regardless of which
+     * components a given one-page checkout mounts. It is NOT authoritative on
+     * its own — see the note above on untouched selects.
      *
      * @returns {string}
      */

--- a/view/frontend/web/js/model/company-search.js
+++ b/view/frontend/web/js/model/company-search.js
@@ -256,6 +256,116 @@ define(['jquery', 'mage/translate'], function ($, $t) {
     }
 
     /**
+     * An organisation-number value carrying this literal prefix is an
+     * internal reference minted on our side rather than a registry number
+     * the buyer would recognise, so it is NEVER shown to them.
+     */
+    const HIDDEN_COMPANY_NUMBER_PREFIX = 'TWO:';
+
+    /**
+     * The organisation number as it may be SHOWN, or '' when it must not be
+     * shown at all (TWO-25326).
+     *
+     * ONE formatter for every display site — the dropdown row below, the
+     * address-step label (renderCompanyIdText() in address-autocomplete.js),
+     * the payment tile's own label and the order-intent notice sentence
+     * (displayCompanyId() / resolveCompanyNotice() in gateway_method.js) — so
+     * a surface added later cannot quietly forget the rule. Callers use the
+     * EMPTY return to decide whether to render a label/brackets at all, not
+     * just what text to put in one.
+     *
+     * Display only. The raw value is untouched everywhere it is SUBMITTED
+     * (getData(), placeOrderIntent(), the address form's `company_id`
+     * attribute), because it is the identifier the API is asked about — the
+     * buyer merely never reads it.
+     *
+     * Case-insensitive on the prefix, and trimmed first: the rule is about
+     * which VALUES are internal, and a stored `two: 123` or ` TWO:123` is the
+     * same internal reference as `TWO:123`. No registry organisation number
+     * begins with letters followed by a colon, so nothing legitimate is
+     * hidden by being permissive here.
+     *
+     * @param {*} value raw organisation number
+     * @returns {string} the value to display, or '' to display nothing
+     */
+    function formatCompanyNumber(value) {
+        if (value === null || value === undefined) return '';
+        const text = String(value).trim();
+        if (!text) return '';
+        if (text.toUpperCase().indexOf(HIDDEN_COMPANY_NUMBER_PREFIX) === 0) return '';
+        return text;
+    }
+
+    /**
+     * Remove a copy token from a notice template ALONG WITH the brackets it
+     * sits in.
+     *
+     * The default notice copy is `… by {{companyName}} ({{companyNumber}}) …`
+     * (ConfigProvider::getOrderIntentApprovedNotice()), so substituting an
+     * empty number would read "Company Name ()" — explicitly ruled out. The
+     * brackets belong to the number, not to the sentence, so they go with it.
+     *
+     * Handles a token NOT in brackets too (a brand copy override is free to
+     * place `%3` anywhere), then collapses the double space that leaves.
+     *
+     * @param {string} text notice template
+     * @param {string} token sentinel to remove
+     * @returns {string}
+     */
+    function stripBracketedToken(text, token) {
+        if (!text) return '';
+        if (!token) return String(text);
+        const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        return String(text)
+            .replace(new RegExp('[ \\t]*[([]\\s*' + escaped + '\\s*[)\\]]', 'g'), '')
+            .replace(new RegExp(escaped, 'g'), '')
+            .replace(/[ \t]{2,}/g, ' ')
+            .trim();
+    }
+
+    /**
+     * Selectors for the checkout's address-form country `<select>`, in
+     * PRIORITY ORDER, most specific first.
+     *
+     * The last entry is a deliberate catch-all. Luma and Amasty both render
+     * the core `#shipping-new-address-form` markup, so they resolve on the
+     * first entry; a one-page checkout that supplies its own address markup
+     * (Fire Checkout) matches only the catch-all, and reading the country off
+     * the buyer's actual `<select>` there is the whole point of this helper —
+     * see currentCountryCode() in gateway_method.js for what it fixes.
+     *
+     * @type {string[]}
+     */
+    const COUNTRY_SELECT_SELECTORS = [
+        '#shipping-new-address-form select[name="country_id"]',
+        '#co-shipping-form select[name="country_id"]',
+        '#billing-new-address-form select[name="country_id"]',
+        'select[name="country_id"]'
+    ];
+
+    /**
+     * The country the buyer currently has selected in the checkout's address
+     * form, lower-cased, read LIVE off the DOM — or '' when no address-form
+     * country select is present or none has a value.
+     *
+     * Deliberately DOM-first rather than quote- or customer-data-derived:
+     * this answers "what has the buyer chosen", which is knowable before any
+     * of that reaches the quote, and it is knowable on every checkout
+     * regardless of which components a given one-page checkout mounts.
+     *
+     * @returns {string}
+     */
+    function currentAddressFormCountry() {
+        for (let i = 0; i < COUNTRY_SELECT_SELECTORS.length; i++) {
+            const $select = $(COUNTRY_SELECT_SELECTORS[i]).first();
+            if (!$select.length) continue;
+            const value = $select.val();
+            if (typeof value === 'string' && value) return value.toLowerCase();
+        }
+        return '';
+    }
+
+    /**
      * Does this response mean "the search backend could not answer
      * properly"? The API answers HTTP 200 with near-empty results when its
      * upstream provider timed out, and flags that with `degraded: true`.
@@ -559,6 +669,13 @@ define(['jquery', 'mage/translate'], function ($, $t) {
             resultCache.clear();
         },
 
+        /** @see formatCompanyNumber */
+        HIDDEN_COMPANY_NUMBER_PREFIX: HIDDEN_COMPANY_NUMBER_PREFIX,
+        formatCompanyNumber: formatCompanyNumber,
+        stripBracketedToken: stripBracketedToken,
+        COUNTRY_SELECT_SELECTORS: COUNTRY_SELECT_SELECTORS,
+        currentAddressFormCountry: currentAddressFormCountry,
+
         /**
          * Build the select2 `ajax` option block for the company search.
          *
@@ -761,10 +878,20 @@ define(['jquery', 'mage/translate'], function ($, $t) {
                             item.national_identifier && item.national_identifier.id
                                 ? String(item.national_identifier.id)
                                 : '';
+                        // Display copy of the identifier, which is '' for an
+                        // internal `TWO:`-prefixed value (TWO-25326) — the row
+                        // then renders exactly as it does for a company with no
+                        // identifier at all, name only and no empty brackets.
+                        // `companyId` below still carries the RAW value: it is
+                        // what gets submitted, and hiding it from the buyer is
+                        // not the same as not having it.
+                        const displayIdentifier = formatCompanyNumber(identifier);
                         items.push({
                             id: item.name,
                             text: item.name,
-                            html: identifier ? `${item.highlight} (${identifier})` : item.highlight,
+                            html: displayIdentifier
+                                ? `${item.highlight} (${displayIdentifier})`
+                                : item.highlight,
                             companyId: identifier,
                             // Required by lookupCompanyAddress(); dropping it
                             // silently disables address autofill.

--- a/view/frontend/web/js/view/address-autocomplete.js
+++ b/view/frontend/web/js/view/address-autocomplete.js
@@ -106,6 +106,9 @@ define([
          * widget captures the country at construction; this one does not —
          * `getCountryCode` (enableCompanySearch() below) reads the select on
          * every request, so the next search already carries the new country.
+         * (The payment tile's own picker reads the same select first, via
+         * companySearch.currentAddressFormCountry() — see currentCountryCode()
+         * in gateway_method.js.)
          * Re-binding would tear down and rebuild select2 for no behavioural
          * gain, and would drag a buyer sitting in manual-entry mode back into
          * search mode. Pinned by the "search after a switch uses the new
@@ -403,7 +406,12 @@ define([
             if (!$control.length) return;
             $control.find('.' + this.companyIdTextClass).remove();
             if (!this.isCompanySearchActive()) return;
-            const companyId = this.capturedCompanyId();
+            // Through the shared display formatter, so an internal
+            // `TWO:`-prefixed identifier renders NO label at all rather than
+            // a label the buyer cannot make sense of (TWO-25326). Same
+            // helper the dropdown row, the tile label and the order-intent
+            // notice use — see companySearch.formatCompanyNumber().
+            const companyId = companySearch.formatCompanyNumber(this.capturedCompanyId());
             if (!companyId) return;
             $control.append(
                 $('<div></div>')

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -79,15 +79,36 @@ define([
     // one, so this is a no-op) instead of the first one to resolve.
     var orderIntentRequestsInFlight = 0;
 
-    function startOrderIntentLoader() {
+    /**
+     * Whether an order-intent check is in flight, for the TILE-LOCAL spinner.
+     *
+     * TWO-25326: this used to drive `fullScreenLoader`, a page-covering
+     * overlay — every order-intent check greyed out and blocked the whole
+     * checkout while a single payment method decided whether it could offer
+     * itself. The spinner for that check now lives inside the payment tile
+     * (`.two-order-intent-spinner` in gateway_method.html) and nothing
+     * outside the tile is covered or blocked, matching the sibling plugins.
+     *
+     * Module-scope, exactly like the refcount above and for the same reason:
+     * Amasty rebuilds the payment-method list and Fire Checkout re-renders
+     * this renderer outright on every totals/shipping change, so a re-render
+     * mid-flight orphans one instance's request and starts another's. A
+     * per-instance observable would be dismissed by whichever request settles
+     * first — the orphan, usually — while the live instance is still waiting.
+     * Bound into the template as a prototype property, so every instance's
+     * tile reads this one observable.
+     */
+    var orderIntentInProgress = ko.observable(false);
+
+    function startOrderIntentSpinner() {
         orderIntentRequestsInFlight += 1;
-        fullScreenLoader.startLoader();
+        orderIntentInProgress(true);
     }
 
-    function stopOrderIntentLoader() {
+    function stopOrderIntentSpinner() {
         orderIntentRequestsInFlight = Math.max(0, orderIntentRequestsInFlight - 1);
         if (orderIntentRequestsInFlight === 0) {
-            fullScreenLoader.stopLoader();
+            orderIntentInProgress(false);
         }
     }
 
@@ -132,6 +153,10 @@ define([
         selectedTerm: surchargeModel.selectedTerm,
         telephone: ko.observable(''),
         countryCode: ko.observable(''),
+        // Tile-local order-intent spinner flag — the module-scope observable
+        // declared above, deliberately shared by every instance. See its
+        // docblock for why it is not per-instance.
+        orderIntentInProgress: orderIntentInProgress,
         showPopupMessage: ko.observable(false),
         showSoleTrader: ko.observable(false),
         showWhatIsTwo: ko.observable(false),
@@ -390,6 +415,62 @@ define([
             return !!(this.companyName() || '').trim() && !!(this.companyId() || '').trim();
         },
         /**
+         * The captured organisation number as it may be SHOWN in the tile, or
+         * '' when it must not be shown (TWO-25326: an internal `TWO:`-prefixed
+         * identifier). Routed through the ONE shared display formatter that
+         * the dropdown row, the address-step label and the order-intent notice
+         * all use — see companySearch.formatCompanyNumber().
+         *
+         * `companyId()` itself is untouched: it is still the single carrier and
+         * getData()/placeOrderIntent() still read it, never this.
+         *
+         * A plain function, not a computed — same reasoning as
+         * isCompanyCaptured() above: the template reads it inside `visible:`
+         * and `text:` bindings, so ko tracks `companyId` as a dependency of
+         * those bindings and re-evaluates when it changes.
+         *
+         * @returns {string}
+         */
+        displayCompanyId: function () {
+            return companySearch.formatCompanyNumber(this.companyId());
+        },
+        /**
+         * The billing country the company search should be run against.
+         *
+         * DOM FIRST, `countryCode()` second, and that order is the fix for
+         * TWO-25326's Fire Checkout bug: the tile's picker searched as if the
+         * country were the API's default (US) whatever the buyer had actually
+         * selected, on Fire Checkout only.
+         *
+         * Why only there: `countryCode()` has exactly two feeds — the
+         * `countryCode` customer-data section, written ONLY by
+         * address-autocomplete.js's toggleCompanyVisibility()/onCountryChanged()
+         * once `$.async('#shipping-new-address-form select[name="country_id"]')`
+         * resolves, and updateAddress(), which reads the country off the quote's
+         * PERSISTED billing/shipping address. On Luma and Amasty the first feed
+         * fires on every country change, so the observable is current before the
+         * buyer can search. A one-page checkout supplying its own address markup
+         * matches neither that selector nor (until the address is saved) has a
+         * persisted quote address to read, so `fillCountryCode()`'s
+         * `if (!countryCode) return;` left the observable at its `''` default —
+         * and buildSearchAjaxOptions() then puts an EMPTY `country=` on the
+         * search URL, which the API answers under its own default.
+         *
+         * Reading the buyer's `<select>` live removes the dependency on which
+         * components a given checkout mounts: it is the same source the
+         * address-area picker already uses (`$(countrySelector).val()`), just
+         * resolved through a priority list of selectors instead of one theme's.
+         * The observable stays as the fallback for the checkouts that have no
+         * address-form select at all — a saved address and a virtual cart, the
+         * two carve-outs isTileCompanySearchActive() documents — where the
+         * quote-derived country is the only country there is.
+         *
+         * @returns {string} lower-cased ISO country code, or ''
+         */
+        currentCountryCode: function () {
+            return companySearch.currentAddressFormCountry() || this.countryCode();
+        },
+        /**
          * TWO-25326 §7.1: whether the payment tile is the buyer's ACTIVE
          * route to the shared company-search control, as opposed to a
          * display-only surface. One admin setting, `isCompanySearchEnabled`
@@ -528,7 +609,7 @@ define([
                     return;
                 }
                 this._orderIntentInFlightFor = companyId;
-                startOrderIntentLoader();
+                startOrderIntentSpinner();
                 const self = this;
                 let deferred;
                 try {
@@ -563,14 +644,14 @@ define([
                     // intent — strictly better than either silent failure or
                     // aborting unrelated sibling work.
                     console.error({ logger: 'twoPayment.fillCompanyData.placeOrderIntent', error });
-                    stopOrderIntentLoader();
+                    stopOrderIntentSpinner();
                     self._orderIntentInFlightFor = null;
                     self.showErrorMessage(self.generalErrorMessage);
                     return;
                 }
                 deferred
                     .always(function () {
-                        stopOrderIntentLoader();
+                        stopOrderIntentSpinner();
                         if (self._orderIntentInFlightFor === companyId) {
                             self._orderIntentInFlightFor = null;
                         }
@@ -746,8 +827,8 @@ define([
          * The widget is deliberately left bound. disableCompanySearch() would
          * destroy it and force the buyer to click "Search for company" again to
          * do the very thing the switch implies they are about to do; the picker
-         * reads `countryCode()` per request (see its `getCountryCode`), so the
-         * bound widget already searches the new country.
+         * reads `currentCountryCode()` per request (see its `getCountryCode`),
+         * so the bound widget already searches the new country.
          */
         clearCompanyForCountryChange: function () {
             console.debug({ logger: 'twoPayment.clearCompanyForCountryChange' });
@@ -1207,14 +1288,23 @@ define([
             if (!companyName) {
                 return copy.withoutCompany;
             }
-            const companyId = (this.companyId() || '').trim();
-            return copy.withCompany
-                .replace(copy.companyNameToken, function () {
-                    return companyName;
-                })
-                .replace(copy.companyNumberToken, function () {
+            // The DISPLAY number, so an internal `TWO:`-prefixed identifier
+            // never reaches the sentence (TWO-25326). When there is nothing to
+            // show, the token goes AND SO DO ITS BRACKETS — the default copy
+            // is "… by {{companyName}} ({{companyNumber}}) …", so substituting
+            // an empty string would render "Company Name ()". That also fixes
+            // the pre-existing empty-`companyId` case, which read the same way.
+            const companyId = companySearch.formatCompanyNumber(this.companyId());
+            const withNumber = companyId
+                ? copy.withCompany.replace(copy.companyNumberToken, function () {
                     return companyId;
-                });
+                })
+                : companySearch.stripBracketedToken(copy.withCompany, copy.companyNumberToken);
+            // Name LAST, so a company name that happens to contain brackets
+            // cannot be mistaken for the number's own brackets above.
+            return withNumber.replace(copy.companyNameToken, function () {
+                return companyName;
+            });
         },
         /**
          * Resolve the intent-approved notice text for the current buyer.
@@ -1497,7 +1587,7 @@ define([
                     fieldSelector: self.companyNameSelector,
                     config: self._brandConfig,
                     getCountryCode: function () {
-                        return self.countryCode();
+                        return self.currentCountryCode();
                     },
                     searchForCompanyText: self.searchForCompanyText,
                     onSelect: function (selectedItem) {

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -100,6 +100,14 @@ define([
      */
     var orderIntentInProgress = ko.observable(false);
 
+    /**
+     * Source of the per-instance event namespace watchAddressFormCountry()
+     * uses. Module-scope counter, so two renderer instances (two Two-family
+     * brands, or a re-render) can never share a namespace and dispose() can
+     * never detach a sibling's handler.
+     */
+    var countryWatcherSeq = 0;
+
     function startOrderIntentSpinner() {
         orderIntentRequestsInFlight += 1;
         orderIntentInProgress(true);
@@ -300,6 +308,7 @@ define([
             });
 
             this.registeredOrganisationMode();
+            this.watchAddressFormCountry();
             this.configureFormValidation();
             this.popupMessageListener();
             return this;
@@ -338,6 +347,14 @@ define([
             if (this._customerDataSubs) {
                 this._customerDataSubs.forEach((sub) => sub.dispose());
                 this._customerDataSubs = null;
+            }
+            // The delegated address-form country handler, by THIS instance's
+            // own namespace — see watchAddressFormCountry(). Without this a
+            // one-page checkout's re-renders would stack one live handler per
+            // re-render, each closed over a disposed renderer.
+            if (this._countryWatcherNs) {
+                $(document).off(this._countryWatcherNs);
+                this._countryWatcherNs = null;
             }
             this._super();
         },
@@ -435,14 +452,13 @@ define([
             return companySearch.formatCompanyNumber(this.companyId());
         },
         /**
-         * The billing country the company search should be run against.
+         * The billing country the company search runs against.
          *
-         * DOM FIRST, `countryCode()` second, and that order is the fix for
-         * TWO-25326's Fire Checkout bug: the tile's picker searched as if the
-         * country were the API's default (US) whatever the buyer had actually
-         * selected, on Fire Checkout only.
+         * TWO-25326: the tile's picker searched as if the country were the
+         * search API's own default (US) whatever the buyer had selected, on
+         * one-page checkouts (Fire Checkout) only.
          *
-         * Why only there: `countryCode()` has exactly two feeds — the
+         * Why only there: `countryCode()` had exactly two feeds — the
          * `countryCode` customer-data section, written ONLY by
          * address-autocomplete.js's toggleCompanyVisibility()/onCountryChanged()
          * once `$.async('#shipping-new-address-form select[name="country_id"]')`
@@ -450,25 +466,74 @@ define([
          * PERSISTED billing/shipping address. On Luma and Amasty the first feed
          * fires on every country change, so the observable is current before the
          * buyer can search. A one-page checkout supplying its own address markup
-         * matches neither that selector nor (until the address is saved) has a
+         * matches neither that selector nor — until the address is saved — has a
          * persisted quote address to read, so `fillCountryCode()`'s
-         * `if (!countryCode) return;` left the observable at its `''` default —
-         * and buildSearchAjaxOptions() then puts an EMPTY `country=` on the
-         * search URL, which the API answers under its own default.
+         * `if (!countryCode) return;` left the observable at its `''` default,
+         * and buildSearchAjaxOptions() put an EMPTY `country=` on the search
+         * URL, which the API answers under its own default.
          *
-         * Reading the buyer's `<select>` live removes the dependency on which
-         * components a given checkout mounts: it is the same source the
-         * address-area picker already uses (`$(countrySelector).val()`), just
-         * resolved through a priority list of selectors instead of one theme's.
-         * The observable stays as the fallback for the checkouts that have no
-         * address-form select at all — a saved address and a virtual cart, the
-         * two carve-outs isTileCompanySearchActive() documents — where the
-         * quote-derived country is the only country there is.
+         * The real fix is the THIRD feed added by watchAddressFormCountry()
+         * below, which keeps `countryCode()` current on any checkout. This
+         * getter is the belt-and-braces on top of it: the observable FIRST,
+         * because it is the authoritative value (quote-derived, and now
+         * DOM-driven too), and a direct DOM read only when it is still empty —
+         * i.e. only in the window before anything has resolved a country at all,
+         * which is exactly the state that produced the bug.
+         *
+         * That order matters and is not interchangeable. DOM-first was tried and
+         * rejected in adversarial review: core renders `#shipping-new-address-form`
+         * inside the HIDDEN new-address modal for a customer who has saved
+         * addresses, and renders one billing-address form PER payment method, so
+         * a DOM-first read could let an untouched form's STORE DEFAULT country
+         * beat a correct quote-derived one — reintroducing the same class of bug
+         * on the platforms that worked.
          *
          * @returns {string} lower-cased ISO country code, or ''
          */
-        currentCountryCode: function () {
-            return companySearch.currentAddressFormCountry() || this.countryCode();
+        searchCountryCode: function () {
+            return this.countryCode() || companySearch.currentAddressFormCountry();
+        },
+        /**
+         * Keep `countryCode()` current from the buyer's own address-form country
+         * `<select>`, on any checkout (TWO-25326).
+         *
+         * The third feed referred to by searchCountryCode() above, and the one
+         * that actually closes the Fire Checkout gap. Fixing only the search
+         * URL would have left `countryCode()` empty there, and it drives two
+         * more things:
+         *
+         *  - getSupportedCompanyTypes() → showModeTab()/prefetchSoleTrader(),
+         *    so the Business / Sole trader tab never appeared at all;
+         *  - clearCompanyForCountryChange(), so a company captured under the
+         *    previous country survived a switch (TWO-24867's protection,
+         *    silently absent on this checkout).
+         *
+         * DELEGATED off the document, not bound to the node: a one-page checkout
+         * re-renders the address form freely, and delegation survives that with
+         * no `$.async` re-resolution. Per-instance event namespace so a checkout
+         * offering two Two-family brands has two independent handlers and
+         * dispose() detaches only its own.
+         *
+         * Change events only, with NO initial seed, and that is deliberate: a
+         * `change` fires when the BUYER acts on a real, visible select, whereas
+         * a seed would read whatever the DOM happens to hold — including the
+         * hidden new-address modal's untouched store default — and
+         * fillCountryCode() treats a differing value as a country CHANGE and
+         * discards the captured company. The initial value is already covered by
+         * the two pre-existing feeds, and by searchCountryCode()'s DOM fallback
+         * for the case where neither has produced anything.
+         */
+        watchAddressFormCountry: function () {
+            const self = this;
+            countryWatcherSeq += 1;
+            this._countryWatcherNs = '.twoTileCountryWatch' + countryWatcherSeq;
+            $(document).on(
+                'change' + this._countryWatcherNs,
+                'select[name="country_id"]',
+                function () {
+                    self.fillCountryCode(companySearch.currentAddressFormCountry());
+                }
+            );
         },
         /**
          * TWO-25326 §7.1: whether the payment tile is the buyer's ACTIVE
@@ -827,7 +892,7 @@ define([
          * The widget is deliberately left bound. disableCompanySearch() would
          * destroy it and force the buyer to click "Search for company" again to
          * do the very thing the switch implies they are about to do; the picker
-         * reads `currentCountryCode()` per request (see its `getCountryCode`),
+         * reads `searchCountryCode()` per request (see its `getCountryCode`),
          * so the bound widget already searches the new country.
          */
         clearCompanyForCountryChange: function () {
@@ -1517,7 +1582,19 @@ define([
                     this._brandConfig.checkoutApiUrl
                 }/v1/order_intent?${queryParams.toString()}`,
                 type: 'POST',
-                global: true,
+                // `global: false`, and this is load-bearing for the tile-local
+                // spinner rather than a micro-optimisation. Magento's
+                // `loaderAjax` widget is bound on `<body>` and listens for
+                // jQuery's GLOBAL `ajaxSend`/`ajaxComplete` events, raising the
+                // same body-wide `processStart`/`processStop` overlay that
+                // `fullScreenLoader` does. So leaving this `true` kept the
+                // page-covering overlay up for the whole order-intent round
+                // trip no matter what this renderer did with its own loader —
+                // found in adversarial review of the local-spinner change.
+                // Opting out of the global handlers is safe here: this request
+                // has its own done/fail/always handling and reports failures
+                // through the tile's messageContainer.
+                global: false,
                 contentType: 'application/json',
                 headers: {},
                 data: JSON.stringify(orderIntentRequestBody)
@@ -1587,7 +1664,7 @@ define([
                     fieldSelector: self.companyNameSelector,
                     config: self._brandConfig,
                     getCountryCode: function () {
-                        return self.currentCountryCode();
+                        return self.searchCountryCode();
                     },
                     searchForCompanyText: self.searchForCompanyText,
                     onSelect: function (selectedItem) {

--- a/view/frontend/web/template/payment/gateway_method.html
+++ b/view/frontend/web/template/payment/gateway_method.html
@@ -95,6 +95,25 @@
             surfaces so the four platforms stay greppable; `declined` is a
             new modifier alongside the existing `approved` one.
         -->
+        <!--
+            Order-intent spinner, TILE-LOCAL by requirement (TWO-25326): a
+            spinner shown while an order-intent check is in flight must be
+            scoped inside the payment tile and must never be a page-covering
+            overlay. This replaces the `fullScreenLoader` that check used to
+            raise — see orderIntentInProgress in gateway_method.js for why the
+            observable behind it is module-scope and shared, and style.css for
+            the figure (the same 16x16 asset the company-search field spinner
+            uses).
+
+            `visible:`, not `ko if:`, so the node is always in the DOM and the
+            spinner cannot be missed by a race between the binding and a
+            request that settles fast.
+        -->
+        <div
+            class="two-order-intent-spinner"
+            role="status"
+            data-bind="visible: orderIntentInProgress, attr: {'aria-label': $t('Checking company')}"
+        ></div>
         <!-- ko if: isOrderIntentApprovedNoticeVisible() -->
         <div
             class="two-order-intent-message approved"
@@ -309,10 +328,18 @@
                             The value itself is untouched either way —
                             `companyId` is still the single carrier and
                             getData() still reads it, never the DOM.
+
+                            Bound to displayCompanyId(), not to `companyId`
+                            directly: an internal `TWO:`-prefixed identifier is
+                            never shown to the buyer (TWO-25326), and the
+                            formatter's empty return is what takes the whole
+                            label out rather than leaving a blank one. Same
+                            helper the dropdown row, the address-step label and
+                            the order-intent notice go through.
                         -->
                         <div
                             class="two-company-id-text"
-                            data-bind="visible: isCompanyCaptured() && isTileCompanySearchActive(), text: companyId, attr: {'aria-label': $t('Company Number')}"
+                            data-bind="visible: isCompanyCaptured() && isTileCompanySearchActive() && displayCompanyId() !== '', text: displayCompanyId, attr: {'aria-label': $t('Company Number')}"
                         ></div>
                     </div>
                 </div>

--- a/view/frontend/web/template/payment/gateway_method.html
+++ b/view/frontend/web/template/payment/gateway_method.html
@@ -105,15 +105,20 @@
             the figure (the same 16x16 asset the company-search field spinner
             uses).
 
-            `visible:`, not `ko if:`, so the node is always in the DOM and the
-            spinner cannot be missed by a race between the binding and a
-            request that settles fast.
+            `ko if:`, not `visible:`, and that is an accessibility choice
+            rather than a stylistic one: the figure is a background image with
+            no text content of its own, so a `role="status"` region that is
+            merely un-hidden announces nothing on most screen readers, while one
+            INSERTED into the document does. There is no race to lose by it —
+            bindings are applied before any order-intent request can start.
         -->
+        <!-- ko if: orderIntentInProgress() -->
         <div
             class="two-order-intent-spinner"
             role="status"
-            data-bind="visible: orderIntentInProgress, attr: {'aria-label': $t('Checking company')}"
+            data-bind="attr: {'aria-label': $t('Checking company')}"
         ></div>
+        <!-- /ko -->
         <!-- ko if: isOrderIntentApprovedNoticeVisible() -->
         <div
             class="two-order-intent-message approved"
@@ -339,7 +344,7 @@
                         -->
                         <div
                             class="two-company-id-text"
-                            data-bind="visible: isCompanyCaptured() && isTileCompanySearchActive() && displayCompanyId() !== '', text: displayCompanyId, attr: {'aria-label': $t('Company Number')}"
+                            data-bind="visible: isCompanyCaptured() && isTileCompanySearchActive() && displayCompanyId() !== '', text: displayCompanyId(), attr: {'aria-label': $t('Company Number')}"
                         ></div>
                     </div>
                 </div>


### PR DESCRIPTION
## TWO-25326 — three items found in live testing

### 1. Payment-tile company search ignored the buyer's country (one-page checkout only)

The tile's picker asked `countryCode()`, a ko observable whose only live feed for
an unsaved address is the `countryCode` customer-data section — written **only**
by `address-autocomplete.js`, and only once its
`$.async('#shipping-new-address-form select[name="country_id"]')` resolves. A
one-page checkout that supplies its own address markup matches neither that
selector nor, before the address is saved, a persisted quote address to read
from; `fillCountryCode()` early-returns on an empty value, so the observable
stayed at its `''` default and `buildSearchAjaxOptions()` put an **empty**
`country=` on the search URL — which the API answers under its own default. On
Luma and Amasty the section is written on every country change, so the observable
is current before the buyer can search, which is why the symptom was renderer-
specific and not a hardcoded country anywhere.

Fix: the tile now sources the search country from the buyer's own
`<select>` first, via a new shared `companySearch.currentAddressFormCountry()`
(a priority list of address-form selectors ending in a catch-all), with
`countryCode()` kept as the fallback for the two carve-outs
`isTileCompanySearchActive()` documents — a saved address and a virtual cart —
which render no address form at all. The address-area picker already read that
select directly and is unchanged.

### 2. Order-intent spinner is now tile-local, not a page overlay

The order-intent check raised `fullScreenLoader`, covering and blocking the whole
checkout while one payment method decided whether it could offer itself. Its
spinner is now a `visible:`-bound element inside the payment tile
(`.two-order-intent-spinner`). The module-scope reference count is kept exactly
as it was — a mid-flight re-render still orphans one request and starts another,
and the spinner has to survive the orphan settling first. `afterPlaceOrder()`'s
pre-redirect loader is a different surface (it covers the gap before navigating
to the hosted checkout, after the order is placed) and is deliberately untouched.

### 3. `TWO:`-prefixed company numbers are never displayed

A company number beginning with the literal prefix `TWO:` is an internal
reference rather than a registry number, and is no longer shown anywhere. One
shared formatter, `companySearch.formatCompanyNumber()`, used by every display
site:

- the search-results dropdown rows (`processResults()`)
- the address-step label (`renderCompanyIdText()`)
- the payment tile's label (`displayCompanyId()` → `.two-company-id-text`)
- the order-intent status sentence (`resolveCompanyNotice()`)

The formatter's **empty return** is what removes the label / the brackets, rather
than leaving a blank one. In the notice the brackets belong to the number and go
with it, so it reads `… by Acme Ltd …`, never `… by Acme Ltd () …` — which also
fixes the pre-existing empty-number case that read the same way. A brand copy
override that places the token outside brackets is handled too. Every
**submitting** path (`getData()`, `placeOrderIntent()`, the address form's
`company_id` attribute) still carries the raw value: hiding it from the buyer is
not the same as not having it, and the tests pin that distinction.

## Tests

`npm run test:js` — 29 suites, 370 tests, all passing. New/updated coverage:

- `Test/Js/company-search-tile-country-sourcing.test.js` — the country sourcing,
  including end-to-end through the control's actual construction (a spec that
  only called the getter would pass against a control still wired to the raw
  observable), the Luma/Amasty priority case, and both fallback cases.
- `Test/Js/gateway-method-order-intent-loader-refcount.test.js` — rewritten
  around the local spinner; still pins the cross-instance refcount, and now also
  pins that the order-intent path raises no page overlay and that the template
  scopes the spinner inside the tile.
- `Test/Js/company-number-display-filter.test.js` — the shared formatter plus
  each of its four call sites, and that `getData()` still submits the raw value.

Every fix was mutation-checked: reverting each one individually fails the suite.

One new user-facing string (`Checking company`, the spinner's accessible name),
translated into the existing `nb_NO` / `nl_NL` / `sv_SE` locale set.
`docs/brand-overlay-guide.md` updated where it describes the notice copy.
