### PR TITLE
feat(TWO-25326): unify Luma order-intent checking UI with the other plugins

### DIFF
--- a/Test/Js/gateway-method-intent-approved-notice.test.js
+++ b/Test/Js/gateway-method-intent-approved-notice.test.js
@@ -31,6 +31,39 @@ const DECLINED_COPY = {
 };
 
 /**
+ * An observable with REAL knockout's notification semantics: writing the value
+ * it already holds notifies nobody.
+ *
+ * The AMD harness's ko double notifies on every write, equal or not, and the
+ * company observables are the one place in these specs where that difference
+ * decides an outcome — "the previous verdict is cleared when a new check
+ * starts" is trivially true under a double that fires the company-change
+ * subscription on an unchanged write, and false in the browser (TWO-25326,
+ * 2026-08-05). Only primitives are compared, which is all these two ever hold.
+ */
+function koObservable(initial) {
+    let value = initial;
+    const subscribers = [];
+    function obs(next) {
+        if (arguments.length === 0) return value;
+        if (next === value) return obs;
+        value = next;
+        subscribers.forEach(function (fn) {
+            fn(value);
+        });
+        return obs;
+    }
+    obs.subscribe = function (fn) {
+        subscribers.push(fn);
+        return { dispose: function () {} };
+    };
+    obs.peek = function () {
+        return value;
+    };
+    return obs;
+}
+
+/**
  * Build a `this` context standing in for a live renderer instance.
  *
  * Calls the renderer's own initOrderIntentApprovedNotice() — the real
@@ -43,8 +76,8 @@ function makeContext(noticeCopy, declinedCopy) {
     const ko = defaultMocks().ko;
 
     const ctx = Object.assign({}, component, {
-        companyName: ko.observable(''),
-        companyId: ko.observable(''),
+        companyName: koObservable(''),
+        companyId: koObservable(''),
         messageContainer: {
             cleared: 0,
             clear: function () {
@@ -144,7 +177,7 @@ describe('gateway_method intent-approved notice', () => {
         expect(ctx.errors).toEqual([]);
     });
 
-    test('an intent error clears both notices', () => {
+    test('an intent error clears both verdict notices', () => {
         const ctx = makeContext(DEFAULT_COPY, DECLINED_COPY);
         ctx.companyName('Acme Widgets AS');
         ctx.companyId('123456789');
@@ -154,6 +187,130 @@ describe('gateway_method intent-approved notice', () => {
 
         expect(ctx.orderIntentApprovedNotice()).toBe('');
         expect(ctx.orderIntentDeclinedNotice()).toBe('');
+    });
+
+    test('an intent error states itself in the tile box, not the checkout toast', () => {
+        // TWO-25326 (2026-08-05): all three outcomes share one bordered
+        // container across the four plugins. The message region this used to
+        // go to is cleared on the next checkout update, so the buyer's only
+        // sign the check failed could vanish on its own.
+        const ctx = makeContext(DEFAULT_COPY, DECLINED_COPY);
+        ctx.generalErrorMessage = 'Something went wrong.';
+
+        ctx.processOrderIntentErrorResponse.call(ctx, {});
+
+        expect(ctx.orderIntentErrorNotice()).toBe('Something went wrong.');
+        expect(ctx.isOrderIntentErrorNoticeVisible.call(ctx)).toBe(true);
+        expect(ctx.errors).toEqual([]);
+    });
+
+    test('the error box is not silenced by the brand suppressing the intent verdict', () => {
+        // A brand turning the approved/declined sentence off is declining to
+        // state a VERDICT; it has not asked for a failed check to be silent.
+        const ctx = makeContext(null, null);
+        ctx.generalErrorMessage = 'Something went wrong.';
+
+        ctx.processOrderIntentErrorResponse.call(ctx, {});
+
+        expect(ctx.orderIntentErrorNotice()).toBe('Something went wrong.');
+    });
+
+    test('a SCHEMA_ERROR keeps its per-field errors in the message region and leaves the box empty', () => {
+        const ctx = makeContext(DEFAULT_COPY, DECLINED_COPY);
+        ctx.generalErrorMessage = 'Something went wrong.';
+        const pushed = [];
+        ctx.messageContainer.errorMessages = {
+            push: function (msg) {
+                pushed.push(msg);
+            },
+            remove: function () {}
+        };
+
+        ctx.processOrderIntentErrorResponse.call(ctx, {
+            responseJSON: {
+                error_code: 'SCHEMA_ERROR',
+                error_json: [{ msg: 'company_name is required' }]
+            }
+        });
+
+        // Several field-level errors at once belong with the fields, not in a
+        // box that states one outcome.
+        expect(pushed).toEqual(['company_name is required']);
+        expect(ctx.orderIntentErrorNotice()).toBe('');
+    });
+
+    test('a later error replaces the earlier one rather than stacking', () => {
+        const ctx = makeContext(DEFAULT_COPY, DECLINED_COPY);
+        ctx.generalErrorMessage = 'Something went wrong.';
+        ctx.processOrderIntentErrorResponse.call(ctx, {});
+
+        ctx.processOrderIntentErrorResponse.call(ctx, {
+            responseJSON: {
+                error_code: 'JSON_MISSING_FIELD',
+                error_details: 'billing_address is missing'
+            }
+        });
+
+        expect(ctx.orderIntentErrorNotice()).toBe('billing_address is missing');
+    });
+
+    test('an approval clears a previous error box', () => {
+        const ctx = makeContext(DEFAULT_COPY, DECLINED_COPY);
+        ctx.generalErrorMessage = 'Something went wrong.';
+        ctx.processOrderIntentErrorResponse.call(ctx, {});
+        expect(ctx.orderIntentErrorNotice()).not.toBe('');
+
+        ctx.companyName('Acme Widgets AS');
+        ctx.processOrderIntentSuccessResponse.call(ctx, { approved: true });
+
+        expect(ctx.orderIntentErrorNotice()).toBe('');
+        expect(ctx.orderIntentApprovedNotice()).not.toBe('');
+    });
+
+    test('a new check clears the previous verdict AS IT STARTS, even when the company observables did not change', () => {
+        // The company-change subscriptions cannot cover this: a re-render
+        // re-applying the already-captured company, or a repeat pick of the
+        // company already in the field, writes the SAME values and ko
+        // notifies nothing — so before TWO-25326 (2026-08-05) the previous
+        // verdict sat on screen under a spinner checking something else.
+        const ctx = makeContext(DEFAULT_COPY, DECLINED_COPY);
+        ctx.isOrderIntentEnabled = true;
+        ctx.companyName('Acme Widgets AS');
+        ctx.companyId('123456789');
+        ctx.processOrderIntentSuccessResponse.call(ctx, { approved: true });
+        expect(ctx.orderIntentApprovedNotice()).not.toBe('');
+
+        // A request that never settles, so what is asserted is the state
+        // DURING the check rather than after it.
+        let settle;
+        ctx.placeOrderIntent = function () {
+            return {
+                always: function (fn) {
+                    settle = fn;
+                    return this;
+                },
+                done: function () {
+                    return this;
+                },
+                fail: function () {
+                    return this;
+                }
+            };
+        };
+
+        ctx.fillCompanyData.call(ctx, {
+            companyName: 'Acme Widgets AS',
+            companyId: '123456789'
+        });
+
+        expect(typeof settle).toBe('function');
+        expect(ctx.orderIntentApprovedNotice()).toBe('');
+        expect(ctx.orderIntentDeclinedNotice()).toBe('');
+        expect(ctx.orderIntentErrorNotice()).toBe('');
+
+        // Let it settle so the module-scope spinner refcount is not left up
+        // for the specs that follow.
+        settle();
     });
 
     test('changing the company clears both notices', () => {
@@ -208,5 +365,107 @@ describe('gateway_method intent-approved notice', () => {
 
         expect(first.orderIntentApprovedNotice()).not.toBe('');
         expect(second.orderIntentApprovedNotice()).toBe('');
+    });
+});
+
+/**
+ * The box itself. TWO-25326 (2026-08-05): one bordered container, the same
+ * three semantic colours, and the message ALONE inside it on all four
+ * plugins — PrestaShop drops its own "Buy now, pay later" title in the same
+ * batch, so a title reintroduced here would break the convergence rather
+ * than just look different.
+ */
+describe('order-intent message box markup and palette', () => {
+    const fs = require('fs');
+    const path = require('path');
+    const ROOT = path.resolve(__dirname, '..', '..');
+
+    function template() {
+        return fs
+            .readFileSync(
+                path.join(ROOT, 'view/frontend/web/template/payment/gateway_method.html'),
+                'utf8'
+            )
+            .replace(/<!--(?!\s*\/?ko\b)[\s\S]*?-->/g, '');
+    }
+
+    function stylesheet() {
+        return fs.readFileSync(path.join(ROOT, 'view/frontend/web/css/style.css'), 'utf8');
+    }
+
+    /** The declaration block of a single flat-class rule. */
+    function ruleBody(css, selector) {
+        const match = css.match(
+            new RegExp('\\n' + selector.replace(/\./g, '\\.') + '\\s*\\{([^}]*)\\}')
+        );
+        if (match === null) {
+            throw new Error('style.css has no `' + selector + '` rule');
+        }
+        return match[1];
+    }
+
+    test('all three outcomes render in the same container class, each with its own modifier', () => {
+        const markup = template();
+        ['approved', 'declined', 'error'].forEach((state) => {
+            const tag = markup.match(
+                new RegExp('<div\\b[^>]*class="two-order-intent-message ' + state + '"[^>]*>')
+            );
+            if (tag === null) {
+                throw new Error('no .two-order-intent-message.' + state + ' element');
+            }
+        });
+    });
+
+    test('the box holds the intent message and nothing else — no title element above it', () => {
+        const markup = template();
+        const blocks = markup.match(
+            /<div\b[^>]*class="two-order-intent-message [a-z]+"[\s\S]*?<\/div>/g
+        );
+        expect(blocks).toHaveLength(3);
+        blocks.forEach((block) => {
+            // A single `text:`-bound element: no nested element to put a
+            // heading in, and no literal copy in the markup either.
+            expect(block).toMatch(/data-bind="text: orderIntent\w+Notice"/);
+            expect(block).not.toMatch(/<(h\d|strong|p|span)\b/);
+        });
+        // Nor a heading immediately before the boxes.
+        expect(markup).not.toMatch(/<(h\d)\b[^>]*>[\s\S]*?two-order-intent-message/);
+    });
+
+    test('the palette is the shared semantic one: success green, danger red, neutral error', () => {
+        const css = stylesheet();
+        const approved = ruleBody(css, '.two-order-intent-message.approved');
+        expect(approved).toMatch(/border-color:\s*#28a745/);
+        expect(approved).toMatch(/background:\s*#d4edda/);
+        expect(approved).toMatch(/color:\s*#155724/);
+
+        const declined = ruleBody(css, '.two-order-intent-message.declined');
+        expect(declined).toMatch(/border-color:\s*#dc3545/);
+        expect(declined).toMatch(/background:\s*#f8d7da/);
+        expect(declined).toMatch(/color:\s*#721c24/);
+
+        // The error state deliberately carries the base neutral values rather
+        // than a third colour, matching PrestaShop.
+        const base = ruleBody(css, '.two-order-intent-message');
+        const error = ruleBody(css, '.two-order-intent-message.error');
+        expect(error).toMatch(/border-color:\s*#e9ecef/);
+        expect(error).toMatch(/background:\s*#fff\b/);
+        expect(error).toMatch(/color:\s*#495057/);
+        expect(base).toMatch(/border:\s*1px solid #e9ecef/);
+        // …and it is a bordered, padded box in the first place, which is the
+        // whole point of the convergence.
+        expect(base).toMatch(/padding:/);
+        expect(base).toMatch(/border-radius:/);
+    });
+
+    test('the in-flight row keeps the spokes GIF and puts the text beside it', () => {
+        const css = stylesheet();
+        expect(ruleBody(css, '.two-order-intent-spinner')).toMatch(
+            /background-image:\s*url\("\.\.\/images\/loader\.gif"\)/
+        );
+        expect(fs.existsSync(path.join(ROOT, 'view/frontend/web/images/loader.gif'))).toBe(true);
+        const row = ruleBody(css, '.two-order-intent-loading');
+        expect(row).toMatch(/display:\s*flex/);
+        expect(row).toMatch(/align-items:\s*center/);
     });
 });

--- a/Test/Js/gateway-method-order-intent-loader-refcount.test.js
+++ b/Test/Js/gateway-method-order-intent-loader-refcount.test.js
@@ -229,19 +229,47 @@ describe('order-intent spinner is tile-local and refcounted (TWO-25326)', () => 
         // pass or fail on documentation rather than on markup.
         const withoutComments = markup.replace(/<!--[\s\S]*?-->/g, '');
 
-        const tag = withoutComments.match(/<div\b[^>]*class="two-order-intent-spinner"[^>]*>/);
-        expect(tag).not.toBeNull();
-        expect(tag[0]).toMatch(/role="status"/);
-        // Accessible name, and translated — the figure itself is a background
-        // image with no text of its own.
-        expect(tag[0]).toMatch(/\$t\('Checking company'\)/);
+        const row = withoutComments.match(
+            /<div\b[^>]*class="two-order-intent-loading"[^>]*>[\s\S]*?<\/div>/
+        );
+        expect(row).not.toBeNull();
+        expect(row[0]).toMatch(/role="status"/);
+        // The figure itself, still the same tile-local background image.
+        expect(row[0]).toMatch(/class="two-order-intent-spinner"/);
+        // TWO-25326 (2026-08-05): the region is named by VISIBLE, translated
+        // text — the same sentence on all four plugins — and the wordless
+        // `aria-label` the figure used to carry is gone, so a screen reader
+        // does not hear the label and then the text.
+        expect(row[0]).toMatch(/i18n: 'Checking availability'/);
+        expect(row[0]).not.toMatch(/aria-label/);
+        expect(withoutComments).not.toMatch(/Checking company/);
         // Gated by `ko if:` on the flag, so the `role="status"` node is
         // INSERTED rather than un-hidden — see the template comment. Matched
         // against the RAW markup: ko's virtual bindings are themselves HTML
         // comments, so the comment-stripped copy above cannot see them.
         expect(markup).toMatch(
-            /<!--\s*ko if:\s*orderIntentInProgress\(\)\s*-->\s*<div\b[^>]*class="two-order-intent-spinner"/
+            /<!--\s*ko if:\s*orderIntentInProgress\(\)\s*-->\s*<div\b[^>]*class="two-order-intent-loading"/
         );
+
+        // The sentence is translatable for every locale this module ships, or
+        // the convergence is English-only in practice. Asserted against the
+        // shipped CSVs rather than a hard-coded locale list, so a locale added
+        // later is covered without editing this spec.
+        const i18nDir = path.resolve(__dirname, '..', '..', 'i18n');
+        const locales = fs.readdirSync(i18nDir).filter((name) => name.endsWith('.csv'));
+        expect(locales.length).toBeGreaterThan(0);
+        locales.forEach((name) => {
+            const csv = fs.readFileSync(path.join(i18nDir, name), 'utf8');
+            const translated = csv.match(/^"Checking availability","([^"]+)"$/m);
+            if (translated === null) {
+                throw new Error(name + ' has no "Checking availability" row');
+            }
+            // A row echoing the source string back is an untranslated stub.
+            expect(translated[1]).not.toBe('Checking availability');
+            // …and the retired string must not linger, or a translator sees
+            // two rows for one surface.
+            expect(csv).not.toMatch(/^"Checking company"/m);
+        });
 
         // The tile must not reach for Magento's page-covering loader markup.
         expect(withoutComments).not.toMatch(/loading-mask/);

--- a/i18n/nb_NO.csv
+++ b/i18n/nb_NO.csv
@@ -30,7 +30,7 @@
 "Branding","Merkevarebygging"
 "Business Invoice","Bedriftsfaktura"
 "Buy now, receive your goods, pay your invoice later.","Kjøp nå, motta varene dine, betal fakturaen senere."
-"Checking company","Sjekker selskap"
+"Checking availability","Sjekker tilgjengelighet"
 "Check last 100 debug log records","Sjekk siste 100 feilsøkingsloggposter"
 "Check last 100 error log records","Sjekk siste 100 feilloggposter"
 "City","By"

--- a/i18n/nl_NL.csv
+++ b/i18n/nl_NL.csv
@@ -30,7 +30,7 @@
 "Branding","Merknaam"
 "Business Invoice","Zakelijke factuur"
 "Buy now, receive your goods, pay your invoice later.","Koop nu, ontvang uw goederen, betaal uw factuur later."
-"Checking company","Bedrijf controleren"
+"Checking availability","Beschikbaarheid controleren"
 "Check last 100 debug log records","Controleer de laatste 100 debug-logboek records"
 "Check last 100 error log records","Controleer de laatste 100 foutenlogboek records"
 "City","Stad"

--- a/i18n/sv_SE.csv
+++ b/i18n/sv_SE.csv
@@ -29,7 +29,7 @@
 "Branding","Branding"
 "Business Invoice","Företagsfaktura"
 "Buy now, receive your goods, pay your invoice later.","Köp nu, få dina varor, betala din faktura senare."
-"Checking company","Kontrollerar företag"
+"Checking availability","Kontrollerar tillgänglighet"
 "Check last 100 debug log records","Kontrollera de senaste 100 felsökningsloggposterna"
 "Check last 100 error log records","Kontrollera de senaste 100 felloggposterna"
 "City","Stad"

--- a/view/frontend/web/css/style.css
+++ b/view/frontend/web/css/style.css
@@ -500,14 +500,34 @@
  * see the comment on `.two-company-search__spinner`.
  */
 .two-order-intent-spinner {
-    display: block;
+    display: inline-block;
+    flex: 0 0 auto;
     width: 16px;
     height: 16px;
-    margin: 8px 0;
     background-image: url("../images/loader.gif");
     background-repeat: no-repeat;
     background-position: left center;
     background-size: 16px 16px;
+}
+
+/*
+ * The row the spinner now sits in, with the "Checking availability" sentence
+ * beside it (TWO-25326, 2026-08-05 four-platform convergence — all four
+ * plugins show the same figure and the same sentence). The row owns the
+ * vertical margin the spinner used to carry itself, so the figure and the text
+ * cannot drift apart when a theme restyles either one.
+ */
+.two-order-intent-loading {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 8px 0;
+}
+
+.two-order-intent-loading__text {
+    color: #495057;
+    font-size: 1.3rem;
+    line-height: 1.4;
 }
 
 .two-company-search__unavailable {
@@ -656,30 +676,55 @@
     margin: 0 0 1.5em;
     padding: 10px 12px;
     border-radius: 8px;
-    border: 1px solid var(--color-gray89);
-    background: #f4f6fd;
-    color: var(--color-brownie-vanilla);
+    border: 1px solid #e9ecef;
+    background: #fff;
+    color: #495057;
     font-size: 1.3rem;
     line-height: 1.4;
 }
 
+/*
+ * TWO-25326 (2026-08-05, four-platform convergence): the palette is now the
+ * SEMANTIC one PrestaShop already uses — success green for an approval, danger
+ * red for a decline, and the box's own neutral colours for an error — rather
+ * than this module's brand blue for approval and a warm red for decline. The
+ * point of the change is that a buyer meeting two of the four plugins reads
+ * the same colour for the same outcome; the flat background (no gradient, no
+ * shadow) is Luma's rendering of it.
+ */
 .two-order-intent-message.approved {
-    border-color: #b7c0ee;
-    color: var(--color-blue2);
+    border-color: #28a745;
+    background: #d4edda;
+    color: #155724;
 }
 
 /*
  * TWO-25326 §7.3 (2026-08-03 ruling): the "not approved" counterpart to
  * `.approved` above, added when the standalone company label was removed
- * and its name/number folded into this sentence instead. A warm, muted
- * red rather than the approved blue — a business decline is not an error
- * the buyer caused, so it deliberately does not reuse `.message-error`'s
- * louder styling.
+ * and its name/number folded into this sentence instead. Recoloured
+ * 2026-08-05 to PrestaShop's danger red for cross-platform convergence
+ * (see the note on `.approved`); it is still this box's own styling and
+ * not Magento's `.message-error`, because a business decline is not an
+ * error the buyer caused.
  */
 .two-order-intent-message.declined {
-    border-color: #e0b7b7;
-    background: #fdf4f4;
-    color: #8a3b3b;
+    border-color: #dc3545;
+    background: #f8d7da;
+    color: #721c24;
+}
+
+/*
+ * The check itself failed (TWO-25326, 2026-08-05). Same container, and
+ * deliberately the base neutral palette rather than a third colour: matching
+ * PrestaShop, which strips its approved/declined classes for this case. The
+ * rule exists explicitly, with nothing but the base values in it, so the
+ * error state is greppable next to its siblings and a later edit to the base
+ * cannot silently repaint it.
+ */
+.two-order-intent-message.error {
+    border-color: #e9ecef;
+    background: #fff;
+    color: #495057;
 }
 
 /*

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -610,6 +610,63 @@ define([
         isOrderIntentDeclinedNoticeVisible: function () {
             return !!(this.orderIntentDeclinedNotice && this.orderIntentDeclinedNotice());
         },
+        /**
+         * Same guard, for the order-intent ERROR notice (TWO-25326,
+         * 2026-08-05 four-platform convergence). The error text renders in
+         * the same bordered box as the other two outcomes instead of a
+         * checkout toast — see processOrderIntentErrorResponse().
+         *
+         * @returns {boolean}
+         */
+        isOrderIntentErrorNoticeVisible: function () {
+            return !!(this.orderIntentErrorNotice && this.orderIntentErrorNotice());
+        },
+        /**
+         * Blank all three order-intent outcome notices.
+         *
+         * Called at the START of every order-intent check as well as from the
+         * company-change subscriptions, because the two are not the same
+         * event and only one of them is guaranteed to fire. The subscriptions
+         * fire on a company OBSERVABLE CHANGING; a check can start with the
+         * observables already holding those values (a re-render re-applying
+         * the captured company, a repeat pick of the company already in the
+         * field), and ko notifies nothing then. Before this, the box kept the
+         * PREVIOUS company's verdict on screen for the whole of the new
+         * request in exactly those cases — a stale approval sitting under a
+         * spinner that is checking something else.
+         *
+         * Guarded on each observable's existence: initialize() creates them
+         * in initOrderIntentApprovedNotice(), and fillCompanyData() is
+         * reachable from contexts (and specs) that never ran it.
+         *
+         * @returns {void}
+         */
+        clearOrderIntentNotices: function () {
+            if (this.orderIntentApprovedNotice) this.orderIntentApprovedNotice('');
+            if (this.orderIntentDeclinedNotice) this.orderIntentDeclinedNotice('');
+            if (this.orderIntentErrorNotice) this.orderIntentErrorNotice('');
+        },
+        /**
+         * Put an order-intent failure in the tile's own bordered box rather
+         * than the checkout message region (TWO-25326, 2026-08-05): the
+         * region is cleared on every checkout update, which is how a buyer
+         * ended up with a spinner that vanished and nothing else to read.
+         *
+         * Falls back to the toast when the observable is absent, which is the
+         * pre-initialize() case the sibling `is…Visible()` guards protect
+         * against — an error is the one message that must not be swallowed
+         * because its own surface was not wired yet.
+         *
+         * @param {string} message
+         * @returns {void}
+         */
+        showOrderIntentErrorNotice: function (message) {
+            if (this.orderIntentErrorNotice) {
+                this.orderIntentErrorNotice(message);
+                return;
+            }
+            this.showErrorMessage(message);
+        },
         selectTerm: function (days) {
             surchargeModel.selectTerm(days);
         },
@@ -674,6 +731,11 @@ define([
                     return;
                 }
                 this._orderIntentInFlightFor = companyId;
+                // The previous verdict goes as the new check STARTS, not when
+                // its answer arrives (TWO-25326, 2026-08-05). See
+                // clearOrderIntentNotices() for why the company-change
+                // subscriptions do not already cover this.
+                this.clearOrderIntentNotices();
                 startOrderIntentSpinner();
                 const self = this;
                 let deferred;
@@ -711,7 +773,10 @@ define([
                     console.error({ logger: 'twoPayment.fillCompanyData.placeOrderIntent', error });
                     stopOrderIntentSpinner();
                     self._orderIntentInFlightFor = null;
-                    self.showErrorMessage(self.generalErrorMessage);
+                    // Same surface as processOrderIntentErrorResponse()'s
+                    // message (TWO-25326, 2026-08-05): a synchronous throw and
+                    // a failed request are the same outcome to the buyer.
+                    self.showOrderIntentErrorNotice(self.generalErrorMessage);
                     return;
                 }
                 deferred
@@ -1310,6 +1375,14 @@ define([
             this.orderIntentDeclinedNoticeCopy = config.orderIntentDeclinedNotice || null;
             this.orderIntentDeclinedNotice = ko.observable('');
 
+            // TWO-25326 (2026-08-05 four-platform convergence): the third
+            // outcome, "the check errored", in the same bordered box. No
+            // brand-supplied copy behind it and no suppression switch — the
+            // text is the renderer's own error message, and a brand that
+            // declines to state a verdict has not thereby asked for failures
+            // to be silent. Per-instance for the same reason as the two above.
+            this.orderIntentErrorNotice = ko.observable('');
+
             // The notice is *persistent* — unlike the message-region
             // treatment it replaces, it survives checkout updates and a
             // failed placeOrder validation (see the deliberate omission in
@@ -1323,12 +1396,10 @@ define([
             // them cleared, which is the correct fail-closed outcome.
             var self = this;
             this.companyName.subscribe(function () {
-                self.orderIntentApprovedNotice('');
-                self.orderIntentDeclinedNotice('');
+                self.clearOrderIntentNotices();
             });
             this.companyId.subscribe(function () {
-                self.orderIntentApprovedNotice('');
-                self.orderIntentDeclinedNotice('');
+                self.clearOrderIntentNotices();
             });
         },
         /**
@@ -1395,8 +1466,8 @@ define([
                     // getRegion('messages') region this renderer used before
                     // is cleared on every checkout update, so on Luma the
                     // approval reassurance was effectively never seen.
+                    this.clearOrderIntentNotices();
                     this.orderIntentApprovedNotice(this.resolveOrderIntentApprovedNotice());
-                    this.orderIntentDeclinedNotice('');
                 } else {
                     // TWO-25326 §7.3 (2026-08-03 ruling): a clean "not
                     // approved" response is a business outcome, not a
@@ -1404,16 +1475,17 @@ define([
                     // tile-notice treatment as approval — a toast that a
                     // later checkout update wipes is not "the tile shows
                     // ONLY the intent message" the ruling asks for.
-                    this.orderIntentApprovedNotice('');
+                    this.clearOrderIntentNotices();
                     this.orderIntentDeclinedNotice(this.resolveOrderIntentDeclinedNotice());
                 }
             }
         },
         processOrderIntentErrorResponse: function (response) {
             // An intent that errored says nothing about approval; drop any
-            // notice from a previous, successful intent.
-            this.orderIntentApprovedNotice('');
-            this.orderIntentDeclinedNotice('');
+            // notice from a previous, successful intent — including a previous
+            // error, so a second attempt does not stack two boxes' worth of
+            // text or leave the first error's wording under a newer one.
+            this.clearOrderIntentNotices();
 
             // `let`, not `const`: the SCHEMA_ERROR branch below reassigns
             // this to '' once it has pushed the field-level errors into
@@ -1458,7 +1530,13 @@ define([
                 }
             }
             if (message) {
-                this.showErrorMessage(message);
+                // The tile's own bordered box, not the checkout message
+                // region (TWO-25326, 2026-08-05). SCHEMA_ERROR is the one
+                // exception and it opts itself out by blanking `message`
+                // above: those are per-FIELD validation errors, several at a
+                // time, which belong with the fields and not in a box that
+                // states one outcome.
+                this.showOrderIntentErrorNotice(message);
             }
         },
         processTermsNotAcceptedErrorResponse: function (response) {

--- a/view/frontend/web/template/payment/gateway_method.html
+++ b/view/frontend/web/template/payment/gateway_method.html
@@ -106,18 +106,28 @@
             uses).
 
             `ko if:`, not `visible:`, and that is an accessibility choice
-            rather than a stylistic one: the figure is a background image with
-            no text content of its own, so a `role="status"` region that is
+            rather than a stylistic one: a `role="status"` region that is
             merely un-hidden announces nothing on most screen readers, while one
             INSERTED into the document does. There is no race to lose by it —
             bindings are applied before any order-intent request can start.
+
+            TWO-25326 (2026-08-05, four-platform convergence): the spinner is
+            no longer text-less. All four plugins now show the SAME spokes
+            figure next to the SAME sentence, "Checking availability" — Luma
+            and WooCommerce previously showed a wordless figure and PrestaShop
+            and Hyva showed two different sentences. The visible text is what
+            names the region, so the figure carries `aria-hidden` and there is
+            no `aria-label` any more: a labelled `role="status"` wrapping
+            visible text is announced twice.
         -->
         <!-- ko if: orderIntentInProgress() -->
-        <div
-            class="two-order-intent-spinner"
-            role="status"
-            data-bind="attr: {'aria-label': $t('Checking company')}"
-        ></div>
+        <div class="two-order-intent-loading" role="status">
+            <span class="two-order-intent-spinner" aria-hidden="true"></span>
+            <span
+                class="two-order-intent-loading__text"
+                data-bind="i18n: 'Checking availability'"
+            ></span>
+        </div>
         <!-- /ko -->
         <!-- ko if: isOrderIntentApprovedNoticeVisible() -->
         <div
@@ -131,6 +141,28 @@
             class="two-order-intent-message declined"
             role="status"
             data-bind="text: orderIntentDeclinedNotice"
+        ></div>
+        <!-- /ko -->
+        <!--
+            TWO-25326 (2026-08-05, four-platform convergence): the THIRD
+            outcome of an order-intent check — it errored — now renders in the
+            same bordered box as approval and decline, instead of only as a
+            checkout toast that the next checkout update wipes. PrestaShop is
+            the reference: it shows all three outcomes in one container and
+            drops the approved/declined colour for the error case, so this
+            modifier is deliberately the box's neutral palette rather than
+            Magento's `.message-error`.
+
+            Not gated on the brand's intent-message suppression switch, unlike
+            the two above: an error is not the intent verdict a brand can
+            choose not to state, it is the buyer's only sign that the check did
+            not happen.
+        -->
+        <!-- ko if: isOrderIntentErrorNoticeVisible() -->
+        <div
+            class="two-order-intent-message error"
+            role="alert"
+            data-bind="text: orderIntentErrorNotice"
         ></div>
         <!-- /ko -->
         <!-- ko if: showModeTab -->


### PR DESCRIPTION
## What

Unifies the order-intent checking UI on Luma with the other three plugins (TWO-25326).

Before, Luma showed a wordless spinner while the check ran, then stated an approval in the module's brand blue, a decline in a warm red, and an error only as a checkout toast. Each plugin looked different.

Now:

1. **During the check** — the same spokes figure (`images/loader.gif`, already shipped) with the sentence **"Checking availability"** beside it. Translated in every locale this module ships (nb_NO, nl_NL, sv_SE); the retired `Checking company` row is removed from all of them. The visible text names the `role="status"` region, so the figure carries `aria-hidden` and the old `aria-label` is gone.
2. **The result** — all three outcomes (approved, declined, errored) render in the one bordered box, with the semantic palette: success green for an approval, danger red for a decline, the box's neutral colours for an error. The intent message is the only thing inside it — no title above it. The error case previously had no persistent surface at all: it went to the checkout message region, which is cleared on the next checkout update.
3. **Stale verdict** — the previous outcome is cleared as a new check **starts**, not when its answer arrives.

## Why (3) was actually broken

The company-change subscriptions looked like they covered it, and they do not. They fire when a company observable *changes*; a check can start with those observables already holding the same values — a re-render re-applying the captured company, or a repeat pick of the company already in the field — and knockout notifies nobody. In exactly those cases the previous company's approval stayed on screen for the whole of the next request, under a spinner checking something else.

## Tests

`npm run test:js` — 29 suites, 383 tests, green. New/changed coverage:

- the in-flight row: spokes GIF retained, text beside it, `aria-label` gone, and every shipped locale CSV carries a non-stub translation of the new string (asserted against the CSVs on disk, so a locale added later is covered without editing the spec)
- all three outcomes share the container class, each box holds only its `text:`-bound message and no heading
- the semantic palette values
- error goes to the box and not the toast; a brand suppressing the verdict does not silence it; `SCHEMA_ERROR`'s per-field errors still go to the fields
- the verdict is cleared *during* a new check, asserted with an observable that has real knockout's equality semantics — the AMD harness's double notifies on every write, which would have made that assertion vacuous

Mutation-checked: removing the clear-at-start call fails exactly one spec.

## Notes

The palette values match the reference box style being normalised on PrestaShop in the same batch, so a buyer meeting two of the four plugins reads the same colour for the same outcome. No brand overlay styles these classes, so nothing downstream is silently overridden.
