### PR TITLE
fix(TWO-25365): stop sending the merchant storefront URL as the buyer company website

### DIFF
--- a/Test/Js/gateway-method-order-intent-request-body.test.js
+++ b/Test/Js/gateway-method-order-intent-request-body.test.js
@@ -8,9 +8,10 @@
  * Luma used to send `buyer.company.website = window.BASE_URL`. That global is
  * the MERCHANT's own storefront URL, so every order intent claimed the
  * merchant's site as the buying company's website — wrong data under a field
- * name that says something else. Nothing downstream reads it (the field is not
- * part of the request Luma is meant to send, and the Hyvä payment component
- * never sent it), so it is gone rather than re-sourced.
+ * name that says something else. The field is not part of the request this
+ * renderer is meant to send, and this module's own PHP order-create path
+ * (`Service\Order`) never sent it either, so it is gone rather than re-sourced
+ * from somewhere else. See TWO-25365 for the API-side reference.
  *
  * The behavioural spec below composes a real request body and asserts on the
  * JSON that would go on the wire, with `window.BASE_URL` deliberately SET — a
@@ -76,7 +77,11 @@ function loadRenderer() {
                     price: '90.00',
                     tax_amount: '21.60',
                     tax_percent: '24',
-                    thumbnail: 'https://merchant-storefront.example/widget.png',
+                    // A DIFFERENT host from STOREFRONT_URL on purpose: a
+                    // product image legitimately carries a merchant-hosted URL,
+                    // and the whole-body guard below would otherwise trip on it
+                    // instead of on the defect.
+                    thumbnail: 'https://cdn.example/media/widget.png',
                     is_virtual: '0'
                 }
             ];
@@ -143,24 +148,41 @@ describe('order-intent request body omits buyer.company.website (TWO-25365)', ()
             country_prefix: 'NO',
             company_name: 'Acme Widgets AS'
         });
-        expect('website' in body.buyer.company).toBe(false);
-        // Belt and braces on the specific defect: the storefront URL must not
-        // appear anywhere in the buyer object under any key.
-        expect(JSON.stringify(body.buyer)).not.toContain(STOREFRONT_URL);
+        // The exact-shape assertion above already pins the key set, so a
+        // separate `'website' in …` check would be dead: JSON.parse produces no
+        // undefined-valued keys, and any defined value fails the toEqual.
+        //
+        // What toEqual canNOT see is the URL reappearing somewhere else in the
+        // body — adversarial review reached a passing `store_url:
+        // window['BASE_' + 'URL']` sitting beside `merchant_id`, outside
+        // `buyer` and past both source-text regexes below. The merchant's own
+        // storefront URL has no business anywhere in this request, so the guard
+        // is on the WHOLE body rather than on the buyer object.
+        expect(JSON.stringify(body)).not.toContain(STOREFRONT_URL);
     });
 
     test('the source no longer reads window.BASE_URL', () => {
-        // The behavioural spec above proves the key is absent from the body
-        // it composes; this pins the GLOBAL itself as unused, so a later
-        // change cannot reintroduce the merchant URL into some other field
-        // without a spec failing.
+        // The behavioural spec above proves the key is absent from the body it
+        // composes; this pins the GLOBAL itself as unused, so a later change
+        // cannot reintroduce the merchant URL down a path this spec's fixture
+        // does not happen to exercise.
         const fs = require('fs');
         const path = require('path');
         const src = fs.readFileSync(path.resolve(__dirname, '..', '..', RENDERER), 'utf8');
+        // COMMENTS STRIPPED, because the rationale prose that documents this
+        // very fix names `window.BASE_URL` — a check matched against the raw
+        // text would go red on someone explaining the change, i.e. fail on
+        // documentation rather than on code. Proved in adversarial review.
+        const code = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
 
-        expect(src).not.toMatch(/BASE_URL/);
-        // Narrow on purpose: the KEY, not the word. Magento's own
-        // website-scope vocabulary is legitimate prose in this file.
-        expect(src).not.toMatch(/\bwebsite\s*:/);
+        expect(code).not.toMatch(/BASE_URL/);
+        // The plain-literal key form only — `'website':`, a computed
+        // `['web' + 'site']` and a newline before the colon all slip past this.
+        // That is fine: those are the mutations the behavioural spec above
+        // catches, and this line exists for the reverse case (the global read
+        // somewhere the fixture never reaches). Narrow on the KEY rather than
+        // the word because Magento's own website-scope vocabulary is legitimate
+        // prose in this file.
+        expect(code).not.toMatch(/\bwebsite\s*:/);
     });
 });

--- a/Test/Js/gateway-method-order-intent-request-body.test.js
+++ b/Test/Js/gateway-method-order-intent-request-body.test.js
@@ -1,0 +1,166 @@
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ *
+ * TWO-25365 — the order-intent request's `buyer.company` object carries only
+ * fields about the BUYER's company.
+ *
+ * Luma used to send `buyer.company.website = window.BASE_URL`. That global is
+ * the MERCHANT's own storefront URL, so every order intent claimed the
+ * merchant's site as the buying company's website — wrong data under a field
+ * name that says something else. Nothing downstream reads it (the field is not
+ * part of the request Luma is meant to send, and the Hyvä payment component
+ * never sent it), so it is gone rather than re-sourced.
+ *
+ * The behavioural spec below composes a real request body and asserts on the
+ * JSON that would go on the wire, with `window.BASE_URL` deliberately SET — a
+ * spec run against a sandbox with no BASE_URL would pass on the missing global
+ * rather than on the composition.
+ */
+
+'use strict';
+
+const { loadAmdModule, defaultMocks } = require('./amd-harness');
+
+const RENDERER = 'view/frontend/web/js/view/payment/method-renderer/gateway_method.js';
+
+const STOREFRONT_URL = 'https://merchant-storefront.example/';
+
+/**
+ * Load the renderer with a quote double carrying one physical line item and a
+ * complete set of totals, plus a jQuery double that RECORDS the `$.ajax`
+ * options instead of issuing a request.
+ *
+ * @returns {{component: object, requests: object[]}}
+ */
+function loadRenderer() {
+    const requests = [];
+    const $ = defaultMocks().jquery;
+
+    $.ajax = function (options) {
+        requests.push(options);
+        return {
+            done: function () { return this; },
+            fail: function () { return this; },
+            always: function () { return this; }
+        };
+    };
+
+    const totals = {
+        grand_total: '124.00',
+        tax_amount: '24.00',
+        shipping_incl_tax: '12.40',
+        shipping_amount: '10.00',
+        shipping_tax_amount: '2.40',
+        quote_currency_code: 'NOK'
+    };
+
+    const quote = {
+        getTotals: function () { return function () { return totals; }; },
+        billingAddress: function () {
+            return {
+                countryId: 'NO',
+                firstname: 'Ola',
+                lastname: 'Nordmann'
+            };
+        },
+        getItems: function () {
+            return [
+                {
+                    name: 'Widget',
+                    description: 'A widget',
+                    discount_amount: '0.00',
+                    row_total_incl_tax: '111.60',
+                    row_total: '90.00',
+                    qty: 1,
+                    price: '90.00',
+                    tax_amount: '21.60',
+                    tax_percent: '24',
+                    thumbnail: 'https://merchant-storefront.example/widget.png',
+                    is_virtual: '0'
+                }
+            ];
+        },
+        isVirtual: function () { return false; },
+        shippingMethod: function () { return { carrier_code: 'flatrate' }; },
+        guestEmail: 'ola@example.com'
+    };
+
+    const component = loadAmdModule(
+        RENDERER,
+        { jquery: $, 'Magento_Checkout/js/model/quote': quote },
+        {
+            // BASE_URL present and non-empty on purpose — see the file header.
+            window: {
+                BASE_URL: STOREFRONT_URL,
+                checkoutConfig: {
+                    payment: {},
+                    customerData: { email: 'ola@example.com' }
+                }
+            }
+        }
+    );
+
+    return { component: component, requests: requests };
+}
+
+/**
+ * A `this` context standing in for a live renderer instance, with just the
+ * members placeOrderIntent() reads.
+ *
+ * @param {object} component the loaded renderer
+ * @returns {object} the context
+ */
+function makeContext(component) {
+    return Object.assign({}, component, {
+        companyId: function () { return '923456789'; },
+        companyName: function () { return 'Acme Widgets AS'; },
+        getTelephone: function () { return '+4712345678'; },
+        _brandConfig: {
+            checkoutApiUrl: 'https://api.example.two.inc',
+            orderIntentConfig: {
+                weightUnit: 'kg',
+                extensionPlatformName: 'magento2',
+                extensionDBVersion: '1.0.0',
+                merchant: { id: 'm-1', short_name: 'acme' }
+            }
+        }
+    });
+}
+
+describe('order-intent request body omits buyer.company.website (TWO-25365)', () => {
+    test('the composed request sends no `website` key at all', () => {
+        const { component, requests } = loadRenderer();
+        const ctx = makeContext(component);
+
+        ctx.placeOrderIntent.call(ctx);
+
+        expect(requests).toHaveLength(1);
+        const body = JSON.parse(requests[0].data);
+
+        expect(body.buyer.company).toEqual({
+            organization_number: '923456789',
+            country_prefix: 'NO',
+            company_name: 'Acme Widgets AS'
+        });
+        expect('website' in body.buyer.company).toBe(false);
+        // Belt and braces on the specific defect: the storefront URL must not
+        // appear anywhere in the buyer object under any key.
+        expect(JSON.stringify(body.buyer)).not.toContain(STOREFRONT_URL);
+    });
+
+    test('the source no longer reads window.BASE_URL', () => {
+        // The behavioural spec above proves the key is absent from the body
+        // it composes; this pins the GLOBAL itself as unused, so a later
+        // change cannot reintroduce the merchant URL into some other field
+        // without a spec failing.
+        const fs = require('fs');
+        const path = require('path');
+        const src = fs.readFileSync(path.resolve(__dirname, '..', '..', RENDERER), 'utf8');
+
+        expect(src).not.toMatch(/BASE_URL/);
+        // Narrow on purpose: the KEY, not the word. Magento's own
+        // website-scope vocabulary is legitimate prose in this file.
+        expect(src).not.toMatch(/\bwebsite\s*:/);
+    });
+});

--- a/Test/Js/gateway-method-order-intent-request-body.test.js
+++ b/Test/Js/gateway-method-order-intent-request-body.test.js
@@ -28,13 +28,12 @@ const RENDERER = 'view/frontend/web/js/view/payment/method-renderer/gateway_meth
 const STOREFRONT_URL = 'https://merchant-storefront.example/';
 
 /**
- * The host alone, matched separately from the full URL above.
- *
- * Magento's `BASE_URL` always ends in a slash, so stripping the trailing slash
- * is the most natural thing a reintroduction would do — and adversarial review
- * proved four such normalisations (`replace(/[/]+$/, '')`, `split('://')[1]`,
- * `encodeURIComponent()`, `toUpperCase()`) sailing past an exact match on the
- * full URL. The host token survives all four.
+ * The host alone, matched separately from the full URL above, because
+ * normalising the value defeats an exact match — Magento's base URL always ends
+ * in a slash, so stripping it is the obvious thing a reintroduction would do.
+ * Adversarial review got four such forms past the full-URL check
+ * (trailing-slash strip, scheme strip, percent-encode, upper-case); the host
+ * token survives all of them.
  *
  * Deliberately NOT shortened to `example`: the fixture's product-image host
  * shares that suffix, so the assertion would fire on a legitimate field.
@@ -91,10 +90,12 @@ function loadRenderer() {
                     price: '90.00',
                     tax_amount: '21.60',
                     tax_percent: '24',
-                    // A DIFFERENT host from STOREFRONT_URL on purpose: a
-                    // product image legitimately carries a merchant-hosted URL,
-                    // and the whole-body guard below would otherwise trip on it
-                    // instead of on the defect.
+                    // A DIFFERENT host from STOREFRONT_URL, and it must STAY
+                    // different: in production this really is the storefront
+                    // base plus `media/...`, so "making the fixture realistic"
+                    // would trip the whole-body guard below with no defect
+                    // present. The guard exists for the merchant URL arriving as
+                    // a company field, which a product image is not.
                     thumbnail: 'https://cdn.example/media/widget.png',
                     is_virtual: '0'
                 }
@@ -107,7 +108,22 @@ function loadRenderer() {
 
     const component = loadAmdModule(
         RENDERER,
-        { jquery: $, 'Magento_Checkout/js/model/quote': quote },
+        {
+            jquery: $,
+            'Magento_Checkout/js/model/quote': quote,
+            // `mage/url` is the OTHER live route to the storefront URL — this
+            // renderer already injects it and calls `url.build(...)` elsewhere.
+            // The harness default returns its argument unchanged, so
+            // `url.build('')` yields '' and a reintroduction through it would be
+            // invisible to the wire assertions. Adversarial review got two such
+            // mutations past this spec, one of them under the removed field's
+            // exact name. Resolving to the real storefront root, as the browser
+            // does, is what makes the body guard cover both routes.
+            'mage/url': {
+                build: function (path) { return STOREFRONT_URL + (path || ''); },
+                setBaseUrl: function () {}
+            }
+        },
         {
             // BASE_URL present and non-empty on purpose — see the file header.
             window: {
@@ -181,43 +197,42 @@ describe('order-intent request body omits buyer.company.website (TWO-25365)', ()
         expect(wire.toLowerCase()).not.toContain(STOREFRONT_HOST);
     });
 
-    test('the source no longer reads window.BASE_URL', () => {
-        // The behavioural spec above proves the key is absent from the body it
-        // composes. This covers the reverse risk: the global read on a path the
-        // fixture never exercises — a country branch, a later mutation of the
-        // composed object — which no single fixture can reach.
+    test('the renderer reintroduces the field on no path, exercised or not', () => {
+        // The behavioural spec above only sees the ONE path its fixture takes.
+        // This covers the reverse risk: the field or the global reappearing on a
+        // path no single fixture reaches — a country branch, a mutation of the
+        // composed object after the literal.
         const fs = require('fs');
         const path = require('path');
         const src = fs.readFileSync(path.resolve(__dirname, '..', '..', RENDERER), 'utf8');
-        // COMMENTS STRIPPED, because the rationale prose that documents this
-        // very fix names `window.BASE_URL` — a check matched against the raw
-        // text would go red on someone explaining the change, i.e. fail on
-        // documentation rather than on code. Proved in adversarial review.
+        // Comments stripped, or this check fails on DOCUMENTATION rather than on
+        // code: prose explaining this very fix necessarily names the global, and
+        // round 1 proved a raw-text match going red on exactly that.
         //
-        // Only the two comment forms this file actually uses: JSDoc blocks and
-        // WHOLE-LINE `//`. A general strip is what the previous round used and
-        // it silently WEAKENS this check rather than breaking it — adversarial
-        // review proved both halves: `//` inside a string literal
-        // (`'https://x'`) deletes the rest of that line, and an unanchored
-        // block strip lets a single `'/*'` string constant open a fake comment
-        // that swallows 400+ real lines. Neither construct is in the file
-        // today; the point is that nothing would surface when one arrives.
+        // Only the two comment forms this file uses — JSDoc blocks and
+        // whole-line `//`. A general strip silently WEAKENS the check instead of
+        // breaking it: `//` inside a string literal eats the rest of that line,
+        // and one `'/*'` string constant opens a fake comment swallowing
+        // hundreds of real lines. Neither shape is in the file today; the point
+        // is that nothing would surface when one arrives.
         const code = src
             .replace(/\/\*\*[\s\S]*?\*\//g, '')
             .replace(/^[ \t]*\/\/[^\n]*$/gm, '');
 
-        // Narrowed to the actual global. A bare /BASE_URL/ also reddens on
-        // `TWO_API_BASE_URL` / `TWO_CHECKOUT_BASE_URL`, which are live
-        // vocabulary elsewhere in this module.
-        expect(code).not.toMatch(/window\s*\.\s*BASE_URL/);
-        // …and the computed form the same review used to evade that regex.
-        // Zero legitimate `window[...]` accesses exist in this file.
+        // The bare token, not `window.BASE_URL`: narrowing to the member access
+        // let `const { BASE_URL } = window` through, and this file contains no
+        // other `*BASE_URL` name to false-positive on (the local-dev env vars of
+        // that shape live in PHP config and shell, which this never reads).
+        expect(code).not.toMatch(/\bBASE_URL\b/);
+        // The computed form evades the token check entirely
+        // (`window['BASE_' + 'URL']`), and this file has no legitimate computed
+        // window access, so banning the construct costs nothing here.
         expect(code).not.toMatch(/window\s*\[/);
-        // Assignment as well as the object-literal key, since a reintroduction
-        // on an unexercised path would most likely mutate the composed object
-        // after the literal (`…company.website = …`) rather than edit it.
-        // Narrow on the KEY rather than the word: Magento's own website-scope
-        // vocabulary is legitimate prose in this file.
-        expect(code).not.toMatch(/\bweb_?site\s*[:=]/);
+        // No `\b` before `web`: the boundary fails after an underscore, so
+        // `company_website:` — a likely name if the field moves out of
+        // `buyer.company` — slipped past. Assignment as well as the literal key,
+        // for the after-the-fact mutation case. Still the KEY rather than the
+        // bare word, so ordinary prose about Magento's website scope stays legal.
+        expect(code).not.toMatch(/web_?site\s*[:=]/);
     });
 });

--- a/Test/Js/gateway-method-order-intent-request-body.test.js
+++ b/Test/Js/gateway-method-order-intent-request-body.test.js
@@ -28,6 +28,20 @@ const RENDERER = 'view/frontend/web/js/view/payment/method-renderer/gateway_meth
 const STOREFRONT_URL = 'https://merchant-storefront.example/';
 
 /**
+ * The host alone, matched separately from the full URL above.
+ *
+ * Magento's `BASE_URL` always ends in a slash, so stripping the trailing slash
+ * is the most natural thing a reintroduction would do — and adversarial review
+ * proved four such normalisations (`replace(/[/]+$/, '')`, `split('://')[1]`,
+ * `encodeURIComponent()`, `toUpperCase()`) sailing past an exact match on the
+ * full URL. The host token survives all four.
+ *
+ * Deliberately NOT shortened to `example`: the fixture's product-image host
+ * shares that suffix, so the assertion would fire on a legitimate field.
+ */
+const STOREFRONT_HOST = 'merchant-storefront.example';
+
+/**
  * Load the renderer with a quote double carrying one physical line item and a
  * complete set of totals, plus a jQuery double that RECORDS the `$.ajax`
  * options instead of issuing a request.
@@ -158,14 +172,20 @@ describe('order-intent request body omits buyer.company.website (TWO-25365)', ()
         // `buyer` and past both source-text regexes below. The merchant's own
         // storefront URL has no business anywhere in this request, so the guard
         // is on the WHOLE body rather than on the buyer object.
-        expect(JSON.stringify(body)).not.toContain(STOREFRONT_URL);
+        //
+        // Two tokens, not one: the full URL, and the bare host for the
+        // normalised forms an exact match cannot see (see STOREFRONT_HOST).
+        // Lower-cased for the guard so an upper-cased value cannot slip by.
+        const wire = JSON.stringify(body);
+        expect(wire).not.toContain(STOREFRONT_URL);
+        expect(wire.toLowerCase()).not.toContain(STOREFRONT_HOST);
     });
 
     test('the source no longer reads window.BASE_URL', () => {
         // The behavioural spec above proves the key is absent from the body it
-        // composes; this pins the GLOBAL itself as unused, so a later change
-        // cannot reintroduce the merchant URL down a path this spec's fixture
-        // does not happen to exercise.
+        // composes. This covers the reverse risk: the global read on a path the
+        // fixture never exercises — a country branch, a later mutation of the
+        // composed object — which no single fixture can reach.
         const fs = require('fs');
         const path = require('path');
         const src = fs.readFileSync(path.resolve(__dirname, '..', '..', RENDERER), 'utf8');
@@ -173,16 +193,31 @@ describe('order-intent request body omits buyer.company.website (TWO-25365)', ()
         // very fix names `window.BASE_URL` — a check matched against the raw
         // text would go red on someone explaining the change, i.e. fail on
         // documentation rather than on code. Proved in adversarial review.
-        const code = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+        //
+        // Only the two comment forms this file actually uses: JSDoc blocks and
+        // WHOLE-LINE `//`. A general strip is what the previous round used and
+        // it silently WEAKENS this check rather than breaking it — adversarial
+        // review proved both halves: `//` inside a string literal
+        // (`'https://x'`) deletes the rest of that line, and an unanchored
+        // block strip lets a single `'/*'` string constant open a fake comment
+        // that swallows 400+ real lines. Neither construct is in the file
+        // today; the point is that nothing would surface when one arrives.
+        const code = src
+            .replace(/\/\*\*[\s\S]*?\*\//g, '')
+            .replace(/^[ \t]*\/\/[^\n]*$/gm, '');
 
-        expect(code).not.toMatch(/BASE_URL/);
-        // The plain-literal key form only — `'website':`, a computed
-        // `['web' + 'site']` and a newline before the colon all slip past this.
-        // That is fine: those are the mutations the behavioural spec above
-        // catches, and this line exists for the reverse case (the global read
-        // somewhere the fixture never reaches). Narrow on the KEY rather than
-        // the word because Magento's own website-scope vocabulary is legitimate
-        // prose in this file.
-        expect(code).not.toMatch(/\bwebsite\s*:/);
+        // Narrowed to the actual global. A bare /BASE_URL/ also reddens on
+        // `TWO_API_BASE_URL` / `TWO_CHECKOUT_BASE_URL`, which are live
+        // vocabulary elsewhere in this module.
+        expect(code).not.toMatch(/window\s*\.\s*BASE_URL/);
+        // …and the computed form the same review used to evade that regex.
+        // Zero legitimate `window[...]` accesses exist in this file.
+        expect(code).not.toMatch(/window\s*\[/);
+        // Assignment as well as the object-literal key, since a reintroduction
+        // on an unexercised path would most likely mutate the composed object
+        // after the literal (`…company.website = …`) rather than edit it.
+        // Narrow on the KEY rather than the word: Magento's own website-scope
+        // vocabulary is legitimate prose in this file.
+        expect(code).not.toMatch(/\bweb_?site\s*[:=]/);
     });
 });

--- a/Test/Js/gateway-method-order-intent-request-body.test.js
+++ b/Test/Js/gateway-method-order-intent-request-body.test.js
@@ -209,30 +209,44 @@ describe('order-intent request body omits buyer.company.website (TWO-25365)', ()
         // code: prose explaining this very fix necessarily names the global, and
         // round 1 proved a raw-text match going red on exactly that.
         //
-        // Only the two comment forms this file uses — JSDoc blocks and
-        // whole-line `//`. A general strip silently WEAKENS the check instead of
-        // breaking it: `//` inside a string literal eats the rest of that line,
-        // and one `'/*'` string constant opens a fake comment swallowing
-        // hundreds of real lines. Neither shape is in the file today; the point
-        // is that nothing would surface when one arrives.
+        // The three comment forms this file uses: JSDoc blocks, whole-line `//`,
+        // and TRAILING `//` after code (there is one at the `termsAccepted`
+        // observable). The trailing form was missed for two rounds, which left
+        // the false-red channel open — appending `// no BASE_URL here` to a line
+        // of code still reddened this check.
+        //
+        // Each strip is deliberately narrow, because a general one silently
+        // WEAKENS the check rather than breaking it: `//` inside a string
+        // literal eats the rest of that line, and one `'/*'` string constant
+        // opens a fake comment swallowing hundreds of real lines. Hence the
+        // quote exclusion on the trailing form — it declines to strip rather
+        // than risk eating a URL in a string, which is the safe direction.
         const code = src
             .replace(/\/\*\*[\s\S]*?\*\//g, '')
-            .replace(/^[ \t]*\/\/[^\n]*$/gm, '');
+            .replace(/^[ \t]*\/\/[^\n]*$/gm, '')
+            .replace(/[ \t]\/\/[^\n'"]*$/gm, '');
 
         // The bare token, not `window.BASE_URL`: narrowing to the member access
-        // let `const { BASE_URL } = window` through, and this file contains no
-        // other `*BASE_URL` name to false-positive on (the local-dev env vars of
-        // that shape live in PHP config and shell, which this never reads).
+        // let `const { BASE_URL } = window` through. No false-positive risk —
+        // this file contains no `BASE_URL` of any kind, and the leading `\b`
+        // could not match the `TWO_*_BASE_URL` env-var names anyway (a word
+        // boundary fails after an underscore, the same property exploited below).
         expect(code).not.toMatch(/\bBASE_URL\b/);
-        // The computed form evades the token check entirely
-        // (`window['BASE_' + 'URL']`), and this file has no legitimate computed
-        // window access, so banning the construct costs nothing here.
-        expect(code).not.toMatch(/window\s*\[/);
         // No `\b` before `web`: the boundary fails after an underscore, so
         // `company_website:` — a likely name if the field moves out of
         // `buyer.company` — slipped past. Assignment as well as the literal key,
         // for the after-the-fact mutation case. Still the KEY rather than the
         // bare word, so ordinary prose about Magento's website scope stays legal.
         expect(code).not.toMatch(/web_?site\s*[:=]/);
+
+        // What this deliberately does NOT catch, so the guards above are not
+        // read as more than they are: the URL reappearing on an unexercised
+        // branch under a name no regex can anticipate (`homepage`, say), or
+        // outside the body altogether (a request header). Both need a key-name
+        // oracle this spec cannot have, and closing the first would mean banning
+        // the URL builder this file legitimately uses elsewhere. A previous
+        // `window[...]` ban was dropped for the same reason: it outlawed a
+        // general JS construct across 2000 lines to cover a case strictly
+        // narrower than the ones already accepted here.
     });
 });

--- a/Test/Js/gateway-method-order-intent-request-body.test.js
+++ b/Test/Js/gateway-method-order-intent-request-body.test.js
@@ -219,12 +219,16 @@ describe('order-intent request body omits buyer.company.website (TWO-25365)', ()
         // WEAKENS the check rather than breaking it: `//` inside a string
         // literal eats the rest of that line, and one `'/*'` string constant
         // opens a fake comment swallowing hundreds of real lines. Hence the
-        // quote exclusion on the trailing form — it declines to strip rather
-        // than risk eating a URL in a string, which is the safe direction.
+        // quote-and-backtick exclusion on the trailing form — it declines to
+        // strip rather than risk eating a URL in a string, which is the safe
+        // direction. The backtick is in that class because this file composes
+        // URLs in template literals; without it, a template literal containing
+        // whitespace-`//` on a line that also read the global would have had its
+        // real code deleted, silently weakening the token check below.
         const code = src
             .replace(/\/\*\*[\s\S]*?\*\//g, '')
             .replace(/^[ \t]*\/\/[^\n]*$/gm, '')
-            .replace(/[ \t]\/\/[^\n'"]*$/gm, '');
+            .replace(/[ \t]\/\/[^\n'"`]*$/gm, '');
 
         // The bare token, not `window.BASE_URL`: narrowing to the member access
         // let `const { BASE_URL } = window` through. No false-positive risk —

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -1634,8 +1634,7 @@ define([
                     company: {
                         organization_number: this.companyId(),
                         country_prefix: billingAddress.countryId,
-                        company_name: this.companyName(),
-                        website: window.BASE_URL
+                        company_name: this.companyName()
                     },
                     representative: {
                         email: this.getEmail(),


### PR DESCRIPTION
## TWO-25365 (part 1 of 4 — Luma)

Luma's order-intent request composed `buyer.company.website` from `window.BASE_URL`. That global is the **merchant's own storefront URL**, not the buying company's website — so every order intent sent the merchant's site under a field name that says something else.

The field is not part of the request this renderer is meant to send. Grepped this repo for other readers or producers: `company.website` appears nowhere else, and after this change `BASE_URL` appears nowhere in the module's JS at all (the `TWO_*_BASE_URL` names elsewhere are unrelated local-dev env vars read by PHP config). So the assignment is **removed** rather than re-sourced from somewhere else.

Per the ticket, this is non-causal for any known bug — a data-correctness defect, not a live failure. Whether the API tolerates or ignores the field is not something this repo can attest to; TWO-25365 carries that reference.

## Change

- `view/frontend/web/js/view/payment/method-renderer/gateway_method.js` — drop the `website` key from `buyer.company`.
- `Test/Js/gateway-method-order-intent-request-body.test.js` — new spec.

## Test

The new spec composes a **real** request body through `placeOrderIntent()` with a recording `$.ajax` double, and asserts on the JSON that would go on the wire — with `window.BASE_URL` deliberately **set**, so it cannot pass on a missing sandbox global rather than on the composition. A second assertion pins the global itself as unused, so the merchant URL cannot reappear under a different key.

Mutation-checked across five review rounds — see the review comment below for the batteries and what they cover. Full suite green (`npm run test:js` — 30 suites, 385 tests).
