### PR TITLE
TWO-25386: port 8 admin controls from woocommerce/prestashop plugins

### DIFF
--- a/Api/Config/RepositoryInterface.php
+++ b/Api/Config/RepositoryInterface.php
@@ -431,4 +431,93 @@ interface RepositoryInterface
      * @return float
      */
     public function getSurchargeRoundingStep(?int $storeId = null): float;
+
+    /**
+     * Optional merchant-entered site/vendor name for multi-site setups
+     * (TWO-25386, ported from woocommerce-plugin). Sent to the API on
+     * order creation as `vendor_name` so a merchant running Two across
+     * several sites/stores that share one merchant account can tell the
+     * orders apart. Empty string means unset.
+     *
+     * @param int|null $storeId
+     *
+     * @return string
+     */
+    public function getVendorSiteName(?int $storeId = null): string;
+
+    /**
+     * Whether the buyer-facing "What is <Product>?" explainer link is
+     * shown on the payment method tile at checkout (TWO-25386, ported
+     * from woocommerce-plugin).
+     *
+     * @param int|null $storeId
+     *
+     * @return bool
+     */
+    public function isAboutLinkEnabled(?int $storeId = null): bool;
+
+    /**
+     * Whether the optional checkout field inputs (PO number, project,
+     * department, order note, invoice email) render a hover tooltip with
+     * the field's label (TWO-25386, ported from woocommerce-plugin).
+     * Defaults to enabled — Magento already rendered these unconditionally
+     * before this flag existed, so the default preserves prior behaviour.
+     *
+     * @param int|null $storeId
+     *
+     * @return bool
+     */
+    public function isDisplayTooltipsEnabled(?int $storeId = null): bool;
+
+    /**
+     * Debug flag: skip the additional confirmation-callback check on
+     * top of the mandatory order-reference match (TWO-25386, ported from
+     * woocommerce-plugin's WordPress-nonce skip). See
+     * Controller\Payment\Confirm for why this is currently a documented
+     * no-op on Magento — kept for admin-surface parity with the other
+     * plugins pending a Magento-side signing mechanism to actually gate.
+     *
+     * @param int|null $storeId
+     *
+     * @return bool
+     */
+    public function isSkipConfirmNonceCheckEnabled(?int $storeId = null): bool;
+
+    /**
+     * Whether stored Two configuration (payment/two_payment/* and
+     * payment/two_search/*) is deleted from core_config_data when the
+     * module is uninstalled (TWO-25386, ported from woocommerce-plugin's
+     * "clear settings on deactivation" — Magento's nearest equivalent
+     * lifecycle event is module uninstall, not deactivation).
+     *
+     * @param int|null $storeId
+     *
+     * @return bool
+     */
+    public function isClearSettingsOnUninstallEnabled(?int $storeId = null): bool;
+
+    /**
+     * Store-view-scoped payment method subtitle shown beneath the title
+     * at checkout (TWO-25386, ported from prestashop-plugin's per-language
+     * PS_TWO_SUB_TITLE). Empty string means unset — callers fall back to
+     * the brand's default subtitle (BrandRegistryInterface::getCheckoutSubtitle).
+     *
+     * @param int|null $storeId
+     *
+     * @return string
+     */
+    public function getSubtitle(?int $storeId = null): string;
+
+    /**
+     * Debug flag: skip TLS certificate verification on outbound API calls
+     * (TWO-25386, ported from prestashop-plugin's PS_TWO_DISABLE_SSL_VERIFY).
+     * Defaults to false (verification ON, secure). Unsafe for production —
+     * intended only for corporate networks that terminate TLS with a
+     * custom/self-signed certificate.
+     *
+     * @param int|null $storeId
+     *
+     * @return bool
+     */
+    public function isSslVerificationDisabled(?int $storeId = null): bool;
 }

--- a/Block/Adminhtml/System/Config/Field/HealthChecklist.php
+++ b/Block/Adminhtml/System/Config/Field/HealthChecklist.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Block\Adminhtml\System\Config\Field;
+
+use Magento\Backend\Block\Template\Context;
+use Magento\Config\Block\System\Config\Form\Field;
+use Magento\Framework\Data\Form\Element\AbstractElement;
+use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
+use Two\Gateway\Service\Merchant\ApiKeyStatus;
+
+/**
+ * Read-only "install health" panel in Stores Configuration (TWO-25386,
+ * ported from prestashop-plugin's renderTwoPluginHealthChecklist).
+ *
+ * Deliberately mirrors the same three checks prestashop-plugin ships —
+ * API key, environment, SSL verification — rather than inventing new ones
+ * (e.g. webhook reachability, PHP extensions) that plugin's checklist does
+ * not have either.
+ *
+ * Uses the cached ApiKeyStatus::getStatus() rather than a live refresh():
+ * the neighbouring "API key check" field (ApiKeyCheck) already performs a
+ * live verification on this same page render, so a second live HTTP call
+ * here would be redundant.
+ */
+class HealthChecklist extends Field
+{
+    /**
+     * @var string
+     */
+    protected $_template = 'Two_Gateway::system/config/field/health-checklist.phtml';
+
+    /**
+     * @var ConfigRepository
+     */
+    private $configRepository;
+
+    /**
+     * @var ApiKeyStatus
+     */
+    private $apiKeyStatus;
+
+    public function __construct(
+        ConfigRepository $configRepository,
+        ApiKeyStatus $apiKeyStatus,
+        Context $context,
+        array $data = []
+    ) {
+        $this->configRepository = $configRepository;
+        $this->apiKeyStatus = $apiKeyStatus;
+        parent::__construct($context, $data);
+    }
+
+    /**
+     * Checklist rows: label, ok (bool), value (display string).
+     *
+     * @return array<int, array{label: string, ok: bool, value: string}>
+     */
+    public function getChecklistRows(): array
+    {
+        $status = $this->apiKeyStatus->getStatus();
+        $apiKeyOk = $status['status'] === ApiKeyStatus::OK;
+
+        $sslDisabled = $this->configRepository->isSslVerificationDisabled();
+        $mode = $this->configRepository->getMode();
+
+        return [
+            [
+                'label' => (string)__('API key'),
+                'ok' => $apiKeyOk,
+                'value' => $apiKeyOk ? (string)__('Verified') : (string)__('Not verified'),
+            ],
+            [
+                'label' => (string)__('Environment'),
+                'ok' => true,
+                'value' => $mode !== '' ? strtoupper($mode) : (string)__('Not set'),
+            ],
+            [
+                'label' => (string)__('SSL verification'),
+                'ok' => !$sslDisabled,
+                'value' => $sslDisabled ? (string)__('Disabled') : (string)__('Enabled'),
+            ],
+        ];
+    }
+
+    /**
+     * True when the environment is production and SSL verification is
+     * disabled — the one combination worth a loud warning, mirroring
+     * prestashop-plugin's equivalent banner.
+     */
+    public function isProductionWithSslDisabled(): bool
+    {
+        return $this->configRepository->getMode() === 'production'
+            && $this->configRepository->isSslVerificationDisabled();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function render(AbstractElement $element)
+    {
+        $element->unsScope()->unsCanUseWebsiteValue()->unsCanUseDefaultValue();
+        return parent::render($element);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function _getElementHtml(AbstractElement $element)
+    {
+        return $this->_toHtml();
+    }
+}

--- a/Controller/Payment/Confirm.php
+++ b/Controller/Payment/Confirm.php
@@ -21,6 +21,17 @@ use Two\Gateway\Service\Payment\OrderService;
 
 /**
  * Payment confirm controller
+ *
+ * TWO-25386: the "Skip confirm-order nonce check" admin toggle
+ * (Api\Config\RepositoryInterface::isSkipConfirmNonceCheckEnabled(), ported
+ * from woocommerce-plugin's WordPress-nonce skip) is DELIBERATELY not
+ * consumed here. This controller identifies the callback solely by the
+ * `_two_order_reference` param (see OrderService::getOrderByReference()),
+ * which is always checked — there is no separate session/nonce layer on
+ * top of it the way WooCommerce's WP nonce sits on top of its own mandatory
+ * order-reference check. The toggle exists for admin-surface parity with
+ * the other plugins; it is a documented no-op until Magento gains an
+ * equivalent signing mechanism to actually gate.
  */
 class Confirm extends Action
 {

--- a/Model/Config/Repository.php
+++ b/Model/Config/Repository.php
@@ -757,4 +757,60 @@ class Repository implements RepositoryInterface
     {
         return (float)$this->getConfig($this->path('surcharge_rounding_step'), $storeId);
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function getVendorSiteName(?int $storeId = null): string
+    {
+        return (string)$this->getConfig($this->path('vendor_site_name'), $storeId);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isAboutLinkEnabled(?int $storeId = null): bool
+    {
+        return $this->isSetFlag($this->path('show_about_link'), $storeId);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isDisplayTooltipsEnabled(?int $storeId = null): bool
+    {
+        return $this->isSetFlag($this->path('display_tooltips'), $storeId);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isSkipConfirmNonceCheckEnabled(?int $storeId = null): bool
+    {
+        return $this->isSetFlag($this->path('skip_confirm_nonce_check'), $storeId);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isClearSettingsOnUninstallEnabled(?int $storeId = null): bool
+    {
+        return $this->isSetFlag($this->path('clear_settings_on_uninstall'), $storeId);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSubtitle(?int $storeId = null): string
+    {
+        return (string)$this->getConfig($this->path('subtitle'), $storeId);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isSslVerificationDisabled(?int $storeId = null): bool
+    {
+        return $this->isSetFlag($this->path('disable_ssl_verify'), $storeId);
+    }
 }

--- a/Model/Ui/ConfigProvider.php
+++ b/Model/Ui/ConfigProvider.php
@@ -62,9 +62,11 @@ class ConfigProvider implements ConfigProviderInterface
      * plain constant here rather than threaded through
      * BrandRegistryInterface — a single marketing URL did not seem worth
      * the blast radius of a new brand.xml tag across the descriptor,
-     * loader, XSD and every implementation; a brand overlay that wants a
-     * different URL should override this constant, or this can be
-     * revisited if that need arises.
+     * loader, XSD and every implementation. A brand overlay only supplies
+     * DATA (its own etc/brand.xml), so it has no subclassing point to
+     * override this constant from; a brand overlay that needs a different
+     * link would need this threaded through BrandRegistryInterface after
+     * all — revisit then, rather than pre-building it now on spec.
      */
     public const ABOUT_URL = 'https://www.two.inc/what-is-two';
 

--- a/Model/Ui/ConfigProvider.php
+++ b/Model/Ui/ConfigProvider.php
@@ -56,6 +56,18 @@ class ConfigProvider implements ConfigProviderInterface
      */
     public const COMPANY_NUMBER_TOKEN = '{{companyNumber}}';
 
+    /**
+     * Buyer-facing "What is Two?" explainer link target (TWO-25386, ported
+     * from woocommerce-plugin's brand-descriptor `about_url`). Kept as a
+     * plain constant here rather than threaded through
+     * BrandRegistryInterface — a single marketing URL did not seem worth
+     * the blast radius of a new brand.xml tag across the descriptor,
+     * loader, XSD and every implementation; a brand overlay that wants a
+     * different URL should override this constant, or this can be
+     * revisited if that need arises.
+     */
+    public const ABOUT_URL = 'https://www.two.inc/what-is-two';
+
     /** @var string */
     private $code;
 
@@ -234,6 +246,11 @@ class ConfigProvider implements ConfigProviderInterface
                     'minimumOrder' => $minimumOrder['minimums'],
                     'minimumOrderUnresolved' => $minimumOrder['unresolved'],
                     'subtitleHtml' => $this->getSubtitleHtml(),
+                    // TWO-25386: ported from woocommerce-plugin.
+                    'showAboutLink' => $this->configRepository->isAboutLinkEnabled(),
+                    'aboutLinkUrl' => self::ABOUT_URL,
+                    'aboutLinkText' => (string)__('What is %1?', $this->brandRegistry->getProductName()),
+                    'displayTooltips' => $this->configRepository->isDisplayTooltipsEnabled(),
                     'surchargeDescription' => $this->configRepository->getSurchargeLineDescription(),
                     'isPaymentTermsEnabled' => true,
                     // null ⇒ the brand suppressed the notice; the renderer
@@ -414,17 +431,31 @@ class ConfigProvider implements ConfigProviderInterface
     }
 
     /**
-     * Resolve the brand's checkout subtitle for the storefront renderer.
+     * Resolve the checkout subtitle for the storefront renderer.
      *
-     * The string is brand data (BrandRegistryInterface::getCheckoutSubtitle,
-     * sourced from brand.xml). The vanilla Two brand returns '' → no
-     * subtitle. We only pass a non-empty key to the translator, so an
-     * unmapped locale falls back to the (brand-owned) source key rather
-     * than ever leaking a vanilla key. May contain HTML (e.g. a link);
-     * the KO template binds it via `html:`.
+     * TWO-25386: a store-view-scoped admin override (ported from
+     * prestashop-plugin's per-language PS_TWO_SUB_TITLE) takes priority
+     * when set. It is merchant-entered free text, so it is HTML-escaped
+     * here rather than treated as a translation source key — unlike the
+     * brand default below, it must never be passed to __().
+     *
+     * Falling back, the string is brand data
+     * (BrandRegistryInterface::getCheckoutSubtitle, sourced from
+     * brand.xml). The vanilla Two brand returns '' → no subtitle. We only
+     * pass a non-empty key to the translator, so an unmapped locale falls
+     * back to the (brand-owned) source key rather than ever leaking a
+     * vanilla key.
+     *
+     * Either way the result may contain HTML; the KO template binds it via
+     * `html:`.
      */
     private function getSubtitleHtml(): string
     {
+        $configured = trim($this->configRepository->getSubtitle());
+        if ($configured !== '') {
+            return htmlspecialchars($configured, ENT_QUOTES, 'UTF-8');
+        }
+
         $key = $this->brandRegistry->getCheckoutSubtitle();
         return $key === '' ? '' : (string)__($key);
     }

--- a/Service/Api/Adapter.php
+++ b/Service/Api/Adapter.php
@@ -108,7 +108,7 @@ class Adapter
             // prestashop-plugin's PS_TWO_DISABLE_SSL_VERIFY) turns it off, for
             // stores behind a corporate proxy that terminates TLS with its own
             // certificate. Previously this was unconditionally disabled here.
-            if ($this->configRepository->isSslVerificationDisabled()) {
+            if ($this->configRepository->isSslVerificationDisabled($storeId)) {
                 $curl->setOption(CURLOPT_SSL_VERIFYHOST, 0);
                 $curl->setOption(CURLOPT_SSL_VERIFYPEER, 0);
             } else {

--- a/Service/Api/Adapter.php
+++ b/Service/Api/Adapter.php
@@ -103,8 +103,18 @@ class Adapter
                 $curl->addHeader($name, $value);
             }
             $curl->setOption(CURLOPT_RETURNTRANSFER, true);
-            $curl->setOption(CURLOPT_SSL_VERIFYHOST, 0);
-            $curl->setOption(CURLOPT_SSL_VERIFYPEER, 0);
+            // TWO-25386: TLS verification is ON by default (secure). Only the
+            // "Disable SSL verification" debug toggle (ported from
+            // prestashop-plugin's PS_TWO_DISABLE_SSL_VERIFY) turns it off, for
+            // stores behind a corporate proxy that terminates TLS with its own
+            // certificate. Previously this was unconditionally disabled here.
+            if ($this->configRepository->isSslVerificationDisabled()) {
+                $curl->setOption(CURLOPT_SSL_VERIFYHOST, 0);
+                $curl->setOption(CURLOPT_SSL_VERIFYPEER, 0);
+            } else {
+                $curl->setOption(CURLOPT_SSL_VERIFYHOST, 2);
+                $curl->setOption(CURLOPT_SSL_VERIFYPEER, true);
+            }
             $curl->setOption(CURLOPT_TIMEOUT, 60);
 
             if ($call->method == "POST" || $call->method == "PUT") {

--- a/Service/Order/ComposeOrder.php
+++ b/Service/Order/ComposeOrder.php
@@ -160,7 +160,10 @@ class ComposeOrder extends OrderService
                     ['_two_order_reference' => base64_encode($orderReference)]
                 ),
             ],
-            'order_note' => $additionalData['orderNote'] ?? ''
+            'order_note' => $additionalData['orderNote'] ?? '',
+            // TWO-25386: ported from woocommerce-plugin's 'vendor_name',
+            // sent unconditionally there (empty string when unset).
+            'vendor_name' => $this->configRepository->getVendorSiteName($storeId),
         ];
 
         // Add invoice_details and required placeholders only if invoiceEmails are present

--- a/Setup/Uninstall.php
+++ b/Setup/Uninstall.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Two\Gateway\Setup;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\Framework\Setup\UninstallInterface;
+use Magento\Framework\Setup\SchemaSetupInterface;
+
+/**
+ * Fires on `bin/magento module:uninstall Two_Gateway` (TWO-25386, ported
+ * from woocommerce-plugin's "clear settings on deactivation" — Magento's
+ * nearest equivalent lifecycle event is uninstall, not deactivation:
+ * Magento has no admin-triggered "disable this module" hook a payment
+ * module can act on the way a WordPress plugin can).
+ *
+ * Deletes stored two_payment/two_search configuration from
+ * core_config_data ONLY when the merchant opted in via the
+ * "Clear settings on module uninstall" toggle. Default off, so uninstall
+ * leaves configuration in place unless the merchant asked otherwise —
+ * matching the WooCommerce default.
+ */
+class Uninstall implements UninstallInterface
+{
+    private ScopeConfigInterface $scopeConfig;
+
+    public function __construct(ScopeConfigInterface $scopeConfig)
+    {
+        $this->scopeConfig = $scopeConfig;
+    }
+
+    public function uninstall(SchemaSetupInterface $setup, ModuleContextInterface $context): void
+    {
+        if (!$this->scopeConfig->isSetFlag('payment/two_payment/clear_settings_on_uninstall')) {
+            return;
+        }
+
+        $setup->startSetup();
+        $connection = $setup->getConnection();
+        $table = $setup->getTable('core_config_data');
+        foreach (['payment/two_payment/%', 'payment/two_search/%'] as $pathLike) {
+            $connection->delete($table, ['path LIKE ?' => $pathLike]);
+        }
+        $setup->endSetup();
+    }
+}

--- a/Setup/Uninstall.php
+++ b/Setup/Uninstall.php
@@ -12,6 +12,7 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Setup\ModuleContextInterface;
 use Magento\Framework\Setup\UninstallInterface;
 use Magento\Framework\Setup\SchemaSetupInterface;
+use Two\Gateway\Api\BrandRegistryInterface;
 
 /**
  * Fires on `bin/magento module:uninstall Two_Gateway` (TWO-25386, ported
@@ -20,33 +21,70 @@ use Magento\Framework\Setup\SchemaSetupInterface;
  * Magento has no admin-triggered "disable this module" hook a payment
  * module can act on the way a WordPress plugin can).
  *
- * Deletes stored two_payment/two_search configuration from
- * core_config_data ONLY when the merchant opted in via the
- * "Clear settings on module uninstall" toggle. Default off, so uninstall
- * leaves configuration in place unless the merchant asked otherwise —
- * matching the WooCommerce default.
+ * Deletes stored `payment/<code>/*` configuration from core_config_data
+ * ONLY when the merchant opted in via the "Clear settings on module
+ * uninstall" toggle. Default off, so uninstall leaves configuration in
+ * place unless the merchant asked otherwise — matching the WooCommerce
+ * default.
+ *
+ * `<code>` is resolved from BrandRegistryInterface::getCode() rather than
+ * hardcoded to `two_payment` — every field this module ships writes to
+ * `payment/<code>/*` (see Model\Config\Repository::path()), and a brand
+ * overlay's active code is not `two_payment` (see
+ * docs/brand-overlay-guide.md, and etc/adminhtml/brand_form_template.xml's
+ * `{{code}}` tokens). There is deliberately no separate `two_search/*`
+ * prefix to clean up: the fields grouped under the admin "Search" section
+ * (`enable_company_search`, `enable_address_search`) are, like everything
+ * else, stored under `payment/<code>/*` — `two_search` is only an
+ * admin-UI section id, never a config path.
  */
 class Uninstall implements UninstallInterface
 {
     private ScopeConfigInterface $scopeConfig;
+    private BrandRegistryInterface $brandRegistry;
 
-    public function __construct(ScopeConfigInterface $scopeConfig)
+    public function __construct(ScopeConfigInterface $scopeConfig, BrandRegistryInterface $brandRegistry)
     {
         $this->scopeConfig = $scopeConfig;
+        $this->brandRegistry = $brandRegistry;
     }
 
     public function uninstall(SchemaSetupInterface $setup, ModuleContextInterface $context): void
     {
-        if (!$this->scopeConfig->isSetFlag('payment/two_payment/clear_settings_on_uninstall')) {
+        $code = $this->brandRegistry->getCode();
+
+        // Default scope, explicitly: the toggle is showInWebsite="0"
+        // showInStore="0" (see system.xml) — it can only ever be set at
+        // default scope, so reading it there is what the field's own
+        // declaration means, not an assumption.
+        if (!$this->scopeConfig->isSetFlag(
+            'payment/' . $code . '/clear_settings_on_uninstall',
+            ScopeConfigInterface::SCOPE_TYPE_DEFAULT
+        )) {
             return;
         }
 
         $setup->startSetup();
         $connection = $setup->getConnection();
         $table = $setup->getTable('core_config_data');
-        foreach (['payment/two_payment/%', 'payment/two_search/%'] as $pathLike) {
-            $connection->delete($table, ['path LIKE ?' => $pathLike]);
-        }
+        // LIKE special characters ('_', '%') in the brand code (e.g. the
+        // literal underscore in "two_payment") must be escaped, or they
+        // widen the match to unrelated config paths rather than narrowing
+        // it to this brand's own rows.
+        $pattern = $this->escapeLike('payment/' . $code . '/') . '%';
+        $connection->delete($table, [
+            $connection->quoteInto("path LIKE ? ESCAPE '\\\\'", $pattern),
+        ]);
         $setup->endSetup();
+    }
+
+    /**
+     * Escapes '\', '_' and '%' for use inside a LIKE pattern with
+     * `ESCAPE '\\'`, so the literal segment of the pattern only ever
+     * matches itself.
+     */
+    private function escapeLike(string $value): string
+    {
+        return str_replace(['\\', '_', '%'], ['\\\\', '\\_', '\\%'], $value);
     }
 }

--- a/Test/Unit/Block/Adminhtml/System/Config/Field/HealthChecklistTest.php
+++ b/Test/Unit/Block/Adminhtml/System/Config/Field/HealthChecklistTest.php
@@ -1,0 +1,111 @@
+<?php
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Block\Adminhtml\System\Config\Field;
+
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
+use Two\Gateway\Block\Adminhtml\System\Config\Field\HealthChecklist;
+use Two\Gateway\Service\Merchant\ApiKeyStatus;
+
+/**
+ * TWO-25386: the admin "Health checklist" panel, ported from
+ * prestashop-plugin's renderTwoPluginHealthChecklist(). Same three checks
+ * as that plugin: API key, environment, SSL verification.
+ */
+class HealthChecklistTest extends TestCase
+{
+    /** @var ConfigRepository|\PHPUnit\Framework\MockObject\MockObject */
+    private $configRepository;
+
+    /** @var ApiKeyStatus|\PHPUnit\Framework\MockObject\MockObject */
+    private $apiKeyStatus;
+
+    /** @var HealthChecklist */
+    private $block;
+
+    protected function setUp(): void
+    {
+        $this->configRepository = $this->createMock(ConfigRepository::class);
+        $this->apiKeyStatus = $this->createMock(ApiKeyStatus::class);
+
+        $this->block = new HealthChecklistTestable();
+        $this->block->setDependencies($this->configRepository, $this->apiKeyStatus);
+    }
+
+    public function testAllHealthyRows(): void
+    {
+        $this->apiKeyStatus->method('getStatus')->willReturn(['status' => ApiKeyStatus::OK]);
+        $this->configRepository->method('getMode')->willReturn('production');
+        $this->configRepository->method('isSslVerificationDisabled')->willReturn(false);
+
+        $rows = $this->block->getChecklistRows();
+
+        $this->assertTrue($rows[0]['ok']);
+        $this->assertSame('PRODUCTION', $rows[1]['value']);
+        $this->assertTrue($rows[2]['ok']);
+        $this->assertFalse($this->block->isProductionWithSslDisabled());
+    }
+
+    public function testUnverifiedApiKeyRowIsNotOk(): void
+    {
+        $this->apiKeyStatus->method('getStatus')->willReturn(['status' => ApiKeyStatus::INVALID_KEY]);
+        $this->configRepository->method('getMode')->willReturn('sandbox');
+        $this->configRepository->method('isSslVerificationDisabled')->willReturn(false);
+
+        $rows = $this->block->getChecklistRows();
+
+        $this->assertFalse($rows[0]['ok']);
+    }
+
+    public function testSslDisabledRowIsNotOk(): void
+    {
+        $this->apiKeyStatus->method('getStatus')->willReturn(['status' => ApiKeyStatus::OK]);
+        $this->configRepository->method('getMode')->willReturn('sandbox');
+        $this->configRepository->method('isSslVerificationDisabled')->willReturn(true);
+
+        $rows = $this->block->getChecklistRows();
+
+        $this->assertFalse($rows[2]['ok']);
+    }
+
+    public function testProductionWithSslDisabledWarns(): void
+    {
+        $this->configRepository->method('getMode')->willReturn('production');
+        $this->configRepository->method('isSslVerificationDisabled')->willReturn(true);
+
+        $this->assertTrue($this->block->isProductionWithSslDisabled());
+    }
+
+    public function testSandboxWithSslDisabledDoesNotWarn(): void
+    {
+        $this->configRepository->method('getMode')->willReturn('sandbox');
+        $this->configRepository->method('isSslVerificationDisabled')->willReturn(true);
+
+        $this->assertFalse($this->block->isProductionWithSslDisabled());
+    }
+}
+
+/**
+ * Constructor-free subclass — the heavy Field base constructor needs a
+ * full Magento admin Context, which this exercises no need for.
+ */
+class HealthChecklistTestable extends HealthChecklist
+{
+    public function __construct()
+    {
+    }
+
+    public function setDependencies(ConfigRepository $configRepository, ApiKeyStatus $apiKeyStatus): void
+    {
+        $ref = new \ReflectionClass(HealthChecklist::class);
+
+        $configProp = $ref->getProperty('configRepository');
+        $configProp->setAccessible(true);
+        $configProp->setValue($this, $configRepository);
+
+        $apiKeyProp = $ref->getProperty('apiKeyStatus');
+        $apiKeyProp->setAccessible(true);
+        $apiKeyProp->setValue($this, $apiKeyStatus);
+    }
+}

--- a/Test/Unit/Config/CheckoutFieldDefaultsTest.php
+++ b/Test/Unit/Config/CheckoutFieldDefaultsTest.php
@@ -30,6 +30,12 @@ class CheckoutFieldDefaultsTest extends TestCase
         'enable_po_number',
         'enable_order_note',
         'enable_invoice_emails',
+        // TWO-25386: ported from woocommerce-plugin. Both default to
+        // enabled — display_tooltips preserves Magento's prior
+        // (unconditional) behaviour, show_about_link matches WC's own
+        // default.
+        'show_about_link',
+        'display_tooltips',
     ];
 
     /** @var \SimpleXMLElement */

--- a/Test/Unit/Config/CheckoutFieldOrderTest.php
+++ b/Test/Unit/Config/CheckoutFieldOrderTest.php
@@ -36,6 +36,11 @@ class CheckoutFieldOrderTest extends TestCase
         'enable_project',
         'enable_department',
         'enable_order_note',
+        // TWO-25386: ported from woocommerce-plugin. Not part of the
+        // load-bearing order-note-last sequence above (TWO-25263) — these
+        // just need to come after it, which this test also pins.
+        'show_about_link',
+        'display_tooltips',
     ];
 
     /**

--- a/Test/Unit/Model/Config/RepositoryAdminControlsTest.php
+++ b/Test/Unit/Model/Config/RepositoryAdminControlsTest.php
@@ -1,0 +1,127 @@
+<?php
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Model\Config;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\ProductMetadataInterface;
+use Magento\Framework\Encryption\EncryptorInterface;
+use Magento\Framework\UrlInterface;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Tax\Model\Calculation as TaxCalculation;
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Api\BrandRegistryInterface;
+use Two\Gateway\Model\Config\Repository;
+use Two\Gateway\Model\Provenance;
+use Two\Gateway\Service\Merchant\SettingsProvider;
+
+/**
+ * TWO-25386: config accessors for the 8 admin controls ported from
+ * woocommerce-plugin and prestashop-plugin.
+ */
+class RepositoryAdminControlsTest extends TestCase
+{
+    private const VENDOR_SITE_NAME_PATH = 'payment/two_payment/vendor_site_name';
+    private const SUBTITLE_PATH = 'payment/two_payment/subtitle';
+    private const ABOUT_LINK_PATH = 'payment/two_payment/show_about_link';
+    private const TOOLTIPS_PATH = 'payment/two_payment/display_tooltips';
+    private const SKIP_NONCE_PATH = 'payment/two_payment/skip_confirm_nonce_check';
+    private const CLEAR_ON_UNINSTALL_PATH = 'payment/two_payment/clear_settings_on_uninstall';
+    private const DISABLE_SSL_VERIFY_PATH = 'payment/two_payment/disable_ssl_verify';
+
+    /** @var ScopeConfigInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $scopeConfig;
+
+    /** @var Repository */
+    private $repository;
+
+    protected function setUp(): void
+    {
+        $this->scopeConfig = $this->createMock(ScopeConfigInterface::class);
+
+        $brandRegistry = $this->createMock(BrandRegistryInterface::class);
+        $brandRegistry->method('getCode')->willReturn('two_payment');
+
+        $this->repository = new Repository(
+            $this->scopeConfig,
+            $this->createMock(EncryptorInterface::class),
+            $this->createMock(UrlInterface::class),
+            $this->createMock(ProductMetadataInterface::class),
+            $this->getMockBuilder(TaxCalculation::class)->disableOriginalConstructor()->getMock(),
+            $brandRegistry,
+            $this->createMock(SettingsProvider::class),
+            $this->createMock(Provenance::class)
+        );
+    }
+
+    public function testGetVendorSiteNameReadsItsOwnPath(): void
+    {
+        $this->scopeConfig->expects($this->once())
+            ->method('getValue')
+            ->with(self::VENDOR_SITE_NAME_PATH, ScopeInterface::SCOPE_STORE, null)
+            ->willReturn('acme-eu-store');
+
+        $this->assertSame('acme-eu-store', $this->repository->getVendorSiteName());
+    }
+
+    public function testGetVendorSiteNameDefaultsToEmptyString(): void
+    {
+        $this->scopeConfig->method('getValue')->willReturn(null);
+
+        $this->assertSame('', $this->repository->getVendorSiteName());
+    }
+
+    public function testGetSubtitleReadsItsOwnPath(): void
+    {
+        $this->scopeConfig->expects($this->once())
+            ->method('getValue')
+            ->with(self::SUBTITLE_PATH, ScopeInterface::SCOPE_STORE, 3)
+            ->willReturn('Buy now, pay later');
+
+        $this->assertSame('Buy now, pay later', $this->repository->getSubtitle(3));
+    }
+
+    public function testGetSubtitleDefaultsToEmptyString(): void
+    {
+        $this->scopeConfig->method('getValue')->willReturn(null);
+
+        $this->assertSame('', $this->repository->getSubtitle());
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function booleanFlagProvider(): array
+    {
+        return [
+            'about link' => ['isAboutLinkEnabled', self::ABOUT_LINK_PATH],
+            'display tooltips' => ['isDisplayTooltipsEnabled', self::TOOLTIPS_PATH],
+            'skip confirm nonce check' => ['isSkipConfirmNonceCheckEnabled', self::SKIP_NONCE_PATH],
+            'clear settings on uninstall' => ['isClearSettingsOnUninstallEnabled', self::CLEAR_ON_UNINSTALL_PATH],
+            'disable ssl verify' => ['isSslVerificationDisabled', self::DISABLE_SSL_VERIFY_PATH],
+        ];
+    }
+
+    /**
+     * @dataProvider booleanFlagProvider
+     */
+    public function testBooleanFlagReadsItsOwnPathAndScope(string $method, string $expectedPath): void
+    {
+        $this->scopeConfig->expects($this->once())
+            ->method('isSetFlag')
+            ->with($expectedPath, ScopeInterface::SCOPE_STORE, null)
+            ->willReturn(true);
+
+        $this->assertTrue($this->repository->{$method}());
+    }
+
+    /**
+     * @dataProvider booleanFlagProvider
+     */
+    public function testBooleanFlagDefaultsToFalse(string $method): void
+    {
+        $this->scopeConfig->method('isSetFlag')->willReturn(false);
+
+        $this->assertFalse($this->repository->{$method}());
+    }
+}

--- a/Test/Unit/Service/Api/AdapterTest.php
+++ b/Test/Unit/Service/Api/AdapterTest.php
@@ -212,6 +212,42 @@ class AdapterTest extends TestCase
         $this->assertEquals('Connection failed', $result['error_message']);
     }
 
+    // ── TWO-25386: SSL verification toggle ───────────────────────────────
+
+    public function testSslVerificationIsOnByDefault(): void
+    {
+        $this->curl->method('getStatus')->willReturn(200);
+        $this->curl->method('getBody')->willReturn('{}');
+        $this->configRepository->method('isSslVerificationDisabled')->willReturn(false);
+
+        $calls = [];
+        $this->curl->method('setOption')->willReturnCallback(function ($opt, $val) use (&$calls) {
+            $calls[$opt] = $val;
+        });
+
+        $this->adapter->execute('/v1/order', ['amount' => 100]);
+
+        $this->assertSame(2, $calls[CURLOPT_SSL_VERIFYHOST]);
+        $this->assertSame(true, $calls[CURLOPT_SSL_VERIFYPEER]);
+    }
+
+    public function testSslVerificationDisabledWhenToggleIsOn(): void
+    {
+        $this->curl->method('getStatus')->willReturn(200);
+        $this->curl->method('getBody')->willReturn('{}');
+        $this->configRepository->method('isSslVerificationDisabled')->willReturn(true);
+
+        $calls = [];
+        $this->curl->method('setOption')->willReturnCallback(function ($opt, $val) use (&$calls) {
+            $calls[$opt] = $val;
+        });
+
+        $this->adapter->execute('/v1/order', ['amount' => 100]);
+
+        $this->assertSame(0, $calls[CURLOPT_SSL_VERIFYHOST]);
+        $this->assertSame(0, $calls[CURLOPT_SSL_VERIFYPEER]);
+    }
+
     // ── ApiTranslator hook ──────────────────────────────────────────────
 
     public function testTranslatorRewritesUrl(): void

--- a/Test/Unit/Service/Api/AdapterTest.php
+++ b/Test/Unit/Service/Api/AdapterTest.php
@@ -248,6 +248,27 @@ class AdapterTest extends TestCase
         $this->assertSame(0, $calls[CURLOPT_SSL_VERIFYPEER]);
     }
 
+    /**
+     * disable_ssl_verify is store-view-scoped (showInWebsite="1"
+     * showInStore="1" in system.xml), same as the other scoped calls this
+     * method already makes (getMode($storeId), getApiKey($storeId)). The
+     * check must resolve at the caller's store, not default/global scope —
+     * otherwise a store-level override (e.g. to work around a corporate
+     * proxy) is silently ignored.
+     */
+    public function testSslVerificationCheckIsScopedToTheCallersStore(): void
+    {
+        $this->curl->method('getStatus')->willReturn(200);
+        $this->curl->method('getBody')->willReturn('{}');
+
+        $this->configRepository->expects($this->once())
+            ->method('isSslVerificationDisabled')
+            ->with(7)
+            ->willReturn(false);
+
+        $this->adapter->execute('/v1/order', ['amount' => 100], 'POST', 7);
+    }
+
     // ── ApiTranslator hook ──────────────────────────────────────────────
 
     public function testTranslatorRewritesUrl(): void

--- a/Test/Unit/Setup/UninstallTest.php
+++ b/Test/Unit/Setup/UninstallTest.php
@@ -7,6 +7,7 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Setup\ModuleContextInterface;
 use Magento\Framework\Setup\SchemaSetupInterface;
 use PHPUnit\Framework\TestCase;
+use Two\Gateway\Api\BrandRegistryInterface;
 use Two\Gateway\Setup\Uninstall;
 
 /**
@@ -14,6 +15,14 @@ use Two\Gateway\Setup\Uninstall;
  * deactivation" — Magento's nearest equivalent lifecycle event is module
  * uninstall. Default off: uninstall must leave configuration in place
  * unless the merchant explicitly opted in.
+ *
+ * Adversarial review (round 1) found the first version of this class
+ * hardcoded `payment/two_payment/%`, ignoring the active brand's own code
+ * — on a brand overlay this both silently no-ops the opt-in AND leaves a
+ * dead `payment/two_search/%` clause that never matched anything (the
+ * "Search" admin section's fields live under `payment/<code>/*` too, same
+ * as everything else). This test pins the brand-code-derived behaviour and
+ * the LIKE-escaping fix that went with it.
  *
  * SchemaSetupInterface/ModuleContextInterface are auto-stubbed as EMPTY
  * interfaces by Test/bootstrap.php's catch-all (no real Magento framework
@@ -23,51 +32,88 @@ use Two\Gateway\Setup\Uninstall;
  */
 class UninstallTest extends TestCase
 {
-    public function testDoesNothingWhenToggleIsOff(): void
+    private function buildUninstall(bool $flagValue, string $code): Uninstall
     {
         $scopeConfig = $this->createMock(ScopeConfigInterface::class);
         $scopeConfig->method('isSetFlag')
-            ->with('payment/two_payment/clear_settings_on_uninstall')
-            ->willReturn(false);
+            ->with('payment/' . $code . '/clear_settings_on_uninstall', ScopeConfigInterface::SCOPE_TYPE_DEFAULT)
+            ->willReturn($flagValue);
 
+        $brandRegistry = $this->createMock(BrandRegistryInterface::class);
+        $brandRegistry->method('getCode')->willReturn($code);
+
+        return new Uninstall($scopeConfig, $brandRegistry);
+    }
+
+    public function testDoesNothingWhenToggleIsOff(): void
+    {
+        $uninstall = $this->buildUninstall(false, 'two_payment');
         $setup = new FakeSchemaSetup();
 
-        $uninstall = new Uninstall($scopeConfig);
         $uninstall->uninstall($setup, new FakeModuleContext());
 
         $this->assertFalse($setup->setupStarted, 'startSetup() must not run when the toggle is off');
-        $this->assertSame([], $setup->connection->deletedPaths);
+        $this->assertSame([], $setup->connection->deletedPatterns);
     }
 
-    public function testDeletesTwoConfigWhenToggleIsOn(): void
+    public function testDeletesOnlyTheActiveBrandsConfigWhenToggleIsOn(): void
     {
-        $scopeConfig = $this->createMock(ScopeConfigInterface::class);
-        $scopeConfig->method('isSetFlag')
-            ->with('payment/two_payment/clear_settings_on_uninstall')
-            ->willReturn(true);
-
+        $uninstall = $this->buildUninstall(true, 'two_payment');
         $setup = new FakeSchemaSetup();
 
-        $uninstall = new Uninstall($scopeConfig);
         $uninstall->uninstall($setup, new FakeModuleContext());
 
         $this->assertTrue($setup->setupStarted);
         $this->assertTrue($setup->setupEnded);
-        $this->assertSame(
-            ['payment/two_payment/%', 'payment/two_search/%'],
-            $setup->connection->deletedPaths
-        );
+        // No separate 'two_search' clause: that admin section's fields are
+        // stored under payment/<code>/* like everything else, so one
+        // pattern covers them too.
+        $this->assertSame(['payment/two\\_payment/%'], $setup->connection->deletedPatterns);
+    }
+
+    public function testUsesTheActiveBrandsOwnCodeNotTheVanillaDefault(): void
+    {
+        $uninstall = $this->buildUninstall(true, 'acmepayment');
+        $setup = new FakeSchemaSetup();
+
+        $uninstall->uninstall($setup, new FakeModuleContext());
+
+        $this->assertSame(['payment/acmepayment/%'], $setup->connection->deletedPatterns);
+    }
+
+    public function testEscapesLikeSpecialCharactersInTheBrandCode(): void
+    {
+        // "two_payment" contains a literal underscore, a LIKE wildcard.
+        // Unescaped, 'payment/two_payment/%' would also match
+        // 'payment/twoXpayment/anything' for any single character X.
+        $uninstall = $this->buildUninstall(true, 'two_payment');
+        $setup = new FakeSchemaSetup();
+
+        $uninstall->uninstall($setup, new FakeModuleContext());
+
+        $this->assertSame(['payment/two\\_payment/%'], $setup->connection->deletedPatterns);
     }
 }
 
 class FakeConnection
 {
     /** @var string[] */
-    public $deletedPaths = [];
+    public $deletedPatterns = [];
+
+    public function quoteInto($text, $value)
+    {
+        // Faithful enough for this test: capture the escaped pattern that
+        // was built, without needing a real DB adapter's quoting.
+        return ['sql' => $text, 'pattern' => $value];
+    }
 
     public function delete($table, array $where)
     {
-        $this->deletedPaths[] = $where['path LIKE ?'];
+        foreach ($where as $condition) {
+            if (is_array($condition) && isset($condition['pattern'])) {
+                $this->deletedPatterns[] = $condition['pattern'];
+            }
+        }
         return 1;
     }
 }

--- a/Test/Unit/Setup/UninstallTest.php
+++ b/Test/Unit/Setup/UninstallTest.php
@@ -1,0 +1,117 @@
+<?php
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Setup;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\Framework\Setup\SchemaSetupInterface;
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Setup\Uninstall;
+
+/**
+ * TWO-25386: ported from woocommerce-plugin's "clear settings on
+ * deactivation" — Magento's nearest equivalent lifecycle event is module
+ * uninstall. Default off: uninstall must leave configuration in place
+ * unless the merchant explicitly opted in.
+ *
+ * SchemaSetupInterface/ModuleContextInterface are auto-stubbed as EMPTY
+ * interfaces by Test/bootstrap.php's catch-all (no real Magento framework
+ * installed in this harness), so createMock() cannot configure methods
+ * that do not exist on them. A hand-written fake, same pattern as
+ * Test\Unit\Setup\Patch\Data\CollapseAddressSearchToggleTest, stands in.
+ */
+class UninstallTest extends TestCase
+{
+    public function testDoesNothingWhenToggleIsOff(): void
+    {
+        $scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $scopeConfig->method('isSetFlag')
+            ->with('payment/two_payment/clear_settings_on_uninstall')
+            ->willReturn(false);
+
+        $setup = new FakeSchemaSetup();
+
+        $uninstall = new Uninstall($scopeConfig);
+        $uninstall->uninstall($setup, new FakeModuleContext());
+
+        $this->assertFalse($setup->setupStarted, 'startSetup() must not run when the toggle is off');
+        $this->assertSame([], $setup->connection->deletedPaths);
+    }
+
+    public function testDeletesTwoConfigWhenToggleIsOn(): void
+    {
+        $scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $scopeConfig->method('isSetFlag')
+            ->with('payment/two_payment/clear_settings_on_uninstall')
+            ->willReturn(true);
+
+        $setup = new FakeSchemaSetup();
+
+        $uninstall = new Uninstall($scopeConfig);
+        $uninstall->uninstall($setup, new FakeModuleContext());
+
+        $this->assertTrue($setup->setupStarted);
+        $this->assertTrue($setup->setupEnded);
+        $this->assertSame(
+            ['payment/two_payment/%', 'payment/two_search/%'],
+            $setup->connection->deletedPaths
+        );
+    }
+}
+
+class FakeConnection
+{
+    /** @var string[] */
+    public $deletedPaths = [];
+
+    public function delete($table, array $where)
+    {
+        $this->deletedPaths[] = $where['path LIKE ?'];
+        return 1;
+    }
+}
+
+class FakeSchemaSetup implements SchemaSetupInterface
+{
+    public $setupStarted = false;
+    public $setupEnded = false;
+
+    /** @var FakeConnection */
+    public $connection;
+
+    public function __construct()
+    {
+        $this->connection = new FakeConnection();
+    }
+
+    public function startSetup()
+    {
+        $this->setupStarted = true;
+        return $this;
+    }
+
+    public function endSetup()
+    {
+        $this->setupEnded = true;
+        return $this;
+    }
+
+    public function getConnection($resourceName = 'default')
+    {
+        return $this->connection;
+    }
+
+    public function getTable($tableName, $moduleName = 'Two_Gateway')
+    {
+        return $tableName;
+    }
+}
+
+class FakeModuleContext implements ModuleContextInterface
+{
+    public function getVersion()
+    {
+        return '2.2.1';
+    }
+}

--- a/etc/adminhtml/brand_form_template.xml
+++ b/etc/adminhtml/brand_form_template.xml
@@ -98,7 +98,7 @@
                        brand_code="{{code}}">
                     <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\ApiKeyCheck</frontend_model>
                 </field>
-                <field id="vendor_site_name" translate="label" type="text" sortOrder="57"
+                <field id="vendor_site_name" translate="label comment" type="text" sortOrder="57"
                        showInDefault="1" showInWebsite="1" showInStore="1"
                        canRestore="1" brand_code="{{code}}">
                     <label>Vendor/site name</label>
@@ -125,7 +125,7 @@
                     <label/>
                     <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Button\ErrorCheck</frontend_model>
                 </field>
-                <field id="skip_confirm_nonce_check" translate="label" type="select" sortOrder="85"
+                <field id="skip_confirm_nonce_check" translate="label comment" type="select" sortOrder="85"
                        showInDefault="1" showInWebsite="1" showInStore="1"
                        canRestore="1" brand_code="{{code}}">
                     <label>Skip confirm-order nonce check</label>
@@ -133,7 +133,7 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <config_path>payment/{{code}}/skip_confirm_nonce_check</config_path>
                 </field>
-                <field id="clear_settings_on_uninstall" translate="label" type="select" sortOrder="90"
+                <field id="clear_settings_on_uninstall" translate="label comment" type="select" sortOrder="90"
                        showInDefault="1" showInWebsite="0" showInStore="0"
                        canRestore="1" brand_code="{{code}}">
                     <label>Clear settings on module uninstall</label>
@@ -179,6 +179,16 @@
                     </depends>
                     <config_path>payment/{{code}}/title</config_path>
                 </field>
+                <field id="subtitle" translate="label comment" type="text" sortOrder="21"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Subtitle</label>
+                    <comment>Optional line shown beneath the title at checkout (e.g. "Buy now, pay later"). Leave blank to use the default. Can be set per store view.</comment>
+                    <depends>
+                        <field id="active">1</field>
+                    </depends>
+                    <config_path>payment/{{code}}/subtitle</config_path>
+                </field>
                 <field id="merchant_minimum_order" translate="label" type="text" sortOrder="25"
                        showInDefault="1" showInWebsite="1" showInStore="1"
                        canRestore="1" brand_code="{{code}}">
@@ -201,16 +211,6 @@
                         <field id="active">1</field>
                     </depends>
                     <config_path>payment/{{code}}/merchant_minimum_order_basis</config_path>
-                </field>
-                <field id="subtitle" translate="label" type="text" sortOrder="21"
-                       showInDefault="1" showInWebsite="1" showInStore="1"
-                       canRestore="1" brand_code="{{code}}">
-                    <label>Subtitle</label>
-                    <comment>Optional line shown beneath the title at checkout (e.g. "Buy now, pay later"). Leave blank to use the default. Can be set per store view.</comment>
-                    <depends>
-                        <field id="active">1</field>
-                    </depends>
-                    <config_path>payment/{{code}}/subtitle</config_path>
                 </field>
             </group>
             <group id="checkout_fields" translate="label" type="text" sortOrder="20"
@@ -291,7 +291,7 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <config_path>payment/{{code}}/enable_order_note</config_path>
                 </field>
-                <field id="show_about_link" translate="label" type="select" sortOrder="60"
+                <field id="show_about_link" translate="label comment" type="select" sortOrder="60"
                        showInDefault="1" showInWebsite="1" showInStore="1"
                        canRestore="1" brand_code="{{code}}">
                     <label>Show "What is Two" link</label>
@@ -299,7 +299,7 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <config_path>payment/{{code}}/show_about_link</config_path>
                 </field>
-                <field id="display_tooltips" translate="label" type="select" sortOrder="70"
+                <field id="display_tooltips" translate="label comment" type="select" sortOrder="70"
                        showInDefault="1" showInWebsite="1" showInStore="1"
                        canRestore="1" brand_code="{{code}}">
                     <label>Display input tooltips</label>
@@ -495,7 +495,7 @@
                     <comment>Controls the position of this payment method relative to other payment methods at checkout. Lower numbers appear first. Default is empty (no specific order).</comment>
                     <config_path>payment/{{code}}/sort_order</config_path>
                 </field>
-                <field id="disable_ssl_verify" translate="label" type="select" sortOrder="80"
+                <field id="disable_ssl_verify" translate="label comment" type="select" sortOrder="80"
                        showInDefault="1" showInWebsite="1" showInStore="1"
                        canRestore="1" brand_code="{{code}}">
                     <label>Disable SSL verification</label>

--- a/etc/adminhtml/brand_form_template.xml
+++ b/etc/adminhtml/brand_form_template.xml
@@ -98,6 +98,13 @@
                        brand_code="{{code}}">
                     <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\ApiKeyCheck</frontend_model>
                 </field>
+                <field id="vendor_site_name" translate="label" type="text" sortOrder="57"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Vendor/site name</label>
+                    <comment>Optional. If you run Two across multiple sites or stores that share one merchant account, enter a name here to identify this site's orders.</comment>
+                    <config_path>payment/{{code}}/vendor_site_name</config_path>
+                </field>
                 <field id="debug" translate="label" type="select" sortOrder="60"
                        showInDefault="1" showInWebsite="1" showInStore="1"
                        brand_code="{{code}}">
@@ -117,6 +124,28 @@
                        brand_code="{{code}}">
                     <label/>
                     <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Button\ErrorCheck</frontend_model>
+                </field>
+                <field id="skip_confirm_nonce_check" translate="label" type="select" sortOrder="85"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Skip confirm-order nonce check</label>
+                    <comment>Debug/support use only. No effect today: Magento's order-confirmation callback is identified solely by the order reference, which is always checked and cannot be skipped.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <config_path>payment/{{code}}/skip_confirm_nonce_check</config_path>
+                </field>
+                <field id="clear_settings_on_uninstall" translate="label" type="select" sortOrder="90"
+                       showInDefault="1" showInWebsite="0" showInStore="0"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Clear settings on module uninstall</label>
+                    <comment>When this module is uninstalled (bin/magento module:uninstall), delete its stored configuration instead of leaving it behind.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <config_path>payment/{{code}}/clear_settings_on_uninstall</config_path>
+                </field>
+                <field id="health_checklist" translate="label" type="button" sortOrder="95"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       brand_code="{{code}}">
+                    <label>Health checklist</label>
+                    <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\HealthChecklist</frontend_model>
                 </field>
             </group>
         </section>
@@ -172,6 +201,16 @@
                         <field id="active">1</field>
                     </depends>
                     <config_path>payment/{{code}}/merchant_minimum_order_basis</config_path>
+                </field>
+                <field id="subtitle" translate="label" type="text" sortOrder="21"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Subtitle</label>
+                    <comment>Optional line shown beneath the title at checkout (e.g. "Buy now, pay later"). Leave blank to use the default. Can be set per store view.</comment>
+                    <depends>
+                        <field id="active">1</field>
+                    </depends>
+                    <config_path>payment/{{code}}/subtitle</config_path>
                 </field>
             </group>
             <group id="checkout_fields" translate="label" type="text" sortOrder="20"
@@ -251,6 +290,22 @@
                     <comment>Optional field which enables the buyer to register a note to the merchant. The information is eventually displayed on the invoice.</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <config_path>payment/{{code}}/enable_order_note</config_path>
+                </field>
+                <field id="show_about_link" translate="label" type="select" sortOrder="60"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Show "What is Two" link</label>
+                    <comment>Show a link at checkout explaining Two's buy-now-pay-later offering to the buyer.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <config_path>payment/{{code}}/show_about_link</config_path>
+                </field>
+                <field id="display_tooltips" translate="label" type="select" sortOrder="70"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Display input tooltips</label>
+                    <comment>Show a hover tooltip with the field label on the optional checkout field inputs above.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <config_path>payment/{{code}}/display_tooltips</config_path>
                 </field>
             </group>
             <group id="payment_terms" translate="label" type="text" sortOrder="25"
@@ -439,6 +494,14 @@
                     <label>Sort order</label>
                     <comment>Controls the position of this payment method relative to other payment methods at checkout. Lower numbers appear first. Default is empty (no specific order).</comment>
                     <config_path>payment/{{code}}/sort_order</config_path>
+                </field>
+                <field id="disable_ssl_verify" translate="label" type="select" sortOrder="80"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Disable SSL verification</label>
+                    <comment><![CDATA[<strong>WARNING: unsafe for production.</strong> Skips TLS certificate verification on outbound calls to the Two API. Only enable this if this store sits behind a corporate proxy that terminates TLS with its own certificate. Leave this Off everywhere else.]]></comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <config_path>payment/{{code}}/disable_ssl_verify</config_path>
                 </field>
             </group>
         </section>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -45,6 +45,13 @@
                        showInWebsite="1" showInStore="1">
                     <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\ApiKeyCheck</frontend_model>
                 </field>
+                <!-- TWO-25386: ported from woocommerce-plugin's 'vendor_name' field. -->
+                <field id="vendor_site_name" translate="label comment" type="text" sortOrder="57" showInDefault="1"
+                       showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Vendor/site name</label>
+                    <comment>Optional. If you run Two across multiple sites or stores that share one merchant account, enter a name here to identify this site's orders.</comment>
+                    <config_path>payment/two_payment/vendor_site_name</config_path>
+                </field>
                 <field id="debug" translate="label comment" type="select" sortOrder="60" showInDefault="1" showInWebsite="1"
                        showInStore="1">
                     <label>Debug mode</label>
@@ -61,6 +68,34 @@
                        showInWebsite="0" showInStore="0">
                     <label/>
                     <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Button\ErrorCheck</frontend_model>
+                </field>
+                <!-- TWO-25386: ported from woocommerce-plugin's 'skip_confirm_auth'.
+                     See Controller\Payment\Confirm — Magento's confirmation callback
+                     has no separate nonce layer to skip today (only the mandatory
+                     order-reference match), so this flag is currently a documented
+                     no-op kept for admin-surface parity across plugins. -->
+                <field id="skip_confirm_nonce_check" translate="label comment" type="select" sortOrder="85"
+                       showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Skip confirm-order nonce check</label>
+                    <comment>Debug/support use only. No effect today: Magento's order-confirmation callback is identified solely by the order reference, which is always checked and cannot be skipped.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <config_path>payment/two_payment/skip_confirm_nonce_check</config_path>
+                </field>
+                <!-- TWO-25386: ported from woocommerce-plugin's 'clear_options_on_deactivation'.
+                     Magento's nearest lifecycle event is module uninstall, not
+                     deactivation; see Setup\Uninstall. -->
+                <field id="clear_settings_on_uninstall" translate="label comment" type="select" sortOrder="90"
+                       showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                    <label>Clear settings on module uninstall</label>
+                    <comment>When this module is uninstalled (bin/magento module:uninstall), delete its stored configuration instead of leaving it behind.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <config_path>payment/two_payment/clear_settings_on_uninstall</config_path>
+                </field>
+                <!-- TWO-25386: ported from prestashop-plugin's install health checklist. -->
+                <field id="health_checklist" translate="label comment" type="button" sortOrder="95"
+                       showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Health checklist</label>
+                    <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\HealthChecklist</frontend_model>
                 </field>
             </group>
         </section>
@@ -110,6 +145,19 @@
                         <field id="active">1</field>
                     </depends>
                     <config_path>payment/two_payment/title</config_path>
+                </field>
+                <!-- TWO-25386: ported from prestashop-plugin's per-language PS_TWO_SUB_TITLE.
+                     showInStore="1" gives the same per-store-view override PrestaShop gets
+                     from its per-language storage; empty falls back to the brand default
+                     (BrandRegistryInterface::getCheckoutSubtitle). -->
+                <field id="subtitle" translate="label comment" type="text" sortOrder="21" showInDefault="1"
+                       showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Subtitle</label>
+                    <comment>Optional line shown beneath the title at checkout (e.g. "Buy now, pay later"). Leave blank to use the default. Can be set per store view.</comment>
+                    <depends>
+                        <field id="active">1</field>
+                    </depends>
+                    <config_path>payment/two_payment/subtitle</config_path>
                 </field>
             </group>
             <group id="checkout_fields" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="1"
@@ -165,6 +213,25 @@
                     <comment>Optional field which enables the buyer to register a note to the merchant. The information is eventually displayed on the invoice.</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <config_path>payment/two_payment/enable_order_note</config_path>
+                </field>
+                <!--
+                    TWO-25386: ported from woocommerce-plugin. Not part of the
+                    load-bearing order-note-last sequence above (TWO-25263) — these
+                    come after it, so their sortOrder is free to change independently.
+                -->
+                <field id="show_about_link" translate="label comment" type="select" sortOrder="60" showInDefault="1"
+                       showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Show "What is Two" link</label>
+                    <comment>Show a link at checkout explaining Two's buy-now-pay-later offering to the buyer.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <config_path>payment/two_payment/show_about_link</config_path>
+                </field>
+                <field id="display_tooltips" translate="label comment" type="select" sortOrder="70" showInDefault="1"
+                       showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Display input tooltips</label>
+                    <comment>Show a hover tooltip with the field label on the optional checkout field inputs above.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <config_path>payment/two_payment/display_tooltips</config_path>
                 </field>
             </group>
             <group id="payment_terms" translate="label comment" type="text" sortOrder="25" showInDefault="1" showInWebsite="1"
@@ -345,6 +412,16 @@
                     <label>Sort order</label>
                     <comment>Controls the position of this payment method relative to other payment methods at checkout. Lower numbers appear first. Default is empty (no specific order).</comment>
                     <config_path>payment/two_payment/sort_order</config_path>
+                </field>
+                <!-- TWO-25386: ported from prestashop-plugin's PS_TWO_DISABLE_SSL_VERIFY.
+                     Default OFF (verification on / secure). Fixes Service\Api\Adapter,
+                     which previously disabled TLS verification unconditionally. -->
+                <field id="disable_ssl_verify" translate="label comment" type="select" sortOrder="80"
+                       showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Disable SSL verification</label>
+                    <comment><![CDATA[<strong>WARNING: unsafe for production.</strong> Skips TLS certificate verification on outbound calls to the Two API. Only enable this if this store sits behind a corporate proxy that terminates TLS with its own certificate. Leave this Off everywhere else.]]></comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <config_path>payment/two_payment/disable_ssl_verify</config_path>
                 </field>
             </group>
         </section>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -33,6 +33,19 @@
                 <enable_order_note>1</enable_order_note>
                 <enable_project>1</enable_project>
                 <enable_po_number>1</enable_po_number>
+                <vendor_site_name/>
+                <subtitle/>
+                <!-- TWO-25386: show_about_link default ON matches
+                     woocommerce-plugin's default. display_tooltips default ON
+                     preserves Magento's prior behaviour — the optional
+                     checkout field inputs rendered their title-attribute
+                     tooltip unconditionally before this flag existed. -->
+                <show_about_link>1</show_about_link>
+                <display_tooltips>1</display_tooltips>
+                <skip_confirm_nonce_check>0</skip_confirm_nonce_check>
+                <clear_settings_on_uninstall>0</clear_settings_on_uninstall>
+                <!-- TWO-25386: default OFF — TLS verification ON/secure. -->
+                <disable_ssl_verify>0</disable_ssl_verify>
                 <payment_terms_type>standard</payment_terms_type>
                 <payment_terms_duration_days/>
                 <payment_terms>14,30,60,90</payment_terms>

--- a/view/adminhtml/templates/system/config/field/health-checklist.phtml
+++ b/view/adminhtml/templates/system/config/field/health-checklist.phtml
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+use Two\Gateway\Block\Adminhtml\System\Config\Field\HealthChecklist;
+
+/**
+ * @var HealthChecklist $block
+ */
+
+$rows = $block->getChecklistRows();
+?>
+<div class="two-health-checklist" style="line-height:1.6;">
+    <div style="display:flex;flex-wrap:wrap;gap:8px 24px;">
+        <?php foreach ($rows as $row): ?>
+            <div>
+                <strong><?= $block->escapeHtml($row['label']); ?>:</strong>
+                <span style="color:<?= $row['ok'] ? '#079633' : '#e02b27'; ?>;">
+                    <?= $block->escapeHtml($row['value']); ?>
+                </span>
+            </div>
+        <?php endforeach; ?>
+    </div>
+    <?php if ($block->isProductionWithSslDisabled()): ?>
+        <div style="margin-top:0.75em;color:#e02b27;font-weight:bold;">
+            <?= $block->escapeHtml(
+                __('Security warning: SSL verification is disabled while the Environment is set to Production.')
+            ); ?>
+        </div>
+    <?php endif; ?>
+</div>

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -200,9 +200,9 @@ define([
             this.supportedCompanyTypes = config.supportedCompanyTypes || {};
 
             this.twoSubtitleHtml = config.subtitleHtml || '';
-            // TWO-25386: ported from woocommerce-plugin's show_abt_link /
-            // display_tooltips. showWhatIsTwo is the pre-existing (unused
-            // until now) observable declared above.
+            // TWO-25386: ported from woocommerce-plugin's about-link toggle
+            // and tooltip-display toggle. showWhatIsTwo is the pre-existing
+            // (unused until now) observable declared above.
             this.showWhatIsTwo(!!config.showAboutLink);
             this.aboutLinkUrl = config.aboutLinkUrl || '';
             this.aboutLinkText = config.aboutLinkText || '';

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -200,6 +200,13 @@ define([
             this.supportedCompanyTypes = config.supportedCompanyTypes || {};
 
             this.twoSubtitleHtml = config.subtitleHtml || '';
+            // TWO-25386: ported from woocommerce-plugin's show_abt_link /
+            // display_tooltips. showWhatIsTwo is the pre-existing (unused
+            // until now) observable declared above.
+            this.showWhatIsTwo(!!config.showAboutLink);
+            this.aboutLinkUrl = config.aboutLinkUrl || '';
+            this.aboutLinkText = config.aboutLinkText || '';
+            this.displayTooltips = config.displayTooltips !== false;
             this.paymentTermsMessage = config.paymentTermsMessage;
             this.termsNotAcceptedMessage = config.termsNotAcceptedMessage;
             this.isPaymentTermsEnabled = config.isPaymentTermsEnabled;

--- a/view/frontend/web/template/payment/gateway_method.html
+++ b/view/frontend/web/template/payment/gateway_method.html
@@ -15,6 +15,13 @@
             <div class="two-title-block">
                 <span class="two-payment-title" data-bind="text: getTitle()"></span>
                 <div class="two-payment-subtitle" data-bind="html: twoSubtitleHtml"></div>
+                <!-- TWO-25386: ported from woocommerce-plugin's show_abt_link. -->
+                <a
+                    class="two-about-link"
+                    target="_blank"
+                    rel="noopener"
+                    data-bind="visible: showWhatIsTwo, attr: {href: aboutLinkUrl}, text: aboutLinkText"
+                ></a>
             </div>
             <div class="two-payment-shield"></div>
         </div>
@@ -398,7 +405,8 @@
                         <input
                             type="text"
                             id="invoice_emails"
-                            data-bind="value: invoiceEmails, event: { change: validateEmails }"
+                            data-bind="value: invoiceEmails, event: { change: validateEmails },
+                            attr: {title: displayTooltips ? $t('Invoice email address') : ''}"
                             class="input-text"
                         />
                     </div>
@@ -413,7 +421,7 @@
                             id="two_po_number"
                             name="payment[poNumber]"
                             data-bind='
-                            attr: {title: $t("PO Number")},
+                            attr: {title: displayTooltips ? $t("PO Number") : ""},
                             value: poNumber'
                             class="input-text"
                         />
@@ -429,7 +437,7 @@
                             id="two_project"
                             name="payment[project]"
                             data-bind='
-                            attr: {title: $t("Project")},
+                            attr: {title: displayTooltips ? $t("Project") : ""},
                             value: project'
                             class="input-text"
                         />
@@ -445,7 +453,7 @@
                             id="two_department"
                             name="payment[department]"
                             data-bind='
-                            attr: {title: $t("Department")},
+                            attr: {title: displayTooltips ? $t("Department") : ""},
                             value: department'
                             class="input-text"
                         />
@@ -461,7 +469,7 @@
                             id="two_order_note"
                             name="payment[orderNote]"
                             data-bind='
-                            attr: {title: $t("Order Note")},
+                            attr: {title: displayTooltips ? $t("Order Note") : ""},
                             value: orderNote'
                             class="input-text"
                         />

--- a/view/frontend/web/template/payment/gateway_method.html
+++ b/view/frontend/web/template/payment/gateway_method.html
@@ -15,7 +15,7 @@
             <div class="two-title-block">
                 <span class="two-payment-title" data-bind="text: getTitle()"></span>
                 <div class="two-payment-subtitle" data-bind="html: twoSubtitleHtml"></div>
-                <!-- TWO-25386: ported from woocommerce-plugin's show_abt_link. -->
+                <!-- TWO-25386: ported from woocommerce-plugin's about-link toggle. -->
                 <a
                     class="two-about-link"
                     target="_blank"


### PR DESCRIPTION
## Summary

Ports the 8 admin controls flagged in [TWO-25386](https://linear.app/two-inc/issue/TWO-25386/admin-controls-unify-captions-groupings-and-choose-which-controls-to) as present on only one or two of the four plugins, onto Magento — each control's Magento admin field mirrors its source plugin's implementation (config key, help text, default), adapted to Magento's own config-model conventions.

**From woocommerce-plugin:**
- Vendor/site name (multi-site) — free-text field, sent as `vendor_name` on order creation
- "What is Two" checkout explainer link — toggle + link, default on
- Display input tooltips on the optional checkout fields — toggle, default on (preserves current always-on behaviour)
- Skip confirm-order nonce check — admin toggle added for parity; **currently a documented no-op** (see Design ambiguity below)
- Clear settings on module uninstall — new `Setup\Uninstall`, gated behind an opt-in toggle (default off)

**From prestashop-plugin:**
- Payment-method subtitle — store-view-scoped free text, overrides the brand default subtitle when set
- Disable SSL verification (debug toggle, default off/secure) — also **fixes** `Service\Api\Adapter`, which previously disabled TLS certificate verification unconditionally regardless of any config
- Install health checklist — read-only admin panel (API key / environment / SSL verification), mirroring prestashop-plugin's exact 3-item checklist

New fields are added to both `etc/adminhtml/system.xml` and `etc/adminhtml/brand_form_template.xml` (the brand-form synthesis template — see the comments in that file for why both need updating).

## Design ambiguity worth a second pair of eyes

**Skip confirm-order nonce check** (#4) has no real Magento analogue. WooCommerce's `Confirm` callback checks a WordPress nonce on top of a mandatory order-reference match; this toggle skips only the nonce. Magento's `Controller\Payment\Confirm` has no equivalent second layer at all — it identifies the callback solely by `_two_order_reference`, always checked, never skippable. The admin toggle is added for cross-plugin admin-surface parity, and `Confirm.php` carries a docblock explaining it is currently a no-op pending a real Magento-side signing mechanism. Flagging in case a different call is wanted here (e.g. not adding the toggle at all until there's something to gate).

Also worth noting: the **SSL-verification toggle backing fix** is larger than "porting a field" — `Service\Api\Adapter` was unconditionally disabling TLS verification before this PR, independent of any config. Fixing that was necessary to make the new toggle meaningful.

## Test plan

- [x] `make test` — full unit suite green (683 tests) in this branch's docker harness
- [x] New/updated tests: `Test/Unit/Model/Config/RepositoryAdminControlsTest.php` (new getters), `Test/Unit/Service/Api/AdapterTest.php` (SSL toggle on/off), `Test/Unit/Block/Adminhtml/System/Config/Field/HealthChecklistTest.php` (checklist rows + warning), `Test/Unit/Setup/UninstallTest.php` (opt-in gate), `Test/Unit/Config/CheckoutFieldOrderTest.php` + `CheckoutFieldDefaultsTest.php` (updated for the 2 new checkout_fields entries)
- [x] `php -l` clean on all changed PHP files; XML well-formedness checked on all 3 modified admin XML files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
