### PR TITLE
TWO-25386: regroup admin Configuration into unified 6-section scheme (Magento)

### DIFF
--- a/Model/Brand/Descriptor.php
+++ b/Model/Brand/Descriptor.php
@@ -148,10 +148,11 @@ final class Descriptor
 
     /**
      * Short identifier used as the prefix for synthesised admin
-     * Configuration section IDs (e.g. `two_general`, `two_payment`,
-     * `two_search`, `two_version`) and the admin tab id
-     * (`{prefix}_gateway`). Falls back to `code` minus a trailing
-     * `_payment` suffix when not explicitly declared.
+     * Configuration section IDs (e.g. `two_general`,
+     * `two_checkout_fields`, `two_search`, `two_payment`,
+     * `two_order_management`, `two_version` — TWO-25386's A-F regroup)
+     * and the admin tab id (`{prefix}_gateway`). Falls back to `code`
+     * minus a trailing `_payment` suffix when not explicitly declared.
      */
     public function getSectionPrefix(): string
     {

--- a/Plugin/Config/Structure/HidePaymentSection.php
+++ b/Plugin/Config/Structure/HidePaymentSection.php
@@ -14,7 +14,10 @@ use Two\Gateway\Api\BrandOverlayRegistryInterface;
 
 /**
  * Hide every vanilla Two_Gateway admin config section (`two_general`,
- * `two_payment`, `two_search`, `two_version`) when:
+ * `two_checkout_fields`, `two_search`, `two_payment`,
+ * `two_order_management`, `two_version` — TWO-25386's A-F regroup:
+ * General/Checkout Fields/Company Lookup/Payment Terms/Order
+ * Management/Diagnostics) when:
  *   - At least one brand overlay (e.g. Overlay_Gateway) is registered, AND
  *   - `two_brand_synthesis/hide_payment_section/enabled` resolves to truthy.
  *
@@ -74,7 +77,14 @@ class HidePaymentSection
     private const HIDE_FLAG_PATH = 'two_brand_synthesis/hide_payment_section/enabled';
     private const LEGACY_HIDE_FLAG_PATH = 'payment/two_payment/hide_when_overlay_installed';
     private const DEFAULT_HIDE = true;
-    private const TARGET_SECTIONS = ['two_general', 'two_payment', 'two_search', 'two_version'];
+    private const TARGET_SECTIONS = [
+        'two_general',
+        'two_checkout_fields',
+        'two_search',
+        'two_payment',
+        'two_order_management',
+        'two_version',
+    ];
 
     public function __construct(
         private readonly BrandOverlayRegistryInterface $overlayRegistry,

--- a/Plugin/Magento/Config/Model/Config/Structure/Reader/SynthesiseBrandAdminForm.php
+++ b/Plugin/Magento/Config/Model/Config/Structure/Reader/SynthesiseBrandAdminForm.php
@@ -16,8 +16,9 @@ use Two\Gateway\Model\Brand\Loader;
 
 /**
  * Synthesises a brand's admin Configuration surface — tab plus
- * the four canonical sections (`{prefix}_general`, `{prefix}_payment`,
- * `{prefix}_search`, `{prefix}_version`) — by stamping
+ * the six canonical sections (`{prefix}_general`, `{prefix}_checkout_fields`,
+ * `{prefix}_search`, `{prefix}_payment`, `{prefix}_order_management`,
+ * `{prefix}_version` — TWO-25386's A-F regroup) — by stamping
  * `etc/adminhtml/brand_form_template.xml` against each brand's
  * `Brand\Descriptor` and feeding the result through
  * `Magento\Config\Model\Config\Structure\Converter::convert`. The

--- a/Test/Unit/Config/CheckoutFieldDefaultsTest.php
+++ b/Test/Unit/Config/CheckoutFieldDefaultsTest.php
@@ -106,7 +106,7 @@ class CheckoutFieldDefaultsTest extends TestCase
         self::assertNotFalse($xml, 'etc/adminhtml/system.xml is not parseable XML');
 
         $paths = $xml->xpath(
-            '/config/system/section[@id="two_payment"]/group[@id="checkout_fields"]/field/config_path'
+            '/config/system/section[@id="two_checkout_fields"]/group[@id="checkout_fields"]/field/config_path'
         );
         self::assertIsArray($paths);
         self::assertNotEmpty($paths, 'no fields found in the checkout_fields admin group');

--- a/Test/Unit/Plugin/Config/Structure/HidePaymentSectionTest.php
+++ b/Test/Unit/Plugin/Config/Structure/HidePaymentSectionTest.php
@@ -109,6 +109,24 @@ class HidePaymentSectionTest extends TestCase
         $this->assertFalse($plugin->afterIsVisible($this->section('two_search'), true));
     }
 
+    public function testHidesTwoCheckoutFieldsSection(): void
+    {
+        $plugin = $this->plugin(true, true);
+        $this->assertFalse($plugin->afterIsVisible($this->section('two_checkout_fields'), true));
+    }
+
+    public function testHidesTwoOrderManagementSection(): void
+    {
+        $plugin = $this->plugin(true, true);
+        $this->assertFalse($plugin->afterIsVisible($this->section('two_order_management'), true));
+    }
+
+    public function testHidesTwoVersionSection(): void
+    {
+        $plugin = $this->plugin(true, true);
+        $this->assertFalse($plugin->afterIsVisible($this->section('two_version'), true));
+    }
+
     // --- TWO-25191: flag moved to two_brand_synthesis/, legacy path still read ---
 
     public function testNewPathSetToZeroShows(): void

--- a/docs/brand-overlay-guide.md
+++ b/docs/brand-overlay-guide.md
@@ -105,7 +105,7 @@ across modules). Elements may appear in any order (`xs:all`).
 | ---------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `code`           | yes      | Brand + payment-method code (`[a-z][a-z0-9_]*`). Keyed into `sales_order.payment.method` and `core_config_data` paths — frozen for live installs.                       |
 | `tab_sort_order` | yes      | Admin Configuration tab ordering.                                                                                                                                       |
-| `section_prefix` | no       | Prefix for synthesised admin section ids (`{prefix}_general`, `{prefix}_payment`, …) and the tab id `{prefix}_gateway`. Defaults to `code` minus a trailing `_payment`. |
+| `section_prefix` | no       | Prefix for synthesised admin section ids (`{prefix}_general`, `{prefix}_checkout_fields`, `{prefix}_search`, `{prefix}_payment`, `{prefix}_order_management`, `{prefix}_version` — TWO-25386's A-F regroup) and the tab id `{prefix}_gateway`. Defaults to `code` minus a trailing `_payment`. |
 
 **Elements**
 
@@ -295,6 +295,19 @@ in the canonical template but doesn't render for this brand. Use this
 instead of shipping a `<section>` stub in the overlay's system.xml —
 a static stub inserts itself into the merged Structure first and
 short-circuits the synthesised section ordering.
+
+**TWO-25386 moved some fields to a different section suffix.** `title`,
+`subtitle`, `sort_order`, `sallowspecific`/`specificcountry`,
+`merchant_minimum_order(_basis)` and `enable_order_intent` now live
+under `{section_prefix}_checkout_fields` (groups `display`/
+`availability`) instead of `{section_prefix}_payment`;
+`fulfill_trigger`, `fulfill_order_status` and `enable_tax_subtotals`
+now live under `{section_prefix}_order_management` (group
+`order_management`) instead of `{section_prefix}_payment`/`advanced`.
+Any `suppressed_fields` entry targeting one of those fields by its old
+`payment/advanced/…` or `payment/payment_method/…` path needs its
+`section_suffix` segment updated to match, or the suppression silently
+stops matching and the field reappears for that brand.
 
 ## Worked example: adding a brand-driven field
 

--- a/etc/adminhtml/brand_form_template.xml
+++ b/etc/adminhtml/brand_form_template.xml
@@ -24,7 +24,8 @@
  *                    Used in CCD config_path values.
  *   section_prefix   Short brand prefix, e.g. "two", "overlay". Used
  *                    for tab id (`{prefix}_gateway`) and section
- *                    ids (`{prefix}_general`/`_payment`/`_search`/
+ *                    ids (`{prefix}_general`/`_checkout_fields`/
+ *                    `_search`/`_payment`/`_order_management`/
  *                    `_version`).
  *   provider         Short brand name. Currently unused at the
  *                    admin-XML level but reserved for label
@@ -50,6 +51,20 @@
  * the canonical body produced by this template; overlay scalars win
  * per-field. Overlays cannot ADD controls via this mechanism — the
  * canonical template is the source of truth for what fields exist.
+ *
+ * TWO-25386 Part 1: unified 6-section admin scheme (A. General,
+ * B. Checkout Fields, C. Company Lookup, D. Payment Terms,
+ * E. Order Management, F. Diagnostics — same names/order as
+ * prestashop-plugin and woocommerce-plugin). `_general`, `_search`
+ * and `_payment` keep their historical suffixes (relabeled); this is
+ * what keeps a brand.xml `<suppressed_fields>` entry of the form
+ * `general/…`, `search/…` or `payment/payment_terms/…` matching
+ * unchanged. `_checkout_fields` and `_order_management` are new
+ * suffixes for content split out of the old `_payment` section — an
+ * overlay that suppressed a field which moved into one of those two
+ * (title, subtitle, sort_order, country availability, minimum order,
+ * order intent, fulfilment trigger/status, tax subtotals) needs its
+ * `suppressed_fields` path updated to match.
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -59,6 +74,7 @@
              class="{{tab_css_class}}" sortOrder="{{tab_sort_order}}">
             <label>{{tab_label}}</label>
         </tab>
+        <!-- A. General -->
         <section id="{{section_prefix}}_general" translate="label" type="text" sortOrder="10"
                  showInDefault="1" showInWebsite="1" showInStore="1"
                  brand_code="{{code}}">
@@ -70,6 +86,14 @@
                    showInDefault="1" showInWebsite="1" showInStore="1"
                    brand_code="{{code}}">
                 <label>General</label>
+                <field id="active" translate="label" type="select" sortOrder="5"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Enable payment method</label>
+                    <comment>Activates this plugin as a payment option in the checkout page</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <config_path>payment/{{code}}/active</config_path>
+                </field>
                 <field id="mode" translate="label" type="select" sortOrder="35"
                        showInDefault="1" showInWebsite="1" showInStore="1"
                        brand_code="{{code}}">
@@ -105,70 +129,29 @@
                     <comment>Optional. If you run Two across multiple sites or stores that share one merchant account, enter a name here to identify this site's orders.</comment>
                     <config_path>payment/{{code}}/vendor_site_name</config_path>
                 </field>
-                <field id="debug" translate="label" type="select" sortOrder="60"
-                       showInDefault="1" showInWebsite="1" showInStore="1"
-                       brand_code="{{code}}">
-                    <label>Debug mode</label>
-                    <comment>The debug mode enables writing to the error logs below. Debug mode should only be enabled when the sandbox environment is active</comment>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <config_path>payment/{{code}}/debug</config_path>
-                </field>
-                <field id="debug_button" translate="label" type="button" sortOrder="70"
-                       showInDefault="1" showInWebsite="0" showInStore="0"
-                       brand_code="{{code}}">
-                    <label/>
-                    <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Button\DebugCheck</frontend_model>
-                </field>
-                <field id="error_button" translate="label" type="button" sortOrder="80"
-                       showInDefault="1" showInWebsite="0" showInStore="0"
-                       brand_code="{{code}}">
-                    <label/>
-                    <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Button\ErrorCheck</frontend_model>
-                </field>
-                <field id="skip_confirm_nonce_check" translate="label comment" type="select" sortOrder="85"
+                <field id="disable_ssl_verify" translate="label comment" type="select" sortOrder="65"
                        showInDefault="1" showInWebsite="1" showInStore="1"
                        canRestore="1" brand_code="{{code}}">
-                    <label>Skip confirm-order nonce check</label>
-                    <comment>Debug/support use only. No effect today: Magento's order-confirmation callback is identified solely by the order reference, which is always checked and cannot be skipped.</comment>
+                    <label>Disable SSL verification</label>
+                    <comment><![CDATA[<strong>WARNING: unsafe for production.</strong> Skips TLS certificate verification on outbound calls to the Two API. Only enable this if this store sits behind a corporate proxy that terminates TLS with its own certificate. Leave this Off everywhere else.]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <config_path>payment/{{code}}/skip_confirm_nonce_check</config_path>
-                </field>
-                <field id="clear_settings_on_uninstall" translate="label comment" type="select" sortOrder="90"
-                       showInDefault="1" showInWebsite="0" showInStore="0"
-                       canRestore="1" brand_code="{{code}}">
-                    <label>Clear settings on module uninstall</label>
-                    <comment>When this module is uninstalled (bin/magento module:uninstall), delete its stored configuration instead of leaving it behind.</comment>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <config_path>payment/{{code}}/clear_settings_on_uninstall</config_path>
-                </field>
-                <field id="health_checklist" translate="label" type="button" sortOrder="95"
-                       showInDefault="1" showInWebsite="1" showInStore="1"
-                       brand_code="{{code}}">
-                    <label>Health checklist</label>
-                    <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\HealthChecklist</frontend_model>
+                    <config_path>payment/{{code}}/disable_ssl_verify</config_path>
                 </field>
             </group>
         </section>
-        <section id="{{section_prefix}}_payment" translate="label" type="text" sortOrder="20"
+        <!-- B. Checkout Fields -->
+        <section id="{{section_prefix}}_checkout_fields" translate="label" type="text" sortOrder="20"
                  showInDefault="1" showInWebsite="1" showInStore="1"
                  brand_code="{{code}}">
             <class>separator-top</class>
-            <label>Payment</label>
+            <label>Checkout Fields</label>
             <tab>{{section_prefix}}_gateway</tab>
             <resource>{{admin_resource}}</resource>
-            <group id="payment_method" translate="label" type="text" sortOrder="10"
+            <group id="display" translate="label" type="text" sortOrder="10"
                    showInDefault="1" showInWebsite="1" showInStore="1"
                    brand_code="{{code}}">
-                <label>Payment method</label>
-                <field id="active" translate="label" type="select" sortOrder="10"
-                       showInDefault="1" showInWebsite="1" showInStore="1"
-                       canRestore="1" brand_code="{{code}}">
-                    <label>Enable payment method</label>
-                    <comment>Activates this plugin as a payment option in the checkout page</comment>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <config_path>payment/{{code}}/active</config_path>
-                </field>
-                <field id="title" translate="label" type="text" sortOrder="20"
+                <label>Title &amp; Display</label>
+                <field id="title" translate="label" type="text" sortOrder="10"
                        showInDefault="1" showInWebsite="1" showInStore="1"
                        canRestore="1" brand_code="{{code}}">
                     <label>Title</label>
@@ -179,7 +162,7 @@
                     </depends>
                     <config_path>payment/{{code}}/title</config_path>
                 </field>
-                <field id="subtitle" translate="label comment" type="text" sortOrder="21"
+                <field id="subtitle" translate="label comment" type="text" sortOrder="20"
                        showInDefault="1" showInWebsite="1" showInStore="1"
                        canRestore="1" brand_code="{{code}}">
                     <label>Subtitle</label>
@@ -189,7 +172,40 @@
                     </depends>
                     <config_path>payment/{{code}}/subtitle</config_path>
                 </field>
-                <field id="merchant_minimum_order" translate="label" type="text" sortOrder="25"
+                <field id="sort_order" translate="label comment" type="text" sortOrder="30"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Sort order</label>
+                    <comment>Controls the position of this payment method relative to other payment methods at checkout. Lower numbers appear first. Default is empty (no specific order).</comment>
+                    <config_path>payment/{{code}}/sort_order</config_path>
+                </field>
+            </group>
+            <group id="availability" translate="label" type="text" sortOrder="20"
+                   showInDefault="1" showInWebsite="1" showInStore="1"
+                   brand_code="{{code}}">
+                <label>Availability &amp; Minimum Order</label>
+                <field id="sallowspecific" translate="label comment" type="select" sortOrder="10"
+                       showInDefault="1" showInWebsite="1" showInStore="0"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Country availability</label>
+                    <comment>Choose whether to enable this payment method for all allowed countries or only specific ones.</comment>
+                    <frontend_class>shipping-applicable-country</frontend_class>
+                    <source_model>Magento\Shipping\Model\Config\Source\Allspecificcountries</source_model>
+                    <config_path>payment/{{code}}/allowspecific</config_path>
+                </field>
+                <field id="specificcountry" translate="label comment" type="multiselect" sortOrder="20"
+                       showInDefault="1" showInWebsite="1" showInStore="0"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Allowed countries</label>
+                    <comment>Select the countries where this payment method should be available.</comment>
+                    <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
+                    <can_be_empty>1</can_be_empty>
+                    <depends>
+                        <field id="sallowspecific">1</field>
+                    </depends>
+                    <config_path>payment/{{code}}/specificcountry</config_path>
+                </field>
+                <field id="merchant_minimum_order" translate="label" type="text" sortOrder="30"
                        showInDefault="1" showInWebsite="1" showInStore="1"
                        canRestore="1" brand_code="{{code}}">
                     <label>Minimum order value</label>
@@ -201,7 +217,7 @@
                     </depends>
                     <config_path>payment/{{code}}/merchant_minimum_order</config_path>
                 </field>
-                <field id="merchant_minimum_order_basis" translate="label comment" type="select" sortOrder="26"
+                <field id="merchant_minimum_order_basis" translate="label comment" type="select" sortOrder="40"
                        showInDefault="1" showInWebsite="1" showInStore="1"
                        canRestore="1" brand_code="{{code}}">
                     <label>Minimum order value tax basis</label>
@@ -212,8 +228,16 @@
                     </depends>
                     <config_path>payment/{{code}}/merchant_minimum_order_basis</config_path>
                 </field>
+                <field id="enable_order_intent" translate="label" type="select" sortOrder="50"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Enable order intent</label>
+                    <comment>Perform a check during checkout to inform the buyer whether an order is likely to be accepted before being placed (recommended).</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <config_path>payment/{{code}}/enable_order_intent</config_path>
+                </field>
             </group>
-            <group id="checkout_fields" translate="label" type="text" sortOrder="20"
+            <group id="checkout_fields" translate="label" type="text" sortOrder="30"
                    showInDefault="1" showInWebsite="1" showInStore="1"
                    brand_code="{{code}}">
                 <label>Checkout fields</label>
@@ -308,11 +332,64 @@
                     <config_path>payment/{{code}}/display_tooltips</config_path>
                 </field>
             </group>
-            <group id="payment_terms" translate="label" type="text" sortOrder="25"
+        </section>
+        <!-- C. Company Lookup -->
+        <section id="{{section_prefix}}_search" translate="label" type="text" sortOrder="30"
+                 showInDefault="1" showInWebsite="1" showInStore="1"
+                 brand_code="{{code}}">
+            <class>separator-top</class>
+            <label>Company Lookup</label>
+            <tab>{{section_prefix}}_gateway</tab>
+            <resource>{{admin_resource}}</resource>
+            <group id="search" translate="label" type="text" sortOrder="10"
+                   showInDefault="1" showInWebsite="1" showInStore="1"
+                   brand_code="{{code}}">
+                <label>Company Lookup</label>
+                <field id="enable_company_search" translate="label comment" type="select" sortOrder="10"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Enable company search in address entry</label>
+                    <comment>When enabled, the buyer may search for their company within the address entry section of the checkout. Otherwise, company search will be visible within the payment method.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends>
+                        <field id="active">1</field>
+                    </depends>
+                    <config_path>payment/{{code}}/enable_company_search</config_path>
+                </field>
+                <field id="enable_address_search" translate="label comment" type="select" sortOrder="20"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Autofill company address</label>
+                    <comment>Autocomplete address based on selected country and company. Only takes effect when company search in address entry is also enabled.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends>
+                        <field id="active">1</field>
+                    </depends>
+                    <config_path>payment/{{code}}/enable_address_search</config_path>
+                </field>
+            </group>
+        </section>
+        <!-- D. Payment Terms -->
+        <section id="{{section_prefix}}_payment" translate="label" type="text" sortOrder="40"
+                 showInDefault="1" showInWebsite="1" showInStore="1"
+                 brand_code="{{code}}">
+            <class>separator-top</class>
+            <label>Payment Terms</label>
+            <tab>{{section_prefix}}_gateway</tab>
+            <resource>{{admin_resource}}</resource>
+            <group id="payment_terms" translate="label" type="text" sortOrder="10"
                    showInDefault="1" showInWebsite="1" showInStore="1"
                    brand_code="{{code}}">
                 <label>Payment terms</label>
-                <field id="payment_terms" translate="label comment" type="text" sortOrder="10"
+                <field id="payment_terms_type" translate="label comment" type="select" sortOrder="10"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Payment terms type</label>
+                    <comment><![CDATA[<strong>Standard:</strong> Payment due after a fixed number of days from fulfilment.<br/><strong>End of Month:</strong> Payment due at the end of month plus additional days from fulfilment.]]></comment>
+                    <source_model>Two\Gateway\Model\Config\Source\PaymentTermsType</source_model>
+                    <config_path>payment/{{code}}/payment_terms_type</config_path>
+                </field>
+                <field id="payment_terms" translate="label comment" type="text" sortOrder="20"
                        showInDefault="1" showInWebsite="1" showInStore="1"
                        canRestore="1" brand_code="{{code}}">
                     <label>Payment terms</label>
@@ -321,21 +398,13 @@
                     <backend_model>Two\Gateway\Model\Config\Backend\PaymentTermsCheckboxes</backend_model>
                     <config_path>payment/{{code}}/payment_terms</config_path>
                 </field>
-                <field id="payment_terms_duration_days" translate="label comment" type="text" sortOrder="20"
+                <field id="payment_terms_duration_days" translate="label comment" type="text" sortOrder="30"
                        showInDefault="1" showInWebsite="1" showInStore="1"
                        canRestore="1" brand_code="{{code}}">
                     <label>Custom payment term (days)</label>
                     <comment>Optional. Enter a custom number of days to offer alongside the selected terms above.</comment>
                     <validate>validate-digits validate-zero-or-greater</validate>
                     <config_path>payment/{{code}}/payment_terms_duration_days</config_path>
-                </field>
-                <field id="payment_terms_type" translate="label comment" type="select" sortOrder="30"
-                       showInDefault="1" showInWebsite="1" showInStore="1"
-                       canRestore="1" brand_code="{{code}}">
-                    <label>Payment terms type</label>
-                    <comment><![CDATA[<strong>Standard:</strong> Payment due after a fixed number of days from fulfilment.<br/><strong>End of Month:</strong> Payment due at the end of month plus additional days from fulfilment.]]></comment>
-                    <source_model>Two\Gateway\Model\Config\Source\PaymentTermsType</source_model>
-                    <config_path>payment/{{code}}/payment_terms_type</config_path>
                 </field>
                 <field id="default_payment_term" translate="label comment" type="select" sortOrder="40"
                        showInDefault="1" showInWebsite="1" showInStore="1"
@@ -367,7 +436,37 @@
                     <comment><![CDATA[Description shown to the buyer for the surcharge line item. Use <strong>%1</strong> to insert the selected number of days (e.g. "Payment terms fee - %1 days"). If you leave the default, the word <em>days</em> is translated per locale.]]></comment>
                     <config_path>payment/{{code}}/surcharge_line_description</config_path>
                 </field>
-                <field id="surcharge_tax_class" translate="label comment" type="select" sortOrder="80"
+                <field id="surcharge_grid" translate="label" type="text" sortOrder="80"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       brand_code="{{code}}">
+                    <label>Payment surcharge configuration</label>
+                    <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\SurchargeGrid</frontend_model>
+                    <backend_model>Two\Gateway\Model\Config\Backend\SurchargeGrid</backend_model>
+                </field>
+                <field id="surcharge_rounding_basis" translate="label comment" type="select" sortOrder="90"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Surcharge rounding</label>
+                    <comment>Snap the buyer surcharge line item to a clean increment. Select None for standard two-decimal amounts.</comment>
+                    <source_model>Two\Gateway\Model\Config\Source\RoundingBasis</source_model>
+                    <config_path>payment/{{code}}/surcharge_rounding_basis</config_path>
+                    <depends>
+                        <field id="surcharge_type" separator=",">percentage,fixed_and_percentage</field>
+                    </depends>
+                </field>
+                <field id="surcharge_rounding_step" translate="label comment" type="select" sortOrder="100"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Rounding step</label>
+                    <comment><![CDATA[Increment the surcharge is rounded to (e.g. 1 = whole units, 0.50 = nearest half).]]></comment>
+                    <source_model>Two\Gateway\Model\Config\Source\RoundingStep</source_model>
+                    <config_path>payment/{{code}}/surcharge_rounding_step</config_path>
+                    <depends>
+                        <field id="surcharge_type" separator=",">percentage,fixed_and_percentage</field>
+                        <field id="surcharge_rounding_basis" separator=",">up,down,standard</field>
+                    </depends>
+                </field>
+                <field id="surcharge_tax_class" translate="label comment" type="select" sortOrder="110"
                        showInDefault="1" showInWebsite="1" showInStore="1"
                        brand_code="{{code}}">
                     <label>Surcharge tax treatment</label>
@@ -383,7 +482,7 @@
                      offered when a value already exists). Field id renamed at the
                      code level only - the persisted config key deliberately stays
                      payment/<code>/surcharge_tax_rate (no data migration). -->
-                <field id="custom_surcharge_tax_rate" translate="label comment" type="text" sortOrder="90"
+                <field id="custom_surcharge_tax_rate" translate="label comment" type="text" sortOrder="120"
                        showInDefault="1" showInWebsite="1" showInStore="1"
                        canRestore="1" brand_code="{{code}}">
                     <label>Custom surcharge tax rate (%)</label>
@@ -397,62 +496,20 @@
                         <field id="surcharge_type" separator=",">percentage,fixed,fixed_and_percentage</field>
                     </depends>
                 </field>
-                <field id="surcharge_grid" translate="label" type="text" sortOrder="100"
-                       showInDefault="1" showInWebsite="1" showInStore="1"
-                       brand_code="{{code}}">
-                    <label>Payment surcharge configuration</label>
-                    <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\SurchargeGrid</frontend_model>
-                    <backend_model>Two\Gateway\Model\Config\Backend\SurchargeGrid</backend_model>
-                </field>
-                <field id="surcharge_rounding_basis" translate="label comment" type="select" sortOrder="110"
-                       showInDefault="1" showInWebsite="1" showInStore="1"
-                       canRestore="1" brand_code="{{code}}">
-                    <label>Surcharge rounding</label>
-                    <comment>Snap the buyer surcharge line item to a clean increment. Select None for standard two-decimal amounts.</comment>
-                    <source_model>Two\Gateway\Model\Config\Source\RoundingBasis</source_model>
-                    <config_path>payment/{{code}}/surcharge_rounding_basis</config_path>
-                    <depends>
-                        <field id="surcharge_type" separator=",">percentage,fixed_and_percentage</field>
-                    </depends>
-                </field>
-                <field id="surcharge_rounding_step" translate="label comment" type="select" sortOrder="120"
-                       showInDefault="1" showInWebsite="1" showInStore="1"
-                       canRestore="1" brand_code="{{code}}">
-                    <label>Rounding step</label>
-                    <comment><![CDATA[Increment the surcharge is rounded to (e.g. 1 = whole units, 0.50 = nearest half).]]></comment>
-                    <source_model>Two\Gateway\Model\Config\Source\RoundingStep</source_model>
-                    <config_path>payment/{{code}}/surcharge_rounding_step</config_path>
-                    <depends>
-                        <field id="surcharge_type" separator=",">percentage,fixed_and_percentage</field>
-                        <field id="surcharge_rounding_basis" separator=",">up,down,standard</field>
-                    </depends>
-                </field>
             </group>
-            <group id="advanced" translate="label" type="text" sortOrder="30"
+        </section>
+        <!-- E. Order Management -->
+        <section id="{{section_prefix}}_order_management" translate="label" type="text" sortOrder="50"
+                 showInDefault="1" showInWebsite="1" showInStore="1"
+                 brand_code="{{code}}">
+            <class>separator-top</class>
+            <label>Order Management</label>
+            <tab>{{section_prefix}}_gateway</tab>
+            <resource>{{admin_resource}}</resource>
+            <group id="order_management" translate="label" type="text" sortOrder="10"
                    showInDefault="1" showInWebsite="1" showInStore="1"
                    brand_code="{{code}}">
-                <label>Advanced</label>
-                <field id="sallowspecific" translate="label comment" type="select" sortOrder="5"
-                       showInDefault="1" showInWebsite="1" showInStore="0"
-                       canRestore="1" brand_code="{{code}}">
-                    <label>Country availability</label>
-                    <comment>Choose whether to enable this payment method for all allowed countries or only specific ones.</comment>
-                    <frontend_class>shipping-applicable-country</frontend_class>
-                    <source_model>Magento\Shipping\Model\Config\Source\Allspecificcountries</source_model>
-                    <config_path>payment/{{code}}/allowspecific</config_path>
-                </field>
-                <field id="specificcountry" translate="label comment" type="multiselect" sortOrder="6"
-                       showInDefault="1" showInWebsite="1" showInStore="0"
-                       canRestore="1" brand_code="{{code}}">
-                    <label>Allowed countries</label>
-                    <comment>Select the countries where this payment method should be available.</comment>
-                    <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
-                    <can_be_empty>1</can_be_empty>
-                    <depends>
-                        <field id="sallowspecific">1</field>
-                    </depends>
-                    <config_path>payment/{{code}}/specificcountry</config_path>
-                </field>
+                <label>Order Management</label>
                 <field id="fulfill_trigger" translate="label" type="select" sortOrder="10"
                        showInDefault="1" showInWebsite="1" showInStore="1"
                        canRestore="1" brand_code="{{code}}">
@@ -472,15 +529,7 @@
                     </depends>
                     <config_path>payment/{{code}}/fulfill_order_status</config_path>
                 </field>
-                <field id="enable_order_intent" translate="label" type="select" sortOrder="30"
-                       showInDefault="1" showInWebsite="1" showInStore="1"
-                       canRestore="1" brand_code="{{code}}">
-                    <label>Enable order intent</label>
-                    <comment>Perform a check during checkout to inform the buyer whether an order is likely to be accepted before being placed (recommended).</comment>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <config_path>payment/{{code}}/enable_order_intent</config_path>
-                </field>
-                <field id="enable_tax_subtotals" translate="label" type="select" sortOrder="40"
+                <field id="enable_tax_subtotals" translate="label" type="select" sortOrder="30"
                        showInDefault="1" showInWebsite="1" showInStore="1"
                        canRestore="1" brand_code="{{code}}">
                     <label>Enable tax subtotals</label>
@@ -488,66 +537,63 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <config_path>payment/{{code}}/enable_tax_subtotals</config_path>
                 </field>
-                <field id="sort_order" translate="label comment" type="text" sortOrder="70"
-                       showInDefault="1" showInWebsite="1" showInStore="1"
-                       canRestore="1" brand_code="{{code}}">
-                    <label>Sort order</label>
-                    <comment>Controls the position of this payment method relative to other payment methods at checkout. Lower numbers appear first. Default is empty (no specific order).</comment>
-                    <config_path>payment/{{code}}/sort_order</config_path>
-                </field>
-                <field id="disable_ssl_verify" translate="label comment" type="select" sortOrder="80"
-                       showInDefault="1" showInWebsite="1" showInStore="1"
-                       canRestore="1" brand_code="{{code}}">
-                    <label>Disable SSL verification</label>
-                    <comment><![CDATA[<strong>WARNING: unsafe for production.</strong> Skips TLS certificate verification on outbound calls to the Two API. Only enable this if this store sits behind a corporate proxy that terminates TLS with its own certificate. Leave this Off everywhere else.]]></comment>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <config_path>payment/{{code}}/disable_ssl_verify</config_path>
-                </field>
             </group>
         </section>
-        <section id="{{section_prefix}}_search" translate="label" type="text" sortOrder="30"
+        <!-- F. Diagnostics -->
+        <section id="{{section_prefix}}_version" translate="label" type="text" sortOrder="60"
                  showInDefault="1" showInWebsite="1" showInStore="1"
                  brand_code="{{code}}">
             <class>separator-top</class>
-            <label>Search</label>
+            <label>Diagnostics</label>
             <tab>{{section_prefix}}_gateway</tab>
             <resource>{{admin_resource}}</resource>
-            <group id="search" translate="label" type="text" sortOrder="10"
+            <group id="logging" translate="label" type="text" sortOrder="10"
                    showInDefault="1" showInWebsite="1" showInStore="1"
                    brand_code="{{code}}">
-                <label>Search</label>
-                <field id="enable_company_search" translate="label comment" type="select" sortOrder="10"
+                <label>Debug &amp; Logging</label>
+                <field id="debug" translate="label" type="select" sortOrder="10"
                        showInDefault="1" showInWebsite="1" showInStore="1"
-                       canRestore="1" brand_code="{{code}}">
-                    <label>Enable company search in address entry</label>
-                    <comment>When enabled, the buyer may search for their company within the address entry section of the checkout. Otherwise, company search will be visible within the payment method.</comment>
+                       brand_code="{{code}}">
+                    <label>Debug mode</label>
+                    <comment>The debug mode enables writing to the error logs below. Debug mode should only be enabled when the sandbox environment is active</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <depends>
-                        <field id="active">1</field>
-                    </depends>
-                    <config_path>payment/{{code}}/enable_company_search</config_path>
+                    <config_path>payment/{{code}}/debug</config_path>
                 </field>
-                <field id="enable_address_search" translate="label comment" type="select" sortOrder="20"
-                       showInDefault="1" showInWebsite="1" showInStore="1"
-                       canRestore="1" brand_code="{{code}}">
-                    <label>Autofill company address</label>
-                    <comment>Autocomplete address based on selected country and company. Only takes effect when company search in address entry is also enabled.</comment>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <depends>
-                        <field id="active">1</field>
-                    </depends>
-                    <config_path>payment/{{code}}/enable_address_search</config_path>
+                <field id="debug_button" translate="label" type="button" sortOrder="20"
+                       showInDefault="1" showInWebsite="0" showInStore="0"
+                       brand_code="{{code}}">
+                    <label/>
+                    <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Button\DebugCheck</frontend_model>
+                </field>
+                <field id="error_button" translate="label" type="button" sortOrder="30"
+                       showInDefault="1" showInWebsite="0" showInStore="0"
+                       brand_code="{{code}}">
+                    <label/>
+                    <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Button\ErrorCheck</frontend_model>
                 </field>
             </group>
-        </section>
-        <section id="{{section_prefix}}_version" translate="label" type="text" sortOrder="100"
-                 showInDefault="1" showInWebsite="1" showInStore="1"
-                 brand_code="{{code}}">
-            <class>separator-top</class>
-            <label>Version</label>
-            <tab>{{section_prefix}}_gateway</tab>
-            <resource>{{admin_resource}}</resource>
-            <group id="general" translate="label" type="text" sortOrder="10"
+            <group id="admin_controls" translate="label" type="text" sortOrder="20"
+                   showInDefault="1" showInWebsite="1" showInStore="1"
+                   brand_code="{{code}}">
+                <label>Admin Controls</label>
+                <field id="skip_confirm_nonce_check" translate="label comment" type="select" sortOrder="10"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Skip confirm-order nonce check</label>
+                    <comment>Debug/support use only. No effect today: Magento's order-confirmation callback is identified solely by the order reference, which is always checked and cannot be skipped.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <config_path>payment/{{code}}/skip_confirm_nonce_check</config_path>
+                </field>
+                <field id="clear_settings_on_uninstall" translate="label comment" type="select" sortOrder="20"
+                       showInDefault="1" showInWebsite="0" showInStore="0"
+                       canRestore="1" brand_code="{{code}}">
+                    <label>Clear settings on module uninstall</label>
+                    <comment>When this module is uninstalled (bin/magento module:uninstall), delete its stored configuration instead of leaving it behind.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <config_path>payment/{{code}}/clear_settings_on_uninstall</config_path>
+                </field>
+            </group>
+            <group id="general" translate="label" type="text" sortOrder="30"
                    showInDefault="1" showInWebsite="1" showInStore="1"
                    brand_code="{{code}}">
                 <label>Version</label>
@@ -556,6 +602,17 @@
                        brand_code="{{code}}">
                     <label/>
                     <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\Version</frontend_model>
+                </field>
+            </group>
+            <group id="health" translate="label" type="text" sortOrder="40"
+                   showInDefault="1" showInWebsite="1" showInStore="1"
+                   brand_code="{{code}}">
+                <label>Health</label>
+                <field id="health_checklist" translate="label" type="button" sortOrder="10"
+                       showInDefault="1" showInWebsite="1" showInStore="1"
+                       brand_code="{{code}}">
+                    <label>Health checklist</label>
+                    <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\HealthChecklist</frontend_model>
                 </field>
             </group>
         </section>

--- a/etc/adminhtml/brand_form_template.xml
+++ b/etc/adminhtml/brand_form_template.xml
@@ -151,15 +151,16 @@
                    showInDefault="1" showInWebsite="1" showInStore="1"
                    brand_code="{{code}}">
                 <label>Title &amp; Display</label>
+                <!-- TWO-25386: no <depends> on "active" here — see the matching
+                     comment in system.xml. Each top-level <section> is its own
+                     admin page; "active" now lives in {{section_prefix}}_general,
+                     a different page, so the dependency could never fire. -->
                 <field id="title" translate="label" type="text" sortOrder="10"
                        showInDefault="1" showInWebsite="1" showInStore="1"
                        canRestore="1" brand_code="{{code}}">
                     <label>Title</label>
                     <comment>Descriptive title which gives the buyer a better understanding of this payment method</comment>
                     <validate>required-entry</validate>
-                    <depends>
-                        <field id="active">1</field>
-                    </depends>
                     <config_path>payment/{{code}}/title</config_path>
                 </field>
                 <field id="subtitle" translate="label comment" type="text" sortOrder="20"
@@ -167,9 +168,6 @@
                        canRestore="1" brand_code="{{code}}">
                     <label>Subtitle</label>
                     <comment>Optional line shown beneath the title at checkout (e.g. "Buy now, pay later"). Leave blank to use the default. Can be set per store view.</comment>
-                    <depends>
-                        <field id="active">1</field>
-                    </depends>
                     <config_path>payment/{{code}}/subtitle</config_path>
                 </field>
                 <field id="sort_order" translate="label comment" type="text" sortOrder="30"
@@ -212,9 +210,6 @@
                     <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\MinimumOrderValue</frontend_model>
                     <backend_model>Two\Gateway\Model\Config\Backend\MerchantMinimumOrder</backend_model>
                     <comment model="Two\Gateway\Model\Config\Comment\MerchantMinimumOrder"/>
-                    <depends>
-                        <field id="active">1</field>
-                    </depends>
                     <config_path>payment/{{code}}/merchant_minimum_order</config_path>
                 </field>
                 <field id="merchant_minimum_order_basis" translate="label comment" type="select" sortOrder="40"
@@ -223,9 +218,6 @@
                     <label>Minimum order value tax basis</label>
                     <comment>Whether the basket is compared against the minimum including or excluding tax</comment>
                     <source_model>Two\Gateway\Model\Config\Source\MinimumOrderBasis</source_model>
-                    <depends>
-                        <field id="active">1</field>
-                    </depends>
                     <config_path>payment/{{code}}/merchant_minimum_order_basis</config_path>
                 </field>
                 <field id="enable_order_intent" translate="label" type="select" sortOrder="50"
@@ -345,15 +337,16 @@
                    showInDefault="1" showInWebsite="1" showInStore="1"
                    brand_code="{{code}}">
                 <label>Company Lookup</label>
+                <!-- TWO-25386: no <depends> on "active" — it lives in a different
+                     top-level <section> ({{section_prefix}}_general) than this
+                     one; pre-existing dead markup (same issue pre-dates this PR),
+                     removed while this PR is already touching the same contract. -->
                 <field id="enable_company_search" translate="label comment" type="select" sortOrder="10"
                        showInDefault="1" showInWebsite="1" showInStore="1"
                        canRestore="1" brand_code="{{code}}">
                     <label>Enable company search in address entry</label>
                     <comment>When enabled, the buyer may search for their company within the address entry section of the checkout. Otherwise, company search will be visible within the payment method.</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <depends>
-                        <field id="active">1</field>
-                    </depends>
                     <config_path>payment/{{code}}/enable_company_search</config_path>
                 </field>
                 <field id="enable_address_search" translate="label comment" type="select" sortOrder="20"
@@ -362,9 +355,6 @@
                     <label>Autofill company address</label>
                     <comment>Autocomplete address based on selected country and company. Only takes effect when company search in address entry is also enabled.</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <depends>
-                        <field id="active">1</field>
-                    </depends>
                     <config_path>payment/{{code}}/enable_address_search</config_path>
                 </field>
             </group>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -11,6 +11,26 @@
         <tab id="two_gateway" translate="label comment" class="two-extension two-extension--no-caption" sortOrder="500">
             <label>Two</label>
         </tab>
+        <!--
+            TWO-25386 Part 1: unified 6-section admin scheme, same names
+            and order as prestashop-plugin and woocommerce-plugin —
+            A. General, B. Checkout Fields, C. Company Lookup,
+            D. Payment Terms, E. Order Management, F. Diagnostics.
+
+            Pure reorganization: no field's config_path or behavior
+            changed here, only which <section>/<group> it renders under
+            and the section/group labels. `two_general`, `two_search` and
+            `two_payment` keep their historical section ids (relabeled)
+            to avoid breaking Plugin\Config\Structure\HidePaymentSection
+            and any brand-overlay `suppressed_fields` path that targets
+            them by section suffix; `two_checkout_fields` and
+            `two_order_management` are new section ids introduced to
+            hold content split out of the old `two_payment` section.
+            `two_version` keeps its id, relabeled to Diagnostics and
+            folding in the general/debug/health fields that used to
+            live in `two_general`/`two_payment`.
+        -->
+        <!-- A. General -->
         <section id="two_general" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1"
                  showInStore="1">
             <class>separator-top</class>
@@ -20,6 +40,13 @@
             <group id="general" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="1"
                    showInStore="1">
                 <label>General</label>
+                <field id="active" translate="label comment" type="select" sortOrder="5" showInDefault="1" showInWebsite="1"
+                       showInStore="1" canRestore="1">
+                    <label>Enable payment method</label>
+                    <comment>Activates this plugin as a payment option in the checkout page</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <config_path>payment/two_payment/active</config_path>
+                </field>
                 <field id="mode" translate="label comment" type="select" sortOrder="35" showInDefault="1" showInWebsite="1"
                        showInStore="1">
                     <label>Environment</label>
@@ -52,91 +79,29 @@
                     <comment>Optional. If you run Two across multiple sites or stores that share one merchant account, enter a name here to identify this site's orders.</comment>
                     <config_path>payment/two_payment/vendor_site_name</config_path>
                 </field>
-                <field id="debug" translate="label comment" type="select" sortOrder="60" showInDefault="1" showInWebsite="1"
-                       showInStore="1">
-                    <label>Debug mode</label>
-                    <comment>The debug mode enables writing to the error logs below. Debug mode should only be enabled when the sandbox environment is active</comment>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <config_path>payment/two_payment/debug</config_path>
-                </field>
-                <field id="debug_button" translate="label comment" type="button" sortOrder="70" showInDefault="1"
-                       showInWebsite="0" showInStore="0">
-                    <label/>
-                    <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Button\DebugCheck</frontend_model>
-                </field>
-                <field id="error_button" translate="label comment" type="button" sortOrder="80" showInDefault="1"
-                       showInWebsite="0" showInStore="0">
-                    <label/>
-                    <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Button\ErrorCheck</frontend_model>
-                </field>
-                <!-- TWO-25386: ported from woocommerce-plugin's 'skip_confirm_auth'.
-                     See Controller\Payment\Confirm — Magento's confirmation callback
-                     has no separate nonce layer to skip today (only the mandatory
-                     order-reference match), so this flag is currently a documented
-                     no-op kept for admin-surface parity across plugins. -->
-                <field id="skip_confirm_nonce_check" translate="label comment" type="select" sortOrder="85"
+                <!-- TWO-25386: ported from prestashop-plugin's PS_TWO_DISABLE_SSL_VERIFY.
+                     Default OFF (verification on / secure). Fixes Service\Api\Adapter,
+                     which previously disabled TLS verification unconditionally. -->
+                <field id="disable_ssl_verify" translate="label comment" type="select" sortOrder="65"
                        showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
-                    <label>Skip confirm-order nonce check</label>
-                    <comment>Debug/support use only. No effect today: Magento's order-confirmation callback is identified solely by the order reference, which is always checked and cannot be skipped.</comment>
+                    <label>Disable SSL verification</label>
+                    <comment><![CDATA[<strong>WARNING: unsafe for production.</strong> Skips TLS certificate verification on outbound calls to the Two API. Only enable this if this store sits behind a corporate proxy that terminates TLS with its own certificate. Leave this Off everywhere else.]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <config_path>payment/two_payment/skip_confirm_nonce_check</config_path>
-                </field>
-                <!-- TWO-25386: ported from woocommerce-plugin's 'clear_options_on_deactivation'.
-                     Magento's nearest lifecycle event is module uninstall, not
-                     deactivation; see Setup\Uninstall. -->
-                <field id="clear_settings_on_uninstall" translate="label comment" type="select" sortOrder="90"
-                       showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
-                    <label>Clear settings on module uninstall</label>
-                    <comment>When this module is uninstalled (bin/magento module:uninstall), delete its stored configuration instead of leaving it behind.</comment>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <config_path>payment/two_payment/clear_settings_on_uninstall</config_path>
-                </field>
-                <!-- TWO-25386: ported from prestashop-plugin's install health checklist. -->
-                <field id="health_checklist" translate="label comment" type="button" sortOrder="95"
-                       showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Health checklist</label>
-                    <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\HealthChecklist</frontend_model>
+                    <config_path>payment/two_payment/disable_ssl_verify</config_path>
                 </field>
             </group>
         </section>
-        <section id="two_payment" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="1"
-                 showInStore="1">
+        <!-- B. Checkout Fields -->
+        <section id="two_checkout_fields" translate="label comment" type="text" sortOrder="20" showInDefault="1"
+                 showInWebsite="1" showInStore="1">
             <class>separator-top</class>
-            <label>Payment</label>
+            <label>Checkout Fields</label>
             <tab>two_gateway</tab>
             <resource>Magento_Sales::config_sales</resource>
-            <group id="payment_method" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1"
+            <group id="display" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1"
                    showInStore="1">
-                <label>Payment method</label>
-                <field id="active" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="1"
-                       showInStore="1" canRestore="1">
-                    <label>Enable payment method</label>
-                    <comment>Activates this plugin as a payment option in the checkout page</comment>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <config_path>payment/two_payment/active</config_path>
-                </field>
-                <field id="merchant_minimum_order" translate="label" type="text" sortOrder="25" showInDefault="1"
-                       showInWebsite="1" showInStore="1" canRestore="1">
-                    <label>Minimum order value</label>
-                    <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\MinimumOrderValue</frontend_model>
-                    <backend_model>Two\Gateway\Model\Config\Backend\MerchantMinimumOrder</backend_model>
-                    <comment model="Two\Gateway\Model\Config\Comment\MerchantMinimumOrder"/>
-                    <depends>
-                        <field id="active">1</field>
-                    </depends>
-                    <config_path>payment/two_payment/merchant_minimum_order</config_path>
-                </field>
-                <field id="merchant_minimum_order_basis" translate="label comment" type="select" sortOrder="26"
-                       showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
-                    <label>Minimum order value tax basis</label>
-                    <comment>Whether the basket is compared against the minimum including or excluding tax</comment>
-                    <source_model>Two\Gateway\Model\Config\Source\MinimumOrderBasis</source_model>
-                    <depends>
-                        <field id="active">1</field>
-                    </depends>
-                    <config_path>payment/two_payment/merchant_minimum_order_basis</config_path>
-                </field>
-                <field id="title" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="1"
+                <label>Title &amp; Display</label>
+                <field id="title" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1"
                        showInStore="1" canRestore="1">
                     <label>Title</label>
                     <comment>Descriptive title which gives the buyer a better understanding of this payment method</comment>
@@ -150,7 +115,7 @@
                      showInStore="1" gives the same per-store-view override PrestaShop gets
                      from its per-language storage; empty falls back to the brand default
                      (BrandRegistryInterface::getCheckoutSubtitle). -->
-                <field id="subtitle" translate="label comment" type="text" sortOrder="21" showInDefault="1"
+                <field id="subtitle" translate="label comment" type="text" sortOrder="20" showInDefault="1"
                        showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Subtitle</label>
                     <comment>Optional line shown beneath the title at checkout (e.g. "Buy now, pay later"). Leave blank to use the default. Can be set per store view.</comment>
@@ -159,8 +124,63 @@
                     </depends>
                     <config_path>payment/two_payment/subtitle</config_path>
                 </field>
+                <field id="sort_order" translate="label comment" type="text" sortOrder="30" showInDefault="1" showInWebsite="1"
+                       showInStore="1" canRestore="1">
+                    <label>Sort order</label>
+                    <comment>Controls the position of this payment method relative to other payment methods at checkout. Lower numbers appear first. Default is empty (no specific order).</comment>
+                    <config_path>payment/two_payment/sort_order</config_path>
+                </field>
             </group>
-            <group id="checkout_fields" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="1"
+            <group id="availability" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="1"
+                   showInStore="1">
+                <label>Availability &amp; Minimum Order</label>
+                <field id="sallowspecific" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
+                    <label>Country availability</label>
+                    <comment>Choose whether to enable this payment method for all allowed countries or only specific ones.</comment>
+                    <frontend_class>shipping-applicable-country</frontend_class>
+                    <source_model>Magento\Shipping\Model\Config\Source\Allspecificcountries</source_model>
+                    <config_path>payment/two_payment/allowspecific</config_path>
+                </field>
+                <field id="specificcountry" translate="label comment" type="multiselect" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
+                    <label>Allowed countries</label>
+                    <comment>Select the countries where this payment method should be available.</comment>
+                    <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
+                    <can_be_empty>1</can_be_empty>
+                    <depends>
+                        <field id="sallowspecific">1</field>
+                    </depends>
+                    <config_path>payment/two_payment/specificcountry</config_path>
+                </field>
+                <field id="merchant_minimum_order" translate="label" type="text" sortOrder="30" showInDefault="1"
+                       showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Minimum order value</label>
+                    <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\MinimumOrderValue</frontend_model>
+                    <backend_model>Two\Gateway\Model\Config\Backend\MerchantMinimumOrder</backend_model>
+                    <comment model="Two\Gateway\Model\Config\Comment\MerchantMinimumOrder"/>
+                    <depends>
+                        <field id="active">1</field>
+                    </depends>
+                    <config_path>payment/two_payment/merchant_minimum_order</config_path>
+                </field>
+                <field id="merchant_minimum_order_basis" translate="label comment" type="select" sortOrder="40"
+                       showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Minimum order value tax basis</label>
+                    <comment>Whether the basket is compared against the minimum including or excluding tax</comment>
+                    <source_model>Two\Gateway\Model\Config\Source\MinimumOrderBasis</source_model>
+                    <depends>
+                        <field id="active">1</field>
+                    </depends>
+                    <config_path>payment/two_payment/merchant_minimum_order_basis</config_path>
+                </field>
+                <field id="enable_order_intent" translate="label comment" type="select" sortOrder="50" showInDefault="1"
+                       showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Enable order intent</label>
+                    <comment>Perform a check during checkout to inform the buyer whether an order is likely to be accepted before being placed (recommended).</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <config_path>payment/two_payment/enable_order_intent</config_path>
+                </field>
+            </group>
+            <group id="checkout_fields" translate="label comment" type="text" sortOrder="30" showInDefault="1" showInWebsite="1"
                    showInStore="1">
                 <label>Checkout fields</label>
                 <!--
@@ -234,10 +254,57 @@
                     <config_path>payment/two_payment/display_tooltips</config_path>
                 </field>
             </group>
-            <group id="payment_terms" translate="label comment" type="text" sortOrder="25" showInDefault="1" showInWebsite="1"
+        </section>
+        <!-- C. Company Lookup -->
+        <section id="two_search" translate="label comment" type="text" sortOrder="30" showInDefault="1" showInWebsite="1"
+                 showInStore="1">
+            <class>separator-top</class>
+            <label>Company Lookup</label>
+            <tab>two_gateway</tab>
+            <resource>Magento_Sales::config_sales</resource>
+            <group id="search" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1"
+                   showInStore="1">
+                <label>Company Lookup</label>
+                <field id="enable_company_search" translate="label comment" type="select" sortOrder="10"
+                       showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Enable company search in address entry</label>
+                    <comment>When enabled, the buyer may search for their company within the address entry section of the checkout. Otherwise, company search will be visible within the payment method.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends>
+                        <field id="active">1</field>
+                    </depends>
+                    <config_path>payment/two_payment/enable_company_search</config_path>
+                </field>
+                <field id="enable_address_search" translate="label comment" type="select" sortOrder="20" showInDefault="1"
+                       showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Autofill company address</label>
+                    <comment>Autocomplete address based on selected country and company. Only takes effect when company search in address entry is also enabled.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends>
+                        <field id="active">1</field>
+                    </depends>
+                    <config_path>payment/two_payment/enable_address_search</config_path>
+                </field>
+            </group>
+        </section>
+        <!-- D. Payment Terms -->
+        <section id="two_payment" translate="label comment" type="text" sortOrder="40" showInDefault="1" showInWebsite="1"
+                 showInStore="1">
+            <class>separator-top</class>
+            <label>Payment Terms</label>
+            <tab>two_gateway</tab>
+            <resource>Magento_Sales::config_sales</resource>
+            <group id="payment_terms" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1"
                    showInStore="1">
                 <label>Payment terms</label>
-                <field id="payment_terms" translate="label comment" type="text" sortOrder="10" showInDefault="1"
+                <field id="payment_terms_type" translate="label comment" type="select" sortOrder="10" showInDefault="1"
+                       showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Payment terms type</label>
+                    <comment><![CDATA[<strong>Standard:</strong> Payment due after a fixed number of days from fulfilment.<br/><strong>End of Month:</strong> Payment due at the end of month plus additional days from fulfilment.]]></comment>
+                    <source_model>Two\Gateway\Model\Config\Source\PaymentTermsType</source_model>
+                    <config_path>payment/two_payment/payment_terms_type</config_path>
+                </field>
+                <field id="payment_terms" translate="label comment" type="text" sortOrder="20" showInDefault="1"
                        showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Payment terms</label>
                     <comment>Select the payment term(s) you want to offer.</comment>
@@ -245,19 +312,12 @@
                     <backend_model>Two\Gateway\Model\Config\Backend\PaymentTermsCheckboxes</backend_model>
                     <config_path>payment/two_payment/payment_terms</config_path>
                 </field>
-                <field id="payment_terms_duration_days" translate="label comment" type="text" sortOrder="20" showInDefault="1"
+                <field id="payment_terms_duration_days" translate="label comment" type="text" sortOrder="30" showInDefault="1"
                        showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Custom payment term (days)</label>
                     <comment>Optional. Enter a custom number of days to offer alongside the selected terms above.</comment>
                     <validate>validate-digits validate-zero-or-greater</validate>
                     <config_path>payment/two_payment/payment_terms_duration_days</config_path>
-                </field>
-                <field id="payment_terms_type" translate="label comment" type="select" sortOrder="30" showInDefault="1"
-                       showInWebsite="1" showInStore="1" canRestore="1">
-                    <label>Payment terms type</label>
-                    <comment><![CDATA[<strong>Standard:</strong> Payment due after a fixed number of days from fulfilment.<br/><strong>End of Month:</strong> Payment due at the end of month plus additional days from fulfilment.]]></comment>
-                    <source_model>Two\Gateway\Model\Config\Source\PaymentTermsType</source_model>
-                    <config_path>payment/two_payment/payment_terms_type</config_path>
                 </field>
                 <field id="default_payment_term" translate="label comment" type="select" sortOrder="40" showInDefault="1"
                        showInWebsite="1" showInStore="1" canRestore="1">
@@ -292,8 +352,35 @@
                     <comment><![CDATA[Description shown to the buyer for the surcharge line item. Use <strong>%1</strong> to insert the selected number of days (e.g. "Payment terms fee - %1 days"). If you leave the default, the word <em>days</em> is translated per locale.]]></comment>
                     <config_path>payment/two_payment/surcharge_line_description</config_path>
                 </field>
-
-                <field id="surcharge_tax_class" translate="label comment" type="select" sortOrder="80"
+                <!-- Per-term surcharge grid (fixed, percentage, limit per term) -->
+                <field id="surcharge_grid" translate="label comment" type="text" sortOrder="80" showInDefault="1"
+                       showInWebsite="1" showInStore="1">
+                    <label>Payment surcharge configuration</label>
+                    <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\SurchargeGrid</frontend_model>
+                    <backend_model>Two\Gateway\Model\Config\Backend\SurchargeGrid</backend_model>
+                </field>
+                <field id="surcharge_rounding_basis" translate="label comment" type="select" sortOrder="90"
+                       showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Surcharge rounding</label>
+                    <comment>Snap the buyer surcharge line item to a clean increment. Select None for standard two-decimal amounts.</comment>
+                    <source_model>Two\Gateway\Model\Config\Source\RoundingBasis</source_model>
+                    <config_path>payment/two_payment/surcharge_rounding_basis</config_path>
+                    <depends>
+                        <field id="surcharge_type" separator=",">percentage,fixed_and_percentage</field>
+                    </depends>
+                </field>
+                <field id="surcharge_rounding_step" translate="label comment" type="select" sortOrder="100"
+                       showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Rounding step</label>
+                    <comment><![CDATA[Increment the surcharge is rounded to (e.g. 1 = whole units, 0.50 = nearest half).]]></comment>
+                    <source_model>Two\Gateway\Model\Config\Source\RoundingStep</source_model>
+                    <config_path>payment/two_payment/surcharge_rounding_step</config_path>
+                    <depends>
+                        <field id="surcharge_type" separator=",">percentage,fixed_and_percentage</field>
+                        <field id="surcharge_rounding_basis" separator=",">up,down,standard</field>
+                    </depends>
+                </field>
+                <field id="surcharge_tax_class" translate="label comment" type="select" sortOrder="110"
                        showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Surcharge tax treatment</label>
                     <!-- The never-taxed options this selector used to offer
@@ -314,7 +401,7 @@
                      offered when a value already exists). Field id renamed at the
                      code level only — the persisted config key deliberately stays
                      payment/two_payment/surcharge_tax_rate (no data migration). -->
-                <field id="custom_surcharge_tax_rate" translate="label comment" type="text" sortOrder="90" showInDefault="1"
+                <field id="custom_surcharge_tax_rate" translate="label comment" type="text" sortOrder="120" showInDefault="1"
                        showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Custom surcharge tax rate (%)</label>
                     <comment>Deprecated flat tax rate. Only used with the Custom surcharge tax treatment above.</comment>
@@ -327,55 +414,18 @@
                         <field id="surcharge_type" separator=",">percentage,fixed,fixed_and_percentage</field>
                     </depends>
                 </field>
-                <!-- Per-term surcharge grid (fixed, percentage, limit per term) -->
-                <field id="surcharge_grid" translate="label comment" type="text" sortOrder="100" showInDefault="1"
-                       showInWebsite="1" showInStore="1">
-                    <label>Payment surcharge configuration</label>
-                    <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\SurchargeGrid</frontend_model>
-                    <backend_model>Two\Gateway\Model\Config\Backend\SurchargeGrid</backend_model>
-                </field>
-                <field id="surcharge_rounding_basis" translate="label comment" type="select" sortOrder="110"
-                       showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
-                    <label>Surcharge rounding</label>
-                    <comment>Snap the buyer surcharge line item to a clean increment. Select None for standard two-decimal amounts.</comment>
-                    <source_model>Two\Gateway\Model\Config\Source\RoundingBasis</source_model>
-                    <config_path>payment/two_payment/surcharge_rounding_basis</config_path>
-                    <depends>
-                        <field id="surcharge_type" separator=",">percentage,fixed_and_percentage</field>
-                    </depends>
-                </field>
-                <field id="surcharge_rounding_step" translate="label comment" type="select" sortOrder="120"
-                       showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
-                    <label>Rounding step</label>
-                    <comment><![CDATA[Increment the surcharge is rounded to (e.g. 1 = whole units, 0.50 = nearest half).]]></comment>
-                    <source_model>Two\Gateway\Model\Config\Source\RoundingStep</source_model>
-                    <config_path>payment/two_payment/surcharge_rounding_step</config_path>
-                    <depends>
-                        <field id="surcharge_type" separator=",">percentage,fixed_and_percentage</field>
-                        <field id="surcharge_rounding_basis" separator=",">up,down,standard</field>
-                    </depends>
-                </field>
             </group>
-            <group id="advanced" translate="label comment" type="text" sortOrder="30" showInDefault="1" showInWebsite="1"
+        </section>
+        <!-- E. Order Management -->
+        <section id="two_order_management" translate="label comment" type="text" sortOrder="50" showInDefault="1"
+                 showInWebsite="1" showInStore="1">
+            <class>separator-top</class>
+            <label>Order Management</label>
+            <tab>two_gateway</tab>
+            <resource>Magento_Sales::config_sales</resource>
+            <group id="order_management" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1"
                    showInStore="1">
-                <label>Advanced</label>
-                <field id="sallowspecific" translate="label comment" type="select" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
-                    <label>Country availability</label>
-                    <comment>Choose whether to enable this payment method for all allowed countries or only specific ones.</comment>
-                    <frontend_class>shipping-applicable-country</frontend_class>
-                    <source_model>Magento\Shipping\Model\Config\Source\Allspecificcountries</source_model>
-                    <config_path>payment/two_payment/allowspecific</config_path>
-                </field>
-                <field id="specificcountry" translate="label comment" type="multiselect" sortOrder="6" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
-                    <label>Allowed countries</label>
-                    <comment>Select the countries where this payment method should be available.</comment>
-                    <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
-                    <can_be_empty>1</can_be_empty>
-                    <depends>
-                        <field id="sallowspecific">1</field>
-                    </depends>
-                    <config_path>payment/two_payment/specificcountry</config_path>
-                </field>
+                <label>Order Management</label>
                 <field id="fulfill_trigger" translate="label comment" type="select" sortOrder="10" showInDefault="1"
                        showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Fulfilment trigger</label>
@@ -393,88 +443,94 @@
                     </depends>
                     <config_path>payment/two_payment/fulfill_order_status</config_path>
                 </field>
-                <field id="enable_order_intent" translate="label comment" type="select" sortOrder="30" showInDefault="1"
-                       showInWebsite="1" showInStore="1" canRestore="1">
-                    <label>Enable order intent</label>
-                    <comment>Perform a check during checkout to inform the buyer whether an order is likely to be accepted before being placed (recommended).</comment>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <config_path>payment/two_payment/enable_order_intent</config_path>
-                </field>
-                <field id="enable_tax_subtotals" translate="label comment" type="select" sortOrder="40" showInDefault="1"
+                <field id="enable_tax_subtotals" translate="label comment" type="select" sortOrder="30" showInDefault="1"
                        showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Enable tax subtotals</label>
                     <comment>Add optional tax_subtotals metadata to order creation payload to enforce additional validation (recommended).</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <config_path>payment/two_payment/enable_tax_subtotals</config_path>
                 </field>
-                <field id="sort_order" translate="label comment" type="text" sortOrder="70" showInDefault="1" showInWebsite="1"
-                       showInStore="1" canRestore="1">
-                    <label>Sort order</label>
-                    <comment>Controls the position of this payment method relative to other payment methods at checkout. Lower numbers appear first. Default is empty (no specific order).</comment>
-                    <config_path>payment/two_payment/sort_order</config_path>
-                </field>
-                <!-- TWO-25386: ported from prestashop-plugin's PS_TWO_DISABLE_SSL_VERIFY.
-                     Default OFF (verification on / secure). Fixes Service\Api\Adapter,
-                     which previously disabled TLS verification unconditionally. -->
-                <field id="disable_ssl_verify" translate="label comment" type="select" sortOrder="80"
-                       showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
-                    <label>Disable SSL verification</label>
-                    <comment><![CDATA[<strong>WARNING: unsafe for production.</strong> Skips TLS certificate verification on outbound calls to the Two API. Only enable this if this store sits behind a corporate proxy that terminates TLS with its own certificate. Leave this Off everywhere else.]]></comment>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <config_path>payment/two_payment/disable_ssl_verify</config_path>
-                </field>
-            </group>
-        </section>
-        <section id="two_search" translate="label comment" type="text" sortOrder="30" showInDefault="1" showInWebsite="1"
-                 showInStore="1">
-            <class>separator-top</class>
-            <label>Search</label>
-            <tab>two_gateway</tab>
-            <resource>Magento_Sales::config_sales</resource>
-            <group id="search" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1"
-                   showInStore="1">
-                <label>Search</label>
-                <field id="enable_company_search" translate="label comment" type="select" sortOrder="10"
-                       showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
-                    <label>Enable company search in address entry</label>
-                    <comment>When enabled, the buyer may search for their company within the address entry section of the checkout. Otherwise, company search will be visible within the payment method.</comment>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <depends>
-                        <field id="active">1</field>
-                    </depends>
-                    <config_path>payment/two_payment/enable_company_search</config_path>
-                </field>
-                <field id="enable_address_search" translate="label comment" type="select" sortOrder="20" showInDefault="1"
-                       showInWebsite="1" showInStore="1" canRestore="1">
-                    <label>Autofill company address</label>
-                    <comment>Autocomplete address based on selected country and company. Only takes effect when company search in address entry is also enabled.</comment>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <depends>
-                        <field id="active">1</field>
-                    </depends>
-                    <config_path>payment/two_payment/enable_address_search</config_path>
-                </field>
             </group>
         </section>
         <!--
-            Deployment version panel. Standalone section so the operator
-            can land directly on it from the left nav rather than scrolling
-            past General config. sortOrder=100 keeps it at the bottom of
-            the "Two" tab regardless of how many config sections grow above.
+            F. Diagnostics. Standalone section so the operator can land
+            directly on it from the left nav. Was the "Version" section
+            (two_version, sortOrder=100, kept at the bottom regardless of
+            how many sections grew above it); now folds in the debug/log/
+            admin-control fields that used to live in two_general and
+            two_payment, and sits last in the 6-section A-F scheme at
+            sortOrder=60.
         -->
-        <section id="two_version" translate="label comment" type="text" sortOrder="100" showInDefault="1" showInWebsite="1"
+        <section id="two_version" translate="label comment" type="text" sortOrder="60" showInDefault="1" showInWebsite="1"
                  showInStore="1">
             <class>separator-top</class>
-            <label>Version</label>
+            <label>Diagnostics</label>
             <tab>two_gateway</tab>
             <resource>Magento_Sales::config_sales</resource>
-            <group id="general" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1"
+            <group id="logging" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1"
+                   showInStore="1">
+                <label>Debug &amp; Logging</label>
+                <field id="debug" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="1"
+                       showInStore="1">
+                    <label>Debug mode</label>
+                    <comment>The debug mode enables writing to the error logs below. Debug mode should only be enabled when the sandbox environment is active</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <config_path>payment/two_payment/debug</config_path>
+                </field>
+                <field id="debug_button" translate="label comment" type="button" sortOrder="20" showInDefault="1"
+                       showInWebsite="0" showInStore="0">
+                    <label/>
+                    <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Button\DebugCheck</frontend_model>
+                </field>
+                <field id="error_button" translate="label comment" type="button" sortOrder="30" showInDefault="1"
+                       showInWebsite="0" showInStore="0">
+                    <label/>
+                    <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Button\ErrorCheck</frontend_model>
+                </field>
+            </group>
+            <group id="admin_controls" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="1"
+                   showInStore="1">
+                <label>Admin Controls</label>
+                <!-- TWO-25386: ported from woocommerce-plugin's 'skip_confirm_auth'.
+                     See Controller\Payment\Confirm — Magento's confirmation callback
+                     has no separate nonce layer to skip today (only the mandatory
+                     order-reference match), so this flag is currently a documented
+                     no-op kept for admin-surface parity across plugins. -->
+                <field id="skip_confirm_nonce_check" translate="label comment" type="select" sortOrder="10"
+                       showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Skip confirm-order nonce check</label>
+                    <comment>Debug/support use only. No effect today: Magento's order-confirmation callback is identified solely by the order reference, which is always checked and cannot be skipped.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <config_path>payment/two_payment/skip_confirm_nonce_check</config_path>
+                </field>
+                <!-- TWO-25386: ported from woocommerce-plugin's 'clear_options_on_deactivation'.
+                     Magento's nearest lifecycle event is module uninstall, not
+                     deactivation; see Setup\Uninstall. -->
+                <field id="clear_settings_on_uninstall" translate="label comment" type="select" sortOrder="20"
+                       showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                    <label>Clear settings on module uninstall</label>
+                    <comment>When this module is uninstalled (bin/magento module:uninstall), delete its stored configuration instead of leaving it behind.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <config_path>payment/two_payment/clear_settings_on_uninstall</config_path>
+                </field>
+            </group>
+            <group id="general" translate="label comment" type="text" sortOrder="30" showInDefault="1" showInWebsite="1"
                    showInStore="1">
                 <label>Version</label>
                 <field id="version" translate="label comment" type="button" sortOrder="10" showInDefault="1"
                        showInWebsite="1" showInStore="1">
                     <label/>
                     <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\Version</frontend_model>
+                </field>
+            </group>
+            <group id="health" translate="label comment" type="text" sortOrder="40" showInDefault="1" showInWebsite="1"
+                   showInStore="1">
+                <label>Health</label>
+                <!-- TWO-25386: ported from prestashop-plugin's install health checklist. -->
+                <field id="health_checklist" translate="label comment" type="button" sortOrder="10"
+                       showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Health checklist</label>
+                    <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\HealthChecklist</frontend_model>
                 </field>
             </group>
         </section>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -101,14 +101,19 @@
             <group id="display" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1"
                    showInStore="1">
                 <label>Title &amp; Display</label>
+                <!-- TWO-25386: no <depends> on "active" here — Magento renders each
+                     top-level <section> as its own admin page, so a <depends> can
+                     only resolve within the section it's declared in (bare id =
+                     same group; "group/field" = same section). "active" lives in
+                     two_general now, a different page from this section, so the
+                     dependency could never fire; kept as dead XML pre-regroup only
+                     because it happened to still be in the same section as "active"
+                     back then. Removed rather than left as inert-looking markup. -->
                 <field id="title" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1"
                        showInStore="1" canRestore="1">
                     <label>Title</label>
                     <comment>Descriptive title which gives the buyer a better understanding of this payment method</comment>
                     <validate>required-entry</validate>
-                    <depends>
-                        <field id="active">1</field>
-                    </depends>
                     <config_path>payment/two_payment/title</config_path>
                 </field>
                 <!-- TWO-25386: ported from prestashop-plugin's per-language PS_TWO_SUB_TITLE.
@@ -119,9 +124,6 @@
                        showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Subtitle</label>
                     <comment>Optional line shown beneath the title at checkout (e.g. "Buy now, pay later"). Leave blank to use the default. Can be set per store view.</comment>
-                    <depends>
-                        <field id="active">1</field>
-                    </depends>
                     <config_path>payment/two_payment/subtitle</config_path>
                 </field>
                 <field id="sort_order" translate="label comment" type="text" sortOrder="30" showInDefault="1" showInWebsite="1"
@@ -157,9 +159,6 @@
                     <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\MinimumOrderValue</frontend_model>
                     <backend_model>Two\Gateway\Model\Config\Backend\MerchantMinimumOrder</backend_model>
                     <comment model="Two\Gateway\Model\Config\Comment\MerchantMinimumOrder"/>
-                    <depends>
-                        <field id="active">1</field>
-                    </depends>
                     <config_path>payment/two_payment/merchant_minimum_order</config_path>
                 </field>
                 <field id="merchant_minimum_order_basis" translate="label comment" type="select" sortOrder="40"
@@ -167,9 +166,6 @@
                     <label>Minimum order value tax basis</label>
                     <comment>Whether the basket is compared against the minimum including or excluding tax</comment>
                     <source_model>Two\Gateway\Model\Config\Source\MinimumOrderBasis</source_model>
-                    <depends>
-                        <field id="active">1</field>
-                    </depends>
                     <config_path>payment/two_payment/merchant_minimum_order_basis</config_path>
                 </field>
                 <field id="enable_order_intent" translate="label comment" type="select" sortOrder="50" showInDefault="1"
@@ -265,14 +261,19 @@
             <group id="search" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1"
                    showInStore="1">
                 <label>Company Lookup</label>
+                <!-- TWO-25386: no <depends> on "active" — it lives in a different
+                     top-level <section> (two_general) than this one, and Magento
+                     can only resolve <depends> within the section it's declared
+                     in, since each section renders as its own admin page. This
+                     was already the case before this PR (the old two_search
+                     section vs. the old two_payment section); pre-existing dead
+                     markup, removed while this PR is already touching the same
+                     contract elsewhere. -->
                 <field id="enable_company_search" translate="label comment" type="select" sortOrder="10"
                        showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Enable company search in address entry</label>
                     <comment>When enabled, the buyer may search for their company within the address entry section of the checkout. Otherwise, company search will be visible within the payment method.</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <depends>
-                        <field id="active">1</field>
-                    </depends>
                     <config_path>payment/two_payment/enable_company_search</config_path>
                 </field>
                 <field id="enable_address_search" translate="label comment" type="select" sortOrder="20" showInDefault="1"
@@ -280,9 +281,6 @@
                     <label>Autofill company address</label>
                     <comment>Autocomplete address based on selected country and company. Only takes effect when company search in address entry is also enabled.</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <depends>
-                        <field id="active">1</field>
-                    </depends>
                     <config_path>payment/two_payment/enable_address_search</config_path>
                 </field>
             </group>

--- a/etc/brand.xsd
+++ b/etc/brand.xsd
@@ -125,10 +125,11 @@
         <!--
             Short identifier used as the prefix for synthesised admin
             Configuration section IDs (e.g. `two` → `two_general`,
-            `two_payment`, `two_search`, `two_version`) and the
-            synthesised admin tab id (`{prefix}_gateway`). Optional —
-            when absent, derived by stripping a trailing `_payment`
-            suffix from `code`.
+            `two_checkout_fields`, `two_search`, `two_payment`,
+            `two_order_management`, `two_version` — TWO-25386's A-F
+            regroup) and the synthesised admin tab id
+            (`{prefix}_gateway`). Optional — when absent, derived by
+            stripping a trailing `_payment` suffix from `code`.
         -->
         <xs:attribute name="section_prefix" type="brandCodeType" use="optional"/>
     </xs:complexType>


### PR DESCRIPTION
## Summary

Part 1 of TWO-25386 (Part 2, the 8-control port, already merged in PR #332): reorganize the admin Configuration pane into the unified 6-section scheme agreed across prestashop-plugin / woocommerce-plugin / magento-plugin — **A. General, B. Checkout Fields, C. Company Lookup, D. Payment Terms, E. Order Management, F. Diagnostics** — same names and order on all three.

Pure reorganization: no field's `config_path` or runtime behaviour changes, only which `<section>`/`<group>` it renders under and the section/group labels.

- `two_general`, `two_search` and `two_payment` keep their historical section ids (relabeled General / Company Lookup / Payment Terms) to avoid breaking `Plugin\Config\Structure\HidePaymentSection` (which hides these sections for overlay-brand merchants) and any brand-overlay `suppressed_fields` path that targets a field by section suffix.
- `two_checkout_fields` and `two_order_management` are new section ids holding content split out of the old `two_payment` section: title/subtitle/sort order/country availability/minimum order/order intent move to Checkout Fields; fulfilment trigger/status/tax subtotals move to Order Management.
- `two_version` is relabeled Diagnostics and now also holds the debug/logging/admin-control/health fields that used to live in General and Payment Terms.
- The TWO-25263 load-bearing invoice-email → PO number → project → department → order-note order is unchanged, still inside the same `checkout_fields` group, still pinned by `Test/Unit/Config/CheckoutFieldOrderTest`.

`etc/adminhtml/brand_form_template.xml` mirrors `system.xml` exactly (tokenised), since `SynthesiseBrandAdminForm` builds every registered brand's admin form from it.

## Coordinated follow-ups (flagging, not fixing here)

- **magento-hyva-extension** reopens the `two_general` section for a read-only version field. `two_general` keeps its id and label here, but the *fields* inside it changed (debug/log/health fields moved out to Diagnostics). If Hyvä's reference assumes a specific field is present in `two_general`, it needs a follow-up check.
- **Brand-overlay `suppressed_fields`** (private overlay repos, not touched here): any overlay `brand.xml` suppressing a field that moved sections — `title`, `subtitle`, `sort_order`, `sallowspecific`/`specificcountry`, `merchant_minimum_order(_basis)`, `enable_order_intent`, `fulfill_trigger`, `fulfill_order_status`, `enable_tax_subtotals` — needs its `section_suffix` segment updated from `payment` to `checkout_fields` or `order_management` respectively, or the suppression stops matching and the field reappears for that brand. Documented in `docs/brand-overlay-guide.md`.

## Test plan

- [x] Full PHPUnit suite green (687 tests, 1256 assertions) via `docker run php:8.1-cli`.
- [x] `Test/Unit/Config/CheckoutFieldOrderTest` and `CheckoutFieldDefaultsTest` pass unmodified in content, updated only for the new section id.
- [x] `Test/Unit/Plugin/Config/Structure/HidePaymentSectionTest` extended to cover all 6 new `TARGET_SECTIONS`.
- [x] No `config_path` values changed — confirmed by diff review.
