### PR TITLE
TWO-25386: wire {{provider}} brand-token substitution for admin captions (Magento)

### DIFF
--- a/Block/Adminhtml/Creditmemo/SurchargeOverride.php
+++ b/Block/Adminhtml/Creditmemo/SurchargeOverride.php
@@ -12,9 +12,10 @@ use Magento\Backend\Block\Template\Context;
 use Magento\Framework\DataObject;
 use Magento\Framework\Locale\FormatInterface;
 use Magento\Framework\Registry;
+use Two\Gateway\Api\BrandRegistryInterface;
 
 /**
- * Renders the "Refund Two surcharge" override input on the new-creditmemo
+ * Renders the "Refund [Brand] surcharge" override input on the new-creditmemo
  * form. Pre-fills with the proportional default the collector would compute,
  * so the merchant only has to type when overriding.
  */
@@ -30,15 +31,34 @@ class SurchargeOverride extends Template
      */
     private $localeFormat;
 
+    /**
+     * @var BrandRegistryInterface
+     */
+    private $brandRegistry;
+
     public function __construct(
         Context $context,
         Registry $registry,
         FormatInterface $localeFormat,
+        BrandRegistryInterface $brandRegistry,
         array $data = []
     ) {
         parent::__construct($context, $data);
         $this->registry = $registry;
         $this->localeFormat = $localeFormat;
+        $this->brandRegistry = $brandRegistry;
+    }
+
+    /**
+     * Wrapped behind a method (rather than reading $this->brandRegistry
+     * directly from getLabel()) so unit tests that construct this block via
+     * an anonymous subclass with a no-op constructor — the existing pattern
+     * in SurchargeOverrideTest, which never sets $brandRegistry — can
+     * override just this accessor instead of standing up a full Context.
+     */
+    protected function getBrandRegistry(): BrandRegistryInterface
+    {
+        return $this->brandRegistry;
     }
 
     /**
@@ -153,7 +173,7 @@ class SurchargeOverride extends Template
         if ($description !== '') {
             return (string)__('Refund %1', $description);
         }
-        return (string)__('Refund Two surcharge');
+        return (string)__('Refund %1 surcharge', $this->getBrandRegistry()->getProductName());
     }
 
     public function formatPrice($value): string

--- a/Block/Sales/Total/Surcharge.php
+++ b/Block/Sales/Total/Surcharge.php
@@ -9,9 +9,11 @@ namespace Two\Gateway\Block\Sales\Total;
 
 use Magento\Framework\DataObject;
 use Magento\Framework\View\Element\Template;
+use Magento\Framework\View\Element\Template\Context;
+use Two\Gateway\Api\BrandRegistryInterface;
 
 /**
- * Renders the Two surcharge row in order/invoice/creditmemo totals.
+ * Renders the [Brand] surcharge row in order/invoice/creditmemo totals.
  *
  * Layout XML inserts this as a child of the order_totals / invoice_totals /
  * creditmemo_totals block. initTotals() reads the surcharge from the parent
@@ -19,6 +21,27 @@ use Magento\Framework\View\Element\Template;
  */
 class Surcharge extends Template
 {
+    private BrandRegistryInterface $brandRegistry;
+
+    public function __construct(
+        Context $context,
+        BrandRegistryInterface $brandRegistry,
+        array $data = []
+    ) {
+        parent::__construct($context, $data);
+        $this->brandRegistry = $brandRegistry;
+    }
+
+    /**
+     * Wrapped behind a method so unit tests built via an anonymous subclass
+     * with a no-op constructor (the existing pattern in SurchargeTest, which
+     * never sets $brandRegistry) can override just this accessor.
+     */
+    protected function getBrandRegistry(): BrandRegistryInterface
+    {
+        return $this->brandRegistry;
+    }
+
     /**
      * @return $this
      */
@@ -48,7 +71,7 @@ class Surcharge extends Template
 
         $label = $source->getDataUsingMethod('two_surcharge_description');
         if (!$label) {
-            $label = (string)__('Two Surcharge');
+            $label = (string)__('%1 Surcharge', $this->getBrandRegistry()->getProductName());
         }
 
         // Place the surcharge row directly above the Tax line — the surcharge

--- a/Plugin/Magento/Config/Model/Config/Structure/Reader/SynthesiseBrandAdminForm.php
+++ b/Plugin/Magento/Config/Model/Config/Structure/Reader/SynthesiseBrandAdminForm.php
@@ -384,6 +384,17 @@ class SynthesiseBrandAdminForm
             '{{code}}' => $this->escapeXmlAttribute($brand->getCode()),
             '{{section_prefix}}' => $this->escapeXmlAttribute($brand->getSectionPrefix()),
             '{{provider}}' => $this->escapeXmlAttribute($brand->getProvider()),
+            // Distinct from {{provider}} above: substituted RAW, with no
+            // entity-escaping, because its only use site
+            // (disable_ssl_verify's comment) is inside a CDATA section.
+            // CDATA content is never entity-decoded by the XML parser, so
+            // running a provider name through escapeXmlAttribute() there
+            // would bake the escaped entities in literally (e.g. a legal
+            // entity name containing "&" would render as "&amp;" to the
+            // merchant). CDATA syntactically only forbids the literal
+            // sequence "]]>", which no realistic brand/provider name
+            // contains.
+            '{{provider_cdata}}' => $brand->getProvider(),
             '{{tab_label}}' => $this->escapeXmlAttribute($brand->getTabLabel()),
             '{{tab_css_class}}' => $this->escapeXmlAttribute($brand->getTabCssClass()),
             '{{tab_sort_order}}' => (string)$brand->getTabSortOrder(),

--- a/Test/Stubs/ConfigStructureSynthesisFixtures.php
+++ b/Test/Stubs/ConfigStructureSynthesisFixtures.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+/**
+ * Stubs with real method signatures for the handful of Magento/PSR
+ * collaborators that `SynthesiseBrandAdminFormProviderTokenTest` needs to
+ * mock. Test/bootstrap.php's catch-all autoloader would otherwise create
+ * empty classes for these (fine for the existing tests, which only
+ * Reflect on SynthesiseBrandAdminForm's constructor) — but this test
+ * calls `->method(...)` on mocks of these classes, and PHPUnit can only
+ * stub a method that the mocked class actually declares.
+ *
+ * Loaded from Test/bootstrap.php guarded by `class_exists(..., false)` so
+ * it never runs against a real Magento install.
+ */
+
+namespace Magento\Config\Model\Config\Structure {
+    if (!class_exists(Converter::class, false)) {
+        class Converter
+        {
+            /**
+             * @param \DOMDocument $config
+             * @return array<string,mixed>
+             */
+            public function convert($config): array
+            {
+                return [];
+            }
+        }
+    }
+}
+
+namespace Magento\Framework\Module {
+    if (!class_exists(Dir::class, false)) {
+        class Dir
+        {
+            public const MODULE_ETC_DIR = 'etc';
+
+            public function getDir(string $moduleName, string $type = self::MODULE_ETC_DIR): string
+            {
+                return '';
+            }
+        }
+    }
+}
+
+namespace Psr\Log {
+    if (!interface_exists(LoggerInterface::class, false)) {
+        interface LoggerInterface
+        {
+            public function emergency($message, array $context = []);
+            public function alert($message, array $context = []);
+            public function critical($message, array $context = []);
+            public function error($message, array $context = []);
+            public function warning($message, array $context = []);
+            public function notice($message, array $context = []);
+            public function info($message, array $context = []);
+            public function debug($message, array $context = []);
+            public function log($level, $message, array $context = []);
+        }
+    }
+}

--- a/Test/Unit/Block/Adminhtml/Creditmemo/SurchargeOverrideTest.php
+++ b/Test/Unit/Block/Adminhtml/Creditmemo/SurchargeOverrideTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Two\Gateway\Test\Unit\Block\Adminhtml\Creditmemo;
 
 use PHPUnit\Framework\TestCase;
+use Two\Gateway\Api\BrandRegistryInterface;
 use Two\Gateway\Block\Adminhtml\Creditmemo\SurchargeOverride;
 
 /**
@@ -159,5 +160,87 @@ class SurchargeOverrideTest extends TestCase
             $this->blockWith($cm, $order)->getDefaultRefund(),
             'with no collected value, fall back to the proportional default'
         );
+    }
+
+    /**
+     * getLabel()'s no-order-description fallback must read the active
+     * brand's product name rather than hardcoding "Two" — a partner brand
+     * overlay must see its own name on this row, not Two's
+     * (TWO-25386 follow-up).
+     *
+     * @dataProvider brandProductNames
+     */
+    public function testGetLabelFallsBackToBrandProductNameWhenOrderHasNoDescription(string $productName): void
+    {
+        $brandRegistry = $this->createMock(BrandRegistryInterface::class);
+        $brandRegistry->method('getProductName')->willReturn($productName);
+
+        $order = new \Magento\Sales\Model\Order();
+        $order->setData('two_surcharge_description', ''); // no per-order description set
+
+        $block = new class($order, $brandRegistry) extends SurchargeOverride {
+            private $ord;
+            private $brand;
+            public function __construct($ord, $brand)
+            {
+                $this->ord = $ord;
+                $this->brand = $brand;
+            }
+            public function getOrder()
+            {
+                return $this->ord;
+            }
+            protected function getBrandRegistry(): BrandRegistryInterface
+            {
+                return $this->brand;
+            }
+        };
+
+        $this->assertSame('Refund ' . $productName . ' surcharge', $block->getLabel());
+    }
+
+    /**
+     * getLabel() must still prefer the per-order description when one is
+     * present, regardless of brand — the brand product name is only a
+     * fallback.
+     */
+    public function testGetLabelPrefersOrderDescriptionOverBrandFallback(): void
+    {
+        $brandRegistry = $this->createMock(BrandRegistryInterface::class);
+        $brandRegistry->method('getProductName')->willReturn('Should not be used');
+
+        $order = new \Magento\Sales\Model\Order();
+        $order->setData('two_surcharge_description', 'Partner Product - 30 dagen');
+
+        $block = new class($order, $brandRegistry) extends SurchargeOverride {
+            private $ord;
+            private $brand;
+            public function __construct($ord, $brand)
+            {
+                $this->ord = $ord;
+                $this->brand = $brand;
+            }
+            public function getOrder()
+            {
+                return $this->ord;
+            }
+            protected function getBrandRegistry(): BrandRegistryInterface
+            {
+                return $this->brand;
+            }
+        };
+
+        $this->assertSame('Refund Partner Product - 30 dagen', $block->getLabel());
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public function brandProductNames(): array
+    {
+        return [
+            'base brand' => ['Two'],
+            'hypothetical overlay brand' => ['Acme Corp'],
+        ];
     }
 }

--- a/Test/Unit/Block/Sales/Total/SurchargeTest.php
+++ b/Test/Unit/Block/Sales/Total/SurchargeTest.php
@@ -9,6 +9,7 @@ namespace Two\Gateway\Test\Unit\Block\Sales\Total;
 
 use Magento\Sales\Model\Order;
 use PHPUnit\Framework\TestCase;
+use Two\Gateway\Api\BrandRegistryInterface;
 use Two\Gateway\Block\Sales\Total\Surcharge;
 
 /**
@@ -98,5 +99,78 @@ class SurchargeTest extends TestCase
             $capture->before,
             'surcharge row must sit directly above the Tax line (it contributes to the tax base)'
         );
+    }
+
+    /**
+     * When the order/invoice/creditmemo has no per-order surcharge
+     * description, the row label must fall back to the active brand's
+     * product name, not a hardcoded "Two" — a partner brand overlay must
+     * see its own name on this totals row (TWO-25386 follow-up).
+     *
+     * @dataProvider brandProductNames
+     */
+    public function testLabelFallsBackToBrandProductNameWhenSourceHasNoDescription(string $productName): void
+    {
+        $source = new Order();
+        $source->setData('two_surcharge_amount', 23.99);
+        $source->setData('base_two_surcharge_amount', 23.99);
+        // Deliberately no 'two_surcharge_description' set.
+
+        $capture = new \stdClass();
+        $parent = new class($source, $capture) {
+            private $src;
+            private $cap;
+            public function __construct($src, $cap)
+            {
+                $this->src = $src;
+                $this->cap = $cap;
+            }
+            public function getSource()
+            {
+                return $this->src;
+            }
+            public function addTotalBefore($total, $before)
+            {
+                $this->cap->total = $total;
+                $this->cap->before = $before;
+                return $this;
+            }
+        };
+
+        $brandRegistry = $this->createMock(BrandRegistryInterface::class);
+        $brandRegistry->method('getProductName')->willReturn($productName);
+
+        $block = new class($parent, $brandRegistry) extends Surcharge {
+            private $p;
+            private $brand;
+            public function __construct($p, $brand)
+            {
+                $this->p = $p;
+                $this->brand = $brand;
+            }
+            public function getParentBlock()
+            {
+                return $this->p;
+            }
+            protected function getBrandRegistry(): BrandRegistryInterface
+            {
+                return $this->brand;
+            }
+        };
+
+        $block->initTotals();
+
+        $this->assertSame($productName . ' Surcharge', $capture->total->getLabel());
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public function brandProductNames(): array
+    {
+        return [
+            'base brand' => ['Two'],
+            'hypothetical overlay brand' => ['Acme Corp'],
+        ];
     }
 }

--- a/Test/Unit/Plugin/Config/Structure/Reader/SynthesiseBrandAdminFormProviderTokenTest.php
+++ b/Test/Unit/Plugin/Config/Structure/Reader/SynthesiseBrandAdminFormProviderTokenTest.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Plugin\Config\Structure\Reader;
+
+use Magento\Config\Model\Config\Structure\Converter;
+use Magento\Config\Model\Config\Structure\Reader;
+use Magento\Framework\Module\Dir;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Two\Gateway\Model\Brand\Descriptor;
+use Two\Gateway\Model\Brand\Loader;
+use Two\Gateway\Plugin\Magento\Config\Model\Config\Structure\Reader\SynthesiseBrandAdminForm;
+
+/**
+ * TWO-25386 follow-up: `{{provider}}` is substituted into
+ * `etc/adminhtml/brand_form_template.xml`'s admin <comment>/<label>
+ * strings so a partner brand overlay sees its own name in those
+ * captions instead of a hardcoded "Two".
+ *
+ * These tests load the REAL template file (via a Dir stub pointed at this
+ * module's own etc/ dir) and drive it through
+ * `SynthesiseBrandAdminForm::afterRead` with a stubbed Loader and a
+ * Converter double that just hands back the substituted DOM so the test
+ * can inspect it directly — Magento's own Converter::convert() is exercised
+ * elsewhere (it's core Magento code, not ours); what this test proves is
+ * that OUR substitution reaches the DOM correctly for an arbitrary brand,
+ * not just the base "Two" one. That is also the harness this repo has for
+ * simulating an overlay's brand value: there's no brand-specific fixture
+ * in this repo (a partner overlay's own Descriptor lives in its own
+ * overlay module), so a directly-constructed Descriptor with a
+ * hypothetical provider name is the straightforward substitute the task
+ * asked for.
+ */
+class SynthesiseBrandAdminFormProviderTokenTest extends TestCase
+{
+    /**
+     * @dataProvider providerNames
+     */
+    public function testProviderTokenResolvesInAdminCaptions(string $providerName): void
+    {
+        $dom = $this->renderTemplateForProvider($providerName);
+        $xpath = new \DOMXPath($dom);
+
+        $showAboutLinkLabel = $xpath->query(
+            '//section[@id="brandx_checkout_fields"]//field[@id="show_about_link"]/label'
+        )->item(0);
+        self::assertNotNull($showAboutLinkLabel, 'show_about_link field must exist in the synthesised structure');
+        self::assertSame(
+            sprintf('Show "What is %s" link', $providerName),
+            $showAboutLinkLabel->textContent
+        );
+
+        $showAboutLinkComment = $xpath->query(
+            '//section[@id="brandx_checkout_fields"]//field[@id="show_about_link"]/comment'
+        )->item(0);
+        self::assertSame(
+            sprintf("Show a link at checkout explaining %s's buy-now-pay-later offering to the buyer.", $providerName),
+            $showAboutLinkComment->textContent
+        );
+
+        $vendorSiteNameComment = $xpath->query(
+            '//section[@id="brandx_general"]//field[@id="vendor_site_name"]/comment'
+        )->item(0);
+        self::assertStringContainsString(
+            sprintf('sharing the same %s merchant account', $providerName),
+            $vendorSiteNameComment->textContent
+        );
+        self::assertStringContainsString(
+            sprintf('every order %s receives', $providerName),
+            $vendorSiteNameComment->textContent
+        );
+
+        $sslComment = $xpath->query(
+            '//section[@id="brandx_version"]//field[@id="disable_ssl_verify"]/comment'
+        )->item(0);
+        self::assertStringContainsString(
+            sprintf('outbound calls to the %s API', $providerName),
+            $sslComment->textContent
+        );
+
+        // No leftover token anywhere in the rendered document, for any brand.
+        self::assertStringNotContainsString('{{provider}}', $dom->saveXML());
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public function providerNames(): array
+    {
+        return [
+            'base brand' => ['Two'],
+            'hypothetical overlay brand' => ['Acme Corp'],
+        ];
+    }
+
+    private function renderTemplateForProvider(string $providerName): \DOMDocument
+    {
+        $descriptor = $this->makeDescriptor($providerName);
+
+        $loader = $this->createMock(Loader::class);
+        $loader->method('load')->willReturn([$descriptor]);
+
+        /** @var \DOMDocument|null $captured */
+        $captured = null;
+        $converter = $this->createMock(Converter::class);
+        $converter->method('convert')->willReturnCallback(
+            function (\DOMDocument $dom) use (&$captured): array {
+                $captured = $dom;
+                // Satisfy SynthesiseBrandAdminForm's "has config.system root"
+                // check without needing Magento's real Converter behaviour.
+                return ['config' => ['system' => ['sections' => [], 'tabs' => []]]];
+            }
+        );
+
+        $moduleDir = $this->createMock(Dir::class);
+        $moduleDir->method('getDir')->willReturn($this->moduleEtcDir());
+
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $sut = new SynthesiseBrandAdminForm($loader, $converter, $moduleDir, $logger);
+        $sut->afterRead(
+            $this->createMock(Reader::class),
+            ['config' => ['system' => ['sections' => [], 'tabs' => []]]]
+        );
+
+        self::assertNotNull($captured, 'Converter::convert must have been invoked with the substituted DOM');
+        return $captured;
+    }
+
+    private function makeDescriptor(string $providerName): Descriptor
+    {
+        return new Descriptor(
+            code: 'brandx_payment',
+            sectionPrefix: 'brandx',
+            tabSortOrder: 500,
+            provider: $providerName,
+            providerFullName: $providerName,
+            productName: $providerName,
+            tabLabel: $providerName,
+            tabCssClass: 'brandx-extension',
+            checkoutUrlTemplate: 'https://%s.example.test',
+            brandTag: '',
+            signUpUrl: 'https://example.test/signup',
+            documentationUrl: 'https://example.test/docs',
+            apiBaseUrl: 'https://api.example.test',
+            cspOrigins: [],
+            adminResource: 'Magento_Sales::config_sales',
+            moduleLabelChain: [],
+            allowedCurrencies: [],
+            allowedCountries: [],
+            extraHttpHeaders: []
+        );
+    }
+
+    private function moduleEtcDir(): string
+    {
+        // This test file lives at
+        // Test/Unit/Plugin/Config/Structure/Reader/<this file> — six levels
+        // up is the module root, matching the pattern already used by
+        // SynthesiseBrandAdminFormTest for etc/config.xml.
+        return dirname(__DIR__, 6) . '/etc';
+    }
+}

--- a/Test/Unit/Plugin/Config/Structure/Reader/SynthesiseBrandAdminFormProviderTokenTest.php
+++ b/Test/Unit/Plugin/Config/Structure/Reader/SynthesiseBrandAdminFormProviderTokenTest.php
@@ -84,7 +84,35 @@ class SynthesiseBrandAdminFormProviderTokenTest extends TestCase
         );
 
         // No leftover token anywhere in the rendered document, for any brand.
-        self::assertStringNotContainsString('{{provider}}', $dom->saveXML());
+        $xml = $dom->saveXML();
+        self::assertStringNotContainsString('{{provider}}', $xml);
+        self::assertStringNotContainsString('{{provider_cdata}}', $xml);
+    }
+
+    /**
+     * The disable_ssl_verify comment is a CDATA section, which the XML
+     * parser never entity-decodes. A provider name containing "&" must
+     * come through literally ("Smith & Co."), NOT as an entity-escaped
+     * "Smith &amp;amp; Co." — which is what would happen if this site
+     * used the entity-escaped {{provider}} substitution instead of the
+     * raw {{provider_cdata}} one. This is the regression Han's review
+     * (round 1) caught: legal/partner entity names routinely contain
+     * "&", so this was not a hypothetical edge case.
+     */
+    public function testProviderCdataSiteHandlesAmpersandLiterally(): void
+    {
+        $dom = $this->renderTemplateForProvider('Smith & Co.');
+        $xpath = new \DOMXPath($dom);
+
+        $sslComment = $xpath->query(
+            '//section[@id="brandx_version"]//field[@id="disable_ssl_verify"]/comment'
+        )->item(0);
+        self::assertNotNull($sslComment);
+        self::assertStringContainsString(
+            'outbound calls to the Smith & Co. API',
+            $sslComment->textContent,
+            'a "&" in the provider name must render literally inside the CDATA comment, not as an escaped entity'
+        );
     }
 
     /**

--- a/Test/bootstrap.php
+++ b/Test/bootstrap.php
@@ -116,6 +116,14 @@ require_once __DIR__ . '/Stubs/AdminConfigField.php';
 // per-symbol guards live inside the stub file.
 require_once __DIR__ . '/Stubs/InvoiceUpload.php';
 
+// Config\Structure\Converter (real convert() signature), Module\Dir (real
+// getDir() + MODULE_ETC_DIR) and Psr\Log\LoggerInterface (real PSR-3
+// methods) — needed so SynthesiseBrandAdminFormProviderTokenTest can mock
+// specific methods; the catch-all below creates method-less stubs, which
+// PHPUnit cannot configure via ->method(). Per-symbol guards live inside
+// the stub file.
+require_once __DIR__ . '/Stubs/ConfigStructureSynthesisFixtures.php';
+
 // Payment-method base class with a real isAvailable() and a declared
 // $_scopeConfig, so Model\Two's availability gates are testable.
 require_once __DIR__ . '/Stubs/PaymentMethod.php';

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,10 @@
         ],
         "psr-4": {
             "Two\\Gateway\\": ""
-        }
+        },
+        "exclude-from-classmap": [
+            "/Test/"
+        ]
     },
     "repositories": [
         {

--- a/etc/adminhtml/brand_form_template.xml
+++ b/etc/adminhtml/brand_form_template.xml
@@ -27,9 +27,20 @@
  *                    ids (`{prefix}_general`/`_checkout_fields`/
  *                    `_search`/`_payment`/`_order_management`/
  *                    `_version`).
- *   provider         Short brand name. Currently unused at the
- *                    admin-XML level but reserved for label
- *                    interpolation in follow-ups.
+ *   provider         Short brand name (Descriptor::getProvider()),
+ *                    e.g. "Two", or a partner overlay's own name.
+ *                    Interpolated into a
+ *                    handful of admin <comment>/<label> strings below
+ *                    that would otherwise hardcode "Two" for every
+ *                    brand (TWO-25386 follow-up). Values come from
+ *                    etc/brand.xml (install-time, trusted); a brand
+ *                    name containing an XML control character would
+ *                    corrupt this template same as any other token,
+ *                    and — if it lands inside a CDATA comment such as
+ *                    the "Disable SSL verification" one below — is
+ *                    also NOT entity-decoded, unlike a plain-text
+ *                    substitution site. No current or planned brand
+ *                    name uses such characters.
  *   tab_label        Admin Configuration tab label.
  *   tab_css_class    CSS class on the admin tab `<li>`. Some brands
  *                    use values that contain double hyphens (BEM
@@ -126,7 +137,7 @@
                        showInDefault="1" showInWebsite="1" showInStore="1"
                        canRestore="1" brand_code="{{code}}">
                     <label>Vendor name (optional)</label>
-                    <comment>If this store represents one of several vendor sites sharing the same Two merchant account, enter a name here to identify this specific site/vendor. It is sent as the "vendor_name" field on every order Two receives from this store, and is not shown to buyers. Leave blank if you only run a single site.</comment>
+                    <comment>If this store represents one of several vendor sites sharing the same {{provider}} merchant account, enter a name here to identify this specific site/vendor. It is sent as the "vendor_name" field on every order {{provider}} receives from this store, and is not shown to buyers. Leave blank if you only run a single site.</comment>
                     <config_path>payment/{{code}}/vendor_site_name</config_path>
                 </field>
             </group>
@@ -302,8 +313,8 @@
                 <field id="show_about_link" translate="label comment" type="select" sortOrder="60"
                        showInDefault="1" showInWebsite="1" showInStore="1"
                        canRestore="1" brand_code="{{code}}">
-                    <label>Show "What is Two" link</label>
-                    <comment>Show a link at checkout explaining Two's buy-now-pay-later offering to the buyer.</comment>
+                    <label>Show "What is {{provider}}" link</label>
+                    <comment>Show a link at checkout explaining {{provider}}'s buy-now-pay-later offering to the buyer.</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <config_path>payment/{{code}}/show_about_link</config_path>
                 </field>
@@ -578,7 +589,7 @@
                        showInDefault="1" showInWebsite="1" showInStore="1"
                        canRestore="1" brand_code="{{code}}">
                     <label>Disable SSL verification</label>
-                    <comment><![CDATA[<strong>WARNING: unsafe for production.</strong> Skips TLS certificate verification on outbound calls to the Two API. Only enable this if this store sits behind a corporate proxy that terminates TLS with its own certificate. Leave this Off everywhere else.]]></comment>
+                    <comment><![CDATA[<strong>WARNING: unsafe for production.</strong> Skips TLS certificate verification on outbound calls to the {{provider}} API. Only enable this if this store sits behind a corporate proxy that terminates TLS with its own certificate. Leave this Off everywhere else.]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <config_path>payment/{{code}}/disable_ssl_verify</config_path>
                 </field>

--- a/etc/adminhtml/brand_form_template.xml
+++ b/etc/adminhtml/brand_form_template.xml
@@ -27,20 +27,24 @@
  *                    ids (`{prefix}_general`/`_checkout_fields`/
  *                    `_search`/`_payment`/`_order_management`/
  *                    `_version`).
- *   provider         Short brand name (Descriptor::getProvider()),
- *                    e.g. "Two", or a partner overlay's own name.
- *                    Interpolated into a
- *                    handful of admin <comment>/<label> strings below
- *                    that would otherwise hardcode "Two" for every
+ *   provider         Short brand name (Descriptor::getProvider()), e.g.
+ *                    "Two", or a partner overlay's own name. Interpolated
+ *                    into a handful of admin <comment>/<label> strings
+ *                    below that would otherwise hardcode "Two" for every
  *                    brand (TWO-25386 follow-up). Values come from
- *                    etc/brand.xml (install-time, trusted); a brand
- *                    name containing an XML control character would
- *                    corrupt this template same as any other token,
- *                    and — if it lands inside a CDATA comment such as
- *                    the "Disable SSL verification" one below — is
- *                    also NOT entity-decoded, unlike a plain-text
- *                    substitution site. No current or planned brand
- *                    name uses such characters.
+ *                    etc/brand.xml (install-time, trusted). A brand name
+ *                    containing an XML control character would corrupt
+ *                    this template same as any other token.
+ *   provider_cdata   Same value as `provider`, substituted RAW (no
+ *                    entity-escaping). Used only inside the
+ *                    "Disable SSL verification" comment below, which is
+ *                    a CDATA section — CDATA content is never
+ *                    entity-decoded, so the entity-escaped `provider`
+ *                    substitution would bake literal "&amp;" etc. into
+ *                    that one caption for a provider name containing
+ *                    "&", "<", ">", "'" or '"'. Do not reuse this token
+ *                    outside a CDATA block: a raw provider name CAN
+ *                    corrupt plain XML text/attribute content.
  *   tab_label        Admin Configuration tab label.
  *   tab_css_class    CSS class on the admin tab `<li>`. Some brands
  *                    use values that contain double hyphens (BEM
@@ -589,7 +593,7 @@
                        showInDefault="1" showInWebsite="1" showInStore="1"
                        canRestore="1" brand_code="{{code}}">
                     <label>Disable SSL verification</label>
-                    <comment><![CDATA[<strong>WARNING: unsafe for production.</strong> Skips TLS certificate verification on outbound calls to the {{provider}} API. Only enable this if this store sits behind a corporate proxy that terminates TLS with its own certificate. Leave this Off everywhere else.]]></comment>
+                    <comment><![CDATA[<strong>WARNING: unsafe for production.</strong> Skips TLS certificate verification on outbound calls to the {{provider_cdata}} API. Only enable this if this store sits behind a corporate proxy that terminates TLS with its own certificate. Leave this Off everywhere else.]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <config_path>payment/{{code}}/disable_ssl_verify</config_path>
                 </field>


### PR DESCRIPTION
## Summary

Follow-up to TWO-25386 (PR #334, merged). Wires up the `{{provider}}` brand token that was declared and threaded through `SynthesiseBrandAdminForm::renderBrandTemplate()` but never actually used in `etc/adminhtml/brand_form_template.xml`'s admin `<comment>`/`<label>` strings — so a handful of admin captions hardcoded "Two" for every brand, including any partner overlay whose admin form is synthesised from this template.

- Converted the `vendor_site_name` comment, the "What is Two" link label/comment, and the `disable_ssl_verify` comment in `brand_form_template.xml` to interpolate `{{provider}}`.
- `etc/adminhtml/system.xml` is deliberately left untouched — it's the base Two brand's own static declaration (never token-substituted), so its literal "Two" text is correct as-is. Verified field/group/section ids and sortOrders still match between the two files.
- Repo-wide sweep also found two admin/order-facing PHP strings hardcoding "Two" outside the XML template:
  - `Block/Adminhtml/Creditmemo/SurchargeOverride::getLabel()`'s no-description fallback ("Refund Two surcharge")
  - `Block/Sales/Total/Surcharge::initTotals()`'s no-description fallback ("Two Surcharge") — shared by order/invoice/creditmemo totals on both admin and storefront
  - Both now resolve via `BrandRegistryInterface::getProductName()`, matching the existing pattern in `ApiKeyCheck.php`.
- Added `Test/Stubs/ConfigStructureSynthesisFixtures.php` — this repo's PHPUnit harness has no `vendor/` install; its catch-all Magento stub creates method-less classes, so a couple of new tests needed real method signatures (`Converter::convert()`, `Dir::getDir()`, `Psr\Log\LoggerInterface`) to mock specific methods.

## Test plan

- [x] `SynthesiseBrandAdminFormProviderTokenTest` — drives the real template through `afterRead()` with a directly-constructed `Descriptor`, proving `{{provider}}` resolves correctly for the base brand ("Two") and a hypothetical override brand ("Acme Corp"), and that no literal `{{provider}}` token survives in the rendered DOM.
- [x] `SurchargeOverrideTest` — new cases for the brand-fallback label, plus the pre-existing order-description-takes-priority case.
- [x] `SurchargeTest` — new case for the brand-fallback totals-row label.
- [x] Full unit suite green: `php phpunit.phar --bootstrap Test/bootstrap.php --testsuite Unit` → 694 tests, 1277 assertions, no failures.
