### PR TITLE
docs(e2e): replace cross-repo source reference with behaviour description

### DIFF
--- a/e2e/tests/_helpers.ts
+++ b/e2e/tests/_helpers.ts
@@ -2,7 +2,8 @@ import { expect, Page } from '@playwright/test';
 
 // GB skip-verification test buyer (auto-approved, no SCA) — the staging store is
 // GBP, so a GB buyer keeps the order coherent and passes the order-intent.
-// Source: two-inc/e2e-tests e2e_tests/config.py GBSettings.TEST_BUYER_COMPANY_SKIP_VERIFICATION.
+// Value mirrors the shared GB skip-verification buyer used by the internal e2e
+// suite; override with COMPANY_QUERY if that fixture changes.
 export const COMPANY_QUERY = process.env.COMPANY_QUERY || 'RESTAURANT 53 LTD';
 export const COUNTRY = process.env.COUNTRY || 'GB';
 export const PRODUCT = process.env.PRODUCT || '/default/push-it-messenger-bag.html';


### PR DESCRIPTION
## Context

A comment in the e2e helpers pointed at an internal repository's internals (`two-inc/e2e-tests` config source) to explain a test fixture value — a leak-gate violation in a public repo. No ticket; housekeeping fix.

Supersedes PR #302, which covered the same change but was closed without merging (reason not recorded). Cherry-picked from its sole commit.

## Changes

- `e2e/tests/_helpers.ts`: replaced the cross-repo comment with a plain-language description of the fixture value and how to override it.

## Scope / Non-goals

- Comment-only change. No functional/test behavior change.

## Validation

- `two-github-leak-gate` run clean across all 7 surfaces (filesystem, commit messages, branch name, author emails, pre-existing remote branches) prior to push.

## Ticket

- None — doc/comment fix, no Linear ticket.