### PR TITLE
fix(order): omit blank optional fields from the create-order payload (TWO-25386)

### DIFF
--- a/Observer/SalesOrderAddressUpdate.php
+++ b/Observer/SalesOrderAddressUpdate.php
@@ -103,48 +103,28 @@ class SalesOrderAddressUpdate implements ObserverInterface
                         'project' => $additionalInformation['buyer_project'] ?? '',
                     ]
                 );
-                // TWO-25386: this is a PUT that merges into the order already
-                // held remotely. A key left out of the payload keeps whatever
-                // is stored; a key sent as an empty string is accepted and
-                // overwrites the stored value with blank. So sending these
-                // unconditionally does not validate-fail — it silently erases
-                // data that this edit was never meant to touch.
+                // TWO-25386: merchant_reference, merchant_additional_info and
+                // shipping_details are deliberately never part of this
+                // request.
                 //
-                // Same allowlist shape as the composer's optional fields, and
-                // for the same reason: never a blanket empty-strip over
-                // $payload, because shipping_address and the amount fields are
-                // required and must survive regardless of their value.
-                $optionalFields = [
-                    'merchant_reference' => (string)($additionalInformation['merchant_reference'] ?? ''),
-                    'merchant_additional_info' => (string)($additionalInformation['merchant_additional_info'] ?? ''),
-                ];
-                foreach ($optionalFields as $key => $value) {
-                    // String comparison rather than empty(), so a legitimate
-                    // '0' reference would still be sent.
-                    if ($value !== '') {
-                        $payload[$key] = $value;
-                    }
-                }
-
-                // shipping_details needs a stronger rule than the scalars
-                // above, because it is not merged key-by-key: sending the
-                // object at all replaces the stored one wholesale, so every
-                // field this payload omits — carrier tracking URL, expected
-                // delivery date, the delivery-method and recipient details —
-                // is cleared as a side effect. Omitting the key entirely is
-                // the only way to leave the stored shipping information
-                // alone. Note this is delivery/tracking metadata, not the
-                // buyer's shipping address: shipping_address is a separate
-                // required field and is composed as usual, above.
-                $carrierName = (string)($additionalInformation['shipping_details']['carrier_name'] ?? '');
-                $trackingNumber = (string)($additionalInformation['shipping_details']['tracking_number'] ?? '');
-                if ($carrierName !== '' || $trackingNumber !== '') {
-                    $payload['shipping_details'] = [
-                        'carrier_name' => $carrierName,
-                        'tracking_number' => $trackingNumber,
-                    ];
-                }
-
+                // Nothing in this plugin ever puts them into the payment's
+                // additional_information, so there is no local value to send:
+                // every write to additional_information either copies the
+                // create-order payload (which does not carry these keys) or
+                // sets the completion marker, and the checkout data-assign
+                // path is limited to its own fixed key list.
+                //
+                // Sending them anyway would be actively harmful. This is a
+                // merging update of an order already held remotely: a key left
+                // out keeps whatever is stored, while a key sent as an empty
+                // string is accepted and overwrites the stored value with
+                // blank. shipping_details is worse still, because it is
+                // replaced as a whole object rather than merged field by
+                // field, so sending a partially populated one discards every
+                // delivery field the payload does not mention. That is
+                // delivery/tracking metadata, not the buyer's shipping
+                // address: shipping_address is a separate required field and
+                // is composed as usual, above.
                 $response = $this->apiAdapter->execute('/v1/order/' . $order->getTwoOrderId(), $payload, 'PUT');
                 $error = $order->getPayment()->getMethodInstance()->getErrorFromResponse($response);
                 if ($response && $error) {

--- a/Observer/SalesOrderAddressUpdate.php
+++ b/Observer/SalesOrderAddressUpdate.php
@@ -87,6 +87,11 @@ class SalesOrderAddressUpdate implements ObserverInterface
         ) {
             try {
                 $additionalInformation = $order->getPayment()->getAdditionalInformation();
+                // Department and Project are optional at checkout, and the
+                // stored payload now leaves the keys out entirely when the
+                // buyer skipped them (TWO-25386) — so they must be coalesced
+                // here. Re-composing with '' is correct: the composer applies
+                // the same omit rule again on the way back out.
                 $payload = $this->compositeOrder->execute(
                     $order,
                     $order->getTwoOrderReference(),
@@ -94,8 +99,8 @@ class SalesOrderAddressUpdate implements ObserverInterface
                         'companyName' => $additionalInformation['buyer']['company']['company_name'],
                         'telephone' => $additionalInformation['buyer']['representative']['phone_number'],
                         'companyId' => $additionalInformation['buyer']['company']['organization_number'],
-                        'department' => $additionalInformation['buyer_department'],
-                        'project' => $additionalInformation['buyer_project'],
+                        'department' => $additionalInformation['buyer_department'] ?? '',
+                        'project' => $additionalInformation['buyer_project'] ?? '',
                     ]
                 );
                 $payload['merchant_reference'] = '';

--- a/Observer/SalesOrderAddressUpdate.php
+++ b/Observer/SalesOrderAddressUpdate.php
@@ -103,12 +103,47 @@ class SalesOrderAddressUpdate implements ObserverInterface
                         'project' => $additionalInformation['buyer_project'] ?? '',
                     ]
                 );
-                $payload['merchant_reference'] = '';
-                $payload['merchant_additional_info'] = '';
-                $payload['shipping_details'] = [
-                    'carrier_name' => '',
-                    'tracking_number' => '',
+                // TWO-25386: this is a PUT that merges into the order already
+                // held remotely. A key left out of the payload keeps whatever
+                // is stored; a key sent as an empty string is accepted and
+                // overwrites the stored value with blank. So sending these
+                // unconditionally does not validate-fail — it silently erases
+                // data that this edit was never meant to touch.
+                //
+                // Same allowlist shape as the composer's optional fields, and
+                // for the same reason: never a blanket empty-strip over
+                // $payload, because shipping_address and the amount fields are
+                // required and must survive regardless of their value.
+                $optionalFields = [
+                    'merchant_reference' => (string)($additionalInformation['merchant_reference'] ?? ''),
+                    'merchant_additional_info' => (string)($additionalInformation['merchant_additional_info'] ?? ''),
                 ];
+                foreach ($optionalFields as $key => $value) {
+                    // String comparison rather than empty(), so a legitimate
+                    // '0' reference would still be sent.
+                    if ($value !== '') {
+                        $payload[$key] = $value;
+                    }
+                }
+
+                // shipping_details needs a stronger rule than the scalars
+                // above, because it is not merged key-by-key: sending the
+                // object at all replaces the stored one wholesale, so every
+                // field this payload omits — carrier tracking URL, expected
+                // delivery date, the delivery-method and recipient details —
+                // is cleared as a side effect. Omitting the key entirely is
+                // the only way to leave the stored shipping information
+                // alone. Note this is delivery/tracking metadata, not the
+                // buyer's shipping address: shipping_address is a separate
+                // required field and is composed as usual, above.
+                $carrierName = (string)($additionalInformation['shipping_details']['carrier_name'] ?? '');
+                $trackingNumber = (string)($additionalInformation['shipping_details']['tracking_number'] ?? '');
+                if ($carrierName !== '' || $trackingNumber !== '') {
+                    $payload['shipping_details'] = [
+                        'carrier_name' => $carrierName,
+                        'tracking_number' => $trackingNumber,
+                    ];
+                }
 
                 $response = $this->apiAdapter->execute('/v1/order/' . $order->getTwoOrderId(), $payload, 'PUT');
                 $error = $order->getPayment()->getMethodInstance()->getErrorFromResponse($response);

--- a/Observer/SalesOrderAddressUpdate.php
+++ b/Observer/SalesOrderAddressUpdate.php
@@ -114,17 +114,12 @@ class SalesOrderAddressUpdate implements ObserverInterface
                 // sets the completion marker, and the checkout data-assign
                 // path is limited to its own fixed key list.
                 //
-                // Sending them anyway would be actively harmful. This is a
-                // merging update of an order already held remotely: a key left
-                // out keeps whatever is stored, while a key sent as an empty
-                // string is accepted and overwrites the stored value with
-                // blank. shipping_details is worse still, because it is
-                // replaced as a whole object rather than merged field by
-                // field, so sending a partially populated one discards every
-                // delivery field the payload does not mention. That is
-                // delivery/tracking metadata, not the buyer's shipping
-                // address: shipping_address is a separate required field and
-                // is composed as usual, above.
+                // Why sending them anyway is harmful — the edit-merge
+                // semantics of this request — is recorded on TWO-25386. The
+                // decision here is to leave all three out unconditionally.
+                // Note that shipping_details is delivery/tracking metadata,
+                // not the buyer's shipping address: shipping_address is a
+                // different field and is composed as usual, above.
                 $response = $this->apiAdapter->execute('/v1/order/' . $order->getTwoOrderId(), $payload, 'PUT');
                 $error = $order->getPayment()->getMethodInstance()->getErrorFromResponse($response);
                 if ($response && $error) {

--- a/Service/Order/ComposeOrder.php
+++ b/Service/Order/ComposeOrder.php
@@ -126,14 +126,13 @@ class ComposeOrder extends OrderService
         // untaxed residual. See Order::reconcileOtherCharges() docblock.
         $lineItems = $this->reconcileOtherCharges($lineItems, $order, $grossTotal, $taxTotal);
 
-        // Compose the final payload for the API call
+        // Compose the final payload for the API call. Fields that may
+        // legitimately be blank are NOT listed here — see the optional-field
+        // allowlist below.
         $payload = [
             'billing_address' => $this->getAddress($order, $additionalData, 'billing'),
             'shipping_address' => $this->getAddress($order, $additionalData, 'shipping'),
             'buyer' => $this->getBuyer($order, $additionalData),
-            'buyer_department' => $additionalData['department'] ?? '',
-            'buyer_project' => $additionalData['project'] ?? '',
-            'buyer_purchase_order_number' => $additionalData['poNumber'] ?? '',
             'currency' => $order->getOrderCurrencyCode(),
             'discount_amount' => $this->roundAmt($this->getDiscountAmountItem($order)),
             'gross_amount' => $this->roundAmt($grossTotal),
@@ -154,26 +153,46 @@ class ComposeOrder extends OrderService
                     'two/payment/cancel',
                     ['_two_order_reference' => base64_encode($orderReference)]
                 ),
-                'merchant_edit_order_url' => '',
+                // merchant_edit_order_url is deliberately absent: the plugin
+                // exposes no merchant-side edit-order route, and the field is
+                // length-constrained, so an empty string is rejected.
                 'merchant_order_verification_failed_url' => $this->url->getUrl(
                     'two/payment/verificationfailed',
                     ['_two_order_reference' => base64_encode($orderReference)]
                 ),
             ],
-            'order_note' => $additionalData['orderNote'] ?? '',
-            // TWO-25386: ported from woocommerce-plugin's 'vendor_name',
-            // sent unconditionally there (empty string when unset).
-            'vendor_name' => $this->configRepository->getVendorSiteName($storeId),
         ];
 
-        // Add invoice_details and required placeholders only if invoiceEmails are present
+        // TWO-25386: these fields are optional, but each is length-constrained
+        // when present, so a blank admin setting or an untouched checkout field
+        // must OMIT the key rather than send an empty string — otherwise every
+        // order is rejected with a schema error. An explicit allowlist, never a
+        // blanket empty-strip over $payload: merchant_confirmation_url and the
+        // amount fields are required and must survive regardless of value.
+        // (woocommerce-plugin guards its equivalent of vendor_name the same
+        // way, conditionally rather than unconditionally.)
+        $optionalFields = [
+            'buyer_department' => $additionalData['department'] ?? '',
+            'buyer_project' => $additionalData['project'] ?? '',
+            'buyer_purchase_order_number' => $additionalData['poNumber'] ?? '',
+            'order_note' => $additionalData['orderNote'] ?? '',
+            'vendor_name' => $this->configRepository->getVendorSiteName($storeId),
+        ];
+        foreach ($optionalFields as $key => $value) {
+            // Compare as string rather than using empty(), so a legitimate
+            // '0' department/project reference is still sent.
+            if ((string)$value !== '') {
+                $payload[$key] = $value;
+            }
+        }
+
+        // Add invoice_details only if invoiceEmails are present. The payment
+        // reference fields are omitted rather than sent blank — the plugin has
+        // no value for them, and they reject null.
         if (!empty($additionalData['invoiceEmails'])) {
-            $invoiceDetails = [
+            $payload['invoice_details'] = [
                 'invoice_emails' => explode(',', $additionalData['invoiceEmails']),
-                'payment_reference_message' => '',
-                'payment_reference_ocr' => ''
             ];
-            $payload['invoice_details'] = $invoiceDetails;
         }
 
         return $payload;

--- a/Service/Order/ComposeOrder.php
+++ b/Service/Order/ComposeOrder.php
@@ -154,8 +154,10 @@ class ComposeOrder extends OrderService
                     ['_two_order_reference' => base64_encode($orderReference)]
                 ),
                 // merchant_edit_order_url is deliberately absent: the plugin
-                // exposes no merchant-side edit-order route, and the field is
-                // length-constrained, so an empty string is rejected.
+                // exposes no merchant-side edit-order route, so there is no
+                // URL to put here. An empty string would be accepted, but it
+                // is still a value nobody set, and on a later order edit an
+                // empty string overwrites while an absent key is left alone.
                 'merchant_order_verification_failed_url' => $this->url->getUrl(
                     'two/payment/verificationfailed',
                     ['_two_order_reference' => base64_encode($orderReference)]
@@ -163,14 +165,23 @@ class ComposeOrder extends OrderService
             ],
         ];
 
-        // TWO-25386: these fields are optional, but each is length-constrained
-        // when present, so a blank admin setting or an untouched checkout field
-        // must OMIT the key rather than send an empty string — otherwise every
-        // order is rejected with a schema error. An explicit allowlist, never a
-        // blanket empty-strip over $payload: merchant_confirmation_url and the
-        // amount fields are required and must survive regardless of value.
-        // (woocommerce-plugin guards its equivalent of vendor_name the same
-        // way, conditionally rather than unconditionally.)
+        // TWO-25386: these fields are optional and are omitted rather than sent
+        // blank. Two different reasons, both real:
+        //
+        // vendor_name is the one that must be non-empty whenever the key is
+        // present. A blank admin setting sent as '' is rejected outright and no
+        // order is created — that rejection is why this ticket exists.
+        //
+        // The other four are accepted as empty strings on create, so they were
+        // never causing rejections. They are omitted because of what happens
+        // afterwards: the order-edit call merges scalar fields, so a key left
+        // out preserves the stored value while a key sent as '' overwrites it
+        // with blank. Composing them empty meant an admin order-address edit
+        // erased whatever the buyer had actually entered at checkout.
+        //
+        // An explicit allowlist, never a blanket empty-strip over $payload:
+        // merchant_confirmation_url and the amount fields are required and must
+        // survive regardless of their value.
         $optionalFields = [
             'buyer_department' => $additionalData['department'] ?? '',
             'buyer_project' => $additionalData['project'] ?? '',
@@ -179,6 +190,15 @@ class ComposeOrder extends OrderService
             'vendor_name' => $this->configRepository->getVendorSiteName($storeId),
         ];
         foreach ($optionalFields as $key => $value) {
+            // $additionalData comes straight from the checkout request, and the
+            // observer that stores it only checks that the top level is an
+            // array — so a crafted request can leave an array sitting in one of
+            // these values. Casting that to string raises a warning, which
+            // developer mode turns into a failed order placement, so drop
+            // anything that is not a scalar instead.
+            if (!is_scalar($value)) {
+                continue;
+            }
             // Compare as string rather than using empty(), so a legitimate
             // '0' department/project reference is still sent.
             if ((string)$value !== '') {
@@ -187,8 +207,9 @@ class ComposeOrder extends OrderService
         }
 
         // Add invoice_details only if invoiceEmails are present. The payment
-        // reference fields are omitted rather than sent blank — the plugin has
-        // no value for them, and they reject null.
+        // reference fields are omitted rather than sent blank: the plugin has
+        // no value to put in them, they are defaulted when the key is absent,
+        // and sending '' would blank the stored value on a later order edit.
         if (!empty($additionalData['invoiceEmails'])) {
             $payload['invoice_details'] = [
                 'invoice_emails' => explode(',', $additionalData['invoiceEmails']),

--- a/Service/Order/ComposeOrder.php
+++ b/Service/Order/ComposeOrder.php
@@ -127,8 +127,8 @@ class ComposeOrder extends OrderService
         $lineItems = $this->reconcileOtherCharges($lineItems, $order, $grossTotal, $taxTotal);
 
         // Compose the final payload for the API call. Fields that may
-        // legitimately be blank are NOT listed here — see the optional-field
-        // allowlist below.
+        // legitimately be blank are NOT listed here — they go through the
+        // omit-when-blank list below.
         $payload = [
             'billing_address' => $this->getAddress($order, $additionalData, 'billing'),
             'shipping_address' => $this->getAddress($order, $additionalData, 'shipping'),
@@ -155,9 +155,7 @@ class ComposeOrder extends OrderService
                 ),
                 // merchant_edit_order_url is deliberately absent: the plugin
                 // exposes no merchant-side edit-order route, so there is no
-                // URL to put here. An empty string would be accepted, but it
-                // is still a value nobody set, and on a later order edit an
-                // empty string overwrites while an absent key is left alone.
+                // URL to put here.
                 'merchant_order_verification_failed_url' => $this->url->getUrl(
                     'two/payment/verificationfailed',
                     ['_two_order_reference' => base64_encode($orderReference)]
@@ -166,22 +164,24 @@ class ComposeOrder extends OrderService
         ];
 
         // TWO-25386: these fields are optional and are omitted rather than sent
-        // blank. Two different reasons, both real:
+        // blank. Two different reasons, both real.
         //
-        // vendor_name is the one that must be non-empty whenever the key is
-        // present. A blank admin setting sent as '' is rejected outright and no
-        // order is created — that rejection is why this ticket exists.
+        // vendor_name is the one that cannot be blank while the key is present:
+        // a blank admin setting sent as '' had the order rejected and nothing
+        // created at all, and that rejection is why this ticket exists.
         //
-        // The other four are accepted as empty strings on create, so they were
-        // never causing rejections. They are omitted because of what happens
-        // afterwards: the order-edit call merges scalar fields, so a key left
-        // out preserves the stored value while a key sent as '' overwrites it
-        // with blank. Composing them empty meant an admin order-address edit
-        // erased whatever the buyer had actually entered at checkout.
+        // The other four never caused a rejection. They are omitted because of
+        // what an omitted key means to a later order edit; the field
+        // constraints and the edit-merge semantics behind that are recorded on
+        // TWO-25386. The decision here is that a value nobody set is left out
+        // of the request entirely. Concretely, composing them blank meant an
+        // admin order-address edit sent buyer_purchase_order_number and
+        // order_note blank (buyer_department and buyer_project were forwarded
+        // from the stored additional_information, so those two survived).
         //
-        // An explicit allowlist, never a blanket empty-strip over $payload:
-        // merchant_confirmation_url and the amount fields are required and must
-        // survive regardless of their value.
+        // An explicit list of what to omit when blank, never a blanket
+        // empty-strip over $payload: merchant_confirmation_url and the amount
+        // fields have to survive regardless of their value.
         $optionalFields = [
             'buyer_department' => $additionalData['department'] ?? '',
             'buyer_project' => $additionalData['project'] ?? '',
@@ -202,14 +202,14 @@ class ComposeOrder extends OrderService
             // Compare as string rather than using empty(), so a legitimate
             // '0' department/project reference is still sent.
             if ((string)$value !== '') {
-                $payload[$key] = $value;
+                $payload[$key] = (string)$value;
             }
         }
 
         // Add invoice_details only if invoiceEmails are present. The payment
-        // reference fields are omitted rather than sent blank: the plugin has
-        // no value to put in them, they are defaulted when the key is absent,
-        // and sending '' would blank the stored value on a later order edit.
+        // reference fields are left out for one reason: the plugin has no value
+        // to put in them, and they are defaulted when the key is absent. Their
+        // constraints are recorded on TWO-25386.
         if (!empty($additionalData['invoiceEmails'])) {
             $payload['invoice_details'] = [
                 'invoice_emails' => explode(',', $additionalData['invoiceEmails']),

--- a/Test/Stubs/FrameworkUrl.php
+++ b/Test/Stubs/FrameworkUrl.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * URL builder stub with a real getUrl() signature, so ComposeOrder's
+ * merchant_urls construction can be exercised. The catch-all autoloader in
+ * Test/bootstrap.php produces a method-less class, which PHPUnit cannot
+ * configure via ->method(); this gives it something to override.
+ */
+declare(strict_types=1);
+
+namespace Magento\Framework {
+    if (!class_exists(Url::class, false)) {
+        class Url
+        {
+            /**
+             * @param string $routePath
+             * @param array $routeParams
+             * @return string
+             */
+            public function getUrl($routePath = null, $routeParams = null)
+            {
+                return '';
+            }
+        }
+    }
+}

--- a/Test/Unit/Observer/SalesOrderAddressUpdateOptionalFieldsTest.php
+++ b/Test/Unit/Observer/SalesOrderAddressUpdateOptionalFieldsTest.php
@@ -212,12 +212,13 @@ class SalesOrderAddressUpdateOptionalFieldsTest extends TestCase
      * order already held remotely. A key left out of the request keeps the
      * stored value; a key sent as an empty string is accepted and overwrites
      * the stored value with blank. The observer used to append three such keys
-     * unconditionally, so every admin address edit blanked them.
+     * unconditionally, so every admin address edit blanked them — and the
+     * plugin never has a value for any of the three in the first place, so
+     * they are now left out of the request under every condition.
      *
-     * shipping_details is the worse of the three, because it is replaced as a
-     * whole object rather than merged field by field — sending it with only
-     * carrier and tracking populated discards every other stored delivery
-     * field. It must be omitted outright when there is nothing to send.
+     * shipping_details is the worst of the three, because it is replaced as a
+     * whole object rather than merged field by field, so sending it at all
+     * discards every stored delivery field the request does not mention.
      */
 
     /**
@@ -276,56 +277,6 @@ class SalesOrderAddressUpdateOptionalFieldsTest extends TestCase
             self::EXPECTED_SHIPPING_ADDRESS,
             $payload['shipping_address'],
             'shipping_address is required and is not the field being omitted'
-        );
-    }
-
-    public function testPopulatedMerchantReferenceFieldsAreSent(): void
-    {
-        $stored = $this->storedInformationWithoutOptionalFields();
-        $stored['merchant_reference'] = 'REF-4471';
-        $stored['merchant_additional_info'] = 'Delivered to loading bay';
-        $this->order = $this->makeOrder($stored);
-
-        $payload = $this->executeAndCapturePayload();
-
-        $this->assertSame('REF-4471', $payload['merchant_reference']);
-        $this->assertSame('Delivered to loading bay', $payload['merchant_additional_info']);
-    }
-
-    public function testPopulatedShippingDetailsIsSentAndShippingAddressIsUnchanged(): void
-    {
-        $stored = $this->storedInformationWithoutOptionalFields();
-        $stored['shipping_details'] = [
-            'carrier_name' => 'Test Carrier',
-            'tracking_number' => 'TRK-99001',
-        ];
-        $this->order = $this->makeOrder($stored);
-
-        $payload = $this->executeAndCapturePayload();
-
-        $this->assertSame(
-            ['carrier_name' => 'Test Carrier', 'tracking_number' => 'TRK-99001'],
-            $payload['shipping_details']
-        );
-        $this->assertSame(
-            self::EXPECTED_SHIPPING_ADDRESS,
-            $payload['shipping_address'],
-            'shipping_address must be untouched whether or not shipping_details is sent'
-        );
-    }
-
-    public function testShippingDetailsIsSentWhenOnlyTrackingNumberIsKnown(): void
-    {
-        $stored = $this->storedInformationWithoutOptionalFields();
-        $stored['shipping_details'] = ['tracking_number' => 'TRK-99001'];
-        $this->order = $this->makeOrder($stored);
-
-        $payload = $this->executeAndCapturePayload();
-
-        $this->assertSame(
-            ['carrier_name' => '', 'tracking_number' => 'TRK-99001'],
-            $payload['shipping_details'],
-            'a partially known delivery record is still worth sending'
         );
     }
 }

--- a/Test/Unit/Observer/SalesOrderAddressUpdateOptionalFieldsTest.php
+++ b/Test/Unit/Observer/SalesOrderAddressUpdateOptionalFieldsTest.php
@@ -27,6 +27,17 @@ use Two\Gateway\Service\Order\ComposeOrder;
  */
 class SalesOrderAddressUpdateOptionalFieldsTest extends TestCase
 {
+    /**
+     * The shipping address the composer produces. Held as a constant so the
+     * "unchanged" assertions compare against the exact composed value.
+     */
+    private const EXPECTED_SHIPPING_ADDRESS = [
+        'street_address' => 'Storgata 1',
+        'city' => 'Oslo',
+        'postal_code' => '0155',
+        'country' => 'NO',
+    ];
+
     /** @var array captured $additionalData handed to the composer */
     private $capturedAdditionalData;
 
@@ -63,7 +74,13 @@ class SalesOrderAddressUpdateOptionalFieldsTest extends TestCase
         $composeOrder->method('execute')
             ->willReturnCallback(function ($order, $orderReference, array $additionalData): array {
                 $this->capturedAdditionalData = $additionalData;
-                return ['order_reference' => $orderReference];
+                return [
+                    'order_reference' => $orderReference,
+                    // shipping_address is required and composed on every call.
+                    // It is a different field from shipping_details and must
+                    // reach the request untouched — see the tests below.
+                    'shipping_address' => self::EXPECTED_SHIPPING_ADDRESS,
+                ];
             });
 
         $this->apiAdapter = $this->createMock(Adapter::class);
@@ -188,6 +205,128 @@ class SalesOrderAddressUpdateOptionalFieldsTest extends TestCase
 
         $this->assertSame('Facilities', $this->capturedAdditionalData['department']);
         $this->assertSame('Q3 Refit', $this->capturedAdditionalData['project']);
+    }
+
+    /*
+     * TWO-25386 (scope extension): the address edit is a merging update of an
+     * order already held remotely. A key left out of the request keeps the
+     * stored value; a key sent as an empty string is accepted and overwrites
+     * the stored value with blank. The observer used to append three such keys
+     * unconditionally, so every admin address edit blanked them.
+     *
+     * shipping_details is the worse of the three, because it is replaced as a
+     * whole object rather than merged field by field — sending it with only
+     * carrier and tracking populated discards every other stored delivery
+     * field. It must be omitted outright when there is nothing to send.
+     */
+
+    /**
+     * @return array the captured request payload for the current order
+     */
+    private function executeAndCapturePayload(): array
+    {
+        $this->makeObserverService()->execute(
+            new AddressUpdateObserverStub(new AddressUpdateEventStub(42))
+        );
+
+        $this->assertNotNull($this->capturedApiCall, 'the edit request must be attempted');
+
+        return $this->capturedApiCall[1];
+    }
+
+    public function testBlankMerchantReferenceFieldsAreOmittedFromTheEditRequest(): void
+    {
+        $this->order = $this->makeOrder($this->storedInformationWithoutOptionalFields());
+
+        $payload = $this->executeAndCapturePayload();
+
+        $this->assertArrayNotHasKey(
+            'merchant_reference',
+            $payload,
+            'sending it blank would overwrite the stored reference'
+        );
+        $this->assertArrayNotHasKey(
+            'merchant_additional_info',
+            $payload,
+            'sending it blank would overwrite the stored additional info'
+        );
+    }
+
+    public function testBlankShippingDetailsIsOmittedFromTheEditRequest(): void
+    {
+        $this->order = $this->makeOrder($this->storedInformationWithoutOptionalFields());
+
+        $payload = $this->executeAndCapturePayload();
+
+        $this->assertArrayNotHasKey(
+            'shipping_details',
+            $payload,
+            'sending it at all replaces the whole stored delivery record'
+        );
+    }
+
+    public function testShippingAddressSurvivesWhenOptionalFieldsAreOmitted(): void
+    {
+        $this->order = $this->makeOrder($this->storedInformationWithoutOptionalFields());
+
+        $payload = $this->executeAndCapturePayload();
+
+        $this->assertArrayHasKey('shipping_address', $payload);
+        $this->assertSame(
+            self::EXPECTED_SHIPPING_ADDRESS,
+            $payload['shipping_address'],
+            'shipping_address is required and is not the field being omitted'
+        );
+    }
+
+    public function testPopulatedMerchantReferenceFieldsAreSent(): void
+    {
+        $stored = $this->storedInformationWithoutOptionalFields();
+        $stored['merchant_reference'] = 'REF-4471';
+        $stored['merchant_additional_info'] = 'Delivered to loading bay';
+        $this->order = $this->makeOrder($stored);
+
+        $payload = $this->executeAndCapturePayload();
+
+        $this->assertSame('REF-4471', $payload['merchant_reference']);
+        $this->assertSame('Delivered to loading bay', $payload['merchant_additional_info']);
+    }
+
+    public function testPopulatedShippingDetailsIsSentAndShippingAddressIsUnchanged(): void
+    {
+        $stored = $this->storedInformationWithoutOptionalFields();
+        $stored['shipping_details'] = [
+            'carrier_name' => 'Test Carrier',
+            'tracking_number' => 'TRK-99001',
+        ];
+        $this->order = $this->makeOrder($stored);
+
+        $payload = $this->executeAndCapturePayload();
+
+        $this->assertSame(
+            ['carrier_name' => 'Test Carrier', 'tracking_number' => 'TRK-99001'],
+            $payload['shipping_details']
+        );
+        $this->assertSame(
+            self::EXPECTED_SHIPPING_ADDRESS,
+            $payload['shipping_address'],
+            'shipping_address must be untouched whether or not shipping_details is sent'
+        );
+    }
+
+    public function testShippingDetailsIsSentWhenOnlyTrackingNumberIsKnown(): void
+    {
+        $stored = $this->storedInformationWithoutOptionalFields();
+        $stored['shipping_details'] = ['tracking_number' => 'TRK-99001'];
+        $this->order = $this->makeOrder($stored);
+
+        $payload = $this->executeAndCapturePayload();
+
+        $this->assertSame(
+            ['carrier_name' => '', 'tracking_number' => 'TRK-99001'],
+            $payload['shipping_details'],
+            'a partially known delivery record is still worth sending'
+        );
     }
 }
 

--- a/Test/Unit/Observer/SalesOrderAddressUpdateOptionalFieldsTest.php
+++ b/Test/Unit/Observer/SalesOrderAddressUpdateOptionalFieldsTest.php
@@ -1,0 +1,293 @@
+<?php
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Observer;
+
+use Magento\Sales\Api\OrderRepositoryInterface;
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Api\BrandOverlayRegistryInterface;
+use Two\Gateway\Api\BrandRegistryInterface;
+use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
+use Two\Gateway\Observer\SalesOrderAddressUpdate;
+use Two\Gateway\Service\Api\Adapter;
+use Two\Gateway\Service\Order\ComposeOrder;
+
+/**
+ * TWO-25386: the admin address-edit observer re-composes the order payload
+ * from the stored payment additional_information. Now that blank optional
+ * fields are omitted rather than sent as '', the Department and Project keys
+ * are simply absent for any buyer who left those checkout fields empty — the
+ * common case. Reading them unguarded raised a PHP warning, which developer
+ * mode promotes to an exception; the observer's own catch swallowed it into
+ * order status history and the edit request was never sent at all.
+ *
+ * The tests below install an error handler that turns warnings into
+ * exceptions, so an unguarded read fails here the way it fails in developer
+ * mode rather than passing silently.
+ */
+class SalesOrderAddressUpdateOptionalFieldsTest extends TestCase
+{
+    /** @var array captured $additionalData handed to the composer */
+    private $capturedAdditionalData;
+
+    /** @var array captured [endpoint, payload, method] of the API call */
+    private $capturedApiCall;
+
+    /** @var Adapter|\PHPUnit\Framework\MockObject\MockObject */
+    private $apiAdapter;
+
+    protected function setUp(): void
+    {
+        $this->capturedAdditionalData = null;
+        $this->capturedApiCall = null;
+
+        set_error_handler(
+            static function (int $severity, string $message, string $file, int $line): bool {
+                throw new \ErrorException($message, 0, $severity, $file, $line);
+            },
+            E_WARNING | E_NOTICE
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        restore_error_handler();
+    }
+
+    private function makeObserverService(): SalesOrderAddressUpdate
+    {
+        $composeOrder = $this->getMockBuilder(ComposeOrder::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['execute'])
+            ->getMock();
+        $composeOrder->method('execute')
+            ->willReturnCallback(function ($order, $orderReference, array $additionalData): array {
+                $this->capturedAdditionalData = $additionalData;
+                return ['order_reference' => $orderReference];
+            });
+
+        $this->apiAdapter = $this->createMock(Adapter::class);
+        $this->apiAdapter->expects($this->once())
+            ->method('execute')
+            ->willReturnCallback(function (
+                string $endpoint,
+                array $payload = [],
+                string $method = 'POST',
+                ?int $storeId = null
+            ): array {
+                $this->capturedApiCall = [$endpoint, $payload, $method];
+                return ['id' => 'remote-order-id'];
+            });
+
+        $orderRepository = $this->createMock(OrderRepositoryInterface::class);
+        $orderRepository->method('get')->willReturn($this->order);
+
+        $overlayRegistry = $this->createMock(BrandOverlayRegistryInterface::class);
+        $overlayRegistry->method('isTwoStackMethod')->willReturn(true);
+
+        $brandRegistry = $this->createMock(BrandRegistryInterface::class);
+        $brandRegistry->method('getProductName')->willReturn('Test Product');
+
+        return new SalesOrderAddressUpdate(
+            $this->createMock(ConfigRepository::class),
+            $brandRegistry,
+            $orderRepository,
+            $composeOrder,
+            $this->apiAdapter,
+            $overlayRegistry
+        );
+    }
+
+    /** @var AddressUpdateOrderStub */
+    private $order;
+
+    private function makeOrder(array $additionalInformation): AddressUpdateOrderStub
+    {
+        $order = new AddressUpdateOrderStub();
+        $order->setData('two_order_id', 'remote-order-id');
+        $order->setData('two_order_reference', 'order-reference');
+        $order->setData('payment', new AddressUpdatePaymentStub($additionalInformation));
+
+        return $order;
+    }
+
+    /**
+     * @return array additional_information as stored for a buyer who left
+     *               both optional checkout fields empty
+     */
+    private function storedInformationWithoutOptionalFields(): array
+    {
+        return [
+            'buyer' => [
+                'company' => [
+                    'company_name' => 'Buyer Company',
+                    'organization_number' => '123456789',
+                ],
+                'representative' => [
+                    'phone_number' => '+4712345678',
+                ],
+            ],
+        ];
+    }
+
+    public function testMissingDepartmentAndProjectKeysStillSendTheEditRequest(): void
+    {
+        $this->order = $this->makeOrder($this->storedInformationWithoutOptionalFields());
+
+        $this->makeObserverService()->execute(
+            new AddressUpdateObserverStub(new AddressUpdateEventStub(42))
+        );
+
+        $this->assertNotNull(
+            $this->capturedApiCall,
+            'the order-edit request must still be attempted'
+        );
+        $this->assertSame('/v1/order/remote-order-id', $this->capturedApiCall[0]);
+        $this->assertSame('PUT', $this->capturedApiCall[2]);
+    }
+
+    public function testMissingDepartmentAndProjectKeysAreNotReportedAsAnError(): void
+    {
+        $this->order = $this->makeOrder($this->storedInformationWithoutOptionalFields());
+
+        $this->makeObserverService()->execute(
+            new AddressUpdateObserverStub(new AddressUpdateEventStub(42))
+        );
+
+        $this->assertSame(
+            ['Order edit request was accepted by Test Product'],
+            $this->order->historyComments,
+            'history should record acceptance, not a swallowed warning'
+        );
+    }
+
+    public function testMissingDepartmentAndProjectAreRecomposedAsBlank(): void
+    {
+        $this->order = $this->makeOrder($this->storedInformationWithoutOptionalFields());
+
+        $this->makeObserverService()->execute(
+            new AddressUpdateObserverStub(new AddressUpdateEventStub(42))
+        );
+
+        // Blank is the right hand-off: the composer applies the omit rule
+        // again, so the outgoing payload leaves both keys out.
+        $this->assertSame('', $this->capturedAdditionalData['department']);
+        $this->assertSame('', $this->capturedAdditionalData['project']);
+    }
+
+    public function testStoredDepartmentAndProjectAreForwardedUnchanged(): void
+    {
+        $stored = $this->storedInformationWithoutOptionalFields();
+        $stored['buyer_department'] = 'Facilities';
+        $stored['buyer_project'] = 'Q3 Refit';
+        $this->order = $this->makeOrder($stored);
+
+        $this->makeObserverService()->execute(
+            new AddressUpdateObserverStub(new AddressUpdateEventStub(42))
+        );
+
+        $this->assertSame('Facilities', $this->capturedAdditionalData['department']);
+        $this->assertSame('Q3 Refit', $this->capturedAdditionalData['project']);
+    }
+}
+
+/**
+ * Test doubles. The bootstrap's catch-all autoloader produces method-less
+ * Magento classes, so the collaborators the observer reaches through are
+ * declared here rather than mocked.
+ */
+class AddressUpdateOrderStub extends \Magento\Sales\Model\Order
+{
+    /** @var array */
+    public $historyComments = [];
+
+    /** @var int */
+    public $saveCount = 0;
+
+    public function getStatus(): string
+    {
+        return 'processing';
+    }
+
+    public function addStatusToHistory($status, $comment = ''): self
+    {
+        $this->historyComments[] = $comment;
+        return $this;
+    }
+
+    public function save(): self
+    {
+        $this->saveCount++;
+        return $this;
+    }
+}
+
+class AddressUpdatePaymentStub
+{
+    /** @var array */
+    private $additionalInformation;
+
+    public function __construct(array $additionalInformation)
+    {
+        $this->additionalInformation = $additionalInformation;
+    }
+
+    public function getMethod(): string
+    {
+        return 'two_payment';
+    }
+
+    public function getAdditionalInformation(): array
+    {
+        return $this->additionalInformation;
+    }
+
+    public function getMethodInstance(): AddressUpdateMethodInstanceStub
+    {
+        return new AddressUpdateMethodInstanceStub();
+    }
+}
+
+class AddressUpdateMethodInstanceStub
+{
+    /**
+     * @param array $response
+     * @return string|null
+     */
+    public function getErrorFromResponse($response)
+    {
+        return null;
+    }
+}
+
+class AddressUpdateEventStub
+{
+    /** @var int */
+    private $orderId;
+
+    public function __construct(int $orderId)
+    {
+        $this->orderId = $orderId;
+    }
+
+    public function getOrderId(): int
+    {
+        return $this->orderId;
+    }
+}
+
+class AddressUpdateObserverStub extends \Magento\Framework\Event\Observer
+{
+    /** @var AddressUpdateEventStub */
+    private $event;
+
+    public function __construct(AddressUpdateEventStub $event)
+    {
+        $this->event = $event;
+    }
+
+    public function getEvent(): AddressUpdateEventStub
+    {
+        return $this->event;
+    }
+}

--- a/Test/Unit/Observer/SalesOrderAddressUpdateOptionalFieldsTest.php
+++ b/Test/Unit/Observer/SalesOrderAddressUpdateOptionalFieldsTest.php
@@ -76,9 +76,9 @@ class SalesOrderAddressUpdateOptionalFieldsTest extends TestCase
                 $this->capturedAdditionalData = $additionalData;
                 return [
                     'order_reference' => $orderReference,
-                    // shipping_address is required and composed on every call.
-                    // It is a different field from shipping_details and must
-                    // reach the request untouched — see the tests below.
+                    // shipping_address is composed on every call. It is a
+                    // different field from shipping_details and must reach the
+                    // request untouched — see the tests below.
                     'shipping_address' => self::EXPECTED_SHIPPING_ADDRESS,
                 ];
             });
@@ -161,6 +161,11 @@ class SalesOrderAddressUpdateOptionalFieldsTest extends TestCase
         );
         $this->assertSame('/v1/order/remote-order-id', $this->capturedApiCall[0]);
         $this->assertSame('PUT', $this->capturedApiCall[2]);
+        $this->assertSame(
+            1,
+            $this->order->saveCount,
+            'the order is saved once, after the edit request'
+        );
     }
 
     public function testMissingDepartmentAndProjectKeysAreNotReportedAsAnError(): void
@@ -208,17 +213,13 @@ class SalesOrderAddressUpdateOptionalFieldsTest extends TestCase
     }
 
     /*
-     * TWO-25386 (scope extension): the address edit is a merging update of an
-     * order already held remotely. A key left out of the request keeps the
-     * stored value; a key sent as an empty string is accepted and overwrites
-     * the stored value with blank. The observer used to append three such keys
-     * unconditionally, so every admin address edit blanked them — and the
-     * plugin never has a value for any of the three in the first place, so
-     * they are now left out of the request under every condition.
-     *
-     * shipping_details is the worst of the three, because it is replaced as a
-     * whole object rather than merged field by field, so sending it at all
-     * discards every stored delivery field the request does not mention.
+     * TWO-25386 (scope extension): the observer used to append
+     * merchant_reference, merchant_additional_info and shipping_details to
+     * every edit request, so every admin address edit sent them blank —
+     * shipping_details as a two-field object with nothing else populated. The
+     * plugin never has a value for any of the three, so they are now left out
+     * of the request under every condition. Why sending them is harmful, and
+     * the edit-merge semantics behind that, are recorded on TWO-25386.
      */
 
     /**
@@ -244,12 +245,12 @@ class SalesOrderAddressUpdateOptionalFieldsTest extends TestCase
         $this->assertArrayNotHasKey(
             'merchant_reference',
             $payload,
-            'sending it blank would overwrite the stored reference'
+            'the plugin never has a value for it, so it must not be sent'
         );
         $this->assertArrayNotHasKey(
             'merchant_additional_info',
             $payload,
-            'sending it blank would overwrite the stored additional info'
+            'the plugin never has a value for it, so it must not be sent'
         );
     }
 
@@ -262,7 +263,7 @@ class SalesOrderAddressUpdateOptionalFieldsTest extends TestCase
         $this->assertArrayNotHasKey(
             'shipping_details',
             $payload,
-            'sending it at all replaces the whole stored delivery record'
+            'the plugin never has a value for it, so it must not be sent'
         );
     }
 

--- a/Test/Unit/Service/Order/ComposeOrderOptionalFieldsTest.php
+++ b/Test/Unit/Service/Order/ComposeOrderOptionalFieldsTest.php
@@ -10,9 +10,17 @@ use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
 use Two\Gateway\Service\Order\ComposeOrder;
 
 /**
- * TWO-25386: several optional payload fields are length-constrained when
- * present, so composing them as empty strings makes the API reject the order
- * outright. The getters are allowed to return '' (see
+ * TWO-25386: optional payload fields must be omitted rather than composed as
+ * empty strings, for two separate reasons.
+ *
+ * vendor_name has to be non-empty whenever the key is present, so a blank admin
+ * setting sent as '' had the order rejected and nothing created at all. The
+ * remaining fields do accept an empty string on create, but the later
+ * order-edit call merges scalars — an absent key keeps the stored value while
+ * an empty one overwrites it — so composing them blank was erasing what the
+ * buyer entered at checkout as soon as an admin edited the order address.
+ *
+ * The getters are allowed to return '' (see
  * Model\Config\RepositoryAdminControlsTest) — it is the caller's job to leave
  * the key out, which is what this covers.
  *
@@ -189,5 +197,106 @@ class ComposeOrderOptionalFieldsTest extends TestCase
         $payload = $this->makeComposeOrder('')->execute($this->makeOrder(), 'ref', []);
 
         $this->assertArrayNotHasKey('invoice_details', $payload);
+    }
+
+    /**
+     * A non-scalar cannot be a value for any of the optional fields, and the
+     * observer that stores checkout data only validates that the top level is
+     * an array — so a crafted request can put an array here. Casting it to
+     * string raises a warning that developer mode turns into a failed order
+     * placement, so the field must simply be dropped.
+     */
+    public function testNonScalarCheckoutFieldIsDroppedWithoutWarning(): void
+    {
+        set_error_handler(
+            static function (int $severity, string $message, string $file, int $line): bool {
+                throw new \ErrorException($message, 0, $severity, $file, $line);
+            },
+            E_WARNING | E_NOTICE
+        );
+
+        try {
+            $payload = $this->makeComposeOrder('')
+                ->execute($this->makeOrder(), 'ref', ['department' => ['x']]);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertArrayNotHasKey('buyer_department', $payload);
+    }
+
+    /**
+     * Payload paths that are legitimately allowed to hold an empty string, each
+     * with the reason it is sanctioned. Adding an entry has to be a deliberate
+     * act — that is the point of the list.
+     *
+     * Numeric array indices are normalised to '*' so a path stays stable
+     * regardless of how many line items a payload happens to carry.
+     *
+     * Empty as of TWO-25386: nothing the composer emits is currently allowed to
+     * be an empty string.
+     */
+    private const ACCEPTED_EMPTY_PATHS = [];
+
+    /**
+     * The general form of the bug this ticket is about: walk every scalar in a
+     * fully composed create payload and fail on any empty string that is not on
+     * the sanctioned list above.
+     *
+     * This is worth more than the per-field assertions, because it needs no
+     * change when a new field is added to the payload — only when a field is
+     * genuinely permitted to be blank, which is exactly the decision that
+     * deserves a second look.
+     *
+     * Scope note: address, buyer and line-item composition are stubbed out by
+     * this test's fixture (they have their own coverage), so this walks the
+     * payload the composer assembles itself, not those nested structures.
+     */
+    public function testComposedPayloadHasNoUnsanctionedEmptyStrings(): void
+    {
+        // Every optional input left blank: the worst case for this check, and
+        // the common one in production.
+        $additionalData = [
+            'companyName' => '',
+            'companyId' => '',
+            'department' => '',
+            'project' => '',
+            'poNumber' => '',
+            'orderNote' => '',
+            'invoiceEmails' => '',
+        ];
+
+        $payload = $this->makeComposeOrder('')->execute($this->makeOrder(), 'ref', $additionalData);
+
+        $offenders = [];
+        $this->collectEmptyStringPaths($payload, '', $offenders);
+
+        $this->assertSame(
+            [],
+            $offenders,
+            'empty strings must be omitted, not composed into the payload'
+        );
+    }
+
+    /**
+     * @param array $node payload fragment being walked
+     * @param string $prefix dotted path of $node within the payload
+     * @param array $offenders collected paths, by reference
+     */
+    private function collectEmptyStringPaths(array $node, string $prefix, array &$offenders): void
+    {
+        foreach ($node as $key => $value) {
+            $segment = is_int($key) ? '*' : (string)$key;
+            $path = $prefix === '' ? $segment : $prefix . '.' . $segment;
+
+            if (is_array($value)) {
+                $this->collectEmptyStringPaths($value, $path, $offenders);
+                continue;
+            }
+
+            if ($value === '' && !array_key_exists($path, self::ACCEPTED_EMPTY_PATHS)) {
+                $offenders[] = $path;
+            }
+        }
     }
 }

--- a/Test/Unit/Service/Order/ComposeOrderOptionalFieldsTest.php
+++ b/Test/Unit/Service/Order/ComposeOrderOptionalFieldsTest.php
@@ -1,0 +1,193 @@
+<?php
+declare(strict_types=1);
+
+namespace Two\Gateway\Test\Unit\Service\Order;
+
+use Magento\Framework\Url;
+use Magento\Sales\Model\Order;
+use PHPUnit\Framework\TestCase;
+use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
+use Two\Gateway\Service\Order\ComposeOrder;
+
+/**
+ * TWO-25386: several optional payload fields are length-constrained when
+ * present, so composing them as empty strings makes the API reject the order
+ * outright. The getters are allowed to return '' (see
+ * Model\Config\RepositoryAdminControlsTest) — it is the caller's job to leave
+ * the key out, which is what this covers.
+ *
+ * Builds ComposeOrder via getMockBuilder() with the constructor disabled and
+ * only the heavy collaborating helpers replaced, so execute() itself runs its
+ * real implementation — same pattern as ComposeCaptureSurchargeLineTest.
+ */
+class ComposeOrderOptionalFieldsTest extends TestCase
+{
+    /** @var ConfigRepository|\PHPUnit\Framework\MockObject\MockObject */
+    private $configRepository;
+
+    /**
+     * @param string $vendorSiteName value the admin config resolves to
+     * @return ComposeOrder|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private function makeComposeOrder(string $vendorSiteName)
+    {
+        $composeOrder = $this->getMockBuilder(ComposeOrder::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'getLineItemsOrder',
+                'getAddress',
+                'getBuyer',
+                'getTaxSubtotals',
+                'getDiscountAmountItem',
+                'getFeeLines',
+                'getOtherChargesLineItem',
+            ])
+            ->getMock();
+
+        $composeOrder->method('getLineItemsOrder')->willReturn([]);
+        $composeOrder->method('getAddress')->willReturn([]);
+        $composeOrder->method('getBuyer')->willReturn([]);
+        $composeOrder->method('getTaxSubtotals')->willReturn([]);
+        $composeOrder->method('getDiscountAmountItem')->willReturn(0.0);
+        // Line-item reconciliation has its own coverage; stubbed out so this
+        // test is about which keys reach the payload, nothing else.
+        $composeOrder->method('getFeeLines')->willReturn([]);
+        $composeOrder->method('getOtherChargesLineItem')->willReturn(null);
+
+        $this->configRepository = $this->createMock(ConfigRepository::class);
+        $this->configRepository->method('getVendorSiteName')->willReturn($vendorSiteName);
+        $this->configRepository->method('getAllBuyerTerms')->willReturn([30]);
+        $this->configRepository->method('getDefaultPaymentTerm')->willReturn(30);
+        $this->configRepository->method('getPaymentTermsType')->willReturn('invoice_date');
+
+        // configRepository and url are public on the parent service, so the
+        // skipped constructor can be compensated for directly.
+        $composeOrder->configRepository = $this->configRepository;
+        $composeOrder->url = $this->createMock(Url::class);
+        $composeOrder->url->method('getUrl')->willReturn('https://example.test/two');
+
+        $property = new \ReflectionProperty(ComposeOrder::class, 'checkoutSession');
+        $property->setAccessible(true);
+        $property->setValue($composeOrder, new \Magento\Checkout\Model\Session());
+
+        return $composeOrder;
+    }
+
+    private function makeOrder(): Order
+    {
+        $order = new Order();
+        $order->setStoreId(1);
+        $order->setGrandTotal(100.00);
+        $order->setTaxAmount(20.00);
+        $order->setOrderCurrencyCode('EUR');
+        $order->setIncrementId('100000001');
+
+        return $order;
+    }
+
+    public function testBlankVendorSiteNameOmitsTheKeyEntirely(): void
+    {
+        $payload = $this->makeComposeOrder('')->execute($this->makeOrder(), 'ref', []);
+
+        $this->assertArrayNotHasKey('vendor_name', $payload);
+    }
+
+    public function testConfiguredVendorSiteNameIsSent(): void
+    {
+        $payload = $this->makeComposeOrder('acme-eu-store')->execute($this->makeOrder(), 'ref', []);
+
+        $this->assertSame('acme-eu-store', $payload['vendor_name']);
+    }
+
+    public function testUntouchedCheckoutFieldsAreOmitted(): void
+    {
+        $payload = $this->makeComposeOrder('')->execute($this->makeOrder(), 'ref', []);
+
+        $this->assertArrayNotHasKey('buyer_department', $payload);
+        $this->assertArrayNotHasKey('buyer_project', $payload);
+        $this->assertArrayNotHasKey('buyer_purchase_order_number', $payload);
+        $this->assertArrayNotHasKey('order_note', $payload);
+    }
+
+    public function testBlankStringCheckoutFieldsAreOmitted(): void
+    {
+        $additionalData = [
+            'department' => '',
+            'project' => '',
+            'poNumber' => '',
+            'orderNote' => '',
+        ];
+
+        $payload = $this->makeComposeOrder('')->execute($this->makeOrder(), 'ref', $additionalData);
+
+        $this->assertArrayNotHasKey('buyer_department', $payload);
+        $this->assertArrayNotHasKey('buyer_project', $payload);
+        $this->assertArrayNotHasKey('buyer_purchase_order_number', $payload);
+        $this->assertArrayNotHasKey('order_note', $payload);
+    }
+
+    public function testPopulatedCheckoutFieldsAreSent(): void
+    {
+        $additionalData = [
+            'department' => 'Facilities',
+            'project' => 'Fit-out',
+            'poNumber' => 'PO-4471',
+            'orderNote' => 'Deliver to the loading bay',
+        ];
+
+        $payload = $this->makeComposeOrder('')->execute($this->makeOrder(), 'ref', $additionalData);
+
+        $this->assertSame('Facilities', $payload['buyer_department']);
+        $this->assertSame('Fit-out', $payload['buyer_project']);
+        $this->assertSame('PO-4471', $payload['buyer_purchase_order_number']);
+        $this->assertSame('Deliver to the loading bay', $payload['order_note']);
+    }
+
+    /**
+     * A '0' reference is a real value, not an absent one — so the guard must
+     * be a string comparison rather than empty().
+     */
+    public function testZeroStringCheckoutFieldIsStillSent(): void
+    {
+        $payload = $this->makeComposeOrder('')
+            ->execute($this->makeOrder(), 'ref', ['department' => '0']);
+
+        $this->assertSame('0', $payload['buyer_department']);
+    }
+
+    /**
+     * The counterpart guard: omission must never reach the required keys.
+     * A blanket empty-strip over the payload would take
+     * merchant_confirmation_url with it and produce a fresh rejection.
+     */
+    public function testRequiredMerchantConfirmationUrlIsAlwaysPresent(): void
+    {
+        $payload = $this->makeComposeOrder('')->execute($this->makeOrder(), 'ref', []);
+
+        $this->assertArrayHasKey('merchant_urls', $payload);
+        $this->assertNotNull($payload['merchant_urls']['merchant_confirmation_url']);
+        $this->assertSame(
+            'https://example.test/two',
+            $payload['merchant_urls']['merchant_confirmation_url']
+        );
+        // Never composed as a blank string; the plugin has no such route.
+        $this->assertArrayNotHasKey('merchant_edit_order_url', $payload['merchant_urls']);
+    }
+
+    public function testInvoiceDetailsOmitsBlankPaymentReferenceFields(): void
+    {
+        $payload = $this->makeComposeOrder('')
+            ->execute($this->makeOrder(), 'ref', ['invoiceEmails' => 'ap@example.test']);
+
+        $this->assertSame(['ap@example.test'], $payload['invoice_details']['invoice_emails']);
+        $this->assertArrayNotHasKey('payment_reference_message', $payload['invoice_details']);
+        $this->assertArrayNotHasKey('payment_reference_ocr', $payload['invoice_details']);
+    }
+
+    public function testInvoiceDetailsAbsentWithoutInvoiceEmails(): void
+    {
+        $payload = $this->makeComposeOrder('')->execute($this->makeOrder(), 'ref', []);
+
+        $this->assertArrayNotHasKey('invoice_details', $payload);
+    }
+}

--- a/Test/Unit/Service/Order/ComposeOrderOptionalFieldsTest.php
+++ b/Test/Unit/Service/Order/ComposeOrderOptionalFieldsTest.php
@@ -13,12 +13,14 @@ use Two\Gateway\Service\Order\ComposeOrder;
  * TWO-25386: optional payload fields must be omitted rather than composed as
  * empty strings, for two separate reasons.
  *
- * vendor_name has to be non-empty whenever the key is present, so a blank admin
+ * vendor_name cannot be blank while the key is present, so a blank admin
  * setting sent as '' had the order rejected and nothing created at all. The
- * remaining fields do accept an empty string on create, but the later
- * order-edit call merges scalars — an absent key keeps the stored value while
- * an empty one overwrites it — so composing them blank was erasing what the
- * buyer entered at checkout as soon as an admin edited the order address.
+ * remaining fields never caused a rejection; they are omitted because of what
+ * an omitted key means to the later order-edit call. Those field constraints
+ * and the edit-merge semantics are recorded on TWO-25386. What the plugin did
+ * wrong: an admin order-address edit re-composed the payload and sent
+ * buyer_purchase_order_number and order_note blank (buyer_department and
+ * buyer_project were forwarded from the stored additional_information).
  *
  * The getters are allowed to return '' (see
  * Model\Config\RepositoryAdminControlsTest) — it is the caller's job to leave
@@ -164,9 +166,10 @@ class ComposeOrderOptionalFieldsTest extends TestCase
     }
 
     /**
-     * The counterpart guard: omission must never reach the required keys.
-     * A blanket empty-strip over the payload would take
-     * merchant_confirmation_url with it and produce a fresh rejection.
+     * The counterpart guard: omission must never reach the keys that have to be
+     * there. A blanket empty-strip over the payload would take
+     * merchant_confirmation_url with it — TWO-25386 records why that one has to
+     * survive whatever its value.
      */
     public function testRequiredMerchantConfirmationUrlIsAlwaysPresent(): void
     {
@@ -226,17 +229,28 @@ class ComposeOrderOptionalFieldsTest extends TestCase
     }
 
     /**
-     * Payload paths that are legitimately allowed to hold an empty string, each
-     * with the reason it is sanctioned. Adding an entry has to be a deliberate
-     * act — that is the point of the list.
+     * Payload paths sanctioned here to hold an empty string, each with the
+     * reason. Adding an entry has to be a deliberate act — that is the point of
+     * the list.
+     *
+     * Entries are KEYS, not values: the lookup below is array_key_exists(), so
+     * a list-style entry would silently match nothing.
      *
      * Numeric array indices are normalised to '*' so a path stays stable
      * regardless of how many line items a payload happens to carry.
      *
-     * Empty as of TWO-25386: nothing the composer emits is currently allowed to
-     * be an empty string.
+     * None of these are reachable under this test's fixture, which stubs
+     * line-item composition out and leaves the surcharge amount at 0. They are
+     * seeded so that enriching makeOrder() later produces a legible list rather
+     * than a failure that reads as a TWO-25386 regression.
      */
-    private const ACCEPTED_EMPTY_PATHS = [];
+    private const ACCEPTED_EMPTY_PATHS = [
+        // Shipping, buyer-fee and other-charges lines are synthesised by the
+        // plugin rather than drawn from the catalogue.
+        'line_items.*.description' => 'the synthesised shipping line carries no description',
+        'line_items.*.image_url' => 'synthesised lines have no catalogue image',
+        'line_items.*.product_page_url' => 'synthesised lines have no catalogue page',
+    ];
 
     /**
      * The general form of the bug this ticket is about: walk every scalar in a
@@ -252,10 +266,13 @@ class ComposeOrderOptionalFieldsTest extends TestCase
      * this test's fixture (they have their own coverage), so this walks the
      * payload the composer assembles itself, not those nested structures.
      */
-    public function testComposedPayloadHasNoUnsanctionedEmptyStrings(): void
+    public function testComposerAssembledKeysHaveNoUnsanctionedEmptyStrings(): void
     {
         // Every optional input left blank: the worst case for this check, and
-        // the common one in production.
+        // the common one in production. companyName and companyId are inert
+        // here — getBuyer() and getAddress() are stubbed to [] by this fixture,
+        // so nothing consumes them; they are listed only to mirror the shape of
+        // a real blank checkout submission.
         $additionalData = [
             'companyName' => '',
             'companyId' => '',

--- a/Test/bootstrap.php
+++ b/Test/bootstrap.php
@@ -124,6 +124,10 @@ require_once __DIR__ . '/Stubs/InvoiceUpload.php';
 // the stub file.
 require_once __DIR__ . '/Stubs/ConfigStructureSynthesisFixtures.php';
 
+// URL builder with a real getUrl() (mock target) so ComposeOrder's
+// merchant_urls construction is exercisable; per-symbol guard lives inside.
+require_once __DIR__ . '/Stubs/FrameworkUrl.php';
+
 // Payment-method base class with a real isAvailable() and a declared
 // $_scopeConfig, so Model\Two's availability gates are testable.
 require_once __DIR__ . '/Stubs/PaymentMethod.php';


### PR DESCRIPTION
## Problem

TWO-25386. The create-order payload was composing several optional fields as empty strings. `vendor_name` is the one that actually breaks: the field cannot be blank while the key is present, so sending `""` has the order rejected and nothing is created at all.

Its admin setting defaults to blank — and the help text explicitly tells merchants to leave it blank when they run a single site — while the composer sent it unconditionally, casting the blank config to `""`. Result: on `staging`, every order failed until a merchant typed a vendor site name. `main` is unaffected; it does not send the field.

## Fix

Omit the key rather than send an empty string, for two **distinct** reasons.

**Reason 1 — the constraint.** `vendor_name` cannot be blank while the key is present. This is the rejection the ticket was raised for, and it is the only field of the set with that constraint.

**Reason 2 — the edit call is a merge.** `buyer_department`, `buyer_project`, `buyer_purchase_order_number` and `order_note` never caused a rejection on create. They still must not be sent blank, because of what an omitted key means to the *edit* path — see below. Composing them empty meant an admin order-address edit sent `buyer_purchase_order_number` and `order_note` blank. (`buyer_department` and `buyer_project` were forwarded from the stored `additional_information` on that path, so those two survived.)

`merchant_urls.merchant_edit_order_url` and `invoice_details.payment_reference_message` / `payment_reference_ocr` are omitted for a third, simpler reason: **the plugin has no value to put in them.** There is no merchant-side edit-order route to point a URL at, and nothing sets a payment reference. Neither is buyer-entered data, and the plugin never sends `invoice_details` on the edit path at all — the observer's `$additionalData` carries no `invoiceEmails`, so the key is absent from the edit request by construction.

The exact field constraints and the edit-merge semantics are recorded on **TWO-25386**; the comments in the code state what this plugin does about them rather than restating them, which is what kept rotting across earlier rounds of this PR.

Mechanism is an **explicit omit-when-blank list** of keys, not a blanket empty-strip over the payload — a blanket strip would also drop `merchant_urls.merchant_confirmation_url` and the amount fields, which have to survive regardless of their value.

Three details:

- The blank check is a string comparison, not `empty()`, so a literal `"0"` department or project reference is still sent.
- Values are cast to string on assignment. `is_scalar()` stops arrays, but `true` and `123` previously passed through uncast and put a boolean or a number into the JSON where a string belongs. This normalises a pre-existing behaviour on `staging`, not only the new omit path.
- Non-scalar values are dropped. `additional_data` reaches the composer from the checkout request, and the observer that stores it validates only that the top level is an array — so a crafted request can leave an array in one of these values. Casting that to string raises `Array to string conversion`, which developer mode promotes to an exception mid-order-placement.

## Scope: this changes the admin order-edit payload too

`Service/Order/ComposeOrder.php` is not only the order-create composer. It feeds **two** outbound calls:

- `POST /v1/order` on placement, from `Model/Two.php`.
- `PUT /v1/order/{id}` when an admin edits the order address, from `Observer/SalesOrderAddressUpdate.php` (wired to `admin_sales_order_address_update` in `etc/adminhtml/events.xml`).

So every omission above applies to the edit payload as well as the create payload.

### On the edit path an empty string is destructive, not a no-op

The edit call is a merging update of an order already held remotely. Sending a field blank is not equivalent to leaving it out, and neither is rejected, so nothing ever surfaced as an error. The precise semantics are recorded on TWO-25386. The consequence for this plugin: previously every admin address edit sent the buyer's order note and purchase order number blank. That is what makes these omissions a data-integrity fix and not merely a schema fix.

### Regression on the edit path, fixed here

The observer re-composes from the stored payment `additional_information`, which is set wholesale from the create payload — so once blank optional fields are omitted, the Department and Project keys are absent for any buyer who left those checkout fields empty, which is the common case. The observer read both without a null-coalesce. Unguarded that raised a PHP warning; developer mode promotes it to an exception, the observer's own `catch` swallowed it into order status history, and the `PUT` was **never sent** — the admin's address edit silently never reached us, and a raw warning string landed in admin-visible order history. Both reads are now coalesced to an empty string, which the composer then correctly omits.

### Three fields appended after the composer — now never sent

The observer appended `merchant_reference`, `merchant_additional_info` and `shipping_details` unconditionally, always empty, *after* the composer's omit list had already run, so that list could not protect them.

Round 1 of this PR guarded them conditionally. Round 2 established that the condition can never be true, because **nothing in this plugin ever writes any of the three into the payment's `additional_information`.** Every write to it either copies the create-order payload (which does not carry these keys) or sets the completion marker, and the checkout data-assign path is limited to its own fixed key list. The sourcing was reading keys that do not exist.

The `shipping_details` guard was worse than merely dead: it sent a reconstructed two-field object whenever *either* carrier name or tracking number was non-empty, discarding the stored delivery record — carrier tracking URL, expected delivery date, delivery method, recipient details — on every branch.

All three keys are therefore now omitted unconditionally, with the local reason recorded in place and the merge semantics left on the ticket.

**`shipping_details` is not the shipping address.** `shipping_address` is a different field, composed as it always was, and is deliberately untouched — a test asserts it is present and unchanged.

## Tests

The existing config-getter test asserting the getter returns an empty string is **correct and unchanged** — an empty string is a legitimate return for an unset setting. The gap was at the caller, so that is where the coverage went.

Removed: the three observer tests that asserted the populated `merchant_reference` / `shipping_details` branches. They exercised a path that cannot be reached, and the `shipping_details` pair asserted the lossy behaviour as if it were correct.

Added, and the more useful half of this revision: **one payload-wide test** that walks the fully composed create payload recursively and fails on any empty-string value not in an explicit **sanctioned-here** list. That list is a local policy statement about what this plugin chooses to emit, not a claim about what the API permits — several of the fields on it are perfectly acceptable to send blank. It is seeded with the three line-item paths that are legitimately empty on the plugin's synthesised shipping, buyer-fee and other-charges lines (`description`, `image_url`, `product_page_url`), each with its reason. None of the three are reachable under the current fixture, which stubs line-item composition out and leaves the surcharge amount at 0 — they are seeded precisely so that enriching the fixture later produces a legible list rather than a failure that reads as a regression in this ticket. Entries are keys, and that is now stated, so a future list-style entry cannot silently match nothing.

This generalises past the per-field assertions: it catches any future field added as `""` without needing an update when the payload grows, only when a field is genuinely sanctioned to be blank, which is the decision worth a second look. Address, buyer and line-item composition are stubbed by the fixture (each has its own coverage), so the sweep covers the keys the composer assembles itself — the test name now says so.

Also added: a test that a non-scalar checkout value is dropped without raising a warning.

Kept: the per-field omission tests over `execute()`, the observer tests proving a stored payload missing both optional keys still attempts the `PUT` and records acceptance rather than a swallowed warning, the absence assertions for the three appended keys, and the `shipping_address`-survives assertion. The observer tests install an error handler that turns warnings into exceptions, so an unguarded read fails there the way it fails in developer mode instead of passing silently.

Reverting either `?? ''` turns **six** tests red, not two. Verified by removing the `buyer_department` guard and re-running: `Tests: 713, Assertions: 1315, Errors: 1, Failures: 5`. The unguarded read throws inside the observer's `try`, the `catch` writes it to order history, and the `expects($this->once())` API expectation never fires — so the failures spread across the history assertion, the payload-capture helper and the API expectation, not just the two direct reads.

`Test/Stubs` gains a URL builder with a real `getUrl()` so the `merchant_urls` construction is exercisable outside the full framework — the catch-all stub autoloader produces a method-less class that cannot be configured.

Full suite, `make test`:

```
OK (713 tests, 1331 assertions)
```

(The `Element 'source': This element is not expected` config warning is pre-existing — `phpunit.xml` is written against a schema newer than the pinned runner.)

Codesniffer at the CI severity (`--severity=6`, same image CI runs) is clean:

```
............................................................ 240 / 246 (98%)
......                                                       246 / 246 (100%)

Time: 2.51 secs; Memory: 14MB
```

## Also checked

- `merchant_user_id` — never composed anywhere in the plugin. No change.
- Line-item-level `vendor_name` — not composed; the only occurrence is the top-level field fixed here. No change.
- `buyer_reference` — nothing in the plugin maps into it. No change.
- The round-1 comment comparing this to a sibling plugin's handling is dropped rather than corrected — the local reason now stands on its own and does not need the comparison.
- `Service/Order.php`'s `company_name` fallback is out of scope here and tracked separately as TWO-25427.

## Docs

No doc, README, CHANGELOG or guide describes these payload fields, so nothing needed updating. The admin help text for the vendor site name setting still reads accurately.
