### PR TITLE
INF-1458/ci: point Auto-PR at staging (develop branch removed)

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -2,16 +2,25 @@ name: Auto-PR
 
 on:
   push:
-    branches: [develop]
+    branches: [staging]
   workflow_dispatch:
+
+# One run at a time for this sync PR. The "is a PR already open?" check
+# below is check-then-create, so two runs racing (two merges landing on
+# `staging` in quick succession) could both pass the check and the second
+# `gh pr create` would fail with a red check. The later run supersedes
+# the earlier one, so cancelling in progress is safe.
+concurrency:
+  group: auto-pr-staging-to-main
+  cancel-in-progress: true
 
 permissions:
   contents: read
   pull-requests: write
 
 jobs:
-  develop-to-main:
-    name: develop → main
+  staging-to-main:
+    name: staging → main
     runs-on: ${{ vars.RUNNER_STANDARD }}
     steps:
       - uses: actions/checkout@v7
@@ -26,34 +35,34 @@ jobs:
           client-id: ${{ vars.TWO_INC_APP_CLIENT_ID }}
           private-key: ${{ secrets.TWO_INC_APP_PRIVATE_KEY }}
 
-      - name: Ensure open PR develop → main
+      - name: Ensure open PR staging → main
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          existing=$(gh pr list --base main --head develop --state open --json number --jq '.[0].number // ""')
+          existing=$(gh pr list --base main --head staging --state open --json number --jq '.[0].number // ""')
           if [ -n "$existing" ]; then
             echo "PR #$existing already open — nothing to do."
             exit 0
           fi
-          # No-op when develop has nothing ahead of main. Happens
-          # right after a merge-back fast-forwards develop to match
+          # No-op when staging has nothing ahead of main. Happens
+          # right after a merge-back fast-forwards staging to match
           # main — there's no diff for `gh pr create`, which would
-          # otherwise fail with "No commits between main and develop"
+          # otherwise fail with "No commits between main and staging"
           # and leave a red check on the auto-PR workflow.
-          ahead=$(gh api "repos/${REPO}/compare/main...develop" --jq '.ahead_by')
+          ahead=$(gh api "repos/${REPO}/compare/main...staging" --jq '.ahead_by')
           if [ "$ahead" = "0" ]; then
-            echo "develop has no commits ahead of main — nothing to sync."
+            echo "staging has no commits ahead of main — nothing to sync."
             exit 0
           fi
           gh pr create \
             --base main \
-            --head develop \
-            --title "chore: sync develop → main" \
+            --head staging \
+            --title "chore: sync staging → main" \
             --body "$(cat <<'EOF'
-          Automated rolling sync PR opened by `.github/workflows/auto-pr-develop-to-main.yml`.
+          Automated rolling sync PR opened by `.github/workflows/auto-pr.yml`.
 
-          Merges everything currently on `develop` into `main`. Auto-updates as new commits land on `develop`. Close manually if you need to skip a sync window.
+          Merges everything currently on `staging` into `main`. Auto-updates as new commits land on `staging`. Close manually if you need to skip a sync window.
           EOF
           )"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, staging, develop]
+    branches: [main, staging]
   pull_request:
-    branches: [main, staging, develop]
+    branches: [main, staging]
 
 # Cancel in-progress runs for the same ref when a new push lands.
 # Each PR / branch gets its own group so concurrent unrelated work is

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -19,16 +19,16 @@ permissions:
 jobs:
   code-review:
     runs-on: ${{ vars.RUNNER_STANDARD }}
-    # Long-lived sync PRs (develop → main) are bot-opened and accumulate
-    # every change from develop — the cumulative diff exceeds the
+    # Long-lived sync PRs (staging → main) are bot-opened and accumulate
+    # every change from staging — the cumulative diff exceeds the
     # reviewer's `gh pr diff` 20000-line ceiling, so the prefetch step
     # hard-fails on every sync. Skip code-review for any PR whose head
     # ref is a long-lived branch; reviewing happens on the topic PRs
-    # into develop instead.
+    # into staging instead.
     if: |
       (
         github.event_name == 'pull_request' &&
-        github.head_ref != 'develop' &&
+        github.head_ref != 'staging' &&
         github.head_ref != 'abn-develop' &&
         vars.CLAUDE_REVIEW_CONFIG != '' &&
         fromJSON(vars.CLAUDE_REVIEW_CONFIG)[format('{0}:{1}', github.base_ref, github.event.action)] == true

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -29,7 +29,6 @@ jobs:
       (
         github.event_name == 'pull_request' &&
         github.head_ref != 'staging' &&
-        github.head_ref != 'abn-develop' &&
         vars.CLAUDE_REVIEW_CONFIG != '' &&
         fromJSON(vars.CLAUDE_REVIEW_CONFIG)[format('{0}:{1}', github.base_ref, github.event.action)] == true
       ) ||

--- a/README.md
+++ b/README.md
@@ -244,7 +244,9 @@ The push goes out under the App token rather than `GITHUB_TOKEN` for two reasons
 
 `.github/workflows/merge-back.yml` keeps `staging` fast-forwarded to match `main` after each release (falling back to a sync PR if the two have diverged).
 
-To trigger a release, merge `staging` into `main`. CI runs on the merged commit; once green, `release.yml` fires.
+`.github/workflows/auto-pr.yml` runs on every push to `staging` (a merge is a push) and keeps a single rolling `staging → main` promotion PR open, no-opping when one already exists or when `staging` is not ahead of `main`.
+
+To trigger a release, merge that `staging → main` PR. CI runs on the merged commit; once green, `release.yml` fires.
 
 ## Links
 

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-develop": "2.0.x-dev",
             "dev-main": "2.0.x-dev"
         }
     }


### PR DESCRIPTION
## Problem

`develop` was renamed to `staging`. `INF-1458` moved `merge-back.yml` over but missed `auto-pr.yml`, which still triggered on `push:` to `develop` — a branch that no longer exists. So nothing has opened the `staging -> main` promotion PR since the rename, and roughly a month of staging work (~361 commits; `staging` declares 2.2.1 against a 2.1.2 last release) sits unpromoted.

## Trigger mechanism was already right

`push:` to a branch already fires on merge into that branch — a merge *is* a push. There was no `pull_request` trigger anywhere in this workflow. This is a branch-name fix only; the "fire on merge, not on PR creation" behaviour was already correct and is unchanged.

## Changes

- **`auto-pr.yml`** — retarget the trigger, job id, check name, `gh pr list` filters, the `compare/main...` API call, and the PR title/body from `develop` to `staging`. Also corrects the body's reference to a workflow filename that was renamed away two commits after it was written.
- **`auto-pr.yml`** — add a `concurrency` group. The "is a PR already open?" test is check-then-create, so two merges landing on `staging` in quick succession could both pass it and the second `gh pr create` would fail with a red check. The later run supersedes the earlier one, so `cancel-in-progress: true` is safe.
- **`claude-code-review.yaml`** — the long-lived-sync-PR skip was keyed on a head ref of `develop`. Without retargeting it, the cumulative promotion PR trips the reviewer's 20000-line `gh pr diff` ceiling and hard-fails on every sync.
- **`ci.yml`** — drop `develop` from the `push` / `pull_request` branch lists (dead entry).
- **`README.md`** — document `auto-pr.yml` alongside `merge-back.yml`; the release section previously described merging `staging` into `main` by hand.

### Second commit — drop a stale `head_ref` exemption

The skip list carried a second `github.head_ref !=` guard naming a branch that has never existed on this remote. `git branch -r` does not list it and the refs API returns 404 for it, so the comparison could never evaluate false and the guard was inert. Removed.

The `staging` exemption stays — that one is load-bearing, and is the whole point of the first commit's retarget.

### Third commit — drop the dead `dev-develop` composer branch alias

`extra.branch-alias` mapped `dev-develop` to `2.0.x-dev`. A branch alias only ever applies to a `dev-<branch>` requirement, and no `develop` branch exists on this remote, so the entry could never resolve. Nothing in the repo, CI or scripts requires or references `dev-develop`. `dev-main` stays, so `branch-alias` is still non-empty and no empty key is left behind. Consumers on a tagged release are unaffected — aliases influence only dev-constraint resolution, never tags. No `dev-staging` replacement is added.

## Idempotency

Already correct and preserved: the step no-ops with `exit 0` when a `staging -> main` PR is open, and again when `staging` is not ahead of `main`. The new `concurrency` group closes the check-then-create race that could have produced a duplicate-create failure. A rolling PR needs no explicit update step — its head branch moves on its own.

## Deliberately left alone

- Every unrelated use of "developer" / "develop": Magento developer mode (`Model/Config/Repository.php`, `Makefile`, `Test/Stubs/State.php`), the `magento/magento2 2.4-develop` upstream reference in `Test/Stubs/TaxEngine.php`, the xdebug `mode=develop` ini note in `dev/install-xdebug`, and the `BASE=released|develop|...` flag in `docs/brand-overlay-guide.md` — `develop` there is one of that installer's mode keywords (pick a VCS base instead of a released tag), not a reference to any branch of this repo, so the rename does not touch it.

## Validation

`actionlint` is not installed in this environment. All three edited workflows parse under a strict `yaml.safe_load`, and the `run:` block's script — extracted post-YAML-dedent, which is what makes the un-indented heredoc terminator valid — passes `bash -n`:

```
auto-pr.yml OK  triggers= ['push', 'workflow_dispatch']
ci.yml OK  triggers= ['push', 'pull_request']
claude-code-review.yaml OK  triggers= ['pull_request', 'issue_comment', 'pull_request_review_comment', 'pull_request_review']
bash syntax OK
```

Re-validated after the second commit:

```
YAML OK: .github/workflows/claude-code-review.yaml
paren balance: 0
head_ref guards: ["github.head_ref != 'staging' &&"]
```

`composer` is not installed in this environment, so `composer validate` could not be run; `composer.json` parses under a strict `json.load` and the change is a single key deletion:

```
composer.json OK
extra: {"branch-alias": {"dev-main": "2.0.x-dev"}}
```

No workflow run was triggered to test this.

## Heads-up

The first thing this does once merged to `staging` is open a `staging -> main` PR containing the full ~361-commit backlog.

---

Footnote: raised and implemented by Claude.
