### PR TITLE
docs(TWO-25386): drop port-provenance comments

### DIFF
--- a/.github/scripts/decide-bump-level.sh
+++ b/.github/scripts/decide-bump-level.sh
@@ -31,8 +31,8 @@
 #     second fix commit on the same PR is a no-op, and the version can NEVER
 #     REGRESS. That last part is load-bearing because `main` sits behind
 #     `staging` in these repos: with a stale main the raw candidate can compute
-#     BELOW the version already on staging, and on PrestaShop that would
-#     resurrect an already-run `upgrade/upgrade-<version>.php` filename.
+#     BELOW the version already on staging, which would resurrect an
+#     already-run `upgrade/upgrade-<version>.php` filename.
 #
 #  3. ONLY `feat` EARNS A MINOR. `chore`, `docs`, `ci`, `test`, `refactor`,
 #     `build`, `perf`, `style` all take a patch. The obvious-looking "minor
@@ -44,14 +44,15 @@
 #
 #         target_major = max(declared, M.major + breaking)
 #
-# PrestaShop-only clause: PrestaShop discovers upgrade scripts BY FILENAME and
-# runs `upgrade/upgrade-<version>.php` only for versions strictly above the
-# installed one. Appending a second migration to an already-installed version's
-# script therefore never runs on a shop that already reached that version -
-# silently, `number_upgraded=0`. So if this PR ADDS a new upgrade script and the
-# rule above produced no version change, force a patch bump so the script gets a
-# filename of its own. Editing an EXISTING script does not trigger this. The
-# clause is inert in the repos that have no `upgrade/upgrade-*.php` at all.
+# Filename-discovered upgrade scripts: where the platform discovers upgrade
+# scripts BY FILENAME and runs `upgrade/upgrade-<version>.php` only for versions
+# strictly above the installed one, appending a second migration to an
+# already-installed version's script never runs on a shop that already reached
+# that version - silently, `number_upgraded=0`. So if this PR ADDS a new upgrade
+# script and the rule above produced no version change, force a patch bump so
+# the script gets a filename of its own. Editing an EXISTING script does not
+# trigger this. The clause is inert in the repos that have no
+# `upgrade/upgrade-*.php` at all.
 #
 # Usage:  decide-bump-level.sh [<base-ref>] [<head-ref>]
 #         defaults: origin/staging HEAD
@@ -78,7 +79,7 @@ die() {
 # --- reading a version out of a ref ------------------------------------------
 #
 # bumpver.toml is the source of truth everywhere it exists. It does NOT exist on
-# `main` in the PrestaShop repo (it was only ever added on `staging`), so fall
+# `main` in every repo (in some it was only ever added on `staging`), so fall
 # back to the module's own declarations rather than crashing - reading M is not
 # optional, it is the base of every candidate below.
 read_version() {
@@ -227,7 +228,7 @@ if [ "$new" != "$candidate" ]; then
     why="${why}; clamped to the version already on the head (${head_version} >= candidate ${candidate})"
 fi
 
-# --- PrestaShop-only: a NEW upgrade script needs a filename of its own -------
+# --- a NEW upgrade script needs a filename of its own ------------------------
 #
 # `--diff-filter=A` against the merge base, so an EDIT to an existing script
 # never triggers this - only a genuinely new file does.

--- a/.github/scripts/test-decide-bump-level.sh
+++ b/.github/scripts/test-decide-bump-level.sh
@@ -38,7 +38,7 @@ new_repo() {
     git config commit.gpgsign false
 
     if [ "$nomain" = "--no-main-bumpver" ]; then
-        # PrestaShop's `main`: no bumpver.toml, version only in the module files.
+        # A `main` with no bumpver.toml: version only in the module files.
         cat >config.xml <<EOF
 <?xml version="1.0" encoding="UTF-8" ?>
 <module>
@@ -114,8 +114,8 @@ check_fails() {
 check_upgrade() {
     local label=$1 expected=$2 want=$3
     local out rc
-    # check-upgrade-script-version.sh only exists in the PrestaShop repo — the
-    # filename-based upgrade mechanism it guards is PrestaShop's alone.
+    # check-upgrade-script-version.sh only exists in the repos that use the
+    # filename-based upgrade mechanism it guards.
     if [ ! -x "$CHECKER" ]; then
         printf 'SKIP  %-58s (no check-upgrade-script-version.sh in this repo)\n' "$label"
         return 0

--- a/Api/Config/RepositoryInterface.php
+++ b/Api/Config/RepositoryInterface.php
@@ -434,10 +434,9 @@ interface RepositoryInterface
 
     /**
      * Optional merchant-entered site/vendor name for multi-site setups
-     * (TWO-25386, ported from woocommerce-plugin). Sent to the API on
-     * order creation as `vendor_name` so a merchant running Two across
-     * several sites/stores that share one merchant account can tell the
-     * orders apart. Empty string means unset.
+     * (TWO-25386). Sent to the API on order creation as `vendor_name` so a
+     * merchant running Two across several sites/stores that share one
+     * merchant account can tell the orders apart. Empty string means unset.
      *
      * @param int|null $storeId
      *
@@ -447,8 +446,7 @@ interface RepositoryInterface
 
     /**
      * Whether the buyer-facing "What is <Product>?" explainer link is
-     * shown on the payment method tile at checkout (TWO-25386, ported
-     * from woocommerce-plugin).
+     * shown on the payment method tile at checkout (TWO-25386).
      *
      * @param int|null $storeId
      *
@@ -459,9 +457,9 @@ interface RepositoryInterface
     /**
      * Whether the optional checkout field inputs (PO number, project,
      * department, order note, invoice email) render a hover tooltip with
-     * the field's label (TWO-25386, ported from woocommerce-plugin).
-     * Defaults to enabled — Magento already rendered these unconditionally
-     * before this flag existed, so the default preserves prior behaviour.
+     * the field's label (TWO-25386). Defaults to enabled — Magento already
+     * rendered these unconditionally before this flag existed, so the
+     * default preserves prior behaviour.
      *
      * @param int|null $storeId
      *
@@ -471,8 +469,7 @@ interface RepositoryInterface
 
     /**
      * Debug flag: skip the additional confirmation-callback check on
-     * top of the mandatory order-reference match (TWO-25386, ported from
-     * woocommerce-plugin's WordPress-nonce skip). See
+     * top of the mandatory order-reference match (TWO-25386). See
      * Controller\Payment\Confirm for why this is currently a documented
      * no-op on Magento — kept for admin-surface parity with the other
      * plugins pending a Magento-side signing mechanism to actually gate.
@@ -486,9 +483,8 @@ interface RepositoryInterface
     /**
      * Whether stored Two configuration (payment/two_payment/* and
      * payment/two_search/*) is deleted from core_config_data when the
-     * module is uninstalled (TWO-25386, ported from woocommerce-plugin's
-     * "clear settings on deactivation" — Magento's nearest equivalent
-     * lifecycle event is module uninstall, not deactivation).
+     * module is uninstalled (TWO-25386). Module uninstall is the nearest
+     * lifecycle event Magento offers for this.
      *
      * @param int|null $storeId
      *
@@ -498,9 +494,9 @@ interface RepositoryInterface
 
     /**
      * Store-view-scoped payment method subtitle shown beneath the title
-     * at checkout (TWO-25386, ported from prestashop-plugin's per-language
-     * PS_TWO_SUB_TITLE). Empty string means unset — callers fall back to
-     * the brand's default subtitle (BrandRegistryInterface::getCheckoutSubtitle).
+     * at checkout (TWO-25386). Empty string means unset — callers fall back
+     * to the brand's default subtitle
+     * (BrandRegistryInterface::getCheckoutSubtitle).
      *
      * @param int|null $storeId
      *
@@ -510,10 +506,9 @@ interface RepositoryInterface
 
     /**
      * Debug flag: skip TLS certificate verification on outbound API calls
-     * (TWO-25386, ported from prestashop-plugin's PS_TWO_DISABLE_SSL_VERIFY).
-     * Defaults to false (verification ON, secure). Unsafe for production —
-     * intended only for corporate networks that terminate TLS with a
-     * custom/self-signed certificate.
+     * (TWO-25386). Defaults to false (verification ON, secure). Unsafe for
+     * production — intended only for corporate networks that terminate TLS
+     * with a custom/self-signed certificate.
      *
      * @param int|null $storeId
      *

--- a/Block/Adminhtml/System/Config/Field/HealthChecklist.php
+++ b/Block/Adminhtml/System/Config/Field/HealthChecklist.php
@@ -14,13 +14,11 @@ use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
 use Two\Gateway\Service\Merchant\ApiKeyStatus;
 
 /**
- * Read-only "install health" panel in Stores Configuration (TWO-25386,
- * ported from prestashop-plugin's renderTwoPluginHealthChecklist).
+ * Read-only "install health" panel in Stores Configuration (TWO-25386).
  *
- * Deliberately mirrors the same three checks prestashop-plugin ships —
- * API key, environment, SSL verification — rather than inventing new ones
- * (e.g. webhook reachability, PHP extensions) that plugin's checklist does
- * not have either.
+ * Deliberately limited to three checks — API key, environment, SSL
+ * verification — rather than inventing new ones (e.g. webhook
+ * reachability, PHP extensions).
  *
  * Uses the cached ApiKeyStatus::getStatus() rather than a live refresh():
  * the neighbouring "API key check" field (ApiKeyCheck) already performs a
@@ -89,8 +87,7 @@ class HealthChecklist extends Field
 
     /**
      * True when the environment is production and SSL verification is
-     * disabled — the one combination worth a loud warning, mirroring
-     * prestashop-plugin's equivalent banner.
+     * disabled — the one combination worth a loud warning.
      */
     public function isProductionWithSslDisabled(): bool
     {

--- a/Controller/Payment/Confirm.php
+++ b/Controller/Payment/Confirm.php
@@ -23,15 +23,13 @@ use Two\Gateway\Service\Payment\OrderService;
  * Payment confirm controller
  *
  * TWO-25386: the "Skip confirm-order nonce check" admin toggle
- * (Api\Config\RepositoryInterface::isSkipConfirmNonceCheckEnabled(), ported
- * from woocommerce-plugin's WordPress-nonce skip) is DELIBERATELY not
- * consumed here. This controller identifies the callback solely by the
- * `_two_order_reference` param (see OrderService::getOrderByReference()),
- * which is always checked — there is no separate session/nonce layer on
- * top of it the way WooCommerce's WP nonce sits on top of its own mandatory
- * order-reference check. The toggle exists for admin-surface parity with
- * the other plugins; it is a documented no-op until Magento gains an
- * equivalent signing mechanism to actually gate.
+ * (Api\Config\RepositoryInterface::isSkipConfirmNonceCheckEnabled()) is
+ * DELIBERATELY not consumed here. This controller identifies the callback
+ * solely by the `_two_order_reference` param (see
+ * OrderService::getOrderByReference()), which is always checked — there is
+ * no separate session/nonce layer on top of it to skip. The toggle exists
+ * for admin-surface parity with the other plugins; it is a documented no-op
+ * until Magento gains an equivalent signing mechanism to actually gate.
  */
 class Confirm extends Action
 {

--- a/Model/Provenance.php
+++ b/Model/Provenance.php
@@ -32,9 +32,7 @@ use Magento\Framework\Component\ComponentRegistrar;
  *     time to close that gap.
  *
  * Resolution order is `.git` gitlink → Composer reference →
- * `.two-deployed-commit` stamp, one org-wide order shared by all six Two
- * plugin artifacts (Magento, Magento overlay, WooCommerce, WooCommerce overlay,
- * PrestaShop, OpenCart). The order is freshness-ranked, not
+ * `.two-deployed-commit` stamp. The order is freshness-ranked, not
  * confidence-ranked: the gitlink is the only signal that reflects what is
  * checked out *right now*, the Composer reference is recorded once at
  * install time, and the build stamp is frozen at build time and so is the

--- a/Model/Ui/ConfigProvider.php
+++ b/Model/Ui/ConfigProvider.php
@@ -57,9 +57,8 @@ class ConfigProvider implements ConfigProviderInterface
     public const COMPANY_NUMBER_TOKEN = '{{companyNumber}}';
 
     /**
-     * Buyer-facing "What is Two?" explainer link target (TWO-25386, ported
-     * from woocommerce-plugin's brand-descriptor `about_url`). Kept as a
-     * plain constant here rather than threaded through
+     * Buyer-facing "What is Two?" explainer link target (TWO-25386). Kept
+     * as a plain constant here rather than threaded through
      * BrandRegistryInterface — a single marketing URL did not seem worth
      * the blast radius of a new brand.xml tag across the descriptor,
      * loader, XSD and every implementation. A brand overlay only supplies
@@ -248,7 +247,6 @@ class ConfigProvider implements ConfigProviderInterface
                     'minimumOrder' => $minimumOrder['minimums'],
                     'minimumOrderUnresolved' => $minimumOrder['unresolved'],
                     'subtitleHtml' => $this->getSubtitleHtml(),
-                    // TWO-25386: ported from woocommerce-plugin.
                     'showAboutLink' => $this->configRepository->isAboutLinkEnabled(),
                     'aboutLinkUrl' => self::ABOUT_URL,
                     'aboutLinkText' => (string)__('What is %1?', $this->brandRegistry->getProductName()),
@@ -435,9 +433,8 @@ class ConfigProvider implements ConfigProviderInterface
     /**
      * Resolve the checkout subtitle for the storefront renderer.
      *
-     * TWO-25386: a store-view-scoped admin override (ported from
-     * prestashop-plugin's per-language PS_TWO_SUB_TITLE) takes priority
-     * when set. It is merchant-entered free text, so it is HTML-escaped
+     * TWO-25386: a store-view-scoped admin override takes priority when
+     * set. It is merchant-entered free text, so it is HTML-escaped
      * here rather than treated as a translation source key — unlike the
      * brand default below, it must never be passed to __().
      *

--- a/Service/Api/Adapter.php
+++ b/Service/Api/Adapter.php
@@ -104,9 +104,8 @@ class Adapter
             }
             $curl->setOption(CURLOPT_RETURNTRANSFER, true);
             // TWO-25386: TLS verification is ON by default (secure). Only the
-            // "Disable SSL verification" debug toggle (ported from
-            // prestashop-plugin's PS_TWO_DISABLE_SSL_VERIFY) turns it off, for
-            // stores behind a corporate proxy that terminates TLS with its own
+            // "Disable SSL verification" debug toggle turns it off, for stores
+            // behind a corporate proxy that terminates TLS with its own
             // certificate. Previously this was unconditionally disabled here.
             if ($this->configRepository->isSslVerificationDisabled($storeId)) {
                 $curl->setOption(CURLOPT_SSL_VERIFYHOST, 0);

--- a/Service/Api/SupportedCompanyTypes.php
+++ b/Service/Api/SupportedCompanyTypes.php
@@ -21,8 +21,7 @@ use Two\Gateway\Api\Log\RepositoryInterface as LogRepository;
  * operates in, so they are deliberately omitted: an empty list is a
  * legitimate answer meaning business-only checkout for that country.
  *
- * Mirrors the WooCommerce / PrestaShop plugins' fetch+cache+fail-soft
- * protocol (WC_Twoinc_Sole_Trader / TwoSoleTrader):
+ * The fetch+cache+fail-soft protocol:
  * - a successful answer (including a genuine empty list) is cached for
  *   CACHE_LIFETIME seconds, matching the endpoint's own Cache-Control
  *   max-age, keyed by country;

--- a/Service/Invoice/UploadService.php
+++ b/Service/Invoice/UploadService.php
@@ -20,8 +20,7 @@ use Two\Gateway\Service\Api\Adapter;
 use Two\Gateway\Service\Merchant\SettingsProvider;
 
 /**
- * Uploads a merchant-generated invoice PDF to Two, mirroring the shipped
- * PrestaShop pattern (TwoInvoiceUploadService.php) via checkout-api's
+ * Uploads a merchant-generated invoice PDF to Two via checkout-api's
  * 3-step signed-URL flow:
  *
  *   1. PUT /uploads/v1/invoice/{invoice_id}/external_invoice/{index}

--- a/Service/Order.php
+++ b/Service/Order.php
@@ -352,9 +352,9 @@ abstract class Order
     public function getDiscountAmountItem($item): float
     {
         // Compute at native float precision — never round the inputs first.
-        // Early per-component rounding is the phantom-negative trap hit on
-        // PrestaShop (TWO-24741). The returned value stays native so the
-        // payload boundary keeps its single roundAmt() call.
+        // Early per-component rounding is the phantom-negative trap
+        // (TWO-24741). The returned value stays native so the payload
+        // boundary keeps its single roundAmt() call.
         $discountAmount = (float)$item->getDiscountAmount()
             - (float)$item->getDiscountTaxCompensationAmount();
 

--- a/Setup/Uninstall.php
+++ b/Setup/Uninstall.php
@@ -15,17 +15,15 @@ use Magento\Framework\Setup\SchemaSetupInterface;
 use Two\Gateway\Api\BrandRegistryInterface;
 
 /**
- * Fires on `bin/magento module:uninstall Two_Gateway` (TWO-25386, ported
- * from woocommerce-plugin's "clear settings on deactivation" — Magento's
- * nearest equivalent lifecycle event is uninstall, not deactivation:
- * Magento has no admin-triggered "disable this module" hook a payment
- * module can act on the way a WordPress plugin can).
+ * Fires on `bin/magento module:uninstall Two_Gateway` (TWO-25386).
+ * Uninstall is the nearest lifecycle event Magento offers for this: there
+ * is no admin-triggered "disable this module" hook a payment module can act
+ * on.
  *
  * Deletes stored `payment/<code>/*` configuration from core_config_data
  * ONLY when the merchant opted in via the "Clear settings on module
  * uninstall" toggle. Default off, so uninstall leaves configuration in
- * place unless the merchant asked otherwise — matching the WooCommerce
- * default.
+ * place unless the merchant asked otherwise.
  *
  * `<code>` is resolved from BrandRegistryInterface::getCode() rather than
  * hardcoded to `two_payment` — every field this module ships writes to

--- a/Test/Js/company-search-country-switch.test.js
+++ b/Test/Js/company-search-country-switch.test.js
@@ -14,12 +14,8 @@
  * country, is refused there, and surfaces to the buyer as a generic failure
  * with nothing on screen saying which field is wrong.
  *
- * Ported from the PrestaShop fix (its country-change listener clears the
- * company and organisation fields, and its server side discards a session
- * company whose country marker does not match the address). The mechanism
- * differs in one deliberate way, pinned below: PrestaShop recreates its
- * autocomplete on a country change because that widget captures the country at
- * construction. This one reads it per request, so the picker is left bound and
+ * The picker is deliberately left bound on a country change rather than
+ * recreated, a divergence pinned below: it reads the country per request, so
  * the NEXT search simply carries the new country.
  *
  * LIMITATIONS OF THE DOUBLES BELOW — read before trusting a pass here.

--- a/Test/Unit/Block/Adminhtml/System/Config/Field/HealthChecklistTest.php
+++ b/Test/Unit/Block/Adminhtml/System/Config/Field/HealthChecklistTest.php
@@ -9,9 +9,8 @@ use Two\Gateway\Block\Adminhtml\System\Config\Field\HealthChecklist;
 use Two\Gateway\Service\Merchant\ApiKeyStatus;
 
 /**
- * TWO-25386: the admin "Health checklist" panel, ported from
- * prestashop-plugin's renderTwoPluginHealthChecklist(). Same three checks
- * as that plugin: API key, environment, SSL verification.
+ * TWO-25386: the admin "Health checklist" panel. Three checks: API key,
+ * environment, SSL verification.
  */
 class HealthChecklistTest extends TestCase
 {

--- a/Test/Unit/Config/CheckoutFieldDefaultsTest.php
+++ b/Test/Unit/Config/CheckoutFieldDefaultsTest.php
@@ -30,10 +30,8 @@ class CheckoutFieldDefaultsTest extends TestCase
         'enable_po_number',
         'enable_order_note',
         'enable_invoice_emails',
-        // TWO-25386: ported from woocommerce-plugin. Both default to
-        // enabled — display_tooltips preserves Magento's prior
-        // (unconditional) behaviour, show_about_link matches WC's own
-        // default.
+        // TWO-25386: both default to enabled — display_tooltips preserves
+        // Magento's prior (unconditional) behaviour.
         'show_about_link',
         'display_tooltips',
     ];

--- a/Test/Unit/Config/CheckoutFieldOrderTest.php
+++ b/Test/Unit/Config/CheckoutFieldOrderTest.php
@@ -36,9 +36,9 @@ class CheckoutFieldOrderTest extends TestCase
         'enable_project',
         'enable_department',
         'enable_order_note',
-        // TWO-25386: ported from woocommerce-plugin. Not part of the
-        // load-bearing order-note-last sequence above (TWO-25263) — these
-        // just need to come after it, which this test also pins.
+        // TWO-25386: not part of the load-bearing order-note-last sequence
+        // above (TWO-25263) — these just need to come after it, which this
+        // test also pins.
         'show_about_link',
         'display_tooltips',
     ];

--- a/Test/Unit/Model/Config/RepositoryAdminControlsTest.php
+++ b/Test/Unit/Model/Config/RepositoryAdminControlsTest.php
@@ -16,8 +16,7 @@ use Two\Gateway\Model\Provenance;
 use Two\Gateway\Service\Merchant\SettingsProvider;
 
 /**
- * TWO-25386: config accessors for the 8 admin controls ported from
- * woocommerce-plugin and prestashop-plugin.
+ * TWO-25386: config accessors for the 8 admin controls.
  */
 class RepositoryAdminControlsTest extends TestCase
 {

--- a/Test/Unit/Service/Order/NegativeDiscountGuardTest.php
+++ b/Test/Unit/Service/Order/NegativeDiscountGuardTest.php
@@ -10,7 +10,7 @@ use Two\Gateway\Service\Order;
 
 /**
  * TWO-25099 — fail loud on negative discount amounts before reaching the
- * Two API (Magento mirror of the PrestaShop guard shipped in TWO-24741).
+ * Two API.
  *
  * Covers:
  *  (a) legitimate positive discounts pass through untouched, at native

--- a/Test/Unit/Setup/UninstallTest.php
+++ b/Test/Unit/Setup/UninstallTest.php
@@ -11,10 +11,9 @@ use Two\Gateway\Api\BrandRegistryInterface;
 use Two\Gateway\Setup\Uninstall;
 
 /**
- * TWO-25386: ported from woocommerce-plugin's "clear settings on
- * deactivation" — Magento's nearest equivalent lifecycle event is module
- * uninstall. Default off: uninstall must leave configuration in place
- * unless the merchant explicitly opted in.
+ * TWO-25386: clear stored settings on module uninstall — Magento's
+ * nearest equivalent lifecycle event for this. Default off: uninstall must
+ * leave configuration in place unless the merchant explicitly opted in.
  *
  * Adversarial review (round 1) found the first version of this class
  * hardcoded `payment/two_payment/%`, ignoring the active brand's own code

--- a/docs/brand-overlay-guide.md
+++ b/docs/brand-overlay-guide.md
@@ -242,25 +242,15 @@ does not know about other separators, so copy shaped `%2 – %3` or
 `%2, %3` leaves the dangling separator behind when the number is
 withheld.
 
-This parent plugin's storefront renderer (Luma/Amasty/Fire, one shared
-code path) emits each notice as a persistent inline element with class
+This plugin's storefront renderer (Luma/Amasty/Fire, one shared code
+path) emits each notice as a persistent inline element with class
 `two-order-intent-message approved` / `two-order-intent-message declined`
-inside the payment-method tile, as does PrestaShop (approved variant
-only, as of writing). WooCommerce uses `twoinc-intent-approved` instead,
-so grep for the platform-specific class names when sweeping the four
-checkout surfaces. `magento-hyva-extension` shares this parent's
-`BrandRegistryInterface`/brand.xml, so a brand's `intent_approved_notice`
-override applies to Hyvä too without any Hyvä-side declaration.
+inside the payment-method tile.
 
-The `intent_approved_notice_enabled` key carries the same name and
-semantics on WooCommerce and PrestaShop, where it is a real PHP boolean
-rather than an XSD enumeration. **The failure mode differs:** an invalid
-value throws here and is a logged error plus the default `true` there,
-because those resolvers run while rendering a buyer-facing checkout,
-where a white screen is worse than a notice that stays on. Don't assume
-Magento's throw when working across platforms. None of the four
-platforms has (or should ever grow) a copy-override element for the
-declined/not-available notice.
+`intent_approved_notice_enabled` is an XSD enumeration here, so an
+invalid value throws rather than falling back to a default. There is no
+copy-override element for the declined/not-available notice, and one
+should never be added.
 
 ### A warning about validation
 

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -72,7 +72,6 @@
                        showInWebsite="1" showInStore="1">
                     <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\ApiKeyCheck</frontend_model>
                 </field>
-                <!-- TWO-25386: ported from woocommerce-plugin's 'vendor_name' field. -->
                 <field id="vendor_site_name" translate="label comment" type="text" sortOrder="57" showInDefault="1"
                        showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Vendor name (optional)</label>
@@ -106,9 +105,8 @@
                     <validate>required-entry</validate>
                     <config_path>payment/two_payment/title</config_path>
                 </field>
-                <!-- TWO-25386: ported from prestashop-plugin's per-language PS_TWO_SUB_TITLE.
-                     showInStore="1" gives the same per-store-view override PrestaShop gets
-                     from its per-language storage; empty falls back to the brand default
+                <!-- TWO-25386: showInStore="1" gives a per-store-view override;
+                     empty falls back to the brand default
                      (BrandRegistryInterface::getCheckoutSubtitle). -->
                 <field id="subtitle" translate="label comment" type="text" sortOrder="20" showInDefault="1"
                        showInWebsite="1" showInStore="1" canRestore="1">
@@ -221,9 +219,9 @@
                     <config_path>payment/two_payment/enable_order_note</config_path>
                 </field>
                 <!--
-                    TWO-25386: ported from woocommerce-plugin. Not part of the
-                    load-bearing order-note-last sequence above (TWO-25263) — these
-                    come after it, so their sortOrder is free to change independently.
+                    TWO-25386: not part of the load-bearing order-note-last
+                    sequence above (TWO-25263) — these come after it, so their
+                    sortOrder is free to change independently.
                 -->
                 <field id="show_about_link" translate="label comment" type="select" sortOrder="60" showInDefault="1"
                        showInWebsite="1" showInStore="1" canRestore="1">
@@ -479,10 +477,10 @@
             <group id="admin_controls" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="1"
                    showInStore="1">
                 <label>Admin Controls</label>
-                <!-- TWO-25386: ported from woocommerce-plugin's 'skip_confirm_auth'.
-                     See Controller\Payment\Confirm — Magento's confirmation callback
-                     has no separate nonce layer to skip today (only the mandatory
-                     order-reference match), so this flag is currently a documented
+                <!-- TWO-25386: see Controller\Payment\Confirm — Magento's
+                     confirmation callback has no separate nonce layer to skip
+                     today (only the mandatory order-reference match), so this
+                     flag is currently a documented
                      no-op kept for admin-surface parity across plugins. -->
                 <field id="skip_confirm_nonce_check" translate="label comment" type="select" sortOrder="10"
                        showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
@@ -491,9 +489,8 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <config_path>payment/two_payment/skip_confirm_nonce_check</config_path>
                 </field>
-                <!-- TWO-25386: ported from woocommerce-plugin's 'clear_options_on_deactivation'.
-                     Magento's nearest lifecycle event is module uninstall, not
-                     deactivation; see Setup\Uninstall. -->
+                <!-- TWO-25386: module uninstall is Magento's nearest lifecycle
+                     event for this; see Setup\Uninstall. -->
                 <field id="clear_settings_on_uninstall" translate="label comment" type="select" sortOrder="20"
                        showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Clear settings on module uninstall</label>
@@ -501,9 +498,9 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <config_path>payment/two_payment/clear_settings_on_uninstall</config_path>
                 </field>
-                <!-- TWO-25386: ported from prestashop-plugin's PS_TWO_DISABLE_SSL_VERIFY.
-                     Default OFF (verification on / secure). Fixes Service\Api\Adapter,
-                     which previously disabled TLS verification unconditionally. Moved
+                <!-- TWO-25386: default OFF (verification on / secure). Fixes
+                     Service\Api\Adapter, which previously disabled TLS
+                     verification unconditionally. Moved
                      here from General (was mis-grouped there during the section
                      regroup) — this is a diagnostics/support-only escape hatch, not
                      a general checkout setting. -->
@@ -527,7 +524,6 @@
             <group id="health" translate="label comment" type="text" sortOrder="40" showInDefault="1" showInWebsite="1"
                    showInStore="1">
                 <label>Health</label>
-                <!-- TWO-25386: ported from prestashop-plugin's install health checklist. -->
                 <field id="health_checklist" translate="label comment" type="button" sortOrder="10"
                        showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Health checklist</label>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -35,9 +35,8 @@
                 <enable_po_number>1</enable_po_number>
                 <vendor_site_name/>
                 <subtitle/>
-                <!-- TWO-25386: show_about_link default ON matches
-                     woocommerce-plugin's default. display_tooltips default ON
-                     preserves Magento's prior behaviour — the optional
+                <!-- TWO-25386: show_about_link defaults ON. display_tooltips
+                     default ON preserves Magento's prior behaviour — the optional
                      checkout field inputs rendered their title-attribute
                      tooltip unconditionally before this flag existed. -->
                 <show_about_link>1</show_about_link>

--- a/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/gateway_method.js
@@ -200,9 +200,8 @@ define([
             this.supportedCompanyTypes = config.supportedCompanyTypes || {};
 
             this.twoSubtitleHtml = config.subtitleHtml || '';
-            // TWO-25386: ported from woocommerce-plugin's about-link toggle
-            // and tooltip-display toggle. showWhatIsTwo is the pre-existing
-            // (unused until now) observable declared above.
+            // TWO-25386: showWhatIsTwo is the pre-existing (unused until now)
+            // observable declared above.
             this.showWhatIsTwo(!!config.showAboutLink);
             this.aboutLinkUrl = config.aboutLinkUrl || '';
             this.aboutLinkText = config.aboutLinkText || '';

--- a/view/frontend/web/template/payment/gateway_method.html
+++ b/view/frontend/web/template/payment/gateway_method.html
@@ -15,7 +15,6 @@
             <div class="two-title-block">
                 <span class="two-payment-title" data-bind="text: getTitle()"></span>
                 <div class="two-payment-subtitle" data-bind="html: twoSubtitleHtml"></div>
-                <!-- TWO-25386: ported from woocommerce-plugin's about-link toggle. -->
                 <a
                     class="two-about-link"
                     target="_blank"


### PR DESCRIPTION
## What

Removes the "ported from &lt;other repo&gt;" provenance comments the TWO-25386
admin-controls work left behind. They record where a control came from —
history the ticket already holds, and not something a reader of this module
needs.

Comments and docblocks only. No code, behaviour, config default, admin label
or user-visible string changed.

## How each hit was handled

- **Comment whose only content was provenance** → deleted outright
  (`etc/adminhtml/system.xml` ×3, `etc/config.xml` clause,
  `Model/Ui/ConfigProvider.php`, `view/frontend/web/template/payment/gateway_method.html`).
- **Provenance as one clause of a useful sentence** → clause removed, the
  explanation kept, and the line re-wrapped where the trim left a ragged
  edge (`Api/Config/RepositoryInterface.php` ×7,
  `Controller/Payment/Confirm.php`, `Setup/Uninstall.php`,
  `Service/Api/Adapter.php`, `Service/Api/SupportedCompanyTypes.php`,
  `Service/Invoice/UploadService.php`,
  `Block/Adminhtml/System/Config/Field/HealthChecklist.php`,
  the six test headers, `gateway_method.js`).

## Second pass — the referred-back set

The first pass held back a set of cross-platform references for a judgement
call. Three of those groups are now removed as well, in the follow-up commit
on this branch, applying the same rule (delete a comment that is wholly a
reference; keep the explanation and cut only the clause otherwise):

- **`Model/Provenance.php`** — the resolution-order docblock enumerated the
  full set of plugin artifacts sharing that order. The enumeration is gone;
  the freshness-ranked rationale it introduced is unchanged.
- **`Service/Order.php`** — the negative-discount guard recorded which
  platform the phantom-negative rounding trap was first seen on. That clause
  is gone; the TWO-24741 reference and the "never round the inputs first"
  rationale stay.
- **`docs/brand-overlay-guide.md`** and the release tooling
  (`.github/scripts/decide-bump-level.sh` + its test) — the order-intent
  notice section compared markup classes and enablement-key semantics across
  platforms, which left both paragraphs as fragments once the comparisons
  came out, so they are restructured to state this module's own behaviour.
  The release-tooling change is comment-only rewording that describes the
  filename-discovered upgrade-script mechanism by behaviour rather than by
  platform.

**One reference deliberately not touched:** `decide-bump-level.sh` also names
a platform inside an emitted `reason=` output string, not a comment. Changing
it would be a behaviour change to release tooling, so it is left as-is and
flagged here rather than edited. Two nearby test-harness section labels are
`echo` strings for the same reason. The script's version-fallback logic also
reads a platform-specific filename — that is logic, untouched.

## Deliberately left in place

Comments that state a live cross-platform **behavioural contract** rather
than provenance. These describe behaviour a merchant or buyer relies on
today, so removing them would delete a real invariant:

- the load-bearing canonical checkout-field order (`etc/adminhtml/system.xml`,
  `etc/adminhtml/brand_form_template.xml`,
  `Test/Unit/Config/CheckoutFieldOrderTest.php`);
- the shared 300ms company-search debounce
  (`view/frontend/web/js/model/company-search.js`,
  `Test/Js/company-search-resilience.test.js`);
- the semantic order-intent palette and the convergence notes
  (`view/frontend/web/css/style.css`,
  `view/frontend/web/template/payment/gateway_method.html`,
  `Test/Js/gateway-method-intent-approved-notice.test.js`);
- the surcharge tax-treatment rule
  (`Model/Config/Source/SurchargeTaxClass.php`);
- design notes explaining why this module's company-search and
  address-ordering wiring diverges from its counterparts
  (`company-search-control.js`, `address-autocomplete.js`,
  `LayoutProcessorPlugin.php` and its test,
  `company-search-country-switch.test.js`,
  `company-search-address-lookup.test.js`).

## `ComposeOrder.php` — now resolved upstream

The first pass left `Service/Order/ComposeOrder.php`'s `vendor_name`
provenance comment alone because it was mid-review elsewhere. That comment no
longer exists on `staging` — magento-plugin PR #338 removed it when it merged,
and `staging` is merged into this branch. Nothing left to do there.

## Verification

Run on this branch with `origin/staging` merged in:

- `make test` — `OK (713 tests, 1331 assertions)`.
- Magento coding standard, the image CI uses, at `--severity=6`:
  `246 / 246 (100%)`, no violations.
- `.github/scripts/test-decide-bump-level.sh` — `26 passed, 0 failed`,
  matching the pre-change baseline.
- Every changed line in the PHP files verified to be a comment or docblock
  line.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
